### PR TITLE
Issue #9 - non-closing stream reader delegate

### DIFF
--- a/fhir-model/src/main/java/com/ibm/watson/health/fhir/model/generator/FHIRXMLGenerator.java
+++ b/fhir-model/src/main/java/com/ibm/watson/health/fhir/model/generator/FHIRXMLGenerator.java
@@ -9,6 +9,7 @@ package com.ibm.watson.health.fhir.model.generator;
 import static com.ibm.watson.health.fhir.model.type.Xhtml.xhtml;
 import static com.ibm.watson.health.fhir.model.util.ModelSupport.isPrimitiveType;
 import static com.ibm.watson.health.fhir.model.util.XMLSupport.FHIR_NS_URI;
+import static com.ibm.watson.health.fhir.model.util.XMLSupport.createNonClosingStreamWriterDelegate;
 import static com.ibm.watson.health.fhir.model.util.XMLSupport.createStreamWriterDelegate;
 
 import java.io.OutputStream;
@@ -259,7 +260,7 @@ public class FHIRXMLGenerator extends FHIRAbstractGenerator {
             try {
                 Transformer transformer = THREAD_LOCAL_TRANSFORMER.get();
                 transformer.reset();
-                transformer.transform(new StreamSource(new StringReader(xhtml.getValue())), new StAXResult(writer));
+                transformer.transform(new StreamSource(new StringReader(xhtml.getValue())), new StAXResult(createNonClosingStreamWriterDelegate(writer)));
             } catch (TransformerException e) {
                 throw new RuntimeException(e);
             }

--- a/fhir-model/src/main/java/com/ibm/watson/health/fhir/model/util/XMLSupport.java
+++ b/fhir-model/src/main/java/com/ibm/watson/health/fhir/model/util/XMLSupport.java
@@ -166,6 +166,15 @@ public final class XMLSupport {
             }
         };
     }
+    
+    public static XMLStreamWriter createNonClosingStreamWriterDelegate(XMLStreamWriter writer) {
+        return new StreamWriterDelegate(writer) {
+            @Override
+            public void close() throws XMLStreamException {
+                // do nothing
+            }
+        };
+    }
 
     private static XMLInputFactory createXMLInputFactory() {
         XMLInputFactory factory = XMLInputFactory.newInstance();


### PR DESCRIPTION
Introduced non-closing stream reader delegate to avoid the scenario where a particular javax.xml.transform.Transformer implementation (e.g. Saxon) closes the XMLStreamWriter after the narrative block is written to the output.