### PR TITLE
_format parameter overrides the HTTP Header Accept #542

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/watson/health/fhir/server/test/BasicServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/watson/health/fhir/server/test/BasicServerTest.java
@@ -125,6 +125,31 @@ public class BasicServerTest extends FHIRServerTestBase {
 
         assertResourceEquals(patient, responsePatient);
     }
+    
+    /**
+     * Create a minimal Patient, then make sure we can retrieve it with varying format
+     */
+    @Test(groups = { "server-basic" })
+    public void testCreatePatientMinimalWithFormat() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = readResource(Patient.class, "Patient_DavidOrtiz.json");
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request().post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        String patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).header("_format", "application/fhir+json").get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+
+        assertResourceEquals(patient, responsePatient);
+    }
 
     /**
      * Create a minimal Patient, then make sure we can retrieve it.

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -27,7 +27,8 @@
          for nonsensical queries like requests for a JSP page that doesn't exist.
     -->
     <webContainer disableXPoweredBy="true" 
-        displaytextwhennoerrorpagedefined="Unexpected request/response. Please check the URL and try again." />
+        displaytextwhennoerrorpagedefined="Unexpected request/response. Please check the URL and try again."
+        deferServletLoad="false" />
 
     <!-- FHIR Server's keystore and truststore configuration -->
     <ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustStoreRef="defaultTrustStore" clientAuthenticationSupported="true" />
@@ -102,8 +103,6 @@
     <applicationManager autoExpand="true"/>
 
     <applicationMonitor updateTrigger="mbean"/>   
-
-    <webContainer deferServletLoad="false"/>   
 
     <!-- This is the main FHIR Server REST API war -->
     <webApplication contextRoot="fhir-server/api/v4" id="fhir-server-webapp" location="fhir-server.war" name="fhir-server-webapp">


### PR DESCRIPTION
- removed extraneous webcontainer
- updated test to reflect _format decoded
- update code to reflect _format in rare circumstance with Accept
conflicting

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>