### PR TITLE
issue #26 - include containing classes in element definition ids to avoid conflicts

### DIFF
--- a/fhir-openapi/pom.xml
+++ b/fhir-openapi/pom.xml
@@ -14,7 +14,6 @@
     <packaging>war</packaging>
 
     <build>
-        <finalName>${project.name}</finalName>
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>

--- a/fhir-openapi/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/fhir-openapi/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -6,7 +6,7 @@
     version="1.0">
 
     <reload-interval value="3"/>
-    <context-root uri="${project.name}" />
+    <context-root uri="fhir-openapi" />
     <enable-directory-browsing value="false"/>
     <enable-file-serving value="true"/>
     <enable-reloading value="true"/>

--- a/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -763,15 +763,15 @@ public class FHIROpenApiGenerator {
                 definition.add("required", requiredArray);
             }
 
-            definitions.add(getFullyQualifiedSimpleName(modelClass), definition);
+            definitions.add(getSimpleNameWithEnclosingNames(modelClass), definition);
         }
     }
 
-    private static String getFullyQualifiedSimpleName(Class<?> modelClass) {
+    private static String getSimpleNameWithEnclosingNames(Class<?> modelClass) {
         StringBuilder fullName = new StringBuilder(modelClass.getSimpleName());
         while (modelClass.isMemberClass()) {
             modelClass = modelClass.getEnclosingClass();
-            fullName.insert(0, modelClass.getSimpleName());
+            fullName.insert(0, modelClass.getSimpleName() + "_");
         }
         return fullName.toString();
     }
@@ -893,7 +893,7 @@ public class FHIROpenApiGenerator {
             property.add("type", "integer");
             property.add("pattern","[0]|[-+]?[1-9][0-9]*");
         } else {
-            property.add("$ref", "#/components/schemas/" + getFullyQualifiedSimpleName(fieldClass));
+            property.add("$ref", "#/components/schemas/" + getSimpleNameWithEnclosingNames(fieldClass));
         }
 
         if (description != null) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -51,6 +51,7 @@ import com.ibm.watson.health.fhir.model.type.DateTime;
 import com.ibm.watson.health.fhir.model.type.ElementDefinition;
 import com.ibm.watson.health.fhir.model.util.FHIRUtil;
 import com.ibm.watson.health.fhir.model.util.ModelSupport;
+import com.ibm.watson.health.fhir.model.visitor.AbstractVisitable;
 import com.ibm.watson.health.fhir.search.util.SearchUtil;
 
 public class FHIROpenApiGenerator {
@@ -735,7 +736,8 @@ public class FHIROpenApiGenerator {
             }
 
             Class<?> superClass = modelClass.getSuperclass();
-            if (superClass != null && superClass.getPackage().getName().startsWith("com.ibm.watson.health.fhir.model")) {
+            if (superClass != null && superClass.getPackage().getName().startsWith("com.ibm.watson.health.fhir.model")
+                    && !superClass.equals(AbstractVisitable.class)) {
                 JsonArrayBuilder allOf = factory.createArrayBuilder();
 
                 JsonObjectBuilder ref = factory.createObjectBuilder();
@@ -761,8 +763,17 @@ public class FHIROpenApiGenerator {
                 definition.add("required", requiredArray);
             }
 
-            definitions.add(modelClass.getSimpleName(), definition);
+            definitions.add(getFullyQualifiedSimpleName(modelClass), definition);
         }
+    }
+
+    private static String getFullyQualifiedSimpleName(Class<?> modelClass) {
+        StringBuilder fullName = new StringBuilder(modelClass.getSimpleName());
+        while (modelClass.isMemberClass()) {
+            modelClass = modelClass.getEnclosingClass();
+            fullName.insert(0, modelClass.getSimpleName());
+        }
+        return fullName.toString();
     }
 
     private static StructureDefinition getStructureDefinition(Class<?> modelClass) {
@@ -882,7 +893,7 @@ public class FHIROpenApiGenerator {
             property.add("type", "integer");
             property.add("pattern","[0]|[-+]?[1-9][0-9]*");
         } else {
-            property.add("$ref", "#/components/schemas/" + fieldClass.getSimpleName());
+            property.add("$ref", "#/components/schemas/" + getFullyQualifiedSimpleName(fieldClass));
         }
 
         if (description != null) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -75,8 +75,12 @@ public class FHIRSwaggerGenerator {
         } else {
             filter = createAcceptAllFilter();
         }
-        // filter =
-        // createFilter("Patient(create,read);Contract(create,read);Questionnaire(create,read),QuestionnaireResponse(create,read);RiskAssessment(read,search)");
+//      filter = createFilter("Patient(create,read,vread,history,search);"
+//          + "Contract(create,read,vread,history,search);"
+//          + "Questionnaire(create,read,vread,history,search);"
+//          + "QuestionnaireResponse(create,read,vread,history,search);"
+//          + "Claim(create,read,vread,history,search);"
+//          + "RiskAssessment(read,vread,history,search)");
         // filter =
         // createFilter("Patient(create,read,vread,update,delete,search,history)");
 
@@ -696,15 +700,15 @@ public class FHIRSwaggerGenerator {
                 definition.add("required", requiredArray);
             }
 
-            definitions.add(getFullyQualifiedSimpleName(modelClass), definition);
+            definitions.add(getSimpleNameWithEnclosingNames(modelClass), definition);
         }
     }
 
-    private static String getFullyQualifiedSimpleName(Class<?> modelClass) {
+    private static String getSimpleNameWithEnclosingNames(Class<?> modelClass) {
         StringBuilder fullName = new StringBuilder(modelClass.getSimpleName());
         while (modelClass.isMemberClass()) {
             modelClass = modelClass.getEnclosingClass();
-            fullName.insert(0, modelClass.getSimpleName());
+            fullName.insert(0, modelClass.getSimpleName() + "_");
         }
         return fullName.toString();
     }
@@ -826,7 +830,7 @@ public class FHIRSwaggerGenerator {
             property.add("type", "integer");
             property.add("pattern","[0]|[-+]?[1-9][0-9]*");
         } else {
-            property.add("$ref", "#/definitions/" + getFullyQualifiedSimpleName(fieldClass));
+            property.add("$ref", "#/definitions/" + getSimpleNameWithEnclosingNames(fieldClass));
         }
 
         if (description != null) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/watson/health/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -50,6 +50,7 @@ import com.ibm.watson.health.fhir.model.type.DateTime;
 import com.ibm.watson.health.fhir.model.type.ElementDefinition;
 import com.ibm.watson.health.fhir.model.util.FHIRUtil;
 import com.ibm.watson.health.fhir.model.util.ModelSupport;
+import com.ibm.watson.health.fhir.model.visitor.AbstractVisitable;
 import com.ibm.watson.health.fhir.openapi.generator.FHIROpenApiGenerator;
 import com.ibm.watson.health.fhir.search.util.SearchUtil;
 
@@ -668,7 +669,8 @@ public class FHIRSwaggerGenerator {
 
             Class<?> superClass = modelClass.getSuperclass();
             if (superClass != null
-                    && superClass.getPackage().getName().startsWith("com.ibm.watson.health.fhir.model")) {
+                    && superClass.getPackage().getName().startsWith("com.ibm.watson.health.fhir.model")
+                    && !superClass.equals(AbstractVisitable.class)) {
                 JsonArrayBuilder allOf = factory.createArrayBuilder();
 
                 JsonObjectBuilder ref = factory.createObjectBuilder();
@@ -694,8 +696,17 @@ public class FHIRSwaggerGenerator {
                 definition.add("required", requiredArray);
             }
 
-            definitions.add(modelClass.getSimpleName(), definition);
+            definitions.add(getFullyQualifiedSimpleName(modelClass), definition);
         }
+    }
+
+    private static String getFullyQualifiedSimpleName(Class<?> modelClass) {
+        StringBuilder fullName = new StringBuilder(modelClass.getSimpleName());
+        while (modelClass.isMemberClass()) {
+            modelClass = modelClass.getEnclosingClass();
+            fullName.insert(0, modelClass.getSimpleName());
+        }
+        return fullName.toString();
     }
 
     private static StructureDefinition getStructureDefinition(Class<?> modelClass) {
@@ -815,7 +826,7 @@ public class FHIRSwaggerGenerator {
             property.add("type", "integer");
             property.add("pattern","[0]|[-+]?[1-9][0-9]*");
         } else {
-            property.add("$ref", "#/definitions/" + fieldClass.getSimpleName());
+            property.add("$ref", "#/definitions/" + getFullyQualifiedSimpleName(fieldClass));
         }
 
         if (description != null) {


### PR DESCRIPTION
In DSTU2 we prefixed classes with the name of the containing type.
However, in R4, we moved to a nested class structure and so the simple names are no longer unique.
Furthermore, there are now some BackboneElements that share a local name
within the same resource (e.g. ImplementationGuide.Definition.resource
and ImplementationGuide.Manifest.resource) and so we need to use the
full path of contained resource simple names to ensure uniqueness.

Signed-off-by: lmsurpre <lmsurpre@us.ibm.com>