### PR TITLE
Update fhir-openapi war name to fix the build

### DIFF
--- a/fhir-openapi/pom.xml
+++ b/fhir-openapi/pom.xml
@@ -18,6 +18,7 @@
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
+                    <warName>fhir-openapi</warName>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>


### PR DESCRIPTION
this is consistent with how we name the fhir-server-webapp war file