### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ For a detailed description of FHIR conformance, please see https://github.com/ib
 The server can be packaged as a set of jar files, a web application archive (war), an application installer, or a Docker image.
 
 ### Running the IBM Server for HL7 FHIR
-For information on installing and running the IBM Server for HL7 FHIR, please see the User Guide at https://github.com/ibm/fhir/blob/master/docs/FHIRServerUsersGuide.md.
+The IBM Server for HL7 FHIR is currently under development. To run the server you must clone or download the project and build it. See https://github.com/IBM/FHIR/wiki/Setting-up-for-development for more info.
+
+Information on installing and running the IBM Server for HL7 FHIR will be available in the User Guide at https://github.com/ibm/fhir/blob/master/docs/FHIRServerUsersGuide.md, but presently this document needs love/attention.
 
 ### Building on top of the IBM Server for HL7 FHIR
-IBM Server for HL7 FHIR artifacts will become available on JCenter and Maven Central with a group ID of `com.ibm.watson.health` in the near future.
+IBM Server for HL7 FHIR artifacts will become available on JCenter and Maven Central with a group ID of `com.ibm.fhir` in the near future.
 
 For example, if you are using Maven and would like to use our object model (including our high-performance parser, generator, and validator), you could declare the dependency like this:
 
@@ -19,7 +21,7 @@ For example, if you are using Maven and would like to use our object model (incl
 ...
 <dependencies>
     <dependency>
-      <groupId>com.ibm.watson.health</groupId>
+      <groupId>com.ibm.fhir</groupId>
       <artifactId>fhir-model</artifactId>
       <version>${fhir.version}</version>
     </dependency>


### PR DESCRIPTION
1. Stop claiming its ready to run.  We can revert this change after we have some initial build artifacts uploaded.
2. Update groupId to more likely name