### PR TITLE
issue #101 use null instead of empty continuetoken for s3

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/BulkImportBatchLet.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/BulkImportBatchLet.java
@@ -150,7 +150,7 @@ public class BulkImportBatchLet implements Batchlet {
         FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null);
 
         boolean moreResults = true;
-        String nextToken = "";
+        String nextToken = null;
         int maxKeys = 100, imported = 0;
         while (moreResults && !stopRequested) {
             ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(cosBucketName).withMaxKeys(maxKeys)
@@ -179,7 +179,6 @@ public class BulkImportBatchLet implements Batchlet {
             if (result.isTruncated()) {
                 nextToken = result.getNextContinuationToken();
             } else {
-                nextToken = "";
                 moreResults = false;
             }
         }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -32,7 +32,7 @@ public class ChunkReader extends AbstractItemReader {
     private AmazonS3 cosClient = null;
 
     int pageNum = 0;
-    String nextToken = "";
+    String nextToken = null;
 
     /**
      * The IBM COS API key or S3 access key.
@@ -133,7 +133,7 @@ public class ChunkReader extends AbstractItemReader {
             }
         }
 
-        if (nextToken.contentEquals("ALLDONE")) {
+        if (nextToken != null && nextToken.contentEquals("ALLDONE")) {
             return null;
         }
 


### PR DESCRIPTION
Signed-off-by: Albert Wang <xuwang@us.ibm.com>

IBM COS can support both null and "" as initial continuetoken, but s3 can only support null, so change to use null to be compatible with s3.