### PR TITLE
Issue 115 - Support return preference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,19 @@ jobs:
         build/pre-integration-test.sh
         mvn test -DskipTests=false -f fhir-server-test/pom.xml
         build/post-integration-test.sh
+    - name: Gather error logs
+      if: failure()
+      run: |
+        it_results=SIT/integration-test-results
+        rm -fr ${it_results} 2>/dev/null
+        mkdir -p ${it_results}/server-logs
+        mkdir -p ${it_results}/fhir-server-test
+        echo "Gathering post-test server logs..."
+        cp -pr SIT/wlp/usr/servers/fhir-server/logs ${it_results}/server-logs
+        echo "Gathering integration test output"
+        cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
     - name: Upload logs
+      if: always()
       uses: actions/upload-artifact@master
       with:
         name: integration-test-results

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 [![Build Status](https://travis-ci.com/IBM/FHIR.svg?branch=master)](https://travis-ci.com/IBM/FHIR)
 
-## IBM Server for HL7 FHIR
-
-The IBM Server for HL7 FHIR is a modular Java implementation of version 4 of the [HL7 FHIR specification](https://www.hl7.org/fhir/r4/http.html) with a focus on performance and configurability.
+## IBM FHIR Server
+The IBM FHIR Server is a modular Java implementation of version 4 of the [HL7 FHIR specification](https://www.hl7.org/fhir/r4/http.html) with a focus on performance and configurability.
 
 For a detailed description of FHIR conformance, please see https://github.com/ibm/fhir/blob/master/docs/Conformance.md.
 
 The server can be packaged as a set of jar files, a web application archive (war), an application installer, or a Docker image.
 
-### Running the IBM Server for HL7 FHIR
-The IBM Server for HL7 FHIR is currently under development. To run the server you must clone or download the project and build it. See https://github.com/IBM/FHIR/wiki/Setting-up-for-development for more info.
+### Running the IBM FHIR Server
+The IBM FHIR Server is currently under development. To run the server you must clone or download the project and build it. See https://github.com/IBM/FHIR/wiki/Setting-up-for-development for more info.
 
-Information on installing and running the IBM Server for HL7 FHIR will be available in the User Guide at https://github.com/ibm/fhir/blob/master/docs/FHIRServerUsersGuide.md, but presently this document needs love/attention.
+Information on installing and running the IBM FHIR Server will be available in the User Guide at https://github.com/ibm/fhir/blob/master/docs/FHIRServerUsersGuide.md, but presently this document needs love/attention.
 
-### Building on top of the IBM Server for HL7 FHIR
-IBM Server for HL7 FHIR artifacts will become available on JCenter and Maven Central with a group ID of `com.ibm.fhir` in the near future.
+### Building on top of the IBM FHIR Server
+IBM FHIR Server artifacts will become available on JCenter and Maven Central with a group ID of `com.ibm.fhir` in the near future.
 
 For example, if you are using Maven and would like to use our object model (including our high-performance parser, generator, and validator), you could declare the dependency like this:
 
@@ -29,9 +28,11 @@ For example, if you are using Maven and would like to use our object model (incl
     ...
 ```
 
-### Contributing to the IBM Server for HL7 FHIR
+### Contributing to the IBM FHIR Server
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### License
-The IBM Server for HL7 FHIR is licensed under the Apache 2.0 license. Full license text is
+The IBM FHIR Server is licensed under the Apache 2.0 license. Full license text is
 available at [LICENSE](LICENSE).
+
+FHIR® is the registered trademark of HL7 and is used with the permission of HL7.

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/BulkExportBatchLet.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/BulkExportBatchLet.java
@@ -301,7 +301,7 @@ public class BulkExportBatchLet implements Batchlet {
             FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
             txn.begin();
             persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
-            List<Resource> resources = fhirPersistence.search(persistenceContext, resourceType);
+            List<Resource> resources = fhirPersistence.search(persistenceContext, resourceType).getResource();
             txn.commit();
 
             if (resources != null) {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/ChunkReader.java
@@ -201,7 +201,7 @@ public class ChunkReader extends AbstractItemReader {
         FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
         txn.begin();
         persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
-        resources = fhirPersistence.search(persistenceContext, resourceType);
+        resources = fhirPersistence.search(persistenceContext, resourceType).getResource();
         txn.commit();
         pageNum++;
 

--- a/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
@@ -138,6 +138,14 @@ public interface FHIRClient {
      */
     public static final String PROPNAME_HTTP_TIMEOUT = "fhirclient.http.receive.timeout";
     
+    /**
+     * The client preference for whether the server response for modification requests like POST or PUT should include
+     * an empty body, the updated resources, or a resource describing the outcome of the interaction.
+     * 
+     * <p>"minimal", "representation", or "OperationOutcome"
+     */
+    public static final String PROPNAME_HTTP_RETURN_PREF = "fhirclient.http.return.pref";
+    
     
     /**
      * Returns a JAX-RS 2.0 WebTarget object associated with the REST API endpoint.

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.exception.FHIRException;
 
 /**
@@ -30,6 +31,9 @@ public class FHIRRequestContext {
     private String tenantKey;
     private String dataStoreId;
     private String requestUniqueId;
+    
+    // Default to the "minimal" representation which means create/update responses won't return the resource body
+    private HTTPReturnPreference returnPreference = HTTPReturnPreference.MINIMAL;
     
     private Pattern validChars = Pattern.compile("[a-zA-Z0-9_\\-]+");
     private String errorMsg = "Only [a-z], [A-Z], [0-9], '_', and '-' characters are allowed.";
@@ -148,5 +152,19 @@ public class FHIRRequestContext {
     
     private static String objectHandle(Object obj) {
         return '@' + Integer.toHexString(System.identityHashCode(obj));
+    }
+
+    /**
+     * @return the returnPreference
+     */
+    public HTTPReturnPreference getReturnPreference() {
+        return returnPreference;
+    }
+
+    /**
+     * @param returnPreference the returnPreference to set
+     */
+    public void setReturnPreference(HTTPReturnPreference returnPreference) {
+        this.returnPreference = returnPreference;
     }
 }

--- a/fhir-core/src/main/java/com/ibm/fhir/core/HTTPReturnPreference.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/HTTPReturnPreference.java
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.core;
+
+/**
+ * An enumeration of return preference codes.
+ * 
+ * @see https://www.hl7.org/fhir/r4/http.html#ops
+ * @author lmsurpre
+ */
+public enum HTTPReturnPreference {
+    /**
+     * minimal
+     * 
+     * <p>A client preference for returning no body.
+     */
+    MINIMAL("minimal"),
+
+    /**
+     * representation
+     * 
+     * <p>A client preference for returning the full resource.
+     */
+    REPRESENTATION("representation"),
+
+    /**
+     * OperationOutcome
+     * 
+     * <p>A client preference for returning an OperationOutcome resource containing hints and warnings about the operation rather than the full resource.
+     */
+    OPERATION_OUTCOME("OperationOutcome");
+
+    private final String value;
+
+    HTTPReturnPreference(String value) {
+        this.value = value;
+    }
+
+    public java.lang.String value() {
+        return value;
+    }
+
+    public static HTTPReturnPreference from(String value) {
+        for (HTTPReturnPreference c : HTTPReturnPreference.values()) {
+            if (c.value.equals(value)) {
+                return c;
+            }
+        }
+        throw new IllegalArgumentException(value);
+    }
+}

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -765,7 +765,7 @@ public class FHIRUtil {
         return false;
     }
     
-    public static Resource addTag(Resource resource, Coding tag) {
+    public static <T extends Resource> T addTag(T resource, Coding tag) {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(tag);
         if (hasTag(resource, tag)) {
@@ -774,11 +774,13 @@ public class FHIRUtil {
         Meta meta = resource.getMeta();
         Meta.Builder metaBuilder = (meta == null) ? Meta.builder() : meta.toBuilder();
         // re-build resource with updated meta element
-        return resource.toBuilder()
-                .meta(metaBuilder
-                    .tag(tag)
-                    .build())
-                .build();
+        @SuppressWarnings("unchecked")
+        T updatedResource = (T) resource.toBuilder()
+                                    .meta(metaBuilder
+                                        .tag(tag)
+                                        .build())
+                                    .build();
+        return updatedResource;
     }
 
     // add for FHIRResource.java

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,6 +56,7 @@ import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.DomainResource;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.type.Address;
 import com.ibm.fhir.model.type.Age;
 import com.ibm.fhir.model.type.Annotation;
@@ -171,6 +173,13 @@ public class FHIRUtil {
         UsageContext.class,
         Dosage.class));
     private static final Map<String, String> CONCRETE_TYPE_NAME_MAP = buildConcreteTypeNameMap();
+    private static final OperationOutcome ALL_OK = OperationOutcome.builder()
+                                                            .issue(Issue.builder()
+                                                                    .severity(IssueSeverity.INFORMATION)
+                                                                    .code(IssueType.INFORMATIONAL)
+                                                                    .details(CodeableConcept.builder().text(string("All OK")).build())
+                                                                    .build())
+                                                            .build();
 
     private FHIRUtil() { }
 
@@ -461,14 +470,23 @@ public class FHIRUtil {
         if (expression == null || expression.isEmpty()) {
             expression = "<no expression>";
         }
-        return OperationOutcome.Issue.builder().severity(IssueSeverity.of(severity)).code(IssueType.of(code)).details(CodeableConcept.builder().text(string(details)).build()).expression(Collections.singletonList(string(expression))).build();
+        return OperationOutcome.Issue.builder()
+                    .severity(IssueSeverity.of(severity))
+                    .code(IssueType.of(code))
+                    .details(CodeableConcept.builder().text(string(details)).build())
+                    .expression(Collections.singletonList(string(expression)))
+                    .build();
     }
 
     /**
      * Build an OperationOutcome that contains the specified list of operation outcome issues.
      */
-    public static OperationOutcome buildOperationOutcome(List<OperationOutcome.Issue> issues) {
-        // Build an OperationOutcome and stuff the issues into it.
+    public static OperationOutcome buildOperationOutcome(Collection<OperationOutcome.Issue> issues) {
+        // If there are no issues, then return the ALL OK OperationOutcome
+        if (issues == null || issues.isEmpty()) {
+            return ALL_OK;
+        }
+        // Otherwise build an OperationOutcome and stuff the issues into it.
         return OperationOutcome.builder().issue(issues).build();
     }
 
@@ -765,6 +783,15 @@ public class FHIRUtil {
         return false;
     }
     
+    /**
+     * Return a copy of resource {@code resource} with tag {@code tag}
+     * @param <T>
+     * @param resource
+     *          the resource to add the tag too
+     * @param tag
+     *          the tag to add
+     * @return a copy of the resource with the new tag (if it didn't already exist), or the resource passed in if the tag is already present
+     */
     public static <T extends Resource> T addTag(T resource, Coding tag) {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(tag);

--- a/fhir-operation/src/main/java/com/ibm/fhir/rest/FHIRRestOperationResponse.java
+++ b/fhir-operation/src/main/java/com/ibm/fhir/rest/FHIRRestOperationResponse.java
@@ -10,6 +10,7 @@ import java.net.URI;
 
 import javax.ws.rs.core.Response;
 
+import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Resource;
 
 /**
@@ -20,6 +21,7 @@ public class FHIRRestOperationResponse {
     private URI locationURI;
     private Resource resource;
     private Resource prevResource;
+    private OperationOutcome operationOutcome;
     
     public FHIRRestOperationResponse() {
     }
@@ -28,6 +30,11 @@ public class FHIRRestOperationResponse {
         setStatus(status);
         setLocationURI(locationURI);
         setResource(resource);
+    }
+    public FHIRRestOperationResponse(Response.Status status, URI locationURI, OperationOutcome operationOutcome) {
+        setStatus(status);
+        setLocationURI(locationURI);
+        setOperationOutcome(operationOutcome);
     }
     public Response.Status getStatus() {
         return status;
@@ -54,5 +61,13 @@ public class FHIRRestOperationResponse {
 
     public void setPrevResource(Resource prevResource) {
         this.prevResource = prevResource;
+    }
+
+    public OperationOutcome getOperationOutcome() {
+        return operationOutcome;
+    }
+
+    public void setOperationOutcome(OperationOutcome operationOutcome) {
+        this.operationOutcome = operationOutcome;
     }
 }

--- a/fhir-persistence-jdbc/pom.xml
+++ b/fhir-persistence-jdbc/pom.xml
@@ -107,10 +107,6 @@
             <artifactId>jsonassert</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -31,7 +31,6 @@ import java.util.zip.GZIPOutputStream;
 import javax.naming.InitialContext;
 import javax.transaction.Status;
 import javax.transaction.UserTransaction;
-import javax.xml.bind.JAXBException;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.PropertyGroup;
@@ -684,13 +683,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @param resourceDTOList
      * @param resourceType
      * @return
-     * @throws JAXBException
+     * @throws FHIRException
      * @throws IOException 
      */
     // This variant uses generics and is used in history.
     // TODO: this method needs to either get merged or better differentiated with the old one used for search
     protected <T extends Resource> List<T> convertResourceDTOList(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList, Class<T> resourceType) 
-                                throws FHIRException, JAXBException, IOException {
+                                throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO List";
         log.entering(CLASSNAME, METHODNAME);
         
@@ -711,14 +710,14 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @param resourceDTOList
      * @param resourceType
      * @return
-     * @throws JAXBException
+     * @throws FHIRException
      * @throws IOException 
      */
     // This variant doesn't use generics and is used in search.
     // TODO: this method needs to either get merged or better differentiated with the new one that supports history operation via generics.
     // Start by better understanding what happens for `_include` and `_revinclude` search results that contain multiple different types
     protected List<Resource> convertResourceDTOListOld(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList, Class<? extends Resource> resourceType) 
-                                throws FHIRException, JAXBException, IOException {
+                                throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO List";
         log.entering(CLASSNAME, METHODNAME);
         
@@ -740,12 +739,12 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @param resourceType - The FHIR type of resource to be converted.
      * @param elements - An optional filter for including only specified elements inside a Resource.
      * @return Resource - A FHIR Resource object representation of the data portion of the passed Resource DTO.
-     * @throws JAXBException
+     * @throws FHIRException
      * @throws IOException 
      */
     protected <T extends Resource> T convertResourceDTO(com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO, 
             Class<T> resourceType, 
-            List<String> elements) throws FHIRException, JAXBException, IOException {
+            List<String> elements) throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO";
         log.entering(CLASSNAME, METHODNAME);
         T resource = null;
@@ -779,12 +778,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @param elements - An optional list of element names to include in the resources. If null, filtering will be skipped.
      * @return List<Resource> - A list of Resources of the passed resourceType, sorted according the order of ids in the passed sortedIdList.
      * @throws FHIRPersistenceException
-     * @throws JAXBException 
      * @throws IOException 
      */
     protected List<Resource> buildSortedFhirResources(FHIRPersistenceContext context, Class<? extends Resource> resourceType, List<Long> sortedIdList, 
                                                       List<String> elements) 
-                            throws FHIRException, FHIRPersistenceException, JAXBException, IOException {
+                            throws FHIRException, FHIRPersistenceException, IOException {
         final String METHOD_NAME = "buildFhirResource";
         log.entering(this.getClass().getName(), METHOD_NAME);
         

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCNormalizedImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCNormalizedImpl.java
@@ -29,7 +29,6 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.naming.InitialContext;
 import javax.transaction.TransactionSynchronizationRegistry;
-import javax.xml.bind.JAXBException;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.PropertyGroup;
@@ -746,12 +745,11 @@ public class FHIRPersistenceJDBCNormalizedImpl extends FHIRPersistenceJDBCImpl i
      * @param resourceDTOList
      * @param resourceType
      * @return
-     * @throws JAXBException
+     * @throws FHIRException
      * @throws IOException 
      */
     protected List<Resource> convertResourceDTOList(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList, 
-            Class<? extends Resource> resourceType, List<String> elements) 
-            throws FHIRException, JAXBException, IOException {
+            Class<? extends Resource> resourceType, List<String> elements) throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO List";
         log.entering(CLASSNAME, METHODNAME);
         

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/CreateOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/CreateOperation.java
@@ -25,7 +25,7 @@ public class CreateOperation extends BaseOperation {
 
         // This needs to be a new resource. If it's not, then the
         // create will fail with a version id mismatch error
-        Resource newResource = tc.getPersistence().create(context, resource);
+        Resource newResource = tc.getPersistence().create(context, resource).getResource();
         check(tc, resource, newResource, this.getClass().getSimpleName());
         
         // Update the context with the modified resource

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/DeleteOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/DeleteOperation.java
@@ -19,7 +19,7 @@ public class DeleteOperation extends BaseOperation {
 
         final String logicalId = resource.getId().getValue();
         
-        Resource newResource = tc.getPersistence().delete(context, resource.getClass(), logicalId);
+        Resource newResource = tc.getPersistence().delete(context, resource.getClass(), logicalId).getResource();
         
         // Update the context with the modified resource. This is the deletion marker
         // and so should be substantially different when compared with the actual resource

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/HistoryOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/HistoryOperation.java
@@ -31,7 +31,7 @@ public class HistoryOperation extends BaseOperation {
         
         final String logicalId = resource.getId().getValue();
         
-        List<Resource> resources = tc.getPersistence().history(context, resource.getClass(), logicalId);
+        List<? extends Resource> resources = tc.getPersistence().history(context, resource.getClass(), logicalId).getResource();
         if (resources.size() != this.expectedCount) {
             throw new AssertionError(resource.getClass().getSimpleName() + "/" + logicalId + " history returned "
                 + resources.size() + ", expected " + this.expectedCount);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/ReadOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/ReadOperation.java
@@ -21,21 +21,21 @@ public class ReadOperation extends BaseOperation {
     private static final Logger logger = Logger.getLogger(ReadOperation.class.getName());
 
 
-	@Override
-	public void process(TestContext tc) throws FHIRPersistenceException {
-		final Resource resource = tc.getResource();
-		final FHIRPersistenceContext context = tc.createPersistenceContext();
-		
-		final String logicalId = resource.getId().getValue();
-		
-		logger.fine("Reading: " + logicalId);
-		
-		Resource newResource = tc.getPersistence().read(context, resource.getClass(), logicalId);
-		
+    @Override
+    public void process(TestContext tc) throws FHIRPersistenceException {
+        final Resource resource = tc.getResource();
+        final FHIRPersistenceContext context = tc.createPersistenceContext();
+        
+        final String logicalId = resource.getId().getValue();
+        
+        logger.fine("Reading: " + logicalId);
+        
+        Resource newResource = tc.getPersistence().read(context, resource.getClass(), logicalId).getResource();
+        
         check(tc, resource, newResource, this.getClass().getSimpleName());
         
-		// Update the context with the modified resource
-		tc.setResource(newResource);
-		
-	}
+        // Update the context with the modified resource
+        tc.setResource(newResource);
+        
+    }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/UpdateOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/UpdateOperation.java
@@ -26,7 +26,7 @@ public class UpdateOperation extends BaseOperation {
         
         logger.fine("Updating: " + logicalId);
 
-        Resource newResource = tc.getPersistence().update(context, logicalId, resource);
+        Resource newResource = tc.getPersistence().update(context, logicalId, resource).getResource();
         check(tc, resource, newResource, this.getClass().getSimpleName());
         
         // Update the context with the modified resource

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/VReadOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/VReadOperation.java
@@ -22,7 +22,7 @@ public class VReadOperation extends BaseOperation {
         final String logicalId = resource.getId().getValue();
         final String versionId = resource.getMeta().getVersionId().getValue();
         
-        Resource newResource = tc.getPersistence().vread(context, resource.getClass(), logicalId, versionId);
+        Resource newResource = tc.getPersistence().vread(context, resource.getClass(), logicalId, versionId).getResource();
         check(tc, resource, newResource, this.getClass().getSimpleName());
 
         // This operation doesn't modify the resource, so we don't

--- a/fhir-persistence-jdbc/src/test/java/testng.xml
+++ b/fhir-persistence-jdbc/src/test/java/testng.xml
@@ -1,3 +1,4 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="JDBCUnitTestsSuite">
     
     <test name="ParameterTests">

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
@@ -1,12 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2016,2017,2018,2019
+ * (C) Copyright IBM Corp. 2016,2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.persistence;
-
-import java.util.List;
 
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Resource;
@@ -26,21 +24,23 @@ public interface FHIRPersistence {
      * Stores a new FHIR Resource in the datastore.
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resource the FHIR Resource instance to be created in the datastore
-     * @return a copy of resource with fields updated by the persistence layer
+     * @return a SingleResourceResult with a copy of resource with Meta fields updated by the persistence layer and/or 
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    Resource create(FHIRPersistenceContext context, Resource resource) throws FHIRPersistenceException;
+    <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
     
     /**
      * Retrieves the most recent version of a FHIR Resource from the datastore.
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
-     * @return the FHIR Resource that was retrieved from the datastore
+     * @return a SingleResourceResult with the FHIR Resource that was retrieved from the datastore and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      * @throws FHIRPersistenceResourceDeletedException
      */
-    Resource read(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId) 
+    <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) 
                             throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException;
     
     /**
@@ -49,32 +49,35 @@ public interface FHIRPersistence {
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
      * @param versionId the version of the Resource instance to be retrieved
-     * @return the FHIR Resource that was retrieved from the datastore
+     * @return a SingleResourceResult with the FHIR Resource that was retrieved from the datastore and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      * @throws FHIRPersistenceResourceDeletedException
      */
-    Resource vread(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId, String versionId) 
-                    throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException;;
+    <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId) 
+                    throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException;
     
     /**
      * Updates an existing FHIR Resource by storing a new version in the datastore.
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param logicalId the logical id of the FHIR Resource to be updated
      * @param resource the new contents of the FHIR Resource to be stored
-     * @return a copy of resource with fields updated by the persistence layer
+     * @return a SingleResourceResult with a copy of resource with fields updated by the persistence layer and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    Resource update(FHIRPersistenceContext context, String logicalId, Resource resource) throws FHIRPersistenceException;
+    <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException;
     
     /**
      * Deletes the specified FHIR Resource from the datastore.
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType The type of FHIR Resource to be deleted.
      * @param logicalId the logical id of the FHIR Resource to be deleted
-     * @return the FHIR Resource that was deleted or null if the specified resource doesn't exist
+     * @return a SingleResourceResult with the FHIR Resource that was deleted or null if the specified resource doesn't exist and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    default Resource delete(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId) throws FHIRPersistenceException {
+    default <T extends Resource> SingleResourceResult<T> delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
         throw new FHIRPersistenceNotSupportedException("The 'delete' operation is not supported by this persistence implementation");
     }
     
@@ -83,19 +86,21 @@ public interface FHIRPersistence {
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instances to be retrieved
      * @param logicalId the logical id of the Resource instances to be retrieved
-     * @return a list containing the available versions of the specified FHIR Resource
+     * @return a MultiResourceResult with a list containing the available versions of the specified FHIR Resource and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    List<Resource> history(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId) throws FHIRPersistenceException;
+    <T extends Resource> MultiResourceResult<T> history(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException;
     
     /**
      * Performs a search on the specified target resource type using the specified search parameters.
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type which is the target of the search
-     * @return the list of FHIR Resources of the specified resource type which forms the search result set
+     * @return a MultiResourceResult with the list of FHIR Resources in the search result set and/or
+     *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    List<Resource> search(FHIRPersistenceContext context, Class<? extends Resource> resourceType) throws FHIRPersistenceException;
+    MultiResourceResult<Resource> search(FHIRPersistenceContext context, Class<? extends Resource> resourceType) throws FHIRPersistenceException;
 
     /**
      * Returns true iff the persistence layer implementation supports transactions.
@@ -104,7 +109,7 @@ public interface FHIRPersistence {
 
     /**
      * Returns an OperationOutcome indicating the current status of the persistence store / backend
-     * @return a list of OperationalOutcomeIssue indicating the status of the underlying datastore
+     * @return An OperationOutcome with a list of 0 or more OperationalOutcomeIssue indicating the status of the underlying datastore
      * @throws FHIRPersistenceException
      */
     OperationOutcome getHealth() throws FHIRPersistenceException;

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
@@ -22,6 +22,7 @@ public interface FHIRPersistence {
     
     /**
      * Stores a new FHIR Resource in the datastore.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resource the FHIR Resource instance to be created in the datastore
      * @return a SingleResourceResult with a copy of resource with Meta fields updated by the persistence layer and/or 
@@ -32,6 +33,7 @@ public interface FHIRPersistence {
     
     /**
      * Retrieves the most recent version of a FHIR Resource from the datastore.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
@@ -45,6 +47,7 @@ public interface FHIRPersistence {
     
     /**
      * Retrieves a specific version of a FHIR Resource from the datastore.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
@@ -59,6 +62,7 @@ public interface FHIRPersistence {
     
     /**
      * Updates an existing FHIR Resource by storing a new version in the datastore.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param logicalId the logical id of the FHIR Resource to be updated
      * @param resource the new contents of the FHIR Resource to be stored
@@ -70,6 +74,7 @@ public interface FHIRPersistence {
     
     /**
      * Deletes the specified FHIR Resource from the datastore.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType The type of FHIR Resource to be deleted.
      * @param logicalId the logical id of the FHIR Resource to be deleted
@@ -83,6 +88,7 @@ public interface FHIRPersistence {
     
     /**
      * Retrieves all of the versions of the specified FHIR Resource.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instances to be retrieved
      * @param logicalId the logical id of the Resource instances to be retrieved
@@ -94,6 +100,7 @@ public interface FHIRPersistence {
     
     /**
      * Performs a search on the specified target resource type using the specified search parameters.
+     * 
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type which is the target of the search
      * @return a MultiResourceResult with the list of FHIR Resources in the search result set and/or

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceFactory.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2017,2019
+ * (C) Copyright IBM Corp. 2016,2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceTransaction.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceTransaction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2017,2019
+ * (C) Copyright IBM Corp. 2016,2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/MultiResourceResult.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/MultiResourceResult.java
@@ -102,7 +102,8 @@ public class MultiResourceResult<T extends Resource> {
          * @return
          *     A reference to this Builder instance
          */
-        public Builder<T> resource(@SuppressWarnings("unchecked") T... resource) {
+        @SafeVarargs
+        public final Builder<T> resource(T... resource) {
             for (T value : resource) {
                 this.resource.add(value);
             }

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/MultiResourceResult.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/MultiResourceResult.java
@@ -1,0 +1,159 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import com.ibm.fhir.model.annotation.Required;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.util.ValidationSupport;
+
+/**
+ * A Result wrapper for FHIR interactions that can return multiple resources.
+ * Instances are immutable and can be constructed via {@code new MultiResourceResult.Builder<T>()}.
+ * 
+ * @author lmsurpre
+ */
+public class MultiResourceResult<T extends Resource> {
+    @Required
+    final boolean success;
+    final List<T> resource;
+    final OperationOutcome outcome;
+    
+    private MultiResourceResult(Builder<T> builder) {
+        success = ValidationSupport.requireNonNull(builder.success, "success");
+        resource = Collections.unmodifiableList(builder.resource);
+        outcome = builder.outcome;
+        if (!success && (outcome == null || outcome.getIssue().isEmpty())) {
+            throw new IllegalStateException("Failed interaction results must include an OperationOutcome with one or more issue.");
+        }
+    }
+    
+    /**
+     * Whether or not the interaction was successful
+     * 
+     * @return
+     *     whether the interaction was successful
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+    /**
+     * The resources returned from the interaction
+     * 
+     * @return
+     *     An unmodifiable list containing immutable objects of type {@link Resource}.
+     */
+    public List<T> getResource() {
+        return resource;
+    }
+    /**
+     * An OperationOutcome that represents the outcome of the interaction
+     * 
+     * @return
+     *     An immutable object of type {@link OperationOutcome}
+     */
+    public OperationOutcome getOutcome() {
+        return outcome;
+    }
+    
+    public static <T extends Resource> Builder<T> builder(Class<T> clazz) {
+        return new Builder<T>();
+    }
+    
+    // result builder
+    public static class Builder<T extends Resource> {
+        boolean success;
+        List<T> resource = new ArrayList<>();
+        OperationOutcome outcome;
+        
+        /**
+         * Whether or not the interaction was successful
+         * 
+         * <p>This field is required.
+         * 
+         * @param success
+         *     whether the interaction was successful
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> success(boolean success) {
+            this.success = success;
+            return this;
+        }
+        
+        /**
+         * The return resources from the interaction
+         * 
+         * <p>Adds new element(s) to the existing list
+         * 
+         * @param resource
+         *     the resources to return from the interaction; this may be empty if there are no results
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> resource(@SuppressWarnings("unchecked") T... resource) {
+            for (T value : resource) {
+                this.resource.add(value);
+            }
+            return this;
+        }
+        
+        /**
+         * The return resources from the interaction
+         * 
+         * <p>Replaces the existing list with a new one containing elements from the Collection
+         * 
+         * @param resource
+         *     the resources to return from the interaction; this may be empty if there are no results
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> resource(Collection<T> resource) {
+            this.resource = new ArrayList<>(resource);
+            return this;
+        }
+        
+        /**
+         * An OperationOutcome that represents the outcome of the interaction
+         * 
+         * <p>This field is required when the interaction is not successful
+         * 
+         * @param outcome
+         *     the outcome of the interaction
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> outcome(OperationOutcome outcome) {
+            this.outcome = outcome;
+            return this;
+        }
+        
+        /**
+         * Build the {@link MultiResourceResult}
+         * 
+         * <p>Required fields:
+         * <ul>
+         * <li>success</li>
+         * </ul>
+         * 
+         * @return
+         *     An immutable object of type {@link MultiResourceResult}
+         */
+        public MultiResourceResult<T> build() {
+            return new MultiResourceResult<T>(this);
+        }
+    }
+}

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/PropertyBasedFHIRPersistenceFactory.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/PropertyBasedFHIRPersistenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2017,2019
+ * (C) Copyright IBM Corp. 2016,2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/SingleResourceResult.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/SingleResourceResult.java
@@ -1,0 +1,130 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence;
+
+import com.ibm.fhir.model.annotation.Required;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.util.ValidationSupport;
+
+/**
+ * A Result wrapper for FHIR interactions that return a single resource.
+ * Instances are immutable and can be constructed via {@code new SingleResourceResult.Builder<T>()}.
+ * 
+ * @author lmsurpre
+ */
+public class SingleResourceResult<T extends Resource> {
+    @Required
+    final boolean success;
+    final T resource;
+    final OperationOutcome outcome;
+    
+    private SingleResourceResult(Builder<T> builder) {
+        success = ValidationSupport.requireNonNull(builder.success, "success");
+        resource = builder.resource;
+        outcome = builder.outcome;
+        if (!success && (outcome == null || outcome.getIssue().isEmpty())) {
+            throw new IllegalStateException("Failed interaction results must include an OperationOutcome with one or more issue.");
+        }
+    }
+    
+    /**
+     * Whether or not the interaction was successful
+     * 
+     * @return
+     *     whether the interaction was successful
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+    /**
+     * The resource resulting from the interaction
+     * 
+     * @return
+     *     An immutable object of type {@link Resource}.
+     */
+    public T getResource() {
+        return resource;
+    }
+    /**
+     * An OperationOutcome that represents the outcome of the interaction
+     * 
+     * @return
+     *     An immutable object of type {@link OperationOutcome}
+     */
+    public OperationOutcome getOutcome() {
+        return outcome;
+    }
+    
+    // result builder
+    public static class Builder<T extends Resource> {
+        boolean success;
+        T resource;
+        OperationOutcome outcome;
+        
+        /**
+         * Whether or not the interaction was successful
+         * 
+         * <p>This field is required.
+         * 
+         * @param success
+         *     whether the interaction was successful
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> success(boolean success) {
+            this.success = success;
+            return this;
+        }
+        
+        /**
+         * The resulting resource from the interaction
+         * 
+         * @param resource
+         *     the resulting resource from the interaction; this may be null if the interaction was not successful
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> resource(T resource) {
+            this.resource = resource;
+            return this;
+        }
+        
+        /**
+         * An OperationOutcome that represents the outcome of the interaction
+         * 
+         * <p>This field is required when the interaction is not successful
+         * 
+         * @param outcome
+         *     the outcome of the interaction
+         * 
+         * @return
+         *     A reference to this Builder instance
+         */
+        public Builder<T> outcome(OperationOutcome outcome) {
+            this.outcome = outcome;
+            return this;
+        }
+        
+        /**
+         * Build the {@link SingleResourceResult}
+         * 
+         * <p>Required fields:
+         * <ul>
+         * <li>success</li>
+         * </ul>
+         * 
+         * @return
+         *     An immutable object of type {@link SingleResourceResult}
+         */
+        public SingleResourceResult<T> build() {
+            return new SingleResourceResult<T>(this);
+        }
+    }
+}

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest{
      * @throws Exception
      */
     protected boolean searchReturnsResource(String searchParamName, String queryValue, Resource expectedResource) throws Exception {
-        List<Resource> resources = runQueryTest(expectedResource.getClass(), persistence, searchParamName, queryValue, Integer.MAX_VALUE);
+        List<? extends Resource> resources = runQueryTest(expectedResource.getClass(), persistence, searchParamName, queryValue, Integer.MAX_VALUE);
         assertNotNull(resources);
         if (resources.size() > 0) {
             Resource returnedResource = findResourceInResponse(expectedResource, resources);
@@ -112,7 +112,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest{
      * Otherwise it returns null.
      * @param resources
      */
-    protected Resource findResourceInResponse(Resource resourceToFind, List<Resource> resources) {
+    protected Resource findResourceInResponse(Resource resourceToFind, List<? extends Resource> resources) {
         Resource returnedResource = null;
         boolean alreadyFound = false;
         int count = 0;

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
@@ -6,12 +6,12 @@
 
 package com.ibm.fhir.persistence.test;
 
-import java.util.List;
-
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
+import com.ibm.fhir.persistence.MultiResourceResult;
+import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
@@ -23,34 +23,34 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedExceptio
 public class MockPersistenceImpl implements FHIRPersistence {
 
     @Override
-    public Resource create(FHIRPersistenceContext context, Resource resource) throws FHIRPersistenceException {
+    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
     	return null;
     }
 
     @Override
-    public Resource read(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId)
+    public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
         throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
         return null;
     }
 
     @Override
-    public Resource vread(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId, String versionId)
+    public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
         throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
         return null;
     }
 
     @Override
-    public Resource update(FHIRPersistenceContext context, String logicalId, Resource resource) throws FHIRPersistenceException {
+    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException {
     	return null;
     }
 
     @Override
-    public List<Resource> history(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId) throws FHIRPersistenceException {
+    public <T extends Resource> MultiResourceResult<T> history(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
         return null;
     }
 
     @Override
-    public List<Resource> search(FHIRPersistenceContext context, Class<? extends Resource> resourceType) throws FHIRPersistenceException {
+    public MultiResourceResult<Resource> search(FHIRPersistenceContext context, Class<? extends Resource> resourceType) throws FHIRPersistenceException {
         return null;
     }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.model.resource.Device;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.Device.UdiCarrier;
+import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
@@ -73,15 +74,15 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
     @Test(groups = { "jdbc-normalized" }, expectedExceptions = FHIRPersistenceResourceNotFoundException.class)
     public void testDeleteInvalidDevice() throws Exception {
         
-        Resource result = persistence.delete(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
-        assertNull(result);
+        SingleResourceResult<Device> result = persistence.delete(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
+        assertNull(result.getResource());
     }
     
     @Test(groups = { "jdbc-normalized" })
     public void testReadInvalidDevice() throws Exception {
         
-        Device device = (Device) persistence.read(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
-        assertNull(device);
+        SingleResourceResult<Device> result = persistence.read(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
+        assertNull(result.getResource());
     }
     
 //    @Test(groups = { "jdbc-normalized" }, dependsOnMethods = { "testCreateDevice", "testReadDevice" })

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
@@ -18,6 +18,7 @@ import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 
 /**
  * This class contains resource deletion tests.

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.BeforeMethod;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.MultiResourceResult;
 import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
@@ -114,9 +115,9 @@ public abstract class AbstractPersistenceTest extends FHIRModelTestBase {
             searchContext.setPageSize(maxPageSize);
         }
         FHIRPersistenceContext persistenceContext = getPersistenceContextForSearch(searchContext);
-        List<Resource> resources = persistence.search(persistenceContext, resourceType);
-        assertNotNull(resources);
-        return resources;
+        MultiResourceResult<Resource> result = persistence.search(persistenceContext, resourceType);
+        assertNotNull(result.getResource());
+        return result.getResource();
     }
 
     protected List<Resource> runQueryTest(String compartmentName, String compartmentLogicalId, Class<? extends Resource> resourceType, FHIRPersistence persistence, String parmName, String parmValue) throws Exception {
@@ -133,8 +134,8 @@ public abstract class AbstractPersistenceTest extends FHIRModelTestBase {
             searchContext.setPageSize(maxPageSize);
         }
         FHIRPersistenceContext persistenceContext = getPersistenceContextForSearch(searchContext);
-        List<Resource> resources = persistence.search(persistenceContext, resourceType);
-        assertNotNull(resources);
-        return resources;
+        MultiResourceResult<Resource> result = persistence.search(persistenceContext, resourceType);
+        assertNotNull(result.getResource());
+        return result.getResource();
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryAuditEventTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryAuditEventTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractQueryAuditEventTest extends AbstractPersistenceTes
      */
     @Test(groups = { "cloudant", "jpa", "jdbc", "jdbc-normalized" }, dependsOnMethods = { "testCreateAuditEvent" })
     public void testAuditEventQuery_noParams() throws Exception {
-        List<Resource> resources = runQueryTest(AuditEvent.class, persistence, null, null);
+        List<? extends Resource> resources = runQueryTest(AuditEvent.class, persistence, null, null);
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryChainedParmTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryChainedParmTest.java
@@ -10,7 +10,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -20,10 +19,10 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.resource.Composition;
 import com.ibm.fhir.model.resource.ImmunizationRecommendation;
+import com.ibm.fhir.model.resource.ImmunizationRecommendation.Recommendation;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.resource.ImmunizationRecommendation.Recommendation;
 import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
@@ -106,24 +105,24 @@ public abstract class AbstractQueryChainedParmTest extends AbstractPersistenceTe
      */
     @Test(groups = { "jpa", "jdbc", "jdbc-normalized" })
     public void testCreateComposition_chained() throws Exception {
-    	
-    	CodeableConcept forecastStatus = CodeableConcept.builder().text(str2model("cloudy")).build();
-    	CodeableConcept vaccineCode = CodeableConcept.builder().text(str2model("a vaccine")).build();
-    	PositiveInt doseNumber = PositiveInt.of(10);
-    	ImmunizationRecommendation.Recommendation recommendation = ImmunizationRecommendation.Recommendation.builder().forecastStatus(forecastStatus)
-    			.vaccineCode(vaccineCode)
-    			.doseNumber(doseNumber)
-    	.build();
+        
+        CodeableConcept forecastStatus = CodeableConcept.builder().text(str2model("cloudy")).build();
+        CodeableConcept vaccineCode = CodeableConcept.builder().text(str2model("a vaccine")).build();
+        PositiveInt doseNumber = PositiveInt.of(10);
+        ImmunizationRecommendation.Recommendation recommendation = ImmunizationRecommendation.Recommendation.builder().forecastStatus(forecastStatus)
+                .vaccineCode(vaccineCode)
+                .doseNumber(doseNumber)
+        .build();
 
-    	List<Recommendation> recommendations = Arrays.asList(recommendation);
-    	Reference patientRef = Reference.builder().display(str2model("Pat Ient")).build();
-    	DateTime date = DateTime.of("2017-09-04");
+        List<Recommendation> recommendations = Arrays.asList(recommendation);
+        Reference patientRef = Reference.builder().display(str2model("Pat Ient")).build();
+        DateTime date = DateTime.of("2017-09-04");
 
-    	ImmunizationRecommendation imm_rec = ImmunizationRecommendation.builder().patient(patientRef).date(date).recommendation(recommendations)
-    			.build();
-    	
-    	// Check the resource was saved correctly
-    	Resource saved = persistence.create(getDefaultPersistenceContext(), imm_rec);
+        ImmunizationRecommendation imm_rec = ImmunizationRecommendation.builder().patient(patientRef).date(date).recommendation(recommendations)
+                .build();
+        
+        // Check the resource was saved correctly
+        Resource saved = persistence.create(getDefaultPersistenceContext(), imm_rec).getResource();
         assertNotNull(saved);
         assertNotNull(saved.getId());
         assertNotNull(saved.getId().getValue());
@@ -132,14 +131,14 @@ public abstract class AbstractQueryChainedParmTest extends AbstractPersistenceTe
         assertEquals("1", saved.getMeta().getVersionId().getValue());
         
         // "Connect" the observation to the patient and encounter via a Reference
-    	Reference immunizationRef = Reference.builder().reference(str2model("ImmunizationRecommendation/" + imm_rec.getId().getValue())).build();
+        Reference immunizationRef = Reference.builder().reference(str2model("ImmunizationRecommendation/" + imm_rec.getId().getValue())).build();
 
-    	DateTime year = DateTime.of("2018");
-    	CompositionStatus status = CompositionStatus.ENTERED_IN_ERROR;
-    	CodeableConcept type = CodeableConcept.builder().text(str2model("test")).build();
-    	Composition composition = Composition.builder().status(status).type(type).date(year).author(Arrays.asList(immunizationRef)).title(str2model("TEST")).build();
-    	
-    	Resource c2 = persistence.create(getDefaultPersistenceContext(), composition);
+        DateTime year = DateTime.of("2018");
+        CompositionStatus status = CompositionStatus.ENTERED_IN_ERROR;
+        CodeableConcept type = CodeableConcept.builder().text(str2model("test")).build();
+        Composition composition = Composition.builder().status(status).type(type).date(year).author(Arrays.asList(immunizationRef)).title(str2model("TEST")).build();
+        
+        Resource c2 = persistence.create(getDefaultPersistenceContext(), composition).getResource();
         assertNotNull(c2);
         assertNotNull(c2.getId());
         assertNotNull(c2.getId().getValue());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryDeviceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryDeviceTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractQueryDeviceTest extends AbstractPersistenceTest {
         assertNotNull(device.getMeta());
         assertNotNull(device.getMeta().getVersionId().getValue());
          
-        Device readDevice = (Device)persistence.read(context, Device.class, device.getId().getValue());
+        Device readDevice = persistence.read(context, Device.class, device.getId().getValue()).getResource();
         assertNotNull(readDevice);
         assertEquals(versionId,readDevice.getMeta().getVersionId().getValue());
         ZonedDateTime tempLastUpdated =  readDevice.getMeta().getLastUpdated().getValue();
@@ -144,7 +144,7 @@ public abstract class AbstractQueryDeviceTest extends AbstractPersistenceTest {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -196,7 +196,7 @@ public abstract class AbstractQueryDeviceTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();
@@ -219,7 +219,7 @@ public abstract class AbstractQueryDeviceTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();
@@ -242,7 +242,7 @@ public abstract class AbstractQueryDeviceTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Device.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((Device)resources.get(0)).getUrl().getValue(),"http://www.testdevice.ibm.com/bogusDeviceId");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryEncounterTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryEncounterTest.java
@@ -33,7 +33,7 @@ public abstract class AbstractQueryEncounterTest extends AbstractPersistenceTest
     public void testCreateEncounter() throws Exception {
             Encounter encounter = readResource(Encounter.class, "Encounter.json");
 
-        Resource created = persistence.create(getDefaultPersistenceContext(), encounter);
+        Resource created = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
         assertNotNull(created);
         assertNotNull(created.getId());
         assertNotNull(created.getId().getValue());
@@ -51,7 +51,7 @@ public abstract class AbstractQueryEncounterTest extends AbstractPersistenceTest
     public void testCreateEncounter_with_relatedPerson() throws Exception {
         Encounter encounter = readResource(Encounter.class, "Encounter-with-RelatedPerson.json");
 
-        Resource created = persistence.create(getDefaultPersistenceContext(), encounter);
+        Resource created = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
         assertNotNull(created);
         assertNotNull(created.getId());
         assertNotNull(created.getId().getValue());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryGroupTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryGroupTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractQueryGroupTest extends AbstractPersistenceTest {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -122,7 +122,7 @@ public abstract class AbstractQueryGroupTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((Group)resources.get(0)).getMember().get(3).getEntity().getReference().getValue(),"Patient/pat4");
@@ -148,7 +148,7 @@ public abstract class AbstractQueryGroupTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Group.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryLocationTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryLocationTest.java
@@ -170,7 +170,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put("near-distance", Collections.singletonList("1|km"));
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
 
@@ -189,7 +189,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
     
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }
@@ -206,7 +206,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
     
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
     }
@@ -225,7 +225,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
          
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }
@@ -245,7 +245,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms,null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         //I know that it will not be match..
         assertTrue(resources.size() == 0);
@@ -265,7 +265,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put("near-distance", Collections.singletonList("4|km"));
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }
@@ -283,7 +283,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put("near-distance", Collections.singletonList("4|kilometers"));
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }
@@ -301,7 +301,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put("near-distance", Collections.singletonList("4|miles"));
         Class<? extends Resource> resourceType = Location.class;
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
     }
@@ -321,7 +321,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -346,7 +346,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((Location)resources.get(0)).getPartOf().getReference().getValue(),"Location/1");
@@ -372,7 +372,7 @@ public abstract class AbstractQueryLocationTest extends AbstractPersistenceTest 
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Location.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryMedicationTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryMedicationTest.java
@@ -124,7 +124,7 @@ public abstract class AbstractQueryMedicationTest extends AbstractPersistenceTes
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Medication.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Medication.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -176,7 +176,7 @@ public abstract class AbstractQueryMedicationTest extends AbstractPersistenceTes
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Medication.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Medication.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryMultiResourceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryMultiResourceTest.java
@@ -56,8 +56,8 @@ public abstract class AbstractQueryMultiResourceTest extends AbstractPersistence
 
         // update the id on the resource
         observation = observation.toBuilder().id(Id.of(commonId)).build();        
-        Resource resource = persistence.create(getDefaultPersistenceContext(), observation);
-        resource = persistence.update(getDefaultPersistenceContext(), commonId, resource);
+        Resource resource = persistence.create(getDefaultPersistenceContext(), observation).getResource();
+        resource = persistence.update(getDefaultPersistenceContext(), commonId, resource).getResource();
         assertNotNull(resource);
         assertNotNull(resource.getId());
         assertNotNull(resource.getId().getValue());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryPatientTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryPatientTest.java
@@ -748,7 +748,7 @@ public abstract class AbstractQueryPatientTest extends AbstractPersistenceTest {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -800,7 +800,7 @@ public abstract class AbstractQueryPatientTest extends AbstractPersistenceTest {
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();
@@ -823,7 +823,7 @@ public abstract class AbstractQueryPatientTest extends AbstractPersistenceTest {
         queryParms.put("_since", Collections.singletonList("2015-06-10T21:32:59.076Z"));
         FHIRHistoryContext context = FHIRPersistenceUtil.parseHistoryParameters(queryParms);
         
-        List<Resource> resources = persistence.history(getPersistenceContextForHistory(context), Patient.class, savedPatient.getId().getValue());
+        List<Patient> resources = persistence.history(getPersistenceContextForHistory(context), Patient.class, savedPatient.getId().getValue()).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -852,7 +852,7 @@ public abstract class AbstractQueryPatientTest extends AbstractPersistenceTest {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Patient.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryPractitionerTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryPractitionerTest.java
@@ -195,7 +195,7 @@ public abstract class AbstractQueryPractitionerTest extends AbstractPersistenceT
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -220,7 +220,7 @@ public abstract class AbstractQueryPractitionerTest extends AbstractPersistenceT
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((Practitioner)resources.get(0)).getAddress().get(0).getCity().getValue(),"Ogalalla");
@@ -249,7 +249,7 @@ public abstract class AbstractQueryPractitionerTest extends AbstractPersistenceT
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Practitioner.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryQuestionnaireRespTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryQuestionnaireRespTest.java
@@ -286,7 +286,7 @@ public abstract class AbstractQueryQuestionnaireRespTest extends AbstractPersist
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -311,7 +311,7 @@ public abstract class AbstractQueryQuestionnaireRespTest extends AbstractPersist
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((QuestionnaireResponse)resources.get(0)).getAuthored().getValue(),"2015-11-25T18:30:50+01:00");
@@ -337,7 +337,7 @@ public abstract class AbstractQueryQuestionnaireRespTest extends AbstractPersist
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), QuestionnaireResponse.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
         long count = context.getTotalCount();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryQuestionnaireTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryQuestionnaireTest.java
@@ -108,7 +108,7 @@ public abstract class AbstractQueryQuestionnaireTest extends AbstractPersistence
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Questionnaire.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Questionnaire.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -133,7 +133,7 @@ public abstract class AbstractQueryQuestionnaireTest extends AbstractPersistence
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Questionnaire.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), Questionnaire.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((Questionnaire)resources.get(0)).getDate().getValue(),"1969-12-31T19:00:02+00:00");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryRiskAssmtTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQueryRiskAssmtTest.java
@@ -166,7 +166,7 @@ public abstract class AbstractQueryRiskAssmtTest extends AbstractPersistenceTest
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), RiskAssessment.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), RiskAssessment.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         long count = context.getTotalCount();
@@ -191,7 +191,7 @@ public abstract class AbstractQueryRiskAssmtTest extends AbstractPersistenceTest
         queryParms.put(parmName, Collections.singletonList(parmValue));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParms, null);
         context.setPageNumber(1);
-        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), RiskAssessment.class);
+        List<Resource> resources = persistence.search(getPersistenceContextForSearch(context), RiskAssessment.class).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() != 0);
         assertEquals(((RiskAssessment)resources.get(0)).getCondition().getReference().getValue(),"Condition/stroke");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQuerySortTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractQuerySortTest.java
@@ -214,7 +214,7 @@ public abstract class AbstractQuerySortTest extends AbstractPersistenceTest {
         searchContext = SearchUtil.parseQueryParameters(resourceType, queryParameters, queryString, true);
         searchContext.setPageSize(100);
         persistenceContext = getPersistenceContextForSearch(searchContext);
-        List<Resource> resources = persistence.search(persistenceContext, resourceType);
+        List<Resource> resources = persistence.search(persistenceContext, resourceType).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() > 0);
     }
@@ -276,7 +276,7 @@ public abstract class AbstractQuerySortTest extends AbstractPersistenceTest {
         searchContext = SearchUtil.parseQueryParameters(resourceType, queryParameters, queryString);
         searchContext.setPageSize(1000);
         persistenceContext = getPersistenceContextForSearch(searchContext);
-        List<Resource> resources = persistence.search(persistenceContext, resourceType);
+        List<Resource> resources = persistence.search(persistenceContext, resourceType).getResource();
         assertNotNull(resources);
         assertFalse(resources.isEmpty());
         

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSearchAllTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSearchAllTest.java
@@ -34,11 +34,11 @@ public abstract class AbstractSearchAllTest extends AbstractPersistenceTest {
         Patient patient = readResource(Patient.class, "Patient_JohnDoe.json");
         
         Coding tag = Coding.builder()
-        		.system(Uri.of("http://ibm.com/fhir/tag"))
-        		.code(Code.of("tag")).build();
+                .system(Uri.of("http://ibm.com/fhir/tag"))
+                .code(Code.of("tag")).build();
         Coding security = Coding.builder()
-        		.system(Uri.of("http://ibm.com/fhir/security"))
-        		.code(Code.of("security")).build();
+                .system(Uri.of("http://ibm.com/fhir/security"))
+                .code(Code.of("security")).build();
 
         Meta meta = patient.getMeta();
         Meta.Builder mb = meta == null ? Meta.builder() : meta.toBuilder();
@@ -48,7 +48,7 @@ public abstract class AbstractSearchAllTest extends AbstractPersistenceTest {
         
         patient = patient.toBuilder().meta(mb.build()).build();
         
-        Resource resource = persistence.create(getDefaultPersistenceContext(), patient);
+        Resource resource = persistence.create(getDefaultPersistenceContext(), patient).getResource();
         assertNotNull(resource);
         assertNotNull(resource.getId());
         assertNotNull(resource.getId().getValue());

--- a/fhir-server-test/src/test/java/com/ibm/fhir/client/test/FHIRClientTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/client/test/FHIRClientTest.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.client.test;
 
 import static com.ibm.fhir.client.FHIRRequestHeader.header;
 import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -151,6 +152,50 @@ public class FHIRClientTest extends FHIRClientTestBase {
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
 
+        assertNotNull(response.getLocation());
+        assertNotNull(response.getLocationURI());
+        assertNotNull(response.getETag());
+        assertNotNull(response.getLastModified());
+    }
+
+    @Test
+    public void testCreatePatientWithReturnPref() throws Exception {
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = readResource(Patient.class, "Patient_JohnDoe.json");
+        assertNotNull(patient);
+
+        FHIRRequestHeader preferHeader;
+        FHIRResponse response;
+        
+        // Create the patient with return=minimal and then validate the response.
+        preferHeader = new FHIRRequestHeader("Prefer", "return=minimal");
+        response = client.create(patient, preferHeader);
+        assertNotNull(response);
+        assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
+        assertTrue(response.isEmpty());
+        assertNotNull(response.getLocation());
+        assertNotNull(response.getLocationURI());
+        assertNotNull(response.getETag());
+        assertNotNull(response.getLastModified());
+        
+        // Create the patient with return=representation and then validate the response.
+        preferHeader = new FHIRRequestHeader("Prefer", "return=representation");
+        response = client.create(patient, preferHeader);
+        assertNotNull(response);
+        assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
+        assertFalse(response.isEmpty());
+        assertNotNull(response.getResource(Patient.class));
+        assertNotNull(response.getLocation());
+        assertNotNull(response.getLocationURI());
+        assertNotNull(response.getETag());
+        assertNotNull(response.getLastModified());
+
+        // Create the patient with return=OperationOutcome and then validate the response.
+        preferHeader = new FHIRRequestHeader("Prefer", "return=representation");
+        response = client.create(patient, preferHeader);
+        assertNotNull(response);
+        assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
+        assertNotNull(response.getResource(OperationOutcome.class));
         assertNotNull(response.getLocation());
         assertNotNull(response.getLocationURI());
         assertNotNull(response.getETag());
@@ -494,6 +539,7 @@ public class FHIRClientTest extends FHIRClientTestBase {
         assertEquals(BundleType.TRANSACTION_RESPONSE.getValue(), responseBundle.getType().getValue());
     }
 
+    
     private Bundle addRequestToBundle(Bundle bundle, HTTPVerb method, String url, Resource resource) throws Exception {
           
         Bundle.Entry.Request request = Bundle.Entry.Request.builder().method(method).url(Uri.of(url)).build();   

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -29,6 +29,7 @@ import javax.xml.bind.JAXBException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.client.FHIRRequestHeader;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.core.HTTPReturnPreference;
@@ -103,6 +104,9 @@ public class BundleTest extends FHIRServerTestBase {
     private static final String ORG_EXTENSION_URL = "http://my.url.domain.com/acme-healthcare/lab-collection-org";
     private static final String PATIENT_EXTENSION_URL = "http://my.url.domain.com/acme-healthcare/related-patient";
 
+    private static final String PREFER_HEADER_RETURN_REPRESENTATION = "return=representation";
+    private static final String PREFER_HEADER_NAME = "Prefer";
+    
     /**
      * Retrieve the server's conformance statement to determine the status of
      * certain runtime options.
@@ -435,7 +439,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -464,7 +470,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
         
@@ -495,7 +503,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -967,7 +977,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1025,7 +1037,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1071,7 +1085,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1521,7 +1537,7 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request().header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION).post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
         
@@ -1577,7 +1593,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1653,7 +1671,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1817,7 +1837,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
@@ -1921,7 +1943,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -1959,8 +1983,8 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = getEntityWithExtraWork(response,method);
         
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 3);
-        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode());
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode());
+        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertBadResponse(responseBundle.getEntry().get(2), Status.BAD_REQUEST.getStatusCode(),
                 "Bundle.Entry.resource not allowed for BundleEntry with DELETE method.");
     }
@@ -2012,7 +2036,9 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", bundle);
 
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
-        Response response = target.request().post(entity, Response.class);
+        Response response = target.request()
+                                .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
+                                .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -2049,8 +2075,8 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = getEntityWithExtraWork(response,method);
         
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
-        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode());
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode());
+        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
     }
 
     @Test(groups = { "transaction" }, dependsOnMethods = { "testTransactionDeletes" })
@@ -2242,7 +2268,8 @@ public class BundleTest extends FHIRServerTestBase {
 
         printBundle(method, "request", bundle);
 
-        FHIRResponse response = client.batch(bundle);
+        FHIRRequestHeader preferHeader = new FHIRRequestHeader(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION);
+        FHIRResponse response = client.batch(bundle, preferHeader);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle responseBundle = response.getResource(Bundle.class);
@@ -2283,7 +2310,7 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "response", responseBundle);
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 4);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode());
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertBadResponse(responseBundle.getEntry().get(2), Status.PRECONDITION_FAILED.getStatusCode(),
                 "returned multiple matches");
         assertBadResponse(responseBundle.getEntry().get(3), Status.BAD_REQUEST.getStatusCode(),
@@ -2358,7 +2385,8 @@ public class BundleTest extends FHIRServerTestBase {
 
         printBundle(method, "request", bundle);
 
-        FHIRResponse response = client.transaction(bundle);
+        FHIRRequestHeader preferHeader = new FHIRRequestHeader(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION);
+        FHIRResponse response = client.transaction(bundle, preferHeader);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
@@ -2417,7 +2445,8 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "request", requestBundle);
 
         // Invoke the REST API and then return the response bundle.
-        FHIRResponse response = client.transaction(requestBundle);
+        FHIRRequestHeader httpReturnPrefHeader = new FHIRRequestHeader(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION);
+        FHIRResponse response = client.transaction(requestBundle, httpReturnPrefHeader);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = response.getResource(Bundle.class);
 
@@ -2471,7 +2500,11 @@ public class BundleTest extends FHIRServerTestBase {
     }
 
     private void assertGoodPostPutResponse(Bundle.Entry entry, int expectedStatusCode) throws Exception {
-        assertGoodGetResponse(entry, expectedStatusCode);
+        assertGoodPostPutResponse(entry, expectedStatusCode, HTTPReturnPreference.MINIMAL);
+    }
+    
+    private void assertGoodPostPutResponse(Bundle.Entry entry, int expectedStatusCode, HTTPReturnPreference returnPref) throws Exception {
+        assertGoodGetResponse(entry, expectedStatusCode, returnPref);
         Bundle.Entry.Response response = entry.getResponse();
 
         assertNotNull(response.getLocation());

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -406,7 +406,7 @@ public class DeleteTest extends FHIRServerTestBase {
         obs = obs.toBuilder().id(Id.of(obsId)).subject(Reference.builder().reference(string(fakePatientRef)).build()).build();
 
         
-        // First conditional delete should find no matches, so we should get back a 404.
+        // First conditional delete should find no matches, so we should get back a 200 OK.
         FHIRParameters query = new FHIRParameters().searchParam("_id", obsId);
         FHIRResponse response = client.conditionalDelete("Observation", query);
         assertNotNull(response);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -144,7 +144,7 @@ public class DeleteTest extends FHIRServerTestBase {
     }
 
     /**
-     * Ensure we get back a 404 Not Found for deleting a resource with an invalid id
+     * Ensure we get back a 200 OK for deleting a resource with an invalid id
      * @throws Exception
      */
     @Test()
@@ -155,8 +155,7 @@ public class DeleteTest extends FHIRServerTestBase {
 
         FHIRResponse response = client.delete(MedicationAdministration.class.getSimpleName(), "invalid-resource-id-testDeleteInvalidResource");
         assertNotNull(response);
-        assertResponse(response.getResponse(), Response.Status.NOT_FOUND.getStatusCode());
-        // 404 doesn't have an etag in the response
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
     }
 
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/UpdateTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/UpdateTest.java
@@ -6,6 +6,8 @@
 
 package com.ibm.fhir.server.test;
 
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -16,7 +18,9 @@ import javax.ws.rs.core.Response;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.FHIRClient;
+import com.ibm.fhir.client.FHIRRequestHeader;
 import com.ibm.fhir.client.FHIRResponse;
+import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.Id;
@@ -222,6 +226,113 @@ public class UpdateTest extends FHIRServerTestBase {
             locationTokens = parseLocationURI(locationURI);
             assertEquals(3, locationTokens.length);
             assertEquals("3", locationTokens[2]);            
+        }
+    }
+    
+    /**
+     * Test the "update/create" return preference behavior.
+     */
+    @Test(dependsOnMethods = {"retrieveConfig"})
+    public void testUpdateCreateWithReturnPref() throws Exception {
+        assertNotNull(updateCreateEnabled);
+        
+        // If the "Update/Create" feature is enabled, then test it.
+        if (updateCreateEnabled.booleanValue()) {
+            
+            Patient patient = readResource(Patient.class, "Patient_JohnDoe.json");
+            FHIRClient client = getFHIRClient();
+            FHIRRequestHeader returnPref;
+            
+            // Create the new resource with return pref of "minimal"
+            String id1 = UUID.randomUUID().toString();
+            patient = patient.toBuilder().id(Id.of(id1)).build();
+            returnPref = new FHIRRequestHeader("Prefer", "return=minimal");
+            FHIRResponse response1 = client.update(patient, returnPref);
+            assertNotNull(response1);
+            assertResponse(response1.getResponse(), Response.Status.CREATED.getStatusCode());
+            assertTrue(response1.isEmpty());
+            // Now read the resource to verify it's there.
+            response1 = client.read("Patient", id1);
+            assertNotNull(response1);
+            assertResponse(response1.getResponse(), Response.Status.OK.getStatusCode());
+            Patient responsePatient1 = response1.getResource(Patient.class);
+            assertNotNull(responsePatient1);
+            
+            // Create the new resource with return pref of "representation"
+            String id2 = UUID.randomUUID().toString();
+            patient = patient.toBuilder().id(Id.of(id2)).build();
+            returnPref = new FHIRRequestHeader("Prefer", "return=representation");
+            FHIRResponse response2 = client.update(patient, returnPref);
+            assertNotNull(response2);
+            assertResponse(response2.getResponse(), Response.Status.CREATED.getStatusCode());
+            assertFalse(response2.isEmpty());
+            Patient responseResource = response2.getResource(Patient.class);
+            // Now read the resource to verify it's there and that it matches the resource in the original response.
+            response2 = client.read("Patient", id2);
+            assertNotNull(response2);
+            assertResponse(response2.getResponse(), Response.Status.OK.getStatusCode());
+            Patient responsePatient2 = response2.getResource(Patient.class);
+            assertNotNull(responsePatient2);
+            assertEquals(responsePatient2, responseResource);
+            
+            // Create the new resource with return pref of "representation"
+            String id3 = UUID.randomUUID().toString();
+            patient = patient.toBuilder().id(Id.of(id3)).build();
+            returnPref = new FHIRRequestHeader("Prefer", "return=OperationOutcome");
+            FHIRResponse response3 = client.update(patient, returnPref);
+            assertNotNull(response3);
+            assertResponse(response3.getResponse(), Response.Status.CREATED.getStatusCode());
+            assertFalse(response3.isEmpty());
+            OperationOutcome oo = response3.getResource(OperationOutcome.class);
+            assertTrue(oo.getIssue().toString().contains("dom-6: A resource should have narrative for robust management"));
+            // Now read the resource to verify it's there.
+            response3 = client.read("Patient", id3);
+            assertNotNull(response3);
+            assertResponse(response3.getResponse(), Response.Status.OK.getStatusCode());
+            Patient responsePatient = response3.getResource(Patient.class);
+            assertNotNull(responsePatient);
+        }
+    }
+    
+    /**
+     * Test the 'normal' update return preference behavior.
+     */
+    @Test(dependsOnMethods = {"testUpdateCreate3"})
+    public void testUpdateCreateWithReturnPref2() throws Exception {
+        assertNotNull(updateCreateEnabled);
+        FHIRClient client = getFHIRClient();
+        FHIRRequestHeader returnPref;
+        
+        // If the "Update/Create" feature is enabled, then test the normal update behavior.
+        if (updateCreateEnabled.booleanValue()) {
+            
+            Patient patient = savedUCPatient;
+            patient = patient.toBuilder().birthDate(Date.of("1986-06-20")).build();
+            
+            // Update the resource that was previously created with return pref "minimal".
+            returnPref = new FHIRRequestHeader("Prefer", "return=minimal");
+            FHIRResponse response = client.update(patient, returnPref);
+            assertNotNull(response);
+            assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+            assertTrue(response.isEmpty());
+            
+            // Update the resource that was previously created with return pref "representation".
+            returnPref = new FHIRRequestHeader("Prefer", "return=representation");
+            FHIRResponse response2 = client.update(patient, returnPref);
+            assertNotNull(response2);
+            assertResponse(response2.getResponse(), Response.Status.OK.getStatusCode());
+            assertFalse(response2.isEmpty());
+            Patient responseResource = response2.getResource(Patient.class);
+            assertNotNull(responseResource);
+            
+            // Update the resource that was previously created with return pref "OperationOutcome".
+            returnPref = new FHIRRequestHeader("Prefer", "return=OperationOutcome");
+            FHIRResponse response3 = client.update(patient, returnPref);
+            assertNotNull(response3);
+            assertResponse(response3.getResponse(), Response.Status.OK.getStatusCode());
+            assertFalse(response3.isEmpty());
+            OperationOutcome oo = response3.getResource(OperationOutcome.class);
+            assertTrue(oo.getIssue().toString().contains("dom-6: A resource should have narrative for robust management"));
         }
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/WebSocketNotificationsTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/WebSocketNotificationsTest.java
@@ -123,7 +123,7 @@ public class WebSocketNotificationsTest extends FHIRServerTestBase {
 
         Observation responseObservation = response.readEntity(Observation.class);
 
-        endpoint.getLatch().await(5, TimeUnit.SECONDS);
+        endpoint.getLatch().await(10, TimeUnit.SECONDS);
 
         FHIRNotificationEvent event = endpoint.getFirstEvent();
         assertTrue(event != null);

--- a/fhir-server-test/src/test/java/testng.xml
+++ b/fhir-server-test/src/test/java/testng.xml
@@ -1,4 +1,5 @@
-<suite name="FHIRServerIntegrationTests">  
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="FHIRServerIntegrationTests">
     <test name="ExampleTest">
         <classes>
             <class name="com.ibm.fhir.server.test.R4ExampleServerTest" />

--- a/fhir-server-test/src/test/resources/test.properties
+++ b/fhir-server-test/src/test/resources/test.properties
@@ -33,3 +33,4 @@ fhirclient.logging.enabled = false
 
 fhirclient.hostnameVerification.enabled = false
 fhirclient.http.receive.timeout = 60000
+fhirclient.http.return.pref = minimal

--- a/fhir-server-webapp/pom.xml
+++ b/fhir-server-webapp/pom.xml
@@ -80,6 +80,16 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-operation-bulkdata</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>fhir-config</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>fhir-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -107,6 +117,16 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-registry</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>fhir-config</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>fhir-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
@@ -25,6 +25,7 @@ import org.owasp.encoder.Encode;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
@@ -44,9 +45,11 @@ public class FHIRRestServletFilter implements Filter {
 
     private static String tenantIdHeaderName = null;
     private static String datastoreIdHeaderName = null;
+    private static final String preferHeaderName = "Prefer";
+    private static final String preferReturnHeaderSectionName = "return";
     
     private static String defaultTenantId = null;
-    
+    private static final HTTPReturnPreference defaultHttpReturnPref = HTTPReturnPreference.MINIMAL;
 
     /*
      * (non-Javadoc)
@@ -63,6 +66,7 @@ public class FHIRRestServletFilter implements Filter {
         
         String tenantId = defaultTenantId;
         String dsId = FHIRConfiguration.DEFAULT_DATASTORE_ID;
+        HTTPReturnPreference returnPref = defaultHttpReturnPref;
         
         // Wrap the incoming servlet request with our own implementation.
         if (request instanceof HttpServletRequest) {
@@ -80,6 +84,16 @@ public class FHIRRestServletFilter implements Filter {
             t = ((HttpServletRequest) request).getHeader(datastoreIdHeaderName);
             if (t != null) {
                 dsId = t;
+            }
+            
+            String returnPrefString = ((HttpServletRequest) request).getHeader(preferHeaderName + ":" + preferReturnHeaderSectionName);
+            if (returnPrefString != null && !returnPrefString.isEmpty()) {
+                try {
+                    returnPref = HTTPReturnPreference.from(returnPrefString);
+                } catch (IllegalArgumentException e) {
+                    log.fine("Invalid HTTP return preference passed in header 'Prefer': '" + returnPrefString + "'; "
+                            + "using " + returnPref.value());
+                }
             }
         }
 
@@ -102,6 +116,7 @@ public class FHIRRestServletFilter implements Filter {
         try {
             // Create a new FHIRRequestContext and set it on the current thread.
             FHIRRequestContext context = new FHIRRequestContext(tenantId, dsId);
+            context.setReturnPreference(returnPref);
             FHIRRequestContext.set(context);
 
             // Pass the request through to the next filter in the chain.

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -524,7 +524,9 @@ public class FHIRResource implements FHIRResourceHelpers {
             checkInitComplete();
 
             ior = doDelete(type, id, null, null);
+            
             ResponseBuilder response = Response.noContent();
+            
             if (ior.getResource() != null) {
                 response = addHeaders(response, ior.getResource());
             }
@@ -532,7 +534,7 @@ public class FHIRResource implements FHIRResourceHelpers {
         } catch (FHIRHttpException e) {
             return exceptionResponse(e);
         } catch (FHIRPersistenceResourceNotFoundException e) {
-            return exceptionResponse(e, Response.Status.NOT_FOUND);
+            return exceptionResponse(e, Response.Status.OK);
         } catch (FHIRPersistenceNotSupportedException e) {
             return exceptionResponse(e, Response.Status.METHOD_NOT_ALLOWED);
         } catch (FHIROperationException e) {
@@ -568,6 +570,9 @@ public class FHIRResource implements FHIRResourceHelpers {
             ior = doDelete(type, null, searchQueryString, null);
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status);
+            if (ior.getOperationOutcome() != null) {
+                response.entity(ior.getOperationOutcome());
+            }
             if (ior.getResource() != null) {
                 response = addHeaders(response, ior.getResource());
             }
@@ -1579,8 +1584,7 @@ public class FHIRResource implements FHIRResourceHelpers {
                         log.fine(msg);
                     }
                     status = Response.Status.OK;
-                    // TODO: setting OO in response causes NullPointer in setBundleResponseFields...it assumes a valid id and Meta.lastUpdated
-//                    ior.setResource(FHIRUtil.buildOperationOutcome(msg, IssueType.ValueSet.NOT_FOUND, IssueSeverity.ValueSet.WARNING));
+                    ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(msg, IssueType.ValueSet.NOT_FOUND, IssueSeverity.ValueSet.WARNING));
                     ior.setStatus(status);
                     return ior;
                 } else if (resultCount == 1) {
@@ -1637,7 +1641,7 @@ public class FHIRResource implements FHIRResourceHelpers {
             return ior;
         } catch (FHIRPersistenceResourceNotFoundException e) {
             log.log(Level.SEVERE, errMsg, e);
-            status = Response.Status.NOT_FOUND;
+            status = Response.Status.OK;
             throw e;
         } catch (FHIRPersistenceNotSupportedException e) {
             log.log(Level.SEVERE, errMsg, e);


### PR DESCRIPTION
### issue #115 - refactor FHIRPersistence interface to return Response wrappers. 

now the PersistenceLayer can return OperationOutcome AND Resource(s) at the same time which will be needed for honoring the return preference indicated by the client.


###  issue #115 - use return preference from Prefer header

1. add support for setting a default HTTPReturnPreference in fhir-client
2. introduce create and update tests for checking the response to returnPreferences
3. add OperationOutcome to FHIRRestOperationResponse
4. set FHIRRequestContext.HttpReturnPreference in the FHIRRestServletFilter (default="minimal")
5. update return entity based on HTTPReturnPreference in FHIRRequestContext
6. update BundleTest to pass return=representation since the tests depend on this