### PR TITLE
issue #117 Create resource if conditionalUpdate not found

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
@@ -257,39 +257,6 @@ public class FHIRCliTest extends FHIRServerTestBase {
         return resourceId;
     }
 
-    /**
-     * Parses a location URI into the resourceType, resourceId, and (optionally) the version id.
-     * @param locationURI
-     * @return
-     */
-    private String[] parseLocationURI(String location) {
-        String[] result = null;
-        if (location == null) {
-            throw new NullPointerException("The 'location' parameter was specified as null.");
-        }
-
-        String[] tokens = location.split("/");
-        // Check if we should expect 4 tokens or only 2.
-        if (location.contains("_history")) {
-            if (tokens.length >= 4) {
-                result = new String[3];
-                result[0] = tokens[tokens.length - 4];
-                result[1] = tokens[tokens.length - 3];
-                result[2] = tokens[tokens.length - 1];
-            } else {
-                throw new IllegalArgumentException("Incorrect location value specified: " + location);
-            }
-        } else {
-            if (tokens.length >= 2) {
-                result = new String[2];
-                result[0] = tokens[tokens.length - 2];
-                result[1] = tokens[tokens.length - 1];
-            } else {
-                throw new IllegalArgumentException("Incorrect location value specified: " + location);
-            }
-        }
-        return result;
-    }
 
     /**
      * Runs a fhir-cli test with the specified list of arguments

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
@@ -535,20 +535,6 @@ public abstract class FHIRServerTestBase extends FHIRModelTestBase {
         return null;
     }
 
-    protected String[] getLocationURITokens(String locationURI) {
-        String[] temp = locationURI.split("/");
-        String[] tokens;
-        if (temp.length > 4) {
-            tokens = new String[4];
-            for (int i = 0; i < 4; i++) {
-                tokens[i] = temp[temp.length - 4 + i];
-            }
-        } else {
-            tokens = temp;
-        }
-        return tokens;
-    }
-    
     protected Patient setUniqueFamilyName(Patient patient, String uniqueName) {
         List<com.ibm.fhir.model.type.String> familyList = new ArrayList<com.ibm.fhir.model.type.String>();
         familyList.add(string(uniqueName));
@@ -599,5 +585,39 @@ public abstract class FHIRServerTestBase extends FHIRModelTestBase {
             assertTrue("Passed with no issues in validation", true);
         }
         
+    }
+    
+    /**
+     * Parses a location URI into the resourceType, resourceId, and (optionally) the version id.
+     * @param locationURI
+     * @return
+     */
+    public static String[] parseLocationURI(String location) {
+        String[] result = null;
+        if (location == null) {
+            throw new NullPointerException("The 'location' parameter was specified as null.");
+        }
+
+        String[] tokens = location.split("/");
+        // Check if we should expect 4 tokens or only 2.
+        if (location.contains("_history")) {
+            if (tokens.length >= 4) {
+                result = new String[3];
+                result[0] = tokens[tokens.length - 4];
+                result[1] = tokens[tokens.length - 3];
+                result[2] = tokens[tokens.length - 1];
+            } else {
+                throw new IllegalArgumentException("Incorrect location value specified: " + location);
+            }
+        } else {
+            if (tokens.length >= 2) {
+                result = new String[2];
+                result[0] = tokens[tokens.length - 2];
+                result[1] = tokens[tokens.length - 1];
+            } else {
+                throw new IllegalArgumentException("Incorrect location value specified: " + location);
+            }
+        }
+        return result;
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/UpdateTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/UpdateTest.java
@@ -90,12 +90,12 @@ public class UpdateTest extends FHIRServerTestBase {
             assertNotNull(response);
             assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             String locationURI = response.getLocation();
-            String[] locationTokens = getLocationURITokens(locationURI);
-            assertEquals(4, locationTokens.length);
-            assertEquals("2", locationTokens[3]);
+            String[] locationTokens = parseLocationURI(locationURI);
+            assertEquals(3, locationTokens.length);
+            assertEquals("2", locationTokens[2]);
             
             // Now read the resource to verify it's there.
-            response = client.vread(locationTokens[0], locationTokens[1], locationTokens[3]);
+            response = client.vread(locationTokens[0], locationTokens[1], locationTokens[2]);
             assertNotNull(response);
             assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             Patient responsePatient = response.getResource(Patient.class);
@@ -147,9 +147,9 @@ public class UpdateTest extends FHIRServerTestBase {
             assertNotNull(response);
             assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
             String locationURI = response.getLocation();
-            String[] locationTokens = getLocationURITokens(locationURI);
-            assertEquals(4, locationTokens.length);
-            assertEquals("1", locationTokens[3]);
+            String[] locationTokens = parseLocationURI(locationURI);
+            assertEquals(3, locationTokens.length);
+            assertEquals("1", locationTokens[2]);
             
             // Read the new patient.
             response = client.read(locationTokens[0], locationTokens[1]);
@@ -163,9 +163,9 @@ public class UpdateTest extends FHIRServerTestBase {
             response = client.update(createdPatient);
             assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             locationURI = response.getLocation();
-            locationTokens = getLocationURITokens(locationURI);
-            assertEquals(4, locationTokens.length);
-            assertEquals("2", locationTokens[3]);            
+            locationTokens = parseLocationURI(locationURI);
+            assertEquals(3, locationTokens.length);
+            assertEquals("2", locationTokens[2]);            
         }
     }
 
@@ -219,9 +219,9 @@ public class UpdateTest extends FHIRServerTestBase {
             response = client.update(createdPatient);
             assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
             locationURI = response.getLocation();
-            locationTokens = getLocationURITokens(locationURI);
-            assertEquals(4, locationTokens.length);
-            assertEquals("3", locationTokens[3]);            
+            locationTokens = parseLocationURI(locationURI);
+            assertEquals(3, locationTokens.length);
+            assertEquals("3", locationTokens[2]);            
         }
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -3710,7 +3710,7 @@ public class FHIRResource implements FHIRResourceHelpers {
         // generate ID for this bundle and set total
 
         Bundle.Builder bundleBuider =
-                Bundle.builder().type(BundleType.SEARCHSET).id(Id.of(UUID.randomUUID().toString())).total(com.ibm.fhir.model.type.UnsignedInt.of((int) (long) searchContext.getTotalCount()));
+                Bundle.builder().type(BundleType.SEARCHSET).id(Id.of(UUID.randomUUID().toString())).total(com.ibm.fhir.model.type.UnsignedInt.of((int) searchContext.getTotalCount()));
 
         for (Resource resource : resources) {
             if (resource.getId() == null || !resource.getId().hasValue()) {


### PR DESCRIPTION
According to the spec, 
(1) Conditional update a resource without match and without id in the input resource, server should create the resource with server assigned resource id and with 201 response code instead of return 400 error.
(2) Conditional update a resource with 1 match but with a id in the input resource which is different from the id of the search result, server should return 400 error.

Signed-off-by: Albert Wang <xuwang@us.ibm.com>