### PR TITLE
issue #170 miss charset in content-type of 400 response

### DIFF
--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/util/FHIRProviderUtil.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/util/FHIRProviderUtil.java
@@ -27,15 +27,24 @@ public final class FHIRProviderUtil {
             // ignore
         }
         if (mediaType != null) {
-            if (mediaType.isCompatible(FHIRMediaType.APPLICATION_FHIR_JSON_TYPE)) {
-                return FHIRMediaType.APPLICATION_FHIR_JSON_TYPE;
+            MediaType outMediaType = null;
+            if (mediaType.isCompatible(FHIRMediaType.APPLICATION_FHIR_JSON_TYPE)) {               
+                outMediaType = FHIRMediaType.APPLICATION_FHIR_JSON_TYPE;
             } else if (mediaType.isCompatible(FHIRMediaType.APPLICATION_JSON_TYPE)) {
-                return MediaType.APPLICATION_JSON_TYPE;
+                outMediaType = MediaType.APPLICATION_JSON_TYPE;
             } else if (mediaType.isCompatible(FHIRMediaType.APPLICATION_FHIR_XML_TYPE)) {
-                return FHIRMediaType.APPLICATION_FHIR_XML_TYPE;
+                outMediaType = FHIRMediaType.APPLICATION_FHIR_XML_TYPE;
             } else if (mediaType.isCompatible(FHIRMediaType.APPLICATION_XML_TYPE)) {
-                return MediaType.APPLICATION_XML_TYPE;
+                outMediaType = MediaType.APPLICATION_XML_TYPE;
+            } else {
+                outMediaType = FHIRMediaType.APPLICATION_FHIR_JSON_TYPE;
             }
+            // Need to get the charset setting from the acceptHeader if there
+            if (mediaType.getParameters() != null
+                    && mediaType.getParameters().get("charset") != null) {
+                outMediaType = outMediaType.withCharset(mediaType.getParameters().get("charset"));
+            }
+            return outMediaType;
         }
         // default
         return FHIRMediaType.APPLICATION_FHIR_JSON_TYPE;


### PR DESCRIPTION
When exception happens during parsing the request body, the charset in accept header of the request is incorrectly dropped from the content-type header of the response.

Codes are changed to use the charset gotten from the accept header(if any) of the request for the content-type response header.

Signed-off-by: Albert Wang <xuwang@us.ibm.com>