### PR TITLE
CI: Tests report failure when messages are sent back. #184

### DIFF
--- a/fhir-server-test/pom.xml
+++ b/fhir-server-test/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,8 +15,8 @@
 
     <properties>
 
-        <!-- We don't want maven to automatically run our tests since they require
-            a server -->
+        <!-- We don't want maven to automatically run our tests since they 
+            require a server -->
         <skipTests>true</skipTests>
         <surefire.suiteXmlFiles>src/test/java/testng.xml</surefire.suiteXmlFiles>
     </properties>
@@ -86,6 +87,11 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.25</version>
         </dependency>
     </dependencies>
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRNotificationServiceClientEndpoint.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRNotificationServiceClientEndpoint.java
@@ -62,6 +62,14 @@ public class FHIRNotificationServiceClientEndpoint extends Endpoint {
         });
     }
     
+    @Override
+    public void onError(Session session, Throwable thr) {
+        System.out.println(">>> Session error: " + session.getId());
+        System.out.println(">>> Stack Trace as follows -> ");
+        thr.printStackTrace();
+        super.onError(session, thr);
+    }
+
     public void onClose(Session session, CloseReason reason) {
         System.out.println(">>> Session closed: " + session.getId());
         latch.countDown();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
@@ -34,6 +34,7 @@ import javax.ws.rs.core.Response;
 
 import org.glassfish.tyrus.client.SslContextConfigurator;
 import org.glassfish.tyrus.client.SslEngineConfigurator;
+import org.glassfish.tyrus.core.TyrusWebSocketEngine;
 import org.testng.annotations.BeforeClass;
 
 import com.ibm.fhir.client.FHIRClient;
@@ -42,12 +43,12 @@ import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.core.FHIRUtilities;
 import com.ibm.fhir.model.resource.CapabilityStatement;
-import com.ibm.fhir.model.resource.OperationOutcome;
-import com.ibm.fhir.model.resource.Patient;
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.CapabilityStatement.Rest;
 import com.ibm.fhir.model.resource.CapabilityStatement.Rest.Resource.Interaction;
+import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.IssueSeverity;
@@ -266,6 +267,10 @@ public abstract class FHIRServerTestBase extends FHIRModelTestBase {
                         false);
                 sslEngineConfigurator.setHostVerificationEnabled(false);
                 config.getUserProperties().put(PROPNAME_SSL_ENGINE_CONFIGURATOR, sslEngineConfigurator);
+                
+                // Enabled Tracing for Testing Only in the limited WebSocket Notification Tests
+                config.getUserProperties().put(TyrusWebSocketEngine.TRACING_TYPE, "ALL");
+                config.getUserProperties().put(TyrusWebSocketEngine.TRACING_THRESHOLD, "TRACE");
             }
             WebSocketContainer container = ContainerProvider.getWebSocketContainer();
             container.connectToServer(endpoint, config, new URI(webSocketURL));

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/WebSocketNotificationsTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/WebSocketNotificationsTest.java
@@ -23,14 +23,22 @@ import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.notification.FHIRNotificationEvent;
 
+/**
+ * 
+ * The following tests are intentionally marked as singleThreaded. 
+ * The singleThreaded property addresses an issue where the 
+ * session does not start-connect-receive a message. 
+ *
+ */
 public class WebSocketNotificationsTest extends FHIRServerTestBase {
+    
     private Patient savedCreatedPatient;
     private Observation savedCreatedObservation;
 
     /**
      * Create a Patient, then make sure we can retrieve it.
      */
-    @Test(groups = { "websocket-notifications" })
+    @Test(groups = { "websocket-notifications" }, singleThreaded = true)
     public void testCreatePatient() throws Exception {
         FHIRNotificationServiceClientEndpoint endpoint = getWebsocketClientEndpoint();
         assertNotNull(endpoint);
@@ -45,6 +53,7 @@ public class WebSocketNotificationsTest extends FHIRServerTestBase {
 
         // Get the patient's logical id value.
         String patientId = getLocationLogicalId(response);
+        System.out.println(">>> [CREATE] Patient Resource -> Id: " + patientId);
 
         // Next, call the 'read' API to retrieve the new patient and verify it.
         response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
@@ -65,7 +74,7 @@ public class WebSocketNotificationsTest extends FHIRServerTestBase {
     /**
      * Create an Observation and make sure we can retrieve it.
      */
-    @Test(groups = { "websocket-notifications" }, dependsOnMethods = { "testCreatePatient" })
+    @Test(groups = { "websocket-notifications" }, dependsOnMethods = { "testCreatePatient" }, singleThreaded = true)
     public void testCreateObservation() throws Exception {
         FHIRNotificationServiceClientEndpoint endpoint = getWebsocketClientEndpoint();
 
@@ -99,7 +108,7 @@ public class WebSocketNotificationsTest extends FHIRServerTestBase {
     /**
      * Tests the update of the original observation that was previously created.
      */
-    @Test(groups = { "websocket-notifications" }, dependsOnMethods = { "testCreateObservation" })
+    @Test(groups = { "websocket-notifications" }, dependsOnMethods = { "testCreateObservation" },  singleThreaded = true)
     public void testUpdateObservation() throws Exception {
         FHIRNotificationServiceClientEndpoint endpoint = getWebsocketClientEndpoint();
 


### PR DESCRIPTION
- configure the base test
- set tests as single threaded
- update the base tests

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>