### PR TITLE
add additional check for Code subtypes in the new types.code subpackage #202

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/impl/ValueTypesR4Impl.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/impl/ValueTypesR4Impl.java
@@ -228,6 +228,10 @@ public class ValueTypesR4Impl implements IValueTypes {
                 // Checks the other possibility
                 found = processClass(clzs, "com.ibm.fhir.model.type", type);
             }
+            if (!found) {
+                // Checks the other possibility
+                found = processClass(clzs, "com.ibm.fhir.model.type.code", type);
+            }
 
             // Logs out if error.
             if (!found) {

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -2,22 +2,17 @@
 
     <!-- Enable features -->
     <featureManager>
-        <feature>localConnector-1.0</feature>
-        <feature>jaxrs-2.1</feature>
-        <!-- <feature>openidConnectClient-1.0</feature> -->
-        <feature>openidConnectServer-1.0</feature>
         <feature>appSecurity-2.0</feature>
-        <feature>transportSecurity-1.0</feature>
-        <feature>cdi-2.0</feature>
-        <feature>jsonp-1.1</feature>
-        <feature>jsf-2.3</feature>
-        <feature>servlet-4.0</feature>
-        <feature>websocket-1.1</feature>
-        <!-- db2 jdbc driver 4.24.92 doesn't fully implement jdbc-4.2 -->
-        <feature>jdbc-4.1</feature>
-        <feature>mpOpenAPI-1.0</feature>
         <feature>batchManagement-1.0</feature>
-        <feature>jaxb-2.2</feature>
+        <feature>jaxrs-2.1</feature>
+        <!-- the db2 jcc driver for 11.5.0.0 doesn't fully implement jdbc-4.2 -->
+        <feature>jdbc-4.1</feature>
+        <feature>jsonp-1.1</feature>
+        <feature>mpOpenAPI-1.0</feature>
+        <feature>openidConnectServer-1.0</feature>
+        <feature>servlet-4.0</feature>
+        <feature>transportSecurity-1.0</feature>    
+        <feature>websocket-1.1</feature>
     </featureManager>
 
     <!-- Disable welcome page so that internal server info won't be revealed in responses


### PR DESCRIPTION
I added this subpackage in #202.
For each type that was moved to the new package, it causes warning like this from ValueTypesR4Impl:
> unable to convert to class while setting value types for AccountStatus