### PR TITLE
Remove Commons-IO and corresponding Gzip usage #232

### DIFF
--- a/fhir-core/pom.xml
+++ b/fhir-core/pom.xml
@@ -23,10 +23,6 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRUtilities.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRUtilities.java
@@ -6,12 +6,9 @@
 
 package com.ibm.fhir.core;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.security.Key;
@@ -22,14 +19,10 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import java.util.Date;
-import java.util.Objects;
 import java.util.TimeZone;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.io.IOUtils;
 
 /**
  * A collection of miscellaneous utility functions used by the various fhir-*
@@ -45,13 +38,6 @@ public class FHIRUtilities {
         public SimpleDateFormat initialValue() {
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
             format.setTimeZone(TimeZone.getTimeZone("GMT"));
-            return format;
-        }
-    };
-    private static final ThreadLocal<SimpleDateFormat> calendarSimpleDateFormat = new ThreadLocal<SimpleDateFormat>() {
-        @Override
-        public SimpleDateFormat initialValue() {
-            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
             return format;
         }
     };
@@ -152,7 +138,6 @@ public class FHIRUtilities {
         return s != null && s.startsWith("{xor}");
     }
 
-
     /**
      * For R4 model, generate a sql timestamp
      * 
@@ -174,10 +159,6 @@ public class FHIRUtilities {
 
     public static String formatTimestamp(Date date) {
         return timestampSimpleDateFormat.get().format(date);
-    }
-
-    public static String formatCalendar(Timestamp timestamp) {
-        return calendarSimpleDateFormat.get().format(timestamp);
     }
 
     /**
@@ -243,63 +224,6 @@ public class FHIRUtilities {
                 is.close();
             }
         }
-    }
-
-    /**
-     * Determines whether or not the passed byte array was previously gzip
-     * compressed.
-     * 
-     * @param inputBytes - A byte array
-     * @return boolean - true if the input stream is gzip compressed; false
-     *         otherwise.
-     */
-    public static boolean isGzipCompressed(byte[] inputBytes) {
-        int head = ((int) inputBytes[0] & 0xff) | ((inputBytes[1] << 8) & 0xff00);
-        return (GZIPInputStream.GZIP_MAGIC == head);
-    }
-
-    /**
-     * Performs a gzip compression of the passed byte array.
-     * 
-     * @param input - Any byte array
-     * @return byte[] - A gzip'd byte array representation of the input byte array.
-     * @throws IOException
-     * 
-     */
-    public static byte[] gzipCompress(byte[] input) throws IOException {
-
-        Objects.requireNonNull(input, "input cannot be null");
-
-        ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzip;
-
-        gzip = new GZIPOutputStream(byteOutputStream);
-        gzip.write(input);
-        gzip.close();
-
-        return byteOutputStream.toByteArray();
-    }
-
-    /**
-     * Decompresses a previously gzip'd compressed byte array. If the input byte
-     * array is not gzip compressed, the input byte array is returned.
-     * 
-     * @param compressedInput - A byte array previously created by a gzip
-     *                        compression.
-     * @return byte[] - The decompressed bytes.
-     * @throws IOException
-     * 
-     */
-    public static byte[] gzipDecompress(byte[] compressedInput) throws IOException {
-        byte[] output = compressedInput;
-        Objects.requireNonNull(compressedInput, "compressedInput cannot be null");
-        if (isGzipCompressed(compressedInput)) {
-            try (GZIPInputStream gzip = new GZIPInputStream(new ByteArrayInputStream(compressedInput))) {
-                output = IOUtils.toByteArray(gzip);
-            }
-        }
-
-        return output;
     }
 
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/LogFormatter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/LogFormatter.java
@@ -26,11 +26,6 @@ import java.util.logging.Logger;
  *
  */
 public class LogFormatter extends Formatter {
-    /**
-     * Copyright Add or Change the 2nd year when the source has changed more
-     * than 5% for example (C) COPYRIGHT 2005, 2007
-     */
-    static final String COPYRIGHT = "(C) Copyright IBM Corp. 2015 All Rights Reserved"; //$NON-NLS-1$
 
     private static final String ISO_TIME = "yyyy-MM-dd HH:mm:ss.SSS";
     /**

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -194,11 +194,6 @@
                 <version>1.1.1</version>
             </dependency>
             <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.6</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
                 <version>1.9.3</version>

--- a/fhir-server-webapp/pom.xml
+++ b/fhir-server-webapp/pom.xml
@@ -102,10 +102,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>


### PR DESCRIPTION
- cleans up commons io usage
- removes unused gzipdecompress/gzipcompress/isgzip
- cleans up unused code in database utils

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>