### PR TITLE
Add JavaDoc for FHIRParser and FHIRGenerator

### DIFF
--- a/fhir-model/pom.xml
+++ b/fhir-model/pom.xml
@@ -21,6 +21,10 @@
             <version>4.5.3</version>
         </dependency>
         <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${project.version}</version>

--- a/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRAbstractGenerator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRAbstractGenerator.java
@@ -27,9 +27,6 @@ public abstract class FHIRAbstractGenerator implements FHIRGenerator {
     @Override
     public abstract boolean isPrettyPrinting();
 
-    @Override
-    public abstract void reset();
-    
     public void setProperty(String name, Object value) {
         Objects.requireNonNull(name);
         if (!isPropertySupported(name)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRGenerator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRGenerator.java
@@ -13,24 +13,98 @@ import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.visitor.Visitable;
 
+/**
+ * Generate FHIR resource representations from fhir-model objects
+ */
 public interface FHIRGenerator {
+    /**
+     * Property name for a property that controls the amount of indentation to use for each indentation "level"
+     */
     public static final java.lang.String PROPERTY_INDENT_AMOUNT = "com.ibm.fhir.model.generator.indentAmount";
     
+    /**
+     * Write {@code visitable} to the passed OutputStream. This method does not close the passed OutputStream.
+     * 
+     * For {@code visitable} of type Resource, this serializes the resource in accordance with the specification.
+     * For {@code visitable} of type Element, this serializes the element content using a suitable wrapper for the configured format.
+     * 
+     * @param visitable The visitable Resource or Element to serialize
+     * @param out
+     * @throws FHIRGeneratorException
+     */
     void generate(Visitable visitable, OutputStream out) throws FHIRGeneratorException;
+    
+    /**
+     * Write {@code visitable} using the passed Writer. This method does not close the passed Writer.
+     * 
+     * For {@code visitable} of type Resource, this serializes the resource in accordance with the specification.
+     * For {@code visitable} of type Element, this serializes the element content using a suitable wrapper for the configured format.
+     * 
+     * @param visitable The visitable Resource or Element to serialize
+     * @param writer
+     * @throws FHIRGeneratorException
+     */
     void generate(Visitable visitable, Writer writer) throws FHIRGeneratorException;
 
+    /**
+     * @return whether this FHIRGenerator is configured to pretty-print its output
+     */
     boolean isPrettyPrinting();
-    void reset();
     
+    /**
+     * Set the property with the given name to the passed value
+     * 
+     * @throws IllegalArgumentException if the property {@code name} is unknown or unsupported
+     * @see {@link #isPropertySupported(String)}
+     */
     void setProperty(String name, Object value);
+    
+    /**
+     * @return the property value or {@code null} if the property has no value
+     */
     Object getProperty(String name);
+    
+    /**
+     * @return the property value or {@code defaultValue} if the property has no value
+     */
     Object getPropertyOrDefault(String name, Object defaultValue);
+    
+    /**
+     * @return the property value or {@code null} if the property has no value
+     */
     <T> T getProperty(String name, Class<T> type);
+    
+    /**
+     * @return the property value or {@code defaultValue} if the property has no value
+     */
     <T> T getPropertyOrDefault(String name, T defaultValue, Class<T> type);
+    
+    /**
+     * Whether the generator supports the property with the passed name
+     */
     boolean isPropertySupported(String name);
     
     <T extends FHIRGenerator> T as(Class<T> generatorClass);
     
+    /**
+     * Create a FHIRGenerator (without pretty-printing) for the given format.
+     * 
+     * @param format
+     * @return
+     * @throws IllegalArgumentException if {@code format} is not supported
+     */
+    static FHIRGenerator generator(Format format) {
+        return generator(format, false);
+    }
+    
+    /**
+     * Create a FHIRGenerator for the given format.
+     * 
+     * @param format
+     * @param prettyPrinting whether the returned FHIRGenerator should pretty-print its output
+     * @return
+     * @throws IllegalArgumentException if {@code format} is not supported
+     */
     static FHIRGenerator generator(Format format, boolean prettyPrinting) {
         switch (format) {
         case JSON:
@@ -41,9 +115,5 @@ public interface FHIRGenerator {
         default:
             throw new IllegalArgumentException("Unsupported format: " + format);
         }
-    }
-    
-    static FHIRGenerator generator(Format format) {
-        return generator(format, false);
     }
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRJsonGenerator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRJsonGenerator.java
@@ -94,11 +94,6 @@ public class FHIRJsonGenerator extends FHIRAbstractGenerator {
         return prettyPrinting;
     }
 
-    @Override
-    public void reset() {
-        // do nothing
-    }
-    
     /**
      * Temporary workaround for: https://github.com/eclipse-ee4j/jsonp/issues/190
      */

--- a/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRXMLGenerator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/generator/FHIRXMLGenerator.java
@@ -102,11 +102,6 @@ public class FHIRXMLGenerator extends FHIRAbstractGenerator {
     }
 
     @Override
-    public void reset() {
-        // do nothing
-    }
-    
-    @Override
     public boolean isPropertySupported(java.lang.String name) {
         if (FHIRGenerator.PROPERTY_INDENT_AMOUNT.equals(name)) {
             return true;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRJsonParser.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRJsonParser.java
@@ -41,6 +41,9 @@ import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.String;
 import com.ibm.fhir.model.util.ElementFilter;
 
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class FHIRJsonParser implements FHIRParser {
     public static boolean DEBUG = false;
@@ -103,8 +106,7 @@ public class FHIRJsonParser implements FHIRParser {
         }
     }
 
-    @Override
-    public void reset() {
+    private void reset() {
         stack.clear();
     }
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRParser.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRParser.java
@@ -13,16 +13,50 @@ import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.Resource;
 
+/**
+ * Parse FHIR resource representations into fhir-model objects
+ */
 public interface FHIRParser {
+    /**
+     * Read a resource from the passed InputStream. This method does not close the passed InputStream.
+     * 
+     * @param <T> The resource type to read
+     * @param in
+     * @return
+     * @throws FHIRParserException
+     * @throws ClassCastException If the InputStream contains a FHIR resource type that cannot be cast to the requested type 
+     */
     <T extends Resource> T parse(InputStream in) throws FHIRParserException;
+    
+    /**
+     * Read a resource using the passed Reader. This method does not close the passed Reader.
+     * 
+     * @param <T> The resource type to read
+     * @param reader
+     * @return
+     * @throws FHIRParserException
+     * @throws ClassCastException If the InputStream contains a FHIR resource type that cannot be cast to the requested type 
+     */
     <T extends Resource> T parse(Reader reader) throws FHIRParserException;
     
-    void reset();
-    
+    /**
+     * Attempt to cast the FHIRParser to a specific subclass
+     * 
+     * @param <T> The FHIRParser subclass to cast to
+     * @return
+     * @throws ClassCastException If the InputStream contains a FHIR resource type that cannot be cast to the requested type 
+     */
     default <T extends FHIRParser> T as(Class<T> parserClass) {
         return parserClass.cast(this);
     }
     
+    /**
+     * Create a FHIRParser for the given format.
+     * 
+     * @param format
+     * @return
+     * @throws IllegalArgumentException if {@code format} is not supported
+     */
     static FHIRParser parser(Format format) {
         switch (format) {
         case JSON:

--- a/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRXMLParser.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRXMLParser.java
@@ -33,6 +33,9 @@ import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.String;
 import com.ibm.fhir.model.util.XMLSupport.StreamReaderDelegate;
 
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class FHIRXMLParser implements FHIRParser {
     public static boolean DEBUG = false;
@@ -47,6 +50,7 @@ public class FHIRXMLParser implements FHIRParser {
     @Override
     public <T extends Resource> T parse(InputStream in) throws FHIRParserException {
         try (StreamReaderDelegate delegate = createStreamReaderDelegate(in)) {
+            reset();
             while (delegate.hasNext()) {
                 int eventType = delegate.next();
                 switch (eventType) {
@@ -65,6 +69,7 @@ public class FHIRXMLParser implements FHIRParser {
     @Override
     public <T extends Resource> T parse(Reader reader) throws FHIRParserException {
         try (StreamReaderDelegate delegate = createStreamReaderDelegate(reader)) {
+            reset();
             while (delegate.hasNext()) {
                 int eventType = delegate.next();
                 switch (eventType) {
@@ -79,8 +84,7 @@ public class FHIRXMLParser implements FHIRParser {
         }
     }
 
-    @Override
-    public void reset() {
+    private void reset() {
         stack.clear();
     }
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/visitor/CopyingVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/visitor/CopyingVisitor.java
@@ -22,18 +22,21 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.util.ModelSupport;
 
+import net.jcip.annotations.NotThreadSafe;
+
 /**
  * Copy a Resource or Element. Because model objects are immutable, by default this will return a reference to
  * the exact same object that was originally visited.
  * 
  * However, subclasses may override this class in order to modify the copied Resource or Element
- * by setting new values on the current builder via ({@code getBuilder())) and marking it dirty via ({@code markDirty())).  
+ * by setting new values on the current builder via ({@code getBuilder())) and marking it dirty via ({@code markDirty())).
  *  
  * Note: this class is NOT threadsafe.  Only one object should be visited at a time.
  * 
  * @author lmsurpre
  * @param <T> The type to copy. Only visitables of this type should be visited.
  */
+@NotThreadSafe
 public class CopyingVisitor<T extends Visitable> extends DefaultVisitor {
     private final Stack<BuilderWrapper> builderStack = new Stack<>();
     private Stack<ListWrapper> listStack = new Stack<>();

--- a/fhir-model/src/main/java/com/ibm/fhir/model/visitor/PathAwareAbstractVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/visitor/PathAwareAbstractVisitor.java
@@ -15,6 +15,9 @@ import java.util.stream.Collectors;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Element;
 
+import net.jcip.annotations.NotThreadSafe;
+
+@NotThreadSafe
 public abstract class PathAwareAbstractVisitor extends DefaultVisitor implements PathAwareVisitor {
     public static boolean DEBUG = false;
     

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -291,6 +291,11 @@
                 <artifactId>ibm-cos-java-sdk</artifactId>
                 <version>2.1.0</version>
             </dependency>
+            <dependency>
+                <groupId>net.jcip</groupId>
+                <artifactId>jcip-annotations</artifactId>
+                <version>1.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -1807,20 +1807,17 @@ public class CodeGenerator {
         cb._importstatic("com.ibm.fhir.model.util.XMLSupport", "isResourceContainer");
         cb._importstatic("com.ibm.fhir.model.util.XMLSupport", "parseDiv");
         cb._importstatic("com.ibm.fhir.model.util.XMLSupport", "requireNamespace");
-
         cb.newLine();
         
         cb._import("java.io.InputStream");
         cb._import("java.io.Reader");
         cb._import("java.util.Stack");
         cb._import("java.util.StringJoiner");
-        
         cb.newLine();
         
         cb._import("javax.annotation.Generated");
         cb._import("javax.xml.stream.XMLStreamException");
         cb._import("javax.xml.stream.XMLStreamReader");
-        
         cb.newLine();
         
         cb._import("com.ibm.fhir.model.parser.FHIRParser");
@@ -1832,23 +1829,23 @@ public class CodeGenerator {
         cb._import("com.ibm.fhir.model.type.Integer");
         cb._import("com.ibm.fhir.model.type.String");
         cb._import("com.ibm.fhir.model.util.XMLSupport.StreamReaderDelegate");
-        
         cb.newLine();
         
+        cb._import("net.jcip.annotations.NotThreadSafe");
+        cb.newLine();
+        
+        cb.annotation("NotThreadSafe");
         cb.annotation("Generated", quote("com.ibm.fhir.tools.CodeGenerator"));
         cb._class(mods("public"), "FHIRXMLParser", null, implementsInterfaces("FHIRParser"));
         cb.field(mods("public", "static"), "boolean", "DEBUG", "false");
-        
         cb.newLine();
         
         cb.field(mods("private", "final"), "Stack<java.lang.String>", "stack", _new("Stack<>"));
-        
         cb.newLine();
         
         cb.constructor(mods(), "FHIRXMLParser");
         cb.comment("only visible to subclasses or classes/interfaces in the same package (e.g. FHIRParser)");
         cb.end();
-        
         cb.newLine();
 
         // public <T extends Resource> T parse(InputStream in) throws FHIRParserException
@@ -1856,6 +1853,7 @@ public class CodeGenerator {
         cb.override();
         cb.method(mods("public"), "<T extends Resource> T", "parse", params("InputStream in"), throwsExceptions("FHIRParserException"))
             ._try("StreamReaderDelegate delegate = createStreamReaderDelegate(in)")
+                .invoke("reset", args())
                 ._while("delegate.hasNext()")
                     .assign("int eventType", "delegate.next()")
                     ._switch("eventType")
@@ -1869,7 +1867,6 @@ public class CodeGenerator {
                 ._throw(_new("FHIRParserException", args("e.getMessage()", "getPath()", "e")))
             ._end()
         .end();
-        
         cb.newLine();
         
         // public <T extends Resource> T parse(Reader reader) throws FHIRParserException
@@ -1877,6 +1874,7 @@ public class CodeGenerator {
         cb.override();
         cb.method(mods("public"), "<T extends Resource> T", "parse", params("Reader reader"), throwsExceptions("FHIRParserException"))
             ._try("StreamReaderDelegate delegate = createStreamReaderDelegate(reader)")
+                .invoke("reset", args())
                 ._while("delegate.hasNext()")
                     .assign("int eventType", "delegate.next()")
                     ._switch("eventType")
@@ -1890,14 +1888,11 @@ public class CodeGenerator {
                 ._throw(_new("FHIRParserException", args("e.getMessage()", "getPath()", "e")))
             ._end()
         .end();
-        
         cb.newLine();
         
-        cb.override();
-        cb.method(mods("public"), "void", "reset")
+        cb.method(mods("private"), "void", "reset")
             .invoke("stack", "clear", args())
         .end();
-        
         cb.newLine();
                 
         cb.method(mods("private"), "Resource", "parseResource", params("java.lang.String elementName", "XMLStreamReader reader", "int elementIndex"), throwsExceptions("XMLStreamException"));
@@ -1916,7 +1911,6 @@ public class CodeGenerator {
         cb._end();
         cb._return("null");
         cb.end();
-        
         cb.newLine();
         
         Collections.sort(generatedClassNames);
@@ -2179,7 +2173,6 @@ public class CodeGenerator {
         cb._importstatic("com.ibm.fhir.model.util.JsonSupport", "nonClosingInputStream");
         cb._importstatic("com.ibm.fhir.model.util.JsonSupport", "nonClosingReader");
         cb._importstatic("com.ibm.fhir.model.util.ModelSupport", "getChoiceElementName");
-        
         cb.newLine();
         
         cb._import("java.io.InputStream");
@@ -2188,7 +2181,6 @@ public class CodeGenerator {
         cb._import("java.util.Collection");
         cb._import("java.util.Stack");
         cb._import("java.util.StringJoiner");
-        
         cb.newLine();
         
         cb._import("javax.annotation.Generated");
@@ -2200,7 +2192,6 @@ public class CodeGenerator {
         cb._import("javax.json.JsonReaderFactory");
         cb._import("javax.json.JsonString");
         cb._import("javax.json.JsonValue");
-        
         cb.newLine();
         
         cb._import("com.ibm.fhir.model.parser.FHIRParser");
@@ -2212,24 +2203,24 @@ public class CodeGenerator {
         cb._import("com.ibm.fhir.model.type.Integer");
         cb._import("com.ibm.fhir.model.type.String");
         cb._import("com.ibm.fhir.model.util.ElementFilter");
-        
         cb.newLine();
         
+        cb._import("net.jcip.annotations.NotThreadSafe");
+        cb.newLine();
+        
+        cb.annotation("NotThreadSafe");
         cb.annotation("Generated", quote("com.ibm.fhir.tools.CodeGenerator"));
         cb._class(mods("public"), "FHIRJsonParser", null, implementsInterfaces("FHIRParser"));
         cb.field(mods("public", "static"), "boolean", "DEBUG", "false");
         cb.field(mods("private", "static", "final"), "JsonReaderFactory", "JSON_READER_FACTORY", "Json.createReaderFactory(null)");
-        
         cb.newLine();
         
         cb.field(mods("private", "final"), "Stack<java.lang.String>", "stack", _new("Stack<>"));
-        
         cb.newLine();
         
         cb.constructor(mods(), "FHIRJsonParser");
         cb.comment("only visible to subclasses or classes/interfaces in the same package (e.g. FHIRParser)");
         cb.end();
-        
         cb.newLine();
         
         // public <T extends Resource> T parse(InputStream in) throws FHIRException
@@ -2237,7 +2228,6 @@ public class CodeGenerator {
         cb.method(mods("public"), "<T extends Resource> T", "parse", params("InputStream in"), throwsExceptions("FHIRParserException"))
             ._return("parseAndFilter(in, null)")
         .end();
-        
         cb.newLine();
         
         // public <T extends Resource> T parseAndFilter(InputStream in, java.util.List<java.lang.String> elementsToInclude) throws FHIRException
@@ -2251,7 +2241,6 @@ public class CodeGenerator {
                 ._throw("new FHIRParserException(e.getMessage(), getPath(), e)")
             ._end()
         .end();
-        
         cb.newLine();
      
         // public <T extends Resource> T parse(Reader reader) throws FHIRException
@@ -2259,7 +2248,6 @@ public class CodeGenerator {
         cb.method(mods("public"), "<T extends Resource> T", "parse", params("Reader reader"), throwsExceptions("FHIRParserException"))
             ._return("parseAndFilter(reader, null)")
         .end();
-        
         cb.newLine();
         
         // public <T extends Resource> T parseAndFilter(Reader reader, java.util.List<java.lang.String> elementsToInclude) throws FHIRException
@@ -2273,13 +2261,11 @@ public class CodeGenerator {
                 ._throw("new FHIRParserException(e.getMessage(), getPath(), e)")
             ._end()
         .end();
-        
         cb.newLine();
         
         cb.method(mods("public"), "<T extends Resource> T", "parse", args("JsonObject jsonObject"), throwsExceptions("FHIRParserException"))
             ._return("parseAndFilter(jsonObject, null)")
         .end();
-    
         cb.newLine();
         
         // public <T extends Resource> T parseAndFilter(JsonObject jsonObject, java.util.List<java.lang.String> elementsToInclude)
@@ -2297,14 +2283,11 @@ public class CodeGenerator {
                 ._throw("new FHIRParserException(e.getMessage(), getPath(), e)")
             ._end()
         .end();
-        
         cb.newLine();
         
-        cb.override();
-        cb.method(mods("public"), "void", "reset")
+        cb.method(mods("private"), "void", "reset")
             .invoke("stack", "clear", args())
         .end();
-        
         cb.newLine();
         
         cb.method(mods("private"), "Resource", "parseResource", params("java.lang.String elementName", "JsonObject jsonObject", "int elementIndex"));
@@ -2323,7 +2306,6 @@ public class CodeGenerator {
         cb._end();
         cb._return("null");
         cb.end();
-        
         cb.newLine();
         
         Collections.sort(generatedClassNames);


### PR DESCRIPTION
Added JavaDoc and removed the `reset()` method from all FHIRGenerator classes (it wasn't doing anything) and also from the public FHIRParser interface as its only used internally (no use case for invoking it as a user).

Also introduced a dependency on
http://jcip.net/annotations/doc/net/jcip/annotations/package-summary.html
to highlight that the FHIRJsonParser and FHIRXMLParser are *not*
threadsafe.

Also added this annotation to the CopyingVisitor and
PathAwareAbstractVisitor which should definitely not be shared across
threads either.

Signed-off-by: lmsurpre <lmsurpre@us.ibm.com>