### PR TITLE
issue #305 - handle more date param values as ranges

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -415,7 +415,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                 lastPageNumber = (int) ((searchResultCount + pageSize - 1) / pageSize);
                 searchContext.setLastPageNumber(lastPageNumber);
                 
-                 
                 // For _summary=count, we don't need to return any resource 
                 if (searchResultCount > 0 && 
                         !(searchContext.getSummaryParameter() != null 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -760,7 +760,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData, JDBCOpe
 
             datetime = QueryBuilderUtil.getInstant(value.getValueDate());
             // If the dateTime value is fully specified down to the microsecond, build a where clause segment with strict equals.
-            if (!value.getValueDate().isPartial() && QueryBuilderUtil.hasMicroseconds(value.getValueDate().getValue())) {
+            if (!value.getValueDate().isPartial() && QueryBuilderUtil.hasSubSeconds(value.getValueDate().getValue())) {
                 start = datetime;
                 end = datetime;
                 if (isDateSearch) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QueryBuilderUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QueryBuilderUtil.java
@@ -26,7 +26,7 @@ import com.ibm.fhir.model.type.DateTime;
 public class QueryBuilderUtil {
     
     // used for adjustInto calls to obtain usable Zulu instants from Year, YearMonth, LocalDate
-    private static final String REFERENCE_DATE_STRING = "2018-01-01T00:00:00";
+    private static final String REFERENCE_DATE_STRING = "2018-01-01T00:00:00.000000";
     private static final LocalDateTime REFERENCE_DATE = LocalDateTime.parse(REFERENCE_DATE_STRING);
 
     /**
@@ -70,6 +70,11 @@ public class QueryBuilderUtil {
     public static java.time.Instant getInstantFromPartial(TemporalAccessor ta) {
         java.time.LocalDateTime result;
         
+        if (ta instanceof ZonedDateTime) {
+            // early exit
+            return ((ZonedDateTime) ta).toInstant();
+        }
+        
         if (ta instanceof Year) {
             result = REFERENCE_DATE.with(ChronoField.YEAR, ((Year)ta).getValue());
         }
@@ -91,29 +96,66 @@ public class QueryBuilderUtil {
     }
         
     public static java.time.Instant getEnd(TemporalAccessor ta) {
-        java.time.LocalDateTime result;
+        java.time.Instant result;
+        java.time.LocalDateTime local;
         
-        if (ta instanceof Year) {
-            Year year = ((Year)ta).plusYears(1);
-            result = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
-        }
-        else if (ta instanceof YearMonth) {
-            YearMonth ym = ((YearMonth)ta).plusMonths(1);
-            result = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
-            result = result.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
-        }
-        else if (ta instanceof LocalDate) {
-            // as long as we follow this order, we should never end up with an invalid date-time
-            LocalDate ld = ((LocalDate) ta).plusDays(1);
-            result = REFERENCE_DATE.with(ChronoField.YEAR, ld.getYear());
-            result = result.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
-            result = result.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
-        }
-        else {
-            throw new IllegalArgumentException("Invalid partial TemporalAccessor: " + ta.getClass().getName());
+        if (ta instanceof ZonedDateTime) {
+            result = ((ZonedDateTime) ta).toInstant();
+            if (!hasMicroseconds(result)) {
+                result = addOne(result);
+            }
+        } else if (ta instanceof java.time.Instant) {
+            result = (Instant) ta;
+            if (!hasMicroseconds(result)) {
+                result = addOne(result);
+            }
+        } else {
+            if (ta instanceof Year) {
+                Year year = ((Year)ta).plusYears(1);
+                local = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
+            }
+            else if (ta instanceof YearMonth) {
+                YearMonth ym = ((YearMonth)ta).plusMonths(1);
+                local = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
+                local = local.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
+            }
+            else if (ta instanceof LocalDate) {
+                // as long as we follow this order, we should never end up with an invalid date-time
+                LocalDate ld = ((LocalDate) ta).plusDays(1);
+                local = REFERENCE_DATE.with(ChronoField.YEAR, ld.getYear());
+                local = local.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
+                local = local.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
+            }
+            else {
+                throw new IllegalArgumentException("Invalid partial TemporalAccessor: " + ta.getClass().getName());
+            }
+            
+            result = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
         }
         
-        return ZonedDateTime.of(result, ZoneOffset.UTC).toInstant();
-        
+        return result;
+    }
+
+    private static java.time.Instant addOne(java.time.Instant instant) {
+        if (instant.get(ChronoField.MILLI_OF_SECOND) > 0) {
+            instant = instant.plusMillis(1);
+        } else {
+            instant = instant.plusSeconds(1);
+        }
+        return instant;
+    }
+    
+    /**
+     * A rough heuristic to guess whether we got an exact instant (down to the millisecond) or something we should treat as an implicit range.
+     * <p>
+     * There is no "correct" way to determine this at the moment since the search parameter comes in as a DateTime and
+     * there is no way to distinguish input like 0001-01-01T01:01:01.1 from 0001-01-01T01:01:01.100000.
+     */
+    public static boolean hasMicroseconds(TemporalAccessor ta) {
+        int micro_of_milli = ta.get(ChronoField.MICRO_OF_SECOND) % 1000;
+        if (micro_of_milli > 0) {
+            return true;
+        }
+        return false;
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -246,26 +246,33 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     
     @Test
     public void testSearchDate_instant_precise() throws Exception {
-        //assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01Z");
+        assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01Z");
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01.1Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:01.12Z");
         
+        assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02Z");
         //assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.1Z");
         assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.12Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0002-02-02T02:02:02.123Z");
         
+        assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03Z");
         //assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.12Z");
         assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.123Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0003-03-03T03:03:03.1234Z");
         
-        //assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.123Z");
+        assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04Z");
+        assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.123Z");
         assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.1234Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0004-04-04T04:04:04.12345Z");
         
+        assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05Z");
+        assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.123Z");
         //assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.1234Z");
         assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0005-05-05T05:05:05.123456Z");
         
+        assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06Z");
+        assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123Z");
         //assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.12345Z");
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123456Z");
     }
@@ -309,7 +316,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_Period() throws Exception {
         // "Period" is 2018-10-29T17:12:00-04:00 to 2018-10-29T17:18:00-04:00
-        
         assertSearchReturnsSavedResource("Period", "2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29");
@@ -324,7 +330,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
+        // 17:12:00 is interpreted as the range [17:12:00 to 17:12:01) and so this does intersect [17:12:00,17:18:00] 
+        //assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:12:00-04:00");
@@ -482,7 +489,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29T17:12:00-04:00");
+        // 17:12:00 is interpreted as the range [17:12:00 to 17:12:01) and so this does intersect [17:12:00,17:18:00]
+        //assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "le2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T17:12:00-04:00");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -246,34 +246,26 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     
     @Test
     public void testSearchDate_instant_precise() throws Exception {
+        // Searching by second should include all instants within that second (regardless of sub-seconds)
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01Z");
+        assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:02Z");
+        
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01.1Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:01.12Z");
         
-        assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02Z");
-        //assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.1Z");
         assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.12Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0002-02-02T02:02:02.123Z");
         
-        assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03Z");
-        //assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.12Z");
         assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.123Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0003-03-03T03:03:03.1234Z");
         
-        assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04Z");
-        assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.123Z");
         assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.1234Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0004-04-04T04:04:04.12345Z");
         
-        assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05Z");
-        assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.123Z");
-        //assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.1234Z");
         assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0005-05-05T05:05:05.123456Z");
         
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06Z");
-        assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123Z");
-        //assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.12345Z");
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123456Z");
     }
     


### PR DESCRIPTION
Now all date param values will be handled as an implicit range unless
there are microseconds given. For example:
* `01:01:01` -> `[01:01:01, 01:01:02)`
* `01:01:01.1` -> `01:01:01.100000`
* `01:01:01.111111` -> `01:01:01.111111`

Once we support passing times without seconds, this should also adjust the implicit range by adding a whole minute:
* `01:01` -> `[01:01, 01:02)`

I considered guessing at the passed precision by looking for the last
non-zero digit, but our DateTime actually doesn't store this type of precision detail.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>