### PR TITLE
update the parent dependencies for jackson libraries #322

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -250,17 +250,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.3</version>
+                <version>2.9.10.1</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION

```
Known  critical severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.9.10 defined in pom.xml. | Known  critical severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.9.10 defined in pom.xml.
Known  critical severity security vulnerability detected in com.fasterxml.jackson.core:jackson-databind < 2.9.10 defined in pom.xml.

```

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>