### PR TITLE
issue #193 - mirror "isServer" logic on the writeTo methods

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -51,7 +51,6 @@ import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.parser.FHIRJsonParser;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.parser.exception.FHIRParserException;
-import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.DomainResource;
 import com.ibm.fhir.model.resource.OperationOutcome;

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRJsonPatchProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRJsonPatchProvider.java
@@ -20,7 +20,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.json.Json;
@@ -71,12 +70,15 @@ public class FHIRJsonPatchProvider implements MessageBodyReader<JsonArray>, Mess
         try (JsonReader reader = JSON_READER_FACTORY.createReader(nonClosingInputStream(entityStream))) {
             return reader.readArray();
         } catch (JsonException e) {
-            log.log(Level.WARNING, "an error occurred during resource deserialization", e);
-            String acceptHeader = httpHeaders.getFirst(HttpHeaders.ACCEPT);
-            Response response = buildResponse(
-                buildOperationOutcome(Collections.singletonList(
-                    buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.EXCEPTION, "FHIRProvider: " + e.getMessage(), null))), getMediaType(acceptHeader));
-            throw new WebApplicationException(response);
+            if (RuntimeType.SERVER.equals(runtimeType)) {
+                String acceptHeader = httpHeaders.getFirst(HttpHeaders.ACCEPT);
+                Response response = buildResponse(
+                    buildOperationOutcome(Collections.singletonList(
+                        buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.INVALID, "FHIRProvider: " + e.getMessage(), null))), getMediaType(acceptHeader));
+                throw new WebApplicationException(response);
+            } else {
+                throw new IOException("an error occurred during JSON Patch deserialization", e);
+            }
         } finally {
             log.exiting(this.getClass().getName(), "readFrom");
         }
@@ -94,12 +96,15 @@ public class FHIRJsonPatchProvider implements MessageBodyReader<JsonArray>, Mess
         try (JsonWriter writer = JSON_WRITER_FACTORY.createWriter(nonClosingOutputStream(entityStream))) {
             writer.writeArray(t);
         } catch (JsonException e) {
-            log.log(Level.WARNING, "an error occurred during resource serialization", e);
-            String acceptHeader = (String) httpHeaders.getFirst(HttpHeaders.ACCEPT);
-            Response response = buildResponse(
-                buildOperationOutcome(Collections.singletonList(
-                    buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.EXCEPTION, "FHIRProvider: " + e.getMessage(), null))), getMediaType(acceptHeader));
-            throw new WebApplicationException(response);
+            if (RuntimeType.SERVER.equals(runtimeType)) {
+                String acceptHeader = (String) httpHeaders.getFirst(HttpHeaders.ACCEPT);
+                Response response = buildResponse(
+                    buildOperationOutcome(Collections.singletonList(
+                        buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.EXCEPTION, "FHIRProvider: " + e.getMessage(), null))), getMediaType(acceptHeader));
+                throw new WebApplicationException(response);
+            } else {
+                throw new IOException("an error occurred during JSON Patch serialization", e);
+            }
         } finally {
             log.exiting(this.getClass().getName(), "writeTo");
         }

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
@@ -18,7 +18,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
@@ -74,12 +73,15 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
         try {
             return FHIRParser.parser(getFormat(mediaType)).parse(entityStream);
         } catch (FHIRParserException e) {
-            log.log(Level.WARNING, "an error occurred during resource deserialization", e);
-            String acceptHeader = httpHeaders.getFirst(HttpHeaders.ACCEPT);
-            Response response = buildResponse(
-                buildOperationOutcome(Collections.singletonList(
-                    buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.INVALID, "FHIRProvider: " + e.getMessage(), e.getPath()))), getMediaType(acceptHeader));
-            throw new WebApplicationException(response);
+            if (RuntimeType.SERVER.equals(runtimeType)) {
+                String acceptHeader = httpHeaders.getFirst(HttpHeaders.ACCEPT);
+                Response response = buildResponse(
+                    buildOperationOutcome(Collections.singletonList(
+                        buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.INVALID, "FHIRProvider: " + e.getMessage(), e.getPath()))), getMediaType(acceptHeader));
+                throw new WebApplicationException(response);
+            } else {
+                throw new IOException("an error occurred during resource deserialization", e);
+            }
         } finally {
             log.exiting(this.getClass().getName(), "readFrom");
         }
@@ -97,12 +99,13 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
         try {
             FHIRGenerator.generator(getFormat(mediaType), isPretty(requestHeaders)).generate(t, entityStream);
         } catch (FHIRGeneratorException e) {
-            log.log(Level.WARNING, "an error occurred during resource serialization", e);
             if (RuntimeType.SERVER.equals(runtimeType)) {
                 Response response = buildResponse(
                     buildOperationOutcome(Collections.singletonList(
                         buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.EXCEPTION, "FHIRProvider: " + e.getMessage(), e.getPath()))), mediaType);
                 throw new WebApplicationException(response);
+            } else {
+                throw new IOException("an error occurred during resource serialization", e);
             }
         } finally {
             log.exiting(this.getClass().getName(), "writeTo");

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
@@ -499,7 +499,7 @@ public abstract class FHIRServerTestBase {
 
             assertNotNull(ooi.getSeverity());
             assertNotNull(ooi.getSeverity().getValue());
-            assertEquals(IssueSeverity.ERROR.getValue(), ooi.getSeverity().getValue());
+            assertTrue(IssueSeverity.ERROR.equals(ooi.getSeverity()) || IssueSeverity.FATAL.equals(ooi.getSeverity()));
 
             assertNotNull(ooi.getDetails());
             String msg = ooi.getDetails().getText().getValue();


### PR DESCRIPTION
Also updated FHIRJsonProvider and FHIRJsonPatchProvider to be consistent
across all 3 providers.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>