### PR TITLE
issue #344 - properly index Address and HumanName

### DIFF
--- a/fhir-examples/src/main/resources/json/ibm/basic/BasicString.json
+++ b/fhir-examples/src/main/resources/json/ibm/basic/BasicString.json
@@ -15,12 +15,25 @@
     {
       "url": "http://example.org/Address",
       "valueAddress": {
-        "text": "4025 S. Miami Blvd., Durham, NC 27703"
+        "use": "work",
+        "type": "both",
+        "text": "4025 S. Miami Blvd., Durham, NC 27703",
+        "line": ["4025 S. Miami Blvd."],
+        "city": "Research Triangle Park",
+        "district": "Durham",
+        "state": "NC",
+        "postalCode": "27703",
+        "country": "USA"
       }
     },
     {
       "url": "http://example.org/HumanName",
       "valueHumanName": {
+        "use": "usual",
+        "prefix": ["Mr."],
+        "given": ["Topo"],
+        "family": "Gigio",
+        "suffix": ["II"],
         "text": "Topo Gigio"
       }
     },

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -174,11 +174,28 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Address address) {
         Parameter p;
-        
+        for (com.ibm.fhir.model.type.String aLine : address.getLine()) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(aLine.getValue());
+            result.add(p);
+        }
         if (address.getCity() != null) {
             p = new Parameter();
             p.setName(name);
             p.setValueString(address.getCity().getValue());
+            result.add(p);
+        }
+        if (address.getDistrict() != null) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(address.getDistrict().getValue());
+            result.add(p);
+        }
+        if (address.getState() != null) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(address.getState().getValue());
             result.add(p);
         }
         if (address.getCountry() != null) {
@@ -187,51 +204,12 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             p.setValueString(address.getCountry().getValue());
             result.add(p);
         }
-
-        if (address.getDistrict() != null) {
-            p = new Parameter();
-            p.setName(name);
-            p.setValueString(address.getDistrict().getValue());
-            result.add(p);
-        }
-
-        if (address.getLine() != null) {
-            for (com.ibm.fhir.model.type.String aLine : address.getLine()) {
-                p = new Parameter();
-                p.setName(name);
-                p.setValueString(aLine.getValue());
-                result.add(p);
-            }
-        }
-
         if (address.getPostalCode() != null) {
             p = new Parameter();
             p.setName(name);
             p.setValueString(address.getPostalCode().getValue());
             result.add(p);
         }
-
-        if (address.getState() != null) {
-            p = new Parameter();
-            p.setName(name);
-            p.setValueString(address.getState().getValue());
-            result.add(p);
-        }
-
-        if (address.getUse() != null) {
-            p = new Parameter();
-            p.setName(name);
-            p.setValueString(address.getUse().getValue());
-            result.add(p);
-        }
-
-        if (address.getType() != null) {
-            p = new Parameter();
-            p.setName(name);
-            p.setValueString(address.getType().getValue());
-            result.add(p);
-        }
-
         if (address.getText() != null) {
             p = new Parameter();
             p.setName(name);
@@ -274,32 +252,34 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     public boolean visit(java.lang.String elementName, int elementIndex, HumanName humanName) {
         Parameter p;
         if (humanName.getFamily() != null) {
-            // family just a string in R4 (not a list)
+            // family is just a string in R4 (not a list)
             p = new Parameter();
             p.setName(name);
             p.setValueString(humanName.getFamily().getValue());
             result.add(p);
         }
-        if (humanName.getGiven() != null) {
-            for (com.ibm.fhir.model.type.String given : humanName.getGiven()) {
-                p = new Parameter();
-                p.setName(name);
-                p.setValueString(given.getValue());
-                result.add(p);
-            }
+        for (com.ibm.fhir.model.type.String given : humanName.getGiven()) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(given.getValue());
+            result.add(p);
+        }
+        for (com.ibm.fhir.model.type.String prefix : humanName.getPrefix()) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(prefix.getValue());
+            result.add(p);
+        }
+        for (com.ibm.fhir.model.type.String suffix : humanName.getSuffix()) {
+            p = new Parameter();
+            p.setName(name);
+            p.setValueString(suffix.getValue());
+            result.add(p);
         }
         if (humanName.getText() != null) {
             p = new Parameter();
             p.setName(name);
             p.setValueString(humanName.getText().getValue());
-
-            result.add(p);
-        }
-        if (humanName.getUse() != null) {
-            p = new Parameter();
-            p.setName(name);
-            p.setValueString(humanName.getUse().getValue());
-
             result.add(p);
         }
         return false;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QueryBuilderUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QueryBuilderUtil.java
@@ -13,7 +13,6 @@ import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.chrono.ChronoZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
@@ -117,5 +117,45 @@ public abstract class AbstractSearchStringTest extends AbstractPLSearchTest {
 //        assertSearchDoesntReturnComposition("subject:Basic.missing-string:missing", "false");
 //    }
     
-    // TODO add tests for Address and HumanName
+    @Test
+    public void testSearchString_HumanName() throws Exception {
+        /*
+        "use": "usual",
+        "prefix": ["Mr."]
+        "given": ["Topo"],
+        "family": "Gigio",
+        "suffix": ["II"],
+        "text": "Topo Gigio"
+        */
+        assertSearchDoesntReturnSavedResource("HumanName", "usual");
+        assertSearchReturnsSavedResource("HumanName", "Mr.");
+        assertSearchReturnsSavedResource("HumanName", "Topo");
+        assertSearchReturnsSavedResource("HumanName", "Gigio");
+        assertSearchReturnsSavedResource("HumanName", "II");
+        assertSearchReturnsSavedResource("HumanName", "Topo Gigio");
+    }
+    
+    @Test
+    public void testSearchString_Address() throws Exception {
+        /*
+        "use": "work",
+        "type", "both",
+        "text": "4025 S. Miami Blvd., Durham, NC 27703",
+        "line": "4025 S. Miami Blvd.",
+        "city": "Research Triangle Park",
+        "district": "Durham",
+        "state": "NC",
+        "postalCode": "27703",
+        "country": "USA"
+        */
+        assertSearchDoesntReturnSavedResource("Address", "work");
+        assertSearchDoesntReturnSavedResource("Address", "both");
+        assertSearchReturnsSavedResource("Address", "4025 S. Miami Blvd., Durham, NC 27703");
+        assertSearchReturnsSavedResource("Address", "4025 S. Miami Blvd.");
+        assertSearchReturnsSavedResource("Address", "Research Triangle Park");
+        assertSearchReturnsSavedResource("Address", "Durham");
+        assertSearchReturnsSavedResource("Address", "NC");
+        assertSearchReturnsSavedResource("Address", "27703");
+        assertSearchReturnsSavedResource("Address", "USA");
+    }
 }


### PR DESCRIPTION
1. add tests in AbstractSearchStringTest
2. modify JDBCParameterBuildingVisitor to pass the tests

previously we were indexing "use" for HumanName and "type" for Addres;
now we index just the string fields


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>