### PR TITLE
issue #348 - add extraction support for multi-type search params

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -6,6 +6,8 @@
 
 package com.ibm.fhir.persistence.jdbc.util;
 
+import static com.ibm.fhir.model.type.code.SearchParamType.*;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -14,20 +16,24 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.type.Address;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.ContactPoint;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Identifier;
+import com.ibm.fhir.model.type.Money;
 import com.ibm.fhir.model.type.Period;
 import com.ibm.fhir.model.type.Quantity;
 import com.ibm.fhir.model.type.Range;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Timing;
 import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.SearchParamType;
 import com.ibm.fhir.model.visitor.DefaultVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 import com.ibm.fhir.persistence.jdbc.dto.Parameter;
@@ -35,13 +41,16 @@ import com.ibm.fhir.persistence.jdbc.dto.Parameter.TimeType;
 
 /**
  * This class is the JDBC persistence layer implementation for transforming SearchParameters into Parameter Data Transfer Objects.
- * 
- * <p>Call {@code Element.accept} with this visitor to add zero to many Parameters to the result list and invoke {@code getResult} 
+ *
+ * <p>Call {@code Element.accept} with this visitor to add zero to many Parameters to the result list and invoke {@code getResult}
  * to get the current list of extracted Parameter objects.
+ *
+ * <p>Note: this class DOES NOT set the resourceType on the underlying JDBC Parameter objects it creates;
+ * that is a responsibility of the caller.
  */
 public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     private static final Logger log = Logger.getLogger(JDBCParameterBuildingVisitor.class.getName());
-    
+
     public static final String EXCEPTION_MSG = "Unexpected error while processing parameter [%s] with value [%s]";
     public static final String EXCEPTION_MSG_NAME_ONLY = "Unexpected error while processing parameter [%s]";
 
@@ -50,13 +59,21 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     // Derby: https://db.apache.org/derby/docs/10.0/manuals/reference/sqlj271.html
     private static final Timestamp SMALLEST_TIMESTAMP = Timestamp.valueOf("0001-01-01 00:00:00.000000");
     private static final Timestamp LARGEST_TIMESTAMP = Timestamp.valueOf("9999-12-31 23:59:59.999999");
-    
-    private String name;
+
+    // We only need the SearchParameter type and code, so just store those directly as members
+    private final String searchParamCode;
+    private final SearchParamType searchParamType;
+
+    /**
+     * The result of the visit(s)
+     */
     private List<Parameter> result;
-    
-    public JDBCParameterBuildingVisitor(String searchParameterName) {
+
+    public JDBCParameterBuildingVisitor(SearchParameter searchParameter) {
         super(false);
-        this.name = searchParameterName;
+        this.searchParamCode = searchParameter.getCode().getValue();
+        this.searchParamType = searchParameter.getType();
+
         result = new ArrayList<Parameter>();
     }
 
@@ -78,11 +95,14 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     /*====================
      * Primitive Types   *
      ====================*/
-    
+
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Boolean _boolean) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, _boolean);
+        }
+        p.setName(searchParamCode);
         p.setValueSystem("http://hl7.org/fhir/special-values");
         if (_boolean.getValue()) {
             p.setValueCode("true");
@@ -93,9 +113,23 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         return false;
     }
     @Override
+    public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Canonical canonical) {
+        Parameter p = new Parameter();
+        if (!REFERENCE.equals(searchParamType) && !URI.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, canonical);
+        }
+        p.setName(searchParamCode);
+        p.setValueString(canonical.getValue());
+        result.add(p);
+        return false;
+    }
+    @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Code code) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, code);
+        }
+        p.setName(searchParamCode);
         // TODO: get the implicit code system
         p.setValueCode(code.getValue());
         result.add(p);
@@ -104,7 +138,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Date date) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!DATE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, date);
+        }
+        p.setName(searchParamCode);
         setDateValues(p, date);
         result.add(p);
         return false;
@@ -112,7 +149,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.DateTime dateTime) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!DATE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, dateTime);
+        }
+        p.setName(searchParamCode);
         setDateValues(p, dateTime);
         result.add(p);
         return false;
@@ -120,7 +160,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Decimal decimal) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!NUMBER.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, decimal);
+        }
+        p.setName(searchParamCode);
         p.setValueNumber(decimal.getValue());
         result.add(p);
         return false;
@@ -128,7 +171,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Id id) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, id);
+        }
+        p.setName(searchParamCode);
         p.setValueCode(id.getValue());
         result.add(p);
         return false;
@@ -136,7 +182,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Instant instant) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!DATE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, instant);
+        }
+        p.setName(searchParamCode);
         p.setValueDate(Timestamp.from(instant.getValue().toInstant()));
         result.add(p);
         return false;
@@ -144,7 +193,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Integer integer) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!NUMBER.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, integer);
+        }
+        p.setName(searchParamCode);
         // TODO: consider moving integer values to separate column so they can be searched different from decimals
         p.setValueNumber(new BigDecimal(integer.getValue()));
         result.add(p);
@@ -153,66 +205,78 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(String elementName, int elementIndex, com.ibm.fhir.model.type.String value) {
         Parameter p = new Parameter();
-        p.setName(name);
-        p.setValueString(value.getValue());
+        if (STRING.equals(searchParamType)) {
+            p.setValueString(value.getValue());
+        } else if (TOKEN.equals(searchParamType)) {
+            p.setValueCode(value.getValue());
+        } else {
+            throw invalidComboException(searchParamType, value);
+        }
+        p.setName(searchParamCode);
         result.add(p);
         return false;
     }
     @Override
     public boolean visit(String elementName, int elementIndex, Uri uri) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!URI.equals(searchParamType) && !REFERENCE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, uri);
+        }
+        p.setName(searchParamCode);
         p.setValueString(uri.getValue());
         result.add(p);
         return false;
     }
-    
+
     /*====================
      * Data Types        *
      ====================*/
-    
+
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Address address) {
         Parameter p;
+        if (!STRING.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, address);
+        }
         for (com.ibm.fhir.model.type.String aLine : address.getLine()) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(aLine.getValue());
             result.add(p);
         }
         if (address.getCity() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getCity().getValue());
             result.add(p);
         }
         if (address.getDistrict() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getDistrict().getValue());
             result.add(p);
         }
         if (address.getState() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getState().getValue());
             result.add(p);
         }
         if (address.getCountry() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getCountry().getValue());
             result.add(p);
         }
         if (address.getPostalCode() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getPostalCode().getValue());
             result.add(p);
         }
         if (address.getText() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(address.getText().getValue());
             result.add(p);
         }
@@ -220,6 +284,9 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, CodeableConcept codeableConcept) {
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, codeableConcept);
+        }
         for (Coding coding : codeableConcept.getCoding()) {
             visit(elementName, elementIndex, coding);
         }
@@ -228,7 +295,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Coding coding) {
         Parameter p = new Parameter();
-        p.setName(name);
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, coding);
+        }
+        p.setName(searchParamCode);
         if (coding.getSystem() != null) {
             p.setValueSystem(coding.getSystem().getValue());
         }
@@ -240,9 +310,12 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, ContactPoint contactPoint) {
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, contactPoint);
+        }
         if (contactPoint.getValue() != null) {
             Parameter telecom = new Parameter();
-            telecom.setName(name);
+            telecom.setName(searchParamCode);
             telecom.setValueCode(contactPoint.getValue().getValue());
             result.add(telecom);
         }
@@ -251,34 +324,37 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, HumanName humanName) {
         Parameter p;
+        if (!STRING.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, humanName);
+        }
         if (humanName.getFamily() != null) {
             // family is just a string in R4 (not a list)
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(humanName.getFamily().getValue());
             result.add(p);
         }
         for (com.ibm.fhir.model.type.String given : humanName.getGiven()) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(given.getValue());
             result.add(p);
         }
         for (com.ibm.fhir.model.type.String prefix : humanName.getPrefix()) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(prefix.getValue());
             result.add(p);
         }
         for (com.ibm.fhir.model.type.String suffix : humanName.getSuffix()) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(suffix.getValue());
             result.add(p);
         }
         if (humanName.getText() != null) {
             p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(humanName.getText().getValue());
             result.add(p);
         }
@@ -286,9 +362,12 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Identifier identifier) {
+        if (!TOKEN.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, identifier);
+        }
         if (identifier != null && identifier.getValue() != null) {
             Parameter p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             if (identifier.getSystem() != null) {
                 p.setValueSystem(identifier.getSystem().getValue());
             }
@@ -298,13 +377,32 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         return false;
     }
     @Override
+    public boolean visit(java.lang.String elementName, int elementIndex, Money money) {
+        if (!QUANTITY.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, money);
+        }
+        if (money != null && money.getValue() != null && money.getValue().getValue() != null) {
+            Parameter p = new Parameter();
+            p.setName(searchParamCode);
+            p.setValueNumber(money.getValue().getValue());
+            if (money.getCurrency() != null) {
+                p.setValueCode(money.getCurrency().getValue());
+            }
+            result.add(p);
+        }
+        return false;
+    }
+    @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Period period) {
+        if (!DATE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, period);
+        }
         if (period.getStart() == null && period.getEnd() == null) {
             // early exit
             return false;
         }
         Parameter p = new Parameter();
-        p.setName(name);
+        p.setName(searchParamCode);
         if (period.getStart() == null || period.getStart().getValue() == null) {
             p.setValueDateStart(SMALLEST_TIMESTAMP);
         } else {
@@ -320,13 +418,16 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         result.add(p);
         return false;
     }
-    // Also handles Quantity subtypes like Age, Money, and Duration
+    // Also handles Quantity subtypes like Age and Duration
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Quantity quantity) {
+        if (!QUANTITY.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, quantity);
+        }
         if (quantity != null && quantity.getValue() != null && quantity.getValue().getValue() != null &&
                 (quantity.getCode() != null || quantity.getUnit() != null)) {
             Parameter p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueNumber(quantity.getValue().getValue());
             // see https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
             if (quantity.getCode() != null) {
@@ -343,9 +444,12 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Range range) {
+        if (!QUANTITY.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, range);
+        }
         // The parameter isn't added unless either low or high holds a value
         Parameter p = new Parameter();
-        p.setName(name);
+        p.setName(searchParamCode);
         if (range.getLow() != null && range.getLow().getValue() != null && range.getLow().getValue().getValue() != null) {
             if (range.getLow().getSystem() != null) {
                 p.setValueSystem(range.getLow().getSystem().getValue());
@@ -379,9 +483,12 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Reference reference) {
+        if (!REFERENCE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, reference);
+        }
         if (reference.getReference() != null) {
             Parameter p = new Parameter();
-            p.setName(name);
+            p.setName(searchParamCode);
             p.setValueString(reference.getReference().getValue());
             result.add(p);
         }
@@ -389,12 +496,15 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Timing timing) {
+        if (!DATE.equals(searchParamType)) {
+            throw invalidComboException(searchParamType, timing);
+        }
         /*
          * The specified scheduling details are ignored and only the outer limits matter. For instance, a schedule that
          * specifies every second day between 31-Jan 2013 and 24-Mar 2013 includes 1-Feb 2013, even though that is on an
          * odd day that is not specified by the period. This is to keep the server load processing queries reasonable.
          */
-        
+
         Timing.Repeat repeat = timing.getRepeat();
         if (repeat != null && repeat.getBounds() != null) {
             // bounds[x] is either Duration, Range, or Period; all 3 have their own visitor method
@@ -405,15 +515,15 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         }
         return false;
     }
-    
+
     /*====================
      * Date/Time helpers *
      ====================*/
-    
+
     /**
      * Configure the date values in the parameter based on the model {@link Date} which again might be partial
      * (Year/YearMonth/LocalDate)
-     * 
+     *
      * @param p
      * @param date
      */
@@ -422,11 +532,11 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         java.time.Instant end = QueryBuilderUtil.getEnd(date);
         setDateValues(p, start, end);
     }
-    
+
     /**
      * Configure the date values in the parameter based on the model {@link DateTime} and the type of date it
      * represents.
-     * 
+     *
      * @param p
      * @param dateTime
      */
@@ -441,10 +551,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             setDateValues(p, start, end);
         }
     }
-    
+
     /**
      * Set the date values on the {@link Parameter}, adjusting the end time slightly to make it exclusive (which is a TODO to fix).
-     * 
+     *
      * @param p
      * @param start
      * @param end
@@ -460,15 +570,20 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         Timestamp implicitEndInclusive = convertToInclusiveEnd(implicitEndExclusive);
         p.setValueDateEnd(implicitEndInclusive);
     }
-    
+
     /**
      * Convert a period's end timestamp from an exclusive end timestamp to an inclusive one
-     * 
+     *
      * @param exlusiveEndTime
      * @return inclusiveEndTime
      */
     private Timestamp convertToInclusiveEnd(Timestamp exlusiveEndTime) {
         // Our current schema uses the db2/derby default of 6 decimal places (1000 nanoseconds) for fractional seconds.
         return Timestamp.from(exlusiveEndTime.toInstant().minusNanos(1000));
+    }
+
+    private IllegalArgumentException invalidComboException(SearchParamType paramType, Element value) {
+        return new IllegalArgumentException("Data type '" + value.getClass().getSimpleName() + "' is not supported "
+                + "for SearchParameter of type '" + paramType.getValue() + "'");
     }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -103,7 +103,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             throw invalidComboException(searchParamType, _boolean);
         }
         p.setName(searchParamCode);
-        p.setValueSystem("http://hl7.org/fhir/special-values");
+        p.setValueSystem("http://terminology.hl7.org/CodeSystem/special-values");
         if (_boolean.getValue()) {
             p.setValueCode("true");
         } else {
@@ -584,6 +584,6 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
 
     private IllegalArgumentException invalidComboException(SearchParamType paramType, Element value) {
         return new IllegalArgumentException("Data type '" + value.getClass().getSimpleName() + "' is not supported "
-                + "for SearchParameter of type '" + paramType.getValue() + "'");
+                + "for SearchParameter '" + searchParamCode + "' of type '" + paramType.getValue() + "'");
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
@@ -19,40 +19,127 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.Address;
+import com.ibm.fhir.model.type.Age;
+import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.ContactPoint;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Decimal;
+import com.ibm.fhir.model.type.Duration;
+import com.ibm.fhir.model.type.HumanName;
+import com.ibm.fhir.model.type.Id;
+import com.ibm.fhir.model.type.Identifier;
+import com.ibm.fhir.model.type.Instant;
+import com.ibm.fhir.model.type.Integer;
+import com.ibm.fhir.model.type.Markdown;
+import com.ibm.fhir.model.type.Money;
+import com.ibm.fhir.model.type.Period;
+import com.ibm.fhir.model.type.Quantity;
 import com.ibm.fhir.model.type.Range;
+import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.SimpleQuantity;
+import com.ibm.fhir.model.type.Timing;
 import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.ContactPointSystem;
+import com.ibm.fhir.model.type.code.PublicationStatus;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.model.type.code.SearchParamType;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceProcessorException;
 import com.ibm.fhir.persistence.jdbc.dto.Parameter;
 import com.ibm.fhir.persistence.jdbc.util.JDBCParameterBuildingVisitor;
 
+/**
+ * Tests all valid combinations of search paramter types and data types
+ * @see http://hl7.org/fhir/R4/search.html#table
+ */
 public class ParameterExtractionTest {
+    private static final String SAMPLE_STRING = "test";
+    private static final String SAMPLE_URI = "http://example.com";
+    private static final String SAMPLE_UNIT = "s";
+    private static final String SAMPLE_REF = "abc";
+    private static final String SAMPLE_DATE_START = "2016-01-01T00:00:00.000000Z";
+    private static final String SAMPLE_DATE_END = "2016-01-02T00:00:00.000000Z";
+    private static final String UNITSOFMEASURE = "http://unitsofmeasure.org";
+
     // custom formatter providing the precision required by the unit tests
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
             .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
             .appendFraction(ChronoField.MICRO_OF_SECOND, 6, 6, true)
             .appendPattern("XXX")
             .toFormatter();
-
+    
+    private static final SearchParameter.Builder searchParamBuilder = SearchParameter.builder()
+            .url(Uri.of("http://ibm.com/fhir/test"))
+            .name(string("test-param"))
+            .status(PublicationStatus.DRAFT)
+            .description(Markdown.of("#Test Parameter"))
+            .code(Code.of("value"))
+            .base(ResourceType.BASIC);
+    private static final SearchParameter numberSearchParam = searchParamBuilder.type(SearchParamType.NUMBER).build();
+    private static final SearchParameter dateSearchParam = searchParamBuilder.type(SearchParamType.DATE).build();
+    private static final SearchParameter referenceSearchParam = searchParamBuilder.type(SearchParamType.REFERENCE).build();
+    private static final SearchParameter quantitySearchParam = searchParamBuilder.type(SearchParamType.QUANTITY).build();
+    private static final SearchParameter uriSearchParam = searchParamBuilder.type(SearchParamType.URI).build();
+    private static final SearchParameter stringSearchParam = searchParamBuilder.type(SearchParamType.STRING).build();
+    private static final SearchParameter tokenSearchParam = searchParamBuilder.type(SearchParamType.TOKEN).build();
+    
+    @Test
+    public void testBoolean() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        com.ibm.fhir.model.type.Boolean.TRUE.accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), "true");
+    }
+    
+    @Test
+    public void testCanonical() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder;
+        Canonical canonical = Canonical.of(SAMPLE_URI);
+        List<Parameter> params;
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(referenceSearchParam);
+        canonical.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_URI);
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(uriSearchParam);
+        canonical.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_URI);
+    }
+    
+    @Test
+    public void testCode() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        Code.of(SAMPLE_STRING).accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), SAMPLE_STRING);
+    }
+    
     @Test
     public void testDate() throws FHIRPersistenceProcessorException {
-        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor("value");
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
         Date.of("2016").accept(parameterBuilder);
         List<Parameter> params = parameterBuilder.getResult();
         for (Parameter param : params) {
-            assertEquals(timestampToString(param.getValueDateStart()), "2016-01-01T00:00:00.000000Z");
-            assertEquals(timestampToString(param.getValueDate()), "2016-01-01T00:00:00.000000Z");
+            assertEquals(timestampToString(param.getValueDateStart()), SAMPLE_DATE_START);
+            assertEquals(timestampToString(param.getValueDate()), SAMPLE_DATE_START);
             assertEquals(timestampToString(param.getValueDateEnd()), "2016-12-31T23:59:59.999999Z");
         }
     }
 
     @Test
     public void testDateTime() throws FHIRPersistenceProcessorException {
-        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor("value");
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
         DateTime.of("2016-01-01T10:10:10.1+04:00").accept(parameterBuilder);
         List<Parameter> params = parameterBuilder.getResult();
         for (Parameter param : params) {
@@ -61,24 +148,320 @@ public class ParameterExtractionTest {
     }
     
     @Test
+    public void testDecimal() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(numberSearchParam);
+        Decimal.of(99.99).accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueNumber().doubleValue(), 99.99);
+    }
+    
+    @Test
+    public void testId() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        Id.of("x").accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), "x");
+    }
+    
+    @Test
+    public void testInstant() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
+        Instant now = Instant.now(ZoneOffset.UTC);
+        now.accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(timestampToString(params.get(0).getValueDate()), TIMESTAMP_FORMATTER.format(now.getValue()));
+    }
+    
+    @Test
+    public void testInteger() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(numberSearchParam);
+        Integer.of(13).accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueNumber().intValue(), 13);
+    }
+    
+    @Test
+    public void testString() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder;
+        com.ibm.fhir.model.type.String stringVal = string(SAMPLE_STRING);
+        List<Parameter> params;
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(stringSearchParam);
+        stringVal.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_STRING);
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        stringVal.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), SAMPLE_STRING);
+    }
+    
+    @Test
+    public void testUri() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder;
+        Uri uri = Uri.of(SAMPLE_URI);
+        List<Parameter> params;
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(referenceSearchParam);
+        uri.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_URI);
+        
+        parameterBuilder = new JDBCParameterBuildingVisitor(uriSearchParam);
+        uri.accept(parameterBuilder);
+        params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_URI);
+    }
+    
+    @Test
+    public void testAddress() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(stringSearchParam);
+        Address.builder()
+               .line(string("4025 S. Miami Blvd."))                    //0
+               .city(string("Durham"))                                 //1
+               .state(string("NC"))                                    //2
+               .postalCode(string("27703"))                            //3
+               .text(string("4025 S. Miami Blvd., Durham, NC 27703"))  //4
+               .build()
+               .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 5, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), "4025 S. Miami Blvd.");
+        assertEquals(params.get(1).getValueString(), "Durham");
+        assertEquals(params.get(2).getValueString(), "NC");
+        assertEquals(params.get(3).getValueString(), "27703");
+        assertEquals(params.get(4).getValueString(), "4025 S. Miami Blvd., Durham, NC 27703");
+    }
+    
+    @Test
+    public void testAge() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(quantitySearchParam);
+        Age.builder()
+           .value(Decimal.of(1))
+           .system(Uri.of(UNITSOFMEASURE))
+           .code(Code.of("a"))
+           .build()
+           .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueNumber().intValue(), 1);
+        assertEquals(params.get(0).getValueSystem(), UNITSOFMEASURE);
+        assertEquals(params.get(0).getValueCode(), "a");
+    }
+    
+    @Test
+    public void testCodeableConcept() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        CodeableConcept.builder()
+                       .coding(Coding.builder().code(Code.of("a")).system(Uri.of(SAMPLE_URI)).build())
+                       .coding(Coding.builder().code(Code.of("b")).system(Uri.of(SAMPLE_URI)).build())
+                       .coding(Coding.builder().code(Code.of("c")).system(Uri.of(SAMPLE_URI)).build())
+                       .build()
+                       .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 3, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), "a");
+        assertEquals(params.get(0).getValueSystem(), SAMPLE_URI);
+        assertEquals(params.get(1).getValueCode(), "b");
+        assertEquals(params.get(1).getValueSystem(), SAMPLE_URI);
+        assertEquals(params.get(2).getValueCode(), "c");
+        assertEquals(params.get(2).getValueSystem(), SAMPLE_URI);
+    }
+    
+    @Test
+    public void testCoding() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        Coding.builder()
+              .code(Code.of(SAMPLE_STRING))
+              .system(Uri.of(SAMPLE_URI))
+              .build()
+              .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), SAMPLE_STRING);
+        assertEquals(params.get(0).getValueSystem(), SAMPLE_URI);
+    }
+    
+    @Test
+    public void testContactPoint() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        ContactPoint.builder()
+                    .system(ContactPointSystem.PHONE)
+                    .value(string("5558675309"))
+                    .build()
+                    .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), "5558675309");
+    }
+    
+    @Test
+    public void testDuration() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(quantitySearchParam);
+        Duration.builder()
+                .value(Decimal.of(1))
+                .system(Uri.of(UNITSOFMEASURE))
+                .code(Code.of(SAMPLE_UNIT))
+                .build()
+                .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueNumber().intValue(), 1);
+        assertEquals(params.get(0).getValueSystem(), UNITSOFMEASURE);
+        assertEquals(params.get(0).getValueCode(), SAMPLE_UNIT);
+    }
+    
+    @Test
+    public void testHumanName() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(stringSearchParam);
+        HumanName.builder()
+                 .family(string("Simpson"))  //0
+                 .given(string("Nick"))      //1
+                 .prefix(string("Dr."))      //2
+                 .suffix(string("III"))      //3
+                 .text(string("Dr. Nick"))   //4
+                 .build()
+                 .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 5, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), "Simpson");
+        assertEquals(params.get(1).getValueString(), "Nick");
+        assertEquals(params.get(2).getValueString(), "Dr.");
+        assertEquals(params.get(3).getValueString(), "III");
+        assertEquals(params.get(4).getValueString(), "Dr. Nick");
+    }
+    
+    @Test
+    public void testIdentifier() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(tokenSearchParam);
+        Identifier.builder()
+                  .system(Uri.of(SAMPLE_URI))
+                  .value(string("abc123"))
+                  .build()
+                  .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueSystem(), SAMPLE_URI);
+        assertEquals(params.get(0).getValueCode(), "abc123");
+    }
+    
+    @Test
+    public void testMoney() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(quantitySearchParam);
+        Money.builder()
+             .currency(Code.of("USD"))
+             .value(Decimal.of(100))
+             .build()
+             .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueCode(), "USD");
+        assertEquals(params.get(0).getValueNumber().intValue(), 100);
+    }
+    
+    @Test
+    public void testPeriod() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
+        Period.builder()
+              .start(DateTime.of(SAMPLE_DATE_START))
+              .end(DateTime.of(SAMPLE_DATE_END))
+              .build()
+              .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(timestampToString(params.get(0).getValueDateStart()), SAMPLE_DATE_START);
+        assertEquals(timestampToString(params.get(0).getValueDateEnd()), SAMPLE_DATE_END);
+    }
+    
+    @Test
+    public void testQuantity() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(quantitySearchParam);
+        Quantity.builder()
+                .value(Decimal.of(1))
+                .system(Uri.of(UNITSOFMEASURE))
+                .code(Code.of(SAMPLE_UNIT))
+                .build()
+                .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueNumber().intValue(), 1);
+        assertEquals(params.get(0).getValueSystem(), UNITSOFMEASURE);
+        assertEquals(params.get(0).getValueCode(), SAMPLE_UNIT);
+    }
+    
+    @Test
     public void testRange() throws FHIRPersistenceProcessorException {
-        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor("value");
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(quantitySearchParam);
         Range range = Range.builder()
                            .high(SimpleQuantity.builder()
-                                              .code(Code.of("s"))
-                                              .system(Uri.of("http://unitsofmeasure.org"))
+                                              .code(Code.of(SAMPLE_UNIT))
+                                              .system(Uri.of(UNITSOFMEASURE))
                                               .unit(string("seconds"))
                                               .value(Decimal.of(1))
                                               .build())
                            .build();
         range.accept(parameterBuilder);
         List<Parameter> params = parameterBuilder.getResult();
-        for (Parameter param : params) {
-            assertNull(param.getValueNumberLow());
-            assertNull(param.getValueNumber());
-            assertEquals(param.getValueNumberHigh(), BigDecimal.valueOf(1));
-        }
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertNull(params.get(0).getValueNumberLow());
+        assertNull(params.get(0).getValueNumber());
+        assertEquals(params.get(0).getValueNumberHigh(), BigDecimal.valueOf(1));
     }
+    
+    @Test
+    public void testReference() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(referenceSearchParam);
+        Reference.builder()
+                 .reference(string(SAMPLE_REF))
+                 .build()
+                 .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(params.get(0).getValueString(), SAMPLE_REF);
+    }
+    
+    @Test
+    public void testTimingBounds() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
+        Period period = Period.builder()
+                              .start(DateTime.of(SAMPLE_DATE_START))
+                              .end(DateTime.of(SAMPLE_DATE_END))
+                              .build();
+        Timing.builder()
+              .repeat(Timing.Repeat.builder().bounds(period).build())
+              .build()
+              .accept(parameterBuilder);
+        List<Parameter> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        Parameter param = params.get(0);
+        assertEquals(timestampToString(param.getValueDateStart()), SAMPLE_DATE_START);
+        assertEquals(timestampToString(param.getValueDateEnd()), SAMPLE_DATE_END);
+    }
+    
+    // Timing doesn't currently extract from "events"
+//    @Test
+//    public void testTimingEvents() throws FHIRPersistenceProcessorException {
+//        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(dateSearchParam);
+//        Timing.builder()
+//              .event(DateTime.of(SAMPLE_DATE_START))
+//              .event(DateTime.of(SAMPLE_DATE_END))
+//              .build()
+//              .accept(parameterBuilder);
+//        List<Parameter> params = parameterBuilder.getResult();
+//        assertEquals(params.size(), 1, "Number of extracted parameters");
+//        Parameter param = params.get(0);
+//        assertEquals(timestampToString(param.getValueDateStart()), SAMPLE_DATE_START);
+//        assertEquals(timestampToString(param.getValueDateEnd()), SAMPLE_DATE_END);
+//    }
     
     /**
      * Formats the given tstamp value as a string. Does not use Timestamp#toString()
@@ -89,7 +472,6 @@ public class ParameterExtractionTest {
     private String timestampToString(java.sql.Timestamp tstamp) {
         // do not use Timestamp#toString() because it converts to local timezone.
         // We need it rendered in UTC
-        return tstamp.toInstant().atZone(ZoneOffset.UTC).format(DATE_TIME_FORMATTER);
+        return tstamp.toInstant().atZone(ZoneOffset.UTC).format(TIMESTAMP_FORMATTER);
     }
-
 }


### PR DESCRIPTION
string, uri, and canonical types can be extracted as multiple different
search parameter types

to address issue #348, we need to store the value in the valueCode when
a string data type is extracted for a search parameter of type token

while there, I flushed out ParameterExtractionTest to cover all valid
combinations of data type + search parameter type (but just one test per
combo)


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>