### PR TITLE
issue #355 - assert baseType is not null before recursing

### DIFF
--- a/fhir-examples/pom.xml
+++ b/fhir-examples/pom.xml
@@ -223,16 +223,6 @@
                 </repository>
             </distributionManagement>
         </profile>
-        
-        <profile>
-            <id>switch-jdk-11</id>
-            <!-- preference is towards 11, when 11-->
-            <activation>
-                <jdk>!1.8</jdk>
-            </activation>
-            <properties>
-                <java.version>11</java.version>
-            </properties>
-        </profile>
+
     </profiles>
 </project>

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathType.java
@@ -80,6 +80,9 @@ import com.ibm.fhir.model.type.Xhtml;
 import com.ibm.fhir.model.util.ModelSupport;
 
 public enum FHIRPathType {
+    // FHIR "special" base type returned from resolve() and assignable from any resource type
+    FHIR_UNKNOWN_RESOURCE_TYPE("FHIR", null),
+    
     // FHIR base types
     FHIR_ANY("FHIR", "Any"),
     FHIR_RESOURCE("FHIR", "Resource", FHIR_ANY, Resource.class),
@@ -372,6 +375,10 @@ public enum FHIRPathType {
     public boolean isAssignableFrom(FHIRPathType type) {
         if (type == null) {
             // every type is assignable from null
+            return true;
+        }
+        if (type == FHIR_UNKNOWN_RESOURCE_TYPE && "FHIR".equals(this.namespace)) {
+            // every resource type is assignable from FHIR_UNKNOWN_RESOURCE_TYPE
             return true;
         }
         if (this == type) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathType.java
@@ -386,7 +386,7 @@ public enum FHIRPathType {
             // FHIR.Any is assignable from any FHIR type
             return true;
         }
-        return isAssignableFrom(type.baseType);
+        return (type.baseType != null && isAssignableFrom(type.baseType));
     }
     
     public static FHIRPathType from(java.lang.String name) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
@@ -184,15 +184,16 @@ public class FHIRPathEvaluator {
             ExpressionContext typeName = arguments.get(0);
             String identifier = typeName.getText();
             FHIRPathType type = FHIRPathType.from(identifier);
-            if (type != null) {
-                for (FHIRPathNode node : getCurrentContext()) {
-                    FHIRPathType nodeType = node.type();
-                    if (SYSTEM_NAMESPACE.equals(type.namespace()) && node.hasValue()) {
-                        nodeType = node.getValue().type();
-                    }
-                    if (type.isAssignableFrom(nodeType)) {
-                        result.add(node);
-                    }
+            if (type == null) {
+                throw new IllegalArgumentException(String.format("Argument '%s' cannot be resolved to a valid type identifier", identifier));
+            }
+            for (FHIRPathNode node : getCurrentContext()) {
+                FHIRPathType nodeType = node.type();
+                if (SYSTEM_NAMESPACE.equals(type.namespace()) && node.hasValue()) {
+                    nodeType = node.getValue().type();
+                }
+                if (type.isAssignableFrom(nodeType)) {
+                    result.add(node);
                 }
             }
             return result;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/function/ResolveFunction.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/function/ResolveFunction.java
@@ -52,9 +52,8 @@ public class ResolveFunction extends FHIRPathAbstractFunction {
      * 
      * <pre>Observation.subject.where(resolve() is Patient)</pre>
      * 
-     * <p>If the resource type cannot be inferred from the reference URL or type, then {@code FHIR_ANY} is used.
-     * 
-     * <p>Type checking on {@code FHIR_ANY} will always return 'true'.
+     * <p>If the resource type cannot be inferred from the reference URL or type, then {@code FHIR_UNKNOWN_RESOURCE_TYPE} is used.
+     * So that we index unresolveable references, {@code FHIR_UNKNOWN_RESOURCE_TYPE is X} will resolve to true for all resource types X.
      * 
      * @param evaluationContext
      *     the evaluation environment
@@ -99,7 +98,7 @@ public class ResolveFunction extends FHIRPathAbstractFunction {
                     resourceType = referenceType;
                 }
                 
-                FHIRPathType type = isResourceType(resourceType) ? FHIRPathType.from(resourceType) : FHIRPathType.FHIR_ANY;
+                FHIRPathType type = isResourceType(resourceType) ? FHIRPathType.from(resourceType) : FHIRPathType.FHIR_UNKNOWN_RESOURCE_TYPE;
                                 
                 result.add(FHIRPathResourceNode.resourceNode(type));
             }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/path/test/AsFunctionTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/path/test/AsFunctionTest.java
@@ -34,6 +34,18 @@ public class AsFunctionTest {
     }
     
     @Test
+    void testResolveAsOperation() throws Exception {
+        Patient patient = Patient.builder()
+                .generalPractitioner(Reference.builder().reference(string("http://example.com/dummyReference")).build())
+                .build();
+
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate(patient, "Patient.generalPractitioner.resolve() as Basic");
+
+        assertEquals(result.size(), 1, "Number of selected nodes");
+    }
+
+    @Test
     void testAsFunction() throws Exception {
         Condition condition = Condition.builder()
                                        .subject(Reference.builder().display(string("dummy reference")).build())

--- a/fhir-model/src/test/java/com/ibm/fhir/model/path/test/AsFunctionTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/path/test/AsFunctionTest.java
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.model.path.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collection;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.path.FHIRPathNode;
+import com.ibm.fhir.model.path.evaluator.FHIRPathEvaluator;
+import com.ibm.fhir.model.resource.Condition;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.type.Boolean;
+import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.Reference;
+
+public class AsFunctionTest {
+    @Test
+    void testAsOperation() throws Exception {
+        Patient patient = Patient.builder()
+                                 .deceased(Boolean.TRUE)
+                                 .build();
+
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate(patient, "Patient.deceased as dateTime");
+
+        assertEquals(result.size(), 0, "Number of selected nodes");
+    }
+    
+    @Test
+    void testAsFunction() throws Exception {
+        Condition condition = Condition.builder()
+                                       .subject(Reference.builder().display(string("dummy reference")).build())
+                                       .onset(DateTime.now())
+                                       .build();
+
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate(condition, "Condition.onset.as(Age) | Condition.onset.as(Range)");
+
+        assertEquals(result.size(), 0, "Number of selected nodes");
+    }
+}

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1041,8 +1041,12 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                         }
                     } catch (IllegalArgumentException e) {
                         // log and continue with the other parameters
-                        log.log(Level.INFO, "Skipping search parameter '" + code + "' "
-                                + " with id '" + sp.getId() + "' for resource type " + fhirResource.getClass().getSimpleName(), e);
+                        StringBuilder msg = new StringBuilder("Skipping search parameter '" + code + "'");
+                        if (sp.getId() != null) {
+                            msg.append(" with id '" + sp.getId().getValue() + "'");
+                        }
+                        msg.append("' for resource type " + fhirResource.getClass().getSimpleName());
+                        log.log(Level.INFO, msg.toString(), e);
                         // TODO: add an issue to the OperationOutcome in the return object
                     }
                 }


### PR DESCRIPTION
In the currently implementation, FHIRPathType.isAssignableFrom will
always return true.

For example, if we check is FHIR_DATE_TIME assignable from FHIR_BOOLEAN,
it will recurse until finally we had a baseType of null:
* is FHIR_DATE_TIME assignable from FHIR_ELEMENT
* is FHIR_DATE_TIME assignable from FHIR_ANY
* is FHIR_DATE_TIME assignable from null

And, since everything is assignable from null, it will always be true.

This PR changes that by returning false when we get to baseType == null.

Additionally:
* removal of jdk11 profile for fhir-examples (to match earlier change with rest of project)
* a logging improvement in FHIRPersistenceJDBCImpl.extractSearchParameters and
* a stricter implementation of `as` wrt error conditions.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>