### PR TITLE
issue #370 - have `is` return false on empty input collection

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
@@ -250,7 +250,7 @@ public class FHIRPathEvaluator {
             Collection<FHIRPathNode> currentContext = getCurrentContext();
             if (currentContext.isEmpty()) {
                 // early exit
-                return empty();
+                return SINGLETON_FALSE;
             } else if (currentContext.size() > 1) {
                 throw new IllegalArgumentException(String.format("Input collection has %d items, but only 1 is allowed", currentContext.size()));
             }
@@ -882,11 +882,7 @@ public class FHIRPathEvaluator {
             indentLevel++;
             
             Collection<FHIRPathNode> nodes = visit(ctx.expression());
-            if (nodes.isEmpty()) {
-                // early exit
-                indentLevel--;
-                return empty();
-            }
+            
             String operator = ctx.getChild(1).getText();
             
             Collection<FHIRPathNode> result = "is".equals(operator) ? SINGLETON_FALSE : new ArrayList<>();
@@ -901,10 +897,11 @@ public class FHIRPathEvaluator {
             case "is":
                 if (!isSingleton(nodes)) {
                     throw new IllegalArgumentException(String.format("Input collection has %d items, but only 1 is allowed", nodes.size()));
-                }
-                FHIRPathNode node = getSingleton(nodes);
-                if (type.isAssignableFrom(node.type())) {
-                    result = SINGLETON_TRUE;
+                } else if (!nodes.isEmpty()) {
+                    FHIRPathNode node = getSingleton(nodes);
+                    if (type.isAssignableFrom(node.type())) {
+                        result = SINGLETON_TRUE;
+                    }
                 }
                 break;
             case "as":


### PR DESCRIPTION
This interpretation was preferred because it allows us to write
constraints like `Observation.subject.resolve().is(Patient)` and always
get a true/false result.

This differs from the implied language in the FHIRPath spec, but matches
both our previous implementation as well as Graham's implementation.

I opened https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=25189 to track this discrepency.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>