### PR TITLE
Patch for 395

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build samples
       run: mvn -B install --file fhir-examples/pom.xml --no-transfer-progress
     - name: Build parent with tests
-      run: mvn -B -T2C package --file fhir-parent/pom.xml --no-transfer-progress
+      run: mvn -B -T2C package --file fhir-parent/pom.xml -P jdbc-all-tests --no-transfer-progress
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/fhir-model/pom.xml
+++ b/fhir-model/pom.xml
@@ -77,6 +77,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>${fhir-model.testType}</com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -685,7 +685,7 @@
             <id>jdbc-all-tests</id>
             <properties>
                 <!-- for the fhir-persistence-jdbc -->
-                <com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>ALL</com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>
+                <com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>ALL</com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>
             </properties>
         </profile>
         <profile>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -22,6 +22,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <my.maven.war.plugin>3.2.3</my.maven.war.plugin>
         <my.maven.jar.plugin>3.1.2</my.maven.jar.plugin>
+        <fhir-model.testType>MINIMAL</fhir-model.testType>
+        <fhir-persistence-jdbc.testType>MINIMAL</fhir-persistence-jdbc.testType>
         <java.version>1.8</java.version>
     </properties>
 
@@ -678,14 +680,14 @@
             <id>model-all-tests</id>
             <properties>
                 <!-- for the fhir-model project -->
-                <com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>ALL</com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType>
+                <fhir-model.testType>ALL</fhir-model.testType>
             </properties>
         </profile>
         <profile>
             <id>jdbc-all-tests</id>
             <properties>
                 <!-- for the fhir-persistence-jdbc -->
-                <com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>ALL</com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>
+                <fhir-persistence-jdbc.testType>ALL</fhir-persistence-jdbc.testType>
             </properties>
         </profile>
         <profile>
@@ -757,9 +759,8 @@
         </profile>
         <profile>
             <id>deploy-version-rc</id>
-            <!-- This profile enables automation to change version and DEPLOY 
-                rc to bintray. There are one input values. mvn clean -Drc=1 -Pdeploy-version-rc 
-                -f fhir-tools/pom.xml -->
+            <!-- This profile enables automation to change version and DEPLOY rc to bintray: 
+                mvn clean -Drc=1 -Pdeploy-version-rc -f fhir-tools/pom.xml -->
             <properties>
                 <!-- the version to be set -->
                 <rc>1</rc>

--- a/fhir-persistence-jdbc/pom.xml
+++ b/fhir-persistence-jdbc/pom.xml
@@ -131,6 +131,14 @@
                     </filesets>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>${fhir-persistence-jdbc.testType}</com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -104,136 +104,155 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
 
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Boolean _boolean) {
-        Parameter p = new Parameter();
-        if (!TOKEN.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, _boolean);
+        if (_boolean.hasValue()) {
+            Parameter p = new Parameter();
+            if (!TOKEN.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, _boolean);
+            }
+            p.setName(searchParamCode);
+            p.setValueSystem("http://terminology.hl7.org/CodeSystem/special-values");
+            if (_boolean.getValue()) {
+                p.setValueCode("true");
+            } else {
+                p.setValueCode("false");
+            }
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        p.setValueSystem("http://terminology.hl7.org/CodeSystem/special-values");
-        if (_boolean.getValue() != null && _boolean.getValue()) {
-            p.setValueCode("true");
-        } else {
-            p.setValueCode("false");
-        }
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Canonical canonical) {
-        Parameter p = new Parameter();
-        if (!REFERENCE.equals(searchParamType) && !URI.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, canonical);
+        if (canonical.hasValue()) {
+            Parameter p = new Parameter();
+            if (!REFERENCE.equals(searchParamType) && !URI.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, canonical);
+            }
+            p.setName(searchParamCode);
+            p.setValueString(canonical.getValue());
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        p.setValueString(canonical.getValue());
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Code code) {
-        Parameter p = new Parameter();
-        if (!TOKEN.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, code);
+        if (code.hasValue()) {
+            Parameter p = new Parameter();
+            if (!TOKEN.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, code);
+            }
+            p.setName(searchParamCode);
+            // TODO: get the implicit code system
+            p.setValueCode(code.getValue());
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        // TODO: get the implicit code system
-        p.setValueCode(code.getValue());
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Date date) {
-        Parameter p = new Parameter();
-        if (!DATE.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, date);
+        if (date.hasValue()) {
+            Parameter p = new Parameter();
+            if (!DATE.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, date);
+            }
+            p.setName(searchParamCode);
+            setDateValues(p, date);
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        setDateValues(p, date);
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.DateTime dateTime) {
-        Parameter p = new Parameter();
-        if (!DATE.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, dateTime);
+        if (dateTime.hasValue()) {
+            Parameter p = new Parameter();
+            if (!DATE.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, dateTime);
+            }
+            p.setName(searchParamCode);
+            setDateValues(p, dateTime);
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        setDateValues(p, dateTime);
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Decimal decimal) {
-        Parameter p = new Parameter();
-        if (!NUMBER.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, decimal);
+        if (decimal.hasValue()) {
+            Parameter p = new Parameter();
+            if (!NUMBER.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, decimal);
+            }
+            p.setName(searchParamCode);
+            p.setValueNumber(decimal.getValue());
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        p.setValueNumber(decimal.getValue());
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Id id) {
-        Parameter p = new Parameter();
-        if (!TOKEN.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, id);
+        if (id.hasValue()) {
+            Parameter p = new Parameter();
+            if (!TOKEN.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, id);
+            }
+            p.setName(searchParamCode);
+            p.setValueCode(id.getValue());
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        p.setValueCode(id.getValue());
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Instant instant) {
-        if (instant == null || instant.getValue() == null) {
-            return false;
+        if (instant.hasValue()) {
+            Parameter p = new Parameter();
+            if (!DATE.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, instant);
+            }
+            p.setName(searchParamCode);
+            p.setValueDate(Timestamp.from(instant.getValue().toInstant()));
+            result.add(p);
         }
-        Parameter p = new Parameter();
-        if (!DATE.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, instant);
-        }
-        p.setName(searchParamCode);
-        p.setValueDate(Timestamp.from(instant.getValue().toInstant()));
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, com.ibm.fhir.model.type.Integer integer) {
-        Parameter p = new Parameter();
-        if (!NUMBER.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, integer);
+        if (integer.hasValue()) {
+            Parameter p = new Parameter();
+            if (!NUMBER.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, integer);
+            }
+            p.setName(searchParamCode);
+            // TODO: consider moving integer values to separate column so they can be searched different from decimals
+            p.setValueNumber(new BigDecimal(integer.getValue()));
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        // TODO: consider moving integer values to separate column so they can be searched different from decimals
-        p.setValueNumber(new BigDecimal(integer.getValue()));
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(String elementName, int elementIndex, com.ibm.fhir.model.type.String value) {
-        Parameter p = new Parameter();
-        if (STRING.equals(searchParamType)) {
-            p.setValueString(value.getValue());
-        } else if (TOKEN.equals(searchParamType)) {
-            p.setValueCode(value.getValue());
-        } else {
-            throw invalidComboException(searchParamType, value);
+        if (value.hasValue()) {
+            Parameter p = new Parameter();
+            if (STRING.equals(searchParamType)) {
+                p.setValueString(value.getValue());
+            } else if (TOKEN.equals(searchParamType)) {
+                p.setValueCode(value.getValue());
+            } else {
+                throw invalidComboException(searchParamType, value);
+            }
+            p.setName(searchParamCode);
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(String elementName, int elementIndex, Uri uri) {
-        Parameter p = new Parameter();
-        if (!URI.equals(searchParamType) && !REFERENCE.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, uri);
+        if (uri.hasValue()) {
+            Parameter p = new Parameter();
+            if (!URI.equals(searchParamType) && !REFERENCE.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, uri);
+            }
+            p.setName(searchParamCode);
+            p.setValueString(uri.getValue());
+            result.add(p);
         }
-        p.setName(searchParamCode);
-        p.setValueString(uri.getValue());
-        result.add(p);
         return false;
     }
 
@@ -303,26 +322,26 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, Coding coding) {
-        Parameter p = new Parameter();
-        if (!TOKEN.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, coding);
-        }
-        p.setName(searchParamCode);
-        if (coding.getSystem() != null) {
-            p.setValueSystem(coding.getSystem().getValue());
-        }
-        if (coding.getCode() != null) {
+        if (coding.getCode() != null && coding.getCode().hasValue()) {
+            Parameter p = new Parameter();
+            if (!TOKEN.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, coding);
+            }
+            p.setName(searchParamCode);
             p.setValueCode(coding.getCode().getValue());
+            if (coding.getSystem() != null) {
+                p.setValueSystem(coding.getSystem().getValue());
+            }
+            result.add(p);
         }
-        result.add(p);
         return false;
     }
     @Override
     public boolean visit(java.lang.String elementName, int elementIndex, ContactPoint contactPoint) {
-        if (!TOKEN.equals(searchParamType)) {
-            throw invalidComboException(searchParamType, contactPoint);
-        }
         if (contactPoint.getValue() != null) {
+            if (!TOKEN.equals(searchParamType)) {
+                throw invalidComboException(searchParamType, contactPoint);
+            }
             Parameter telecom = new Parameter();
             telecom.setName(searchParamCode);
             telecom.setValueCode(contactPoint.getValue().getValue());
@@ -548,39 +567,40 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
      *
      * @param p
      * @param dateTime
+     * @throws NullPointerException if p or dateTime are null
      */
     private void setDateValues(Parameter p, DateTime dateTime) {
-
-        if (!dateTime.isPartial()) {
-            // fully specified time including zone, so we can interpret as an instant
-            p.setValueDate(java.sql.Timestamp.from(java.time.Instant.from(dateTime.getValue())));
-        } else {
+        if (dateTime.isPartial()) {
             java.time.Instant start = QueryBuilderUtil.getStart(dateTime);
             java.time.Instant end = QueryBuilderUtil.getEnd(dateTime);
             setDateValues(p, start, end);
+        } else {
+            // fully specified time including zone, so we can interpret as an instant
+            p.setValueDate(java.sql.Timestamp.from(java.time.Instant.from(dateTime.getValue())));
         }
     }
 
     /**
-     * Set the date values on the {@link Parameter}, adjusting the end time slightly to make it exclusive (which is a TODO to fix).
+     * Set the date values on the {@link Parameter}, adjusting the end time slightly to make it inclusive (which is a TODO to fix).
      *
      * @param p
      * @param start
      * @param end
      */
     private void setDateValues(Parameter p, java.time.Instant start, java.time.Instant end) {
-        if (start == null) {
-            return;
+        if (start != null) {
+            Timestamp startTime = Timestamp.from(start);
+            p.setValueDateStart(startTime);
+            p.setValueDate(startTime);
+            p.setTimeType(TimeType.UNKNOWN);
         }
-        Timestamp startTime = Timestamp.from(start);
-        p.setValueDateStart(startTime);
-        p.setValueDate(startTime);
-        p.setTimeType(TimeType.UNKNOWN);
 
-        Timestamp implicitEndExclusive = Timestamp.from(end);
-        // TODO: Is it possible to avoid this by using <= or BETWEEN instead of < when constructing the query?
-        Timestamp implicitEndInclusive = convertToInclusiveEnd(implicitEndExclusive);
-        p.setValueDateEnd(implicitEndInclusive);
+        if (end != null) {
+            Timestamp implicitEndExclusive = Timestamp.from(end);
+            // TODO: Is it possible to avoid this by using <= or BETWEEN instead of < when constructing the query?
+            Timestamp implicitEndInclusive = convertToInclusiveEnd(implicitEndExclusive);
+            p.setValueDateEnd(implicitEndInclusive);
+        }
     }
 
     /**

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
@@ -51,7 +51,7 @@ public class R4JDBCExamplesTest extends AbstractPersistenceTest {
 
         // Overriding the JDBC ALL to Minimal.
         // Unless the profile tells us differently
-        String testType = System.getProperty("com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest", TestType.MINIMAL.toString());
+        String testType = System.getProperty("com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType", TestType.MINIMAL.toString());
         System.setProperty("com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType", testType);
 
         // The driver will iterate over all the JSON examples in the R4 specification, parse

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ExtractorValidator.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ExtractorValidator.java
@@ -31,20 +31,13 @@ import com.ibm.fhir.model.path.FHIRPathStringValue;
 import com.ibm.fhir.model.resource.SearchParameter;
 
 /**
- * 
- * @author pbastide
- *
+ * Helper class for validating that a given FHIRPath SearchParameter expression extracts nodes as expected.
  */
 public class ExtractorValidator {
 
     private Map<String, List<String>> expected = new HashMap<>();
     boolean strict = false;
 
-    /**
-     * 
-     * @param name
-     * @param values
-     */
     public void addExpected(String name, List<String> values) {
         expected.put(name, values);
     }
@@ -57,7 +50,6 @@ public class ExtractorValidator {
 
         printOutput(output);
 
-        //
         for (Entry<SearchParameter, List<FHIRPathNode>> entry : output.entrySet()) {
             String code = entry.getKey().getCode().getValue();
 
@@ -85,8 +77,6 @@ public class ExtractorValidator {
                         if (expectedValues == null) {
                             expectedValues = Collections.emptyList();
                         }
-
-                        // expectedValues.remove(tmp);
                     }
                 }
 
@@ -95,7 +85,6 @@ public class ExtractorValidator {
                 }
                 assertEquals(expectedValues.size(), 0);
             }
-
         }
 
         // Dummy Assertion in case of empty expected
@@ -114,24 +103,20 @@ public class ExtractorValidator {
 
                 String outputStr = i++ + "|" + name + "|=[";
                 StringJoiner joiner = new StringJoiner(",");
-                
+
                 for (FHIRPathNode node : entry.getValue()) {
                     joiner.add(processOutput(node));
                 }
                 outputStr += joiner.toString() + "]";
                 System.out.println(outputStr);
-
             }
         }
-
     }
 
     /**
-     * 
-     * @param node
-     * @return
+     * Process the FHIRPathNode into a String value
      */
-    public static String processOutput(FHIRPathNode node) {
+    private static String processOutput(FHIRPathNode node) {
         
         String val = "";
         if (node.getClass().getSimpleName().contains("FHIRPathBooleanValue")) {
@@ -145,15 +130,14 @@ public class ExtractorValidator {
         } else if (node.isPrimitiveValue()) {
             FHIRPathPrimitiveValue nodeConverted = node.asPrimitiveValue();
             if (nodeConverted.isDateTimeValue()) {
-                // FHIRPathDateTimeValue v = (FHIRPathDateTimeValue) node;
-
+                FHIRPathDateTimeValue v = (FHIRPathDateTimeValue) node;
+                val = "" + v.toString();
             } else if (nodeConverted.isStringValue()) {
                 FHIRPathStringValue v = nodeConverted.asStringValue();
                 val = "" + v.string();
             }
 
         } else if (node.is(FHIRPathElementNode.class)) {
-            //
             FHIRPathElementNode tNode = node.asElementNode();
 
             FHIRPathPrimitiveValue v = tNode.getValue();
@@ -165,9 +149,7 @@ public class ExtractorValidator {
                 } else if (v.isDateTimeValue()) {
                     FHIRPathDateTimeValue vv = v.asDateTimeValue();
                     TemporalAccessor acc = vv.dateTime();
-
                     val = "" + acc.toString(); //DATE_TIME_FORMATTER.format(acc);
-                    System.out.println("Value DateTime: [" + val + "]");
                 }
             } else {
                 Collection<FHIRPathNode> children = tNode.children();
@@ -183,9 +165,7 @@ public class ExtractorValidator {
                             val = "" + sv.string() + ",";
                         }
                     }
-
                 }
-
             }
 
         } else {
@@ -198,19 +178,20 @@ public class ExtractorValidator {
     public static ExtractorValidator.Builder builder() {
         return new ExtractorValidator.Builder();
     }
-    
+
+    public void setStrict(boolean strict) {
+        this.strict = strict;
+    }
+
     /**
-     * Builder
-     * 
-     * @author pbastide
-     *
+     * For building ExtractorValidators
      */
     public static class Builder {
 
-        private ExtractorValidator validator = new ExtractorValidator();
+        private final ExtractorValidator validator;
 
         public Builder() {
-
+            validator = new ExtractorValidator();
         }
 
         public Builder add(String name, List<String> values) {
@@ -231,11 +212,5 @@ public class ExtractorValidator {
         public ExtractorValidator build() {
             return validator;
         }
-
     }
-
-    public void setStrict(boolean strict) {
-        this.strict = strict;
-    }
-
 }


### PR DESCRIPTION
### commit 1
    issue #395 - add guards for missing values

    privitive elements with no values (only extensions) are not common, but
    they are allowed and we shouldn't fail on them
    
    also note: i updated the `Coding` (and `CodeableConcept`) extraction so
    that a Coding won't get indexed unless it has a code value.
    
    also updated parent-pom jdbc-all-tests profile to enable setting of
    JDBC testType independent of the model testType

### commit 2
    I found that the existing profiles (`model-all-tests` and
    `jdbc-all-tests`) didn't actual set any system properties at runtime. I
    fixed this by
    1. introducing `fhir-model.testType` and
    `fhir-persistence-jdbc.testType` parameters with a default value of
    MINIMAL
    2. updating the profile definitions to set these properties when
    activated
    3. updating surefire-plugin config in `fhir-model/pom.xml` and
    `fhir-persistence-jdbc/pom.xml` to use these properties to set the
    `com.ibm.fhir.model.spec.test.R4ExamplesDriver.testType` and
    `com.ibm.fhir.persistence.jdbc.test.spec.R4JDBCExamplesTest.testType`
    system properties respectively.
    
    Also, minor cleanup in ExtractorValidator.