### PR TITLE
issue-370 - fixup 1c6498f1b41b9f790ef8673dc45e2048dd447cce

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
@@ -904,14 +904,14 @@ public class FHIRPathEvaluator {
 
             switch (operator) {
             case "is":
-                if (!isSingleton(nodes)) {
+                if (nodes.size() > 1) {
                     throw new IllegalArgumentException(String.format("Input collection has %d items, but only 1 is allowed", nodes.size()));
                 } else if (!nodes.isEmpty()) {
                     FHIRPathNode node = getSingleton(nodes);
                     if (type.isAssignableFrom(node.type())) {
                         result = SINGLETON_TRUE;
                     }
-                }
+                } // else it stays SINGLETON_FALSE
                 break;
             case "as":
                 for (FHIRPathNode fhirPathNode : nodes) {


### PR DESCRIPTION
In pull request https://github.com/IBM/FHIR/pull/376 I missed that `!isSingleton(nodes)` would be true for empty collections and so I didn't get the intended behavior.
Now `is` will evaluate to SINGLETON_FALSE for in both the operation and function contexts.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>