### PR TITLE
fix logging for SearchUtil extractParametersValues #255

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -480,7 +480,12 @@ public class SearchUtil {
             // Outputs the Expression and the Name of the SearchParameter
             if (log.isLoggable(Level.FINEST)) {
                 // This used to "name" but now correctly uses "code"
-                log.finest(String.format(EXTRACT_PARAMETERS_LOGGING, parameter.getCode().getValue(), expression.getValue()));
+                String loggedValue = "EMPTY";
+                if(expression != null) {
+                    loggedValue = expression.getValue();
+                }
+                
+                log.finest(String.format(EXTRACT_PARAMETERS_LOGGING, parameter.getCode().getValue(), loggedValue));
             }
 
             // Process the Expression


### PR DESCRIPTION
- When the DomainResource is returned, without an expression, the
logging fails.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>