### PR TITLE
WIP: Issue 255

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyTranslator.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyTranslator.java
@@ -139,10 +139,10 @@ public class DerbyTranslator implements IDatabaseTranslator {
     public String getUrl(Properties connectionProperties) {
         DerbyPropertyAdapter adapter = new DerbyPropertyAdapter(connectionProperties);
         if (adapter.isMemory()) {
-            return "jdbc:derby:memory:" + adapter.getDatabase();
+            return "jdbc:derby:memory:" + adapter.getDatabase() + ";traceLevel=2";
         }
         else {
-            return "jdbc:derby:" + adapter.getDatabase();
+            return "jdbc:derby:" + adapter.getDatabase() + ";traceLevel=2;traceFile=trace.out;";
         }
     }
     

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
@@ -11,6 +11,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -178,6 +179,9 @@ public class FHIRDbDAOImpl implements FHIRDbDAO {
 
                 dbUrl = this.getDbProps().getProperty(PROPERTY_DB_URL);
                 try {
+                    this.getDbProps().put("traceLevel", "-1");
+                    //this.getDbProps().put("traceFile", "trace.log");
+                    
                     connection = DriverManager.getConnection(dbUrl, this.getDbProps());
 
                     // Most queries assume the current schema is set up properly
@@ -418,7 +422,15 @@ public class FHIRDbDAOImpl implements FHIRDbDAO {
             stmt = connection.prepareStatement(sql);
             // Inject arguments into the prepared stmt.
             for (int i = 0; i <searchArgs.length;  i++) {
-                stmt.setObject(i+1, searchArgs[i]);
+                Object o = searchArgs[i];
+                if(o instanceof Timestamp) {
+                    Timestamp timestamp = (Timestamp) o;
+                    stmt.setTimestamp(i+1, timestamp);
+                    System.out.println(timestamp);
+                } else {
+                    stmt.setObject(i+1, o);
+                }
+                
             }
             dbCallStartTime = System.nanoTime();
             resultSet = stmt.executeQuery();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
@@ -360,6 +360,7 @@ public class FHIRDbDAOImpl implements FHIRDbDAO {
         try {
             connection = this.getConnection();
             stmt = connection.prepareStatement(sql);
+            
             // Inject arguments into the prepared stmt.
             for (int i = 0; i <searchArgs.length;  i++) {
                 stmt.setObject(i+1, searchArgs[i]);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/FHIRDbDAOImpl.java
@@ -360,7 +360,6 @@ public class FHIRDbDAOImpl implements FHIRDbDAO {
         try {
             connection = this.getConnection();
             stmt = connection.prepareStatement(sql);
-            
             // Inject arguments into the prepared stmt.
             for (int i = 0; i <searchArgs.length;  i++) {
                 stmt.setObject(i+1, searchArgs[i]);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -274,6 +274,7 @@ public class ParameterVisitorBatchDAO implements IParameterVisitor, AutoCloseabl
                 dates.setTimestamp(2, date);
                 dates.setTimestamp(3, dateStart);
                 dates.setTimestamp(4, dateEnd);
+                System.out.println(date + " " + dateStart + " " + dateEnd);
                 dates.setLong(5, logicalResourceId);
                 dates.addBatch();
                 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -671,6 +671,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             }
 
             lastUpdated = resource.getLastUpdated();
+            System.out.println("LAST_UPDATED -> "+ lastUpdated);
             dbCallStartTime = System.nanoTime();
 
             final String sourceKey = UUID.randomUUID().toString();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -304,6 +304,7 @@ public class DerbyResourceDAO {
             stmt.setLong(2, v_logical_resource_id);
             stmt.setInt(3, v_insert_version);
             stmt.setBytes(4, p_payload);
+            System.out.println("Last Updated -> " + p_last_updated);
             stmt.setTimestamp(5, p_last_updated);
             stmt.setString(6, p_is_deleted ? "Y" : "N");
             stmt.executeUpdate();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
@@ -228,7 +228,6 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         queryString.append(")");
     }
 
-
     private void processIncludeParameters(StringBuilder queryString, List<Object> bindVariables) throws Exception {
         final String METHODNAME = "processIncludeParameters";
         log.entering(CLASSNAME, METHODNAME);
@@ -239,7 +238,9 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
             // SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID 
             queryString.append(QuerySegmentAggregator.SELECT_ROOT);
             // FROM Organization_RESOURCES R JOIN Organization_LOGICAL_RESOURCES LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID
-            queryString.append(MessageFormat.format(QuerySegmentAggregator.FROM_CLAUSE_ROOT, includeParm.getSearchParameterTargetType()));
+            String logicalResourceTable = includeParm.getSearchParameterTargetType() + "_LOGICAL_RESOURCES";
+            String resourceTable =  includeParm.getSearchParameterTargetType() + "_RESOURCES";
+            queryString.append(MessageFormat.format(QuerySegmentAggregator.FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable));
             // WHERE R.IS_DELETED <> 'Y' AND
             queryString.append(QuerySegmentAggregator.WHERE_CLAUSE_ROOT).append(" AND ");
             // R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID AND
@@ -265,7 +266,9 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
             // SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID 
             queryString.append(QuerySegmentAggregator.SELECT_ROOT);
             // FROM Observation_RESOURCES R JOIN Observation_LOGICAL_RESOURCES LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID
-            queryString.append(MessageFormat.format(QuerySegmentAggregator.FROM_CLAUSE_ROOT, includeParm.getJoinResourceType()));
+            String logicalResourceTable = includeParm.getJoinResourceType() + "_LOGICAL_RESOURCES";
+            String resourceTable =  includeParm.getJoinResourceType() + "_RESOURCES";
+            queryString.append(MessageFormat.format(QuerySegmentAggregator.FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable));
             // JOIN Observation_STR_VALUES P1 ON P1.RESOURCE_ID = R.RESOURCE_ID
             queryString.append(MessageFormat.format(REVINCLUDE_JOIN, includeParm.getJoinResourceType()));
             // WHERE R.IS_DELETED <> 'Y' AND

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -189,7 +189,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData, JDBCOpe
         boolean isValidQuery = true;
 
         helper = QuerySegmentAggregatorFactory.buildQuerySegmentAggregator(resourceType, offset, pageSize, this.parameterDao, this.resourceDao, searchContext);
-        
+
         // Special logic for handling LocationPosition queries. These queries have interdependencies between
         // a couple of related input query parameters
         if (Location.class.equals(resourceType)) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -189,7 +189,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData, JDBCOpe
         boolean isValidQuery = true;
 
         helper = QuerySegmentAggregatorFactory.buildQuerySegmentAggregator(resourceType, offset, pageSize, this.parameterDao, this.resourceDao, searchContext);
-
+        
         // Special logic for handling LocationPosition queries. These queries have interdependencies between
         // a couple of related input query parameters
         if (Location.class.equals(resourceType)) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -8,12 +8,9 @@ package com.ibm.fhir.persistence.jdbc.util;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -26,28 +23,21 @@ import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.parameters.Parameter;
 
 /**
- * This class assists the JDBCQueryBuilder. Its purpose is to aggregate SQL
- * query segments together to produce a well-formed FHIR Resource query or
- * FHIR Resource count query.
+ * This class assists the JDBCQueryBuilder. Its purpose is to aggregate SQL query segments together to produce a well-formed FHIR Resource query or 
+ * FHIR Resource count query. 
  */
 class QuerySegmentAggregator {
-
+    
     private static final String CLASSNAME = QuerySegmentAggregator.class.getName();
     private static final Logger log = java.util.logging.Logger.getLogger(CLASSNAME);
-
-    protected static final String SELECT_ROOT =
-            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
-    protected static final String SYSTEM_LEVEL_SELECT_ROOT =
-            "SELECT RESOURCE_ID, LOGICAL_RESOURCE_ID, VERSION_ID, LAST_UPDATED, IS_DELETED, DATA, LOGICAL_ID ";
+    
+    protected static final String SELECT_ROOT = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
+    protected static final String SYSTEM_LEVEL_SELECT_ROOT = "SELECT RESOURCE_ID, LOGICAL_RESOURCE_ID, VERSION_ID, LAST_UPDATED, IS_DELETED, DATA, LOGICAL_ID ";
     protected static final String SYSTEM_LEVEL_SUBSELECT_ROOT = SELECT_ROOT;
     private static final String SELECT_COUNT_ROOT = "SELECT COUNT(R.RESOURCE_ID) ";
     private static final String SYSTEM_LEVEL_SELECT_COUNT_ROOT = "SELECT COUNT(RESOURCE_ID) ";
     private static final String SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT = " SELECT R.RESOURCE_ID ";
-
-    // {0}_RESOURCES and {0}_LOGICAL_RESOURCES are replaced
-    // so derived tables can be used. 
-    protected static final String FROM_CLAUSE_ROOT =
-            "FROM {0} R JOIN {1} LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ";
+    protected static final String FROM_CLAUSE_ROOT = "FROM {0}_RESOURCES R JOIN {0}_LOGICAL_RESOURCES LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ";
     protected static final String WHERE_CLAUSE_ROOT = "WHERE R.IS_DELETED <> 'Y'";
     protected static final String PARAMETER_TABLE_ALIAS = "pX";
     private static final String FROM = " FROM ";
@@ -56,169 +46,143 @@ class QuerySegmentAggregator {
     private static final String AND = " AND ";
     protected static final String COMBINED_RESULTS = " COMBINED_RESULTS";
     private static final String DEFAULT_ORDERING = " ORDER BY R.RESOURCE_ID ASC ";
-
-    private static final Set<String> SKIP_WHERE = new HashSet<>(Arrays.asList("_id", "_lastUpdated"));
-
+        
     protected Class<?> resourceType;
 
     /**
      * querySegments and searchQueryParameters are used as parallel arrays
-     * and should be added to/removed together.
+     * and should be added to/removed together. 
      */
-    protected List<SqlQueryData> querySegments = new ArrayList<>();
-    protected List<Parameter> searchQueryParameters = new ArrayList<>();
-
-    protected Parameter queryParamId;
-    protected Parameter queryParamLastUpdated;
-
+    protected List<SqlQueryData> querySegments;
+    protected List<Parameter> searchQueryParameters;
+    
     private int offset;
     private int pageSize;
     protected ParameterDAO parameterDao;
     protected ResourceDAO resourceDao;
+    
 
     /**
      * Constructs a new QueryBuilderHelper
-     * 
      * @param resourceType - The type of FHIR Resource to be searched for.
-     * @param offset       - The beginning index of the first search result.
-     * @param pageSize     - The max number of requested search results.
+     * @param offset - The beginning index of the first search result.
+     * @param pageSize - The max number of requested search results.
      */
-    protected QuerySegmentAggregator(Class<?> resourceType, int offset, int pageSize,
-            ParameterDAO parameterDao, ResourceDAO resourceDao) {
+    protected QuerySegmentAggregator(Class<?> resourceType, int offset, int pageSize, 
+                                    ParameterDAO parameterDao, ResourceDAO resourceDao) {
         super();
-        this.resourceType          = resourceType;
-        this.offset                = offset;
-        this.pageSize              = pageSize;
-        this.parameterDao          = parameterDao;
-        this.resourceDao           = resourceDao;
-        this.querySegments         = new ArrayList<>();
+        this.resourceType = resourceType;
+        this.offset = offset;
+        this.pageSize = pageSize;
+        this.parameterDao = parameterDao;
+        this.resourceDao = resourceDao;
+        this.querySegments = new ArrayList<>();
         this.searchQueryParameters = new ArrayList<>();
-
+         
     }
-
+    
     /**
-     * Adds a query segment, which is a where clause segment corresponding to the
-     * passed query Parameter and its encapsulated search values.
-     * 
-     * @param querySegment A piece of a SQL WHERE clause
-     * @param queryParm    - The corresponding query parameter
+     * Adds a query segment, which is a where clause segment corresponding to the passed query Parameter and its encapsulated search values.
+     * @param querySegment A piece of a SQL WHERE clause 
+     * @param queryParm - The corresponding query parameter
      */
-    protected void addQueryData(SqlQueryData querySegment, Parameter queryParm) {
+    protected void addQueryData(SqlQueryData querySegment,Parameter queryParm) {
         final String METHODNAME = "addQueryData";
         log.entering(CLASSNAME, METHODNAME);
-
+        
         //parallel arrays
         this.querySegments.add(querySegment);
-
-        String name = queryParm.getName();
-        if ("_id".compareTo(name) == 0) {
-            queryParamId = queryParm;
-        } else if ("_lastUpdated".compareTo(name) == 0) {
-            queryParamLastUpdated = queryParm;
-        } else {
-            this.searchQueryParameters.add(queryParm);
-        }
-
+        this.searchQueryParameters.add(queryParm);
+        
         log.exiting(CLASSNAME, METHODNAME);
+         
     }
-
+    
     /**
-     * Builds a complete SQL Query based upon the encapsulated query segments and
-     * bind variables.
-     * 
-     * @return SqlQueryData - contains the complete SQL query string and any
-     *         associated bind variables.
-     * @throws Exception
+     * Builds a complete SQL Query based upon the encapsulated query segments and bind variables.
+     * @return SqlQueryData - contains the complete SQL query string and any associated bind variables.
+     * @throws Exception 
      */
     protected SqlQueryData buildQuery() throws Exception {
         final String METHODNAME = "buildQuery";
         log.entering(CLASSNAME, METHODNAME);
-
+        
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
-
+        
         if (this.isSystemLevelSearch()) {
             queryData = this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_ROOT, SYSTEM_LEVEL_SUBSELECT_ROOT, true);
-        } else {
+        }
+        else {
             queryString.append(SELECT_ROOT);
-
+                    
             queryString.append(this.buildFromClause());
-
+            
             queryString.append(this.buildWhereClause());
-
+            
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
             // Add default ordering
             queryString.append(DEFAULT_ORDERING);
-            this.addPaginationClauses(queryString);
+            this.addPaginationClauses(queryString);        
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
         }
-
+        
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
     }
-
+    
     /**
-     * Builds a complete SQL count query based upon the encapsulated query segments
-     * and bind variables.
-     * 
-     * @return SqlQueryData - contains the complete SQL count query string and any
-     *         associated bind variables.
-     * @throws Exception
+     *   Builds a complete SQL count query based upon the encapsulated query segments and bind variables.
+     * @return SqlQueryData - contains the complete SQL count query string and any associated bind variables.
+     * @throws Exception 
      */
     protected SqlQueryData buildCountQuery() throws Exception {
         final String METHODNAME = "buildCountQuery";
         log.entering(CLASSNAME, METHODNAME);
-
+        
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
-
+        
         if (this.isSystemLevelSearch()) {
-            queryData =
-                    this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_COUNT_ROOT, SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT,
-                            false);
-        } else {
+            queryData = this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_COUNT_ROOT, SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT, false);
+        }
+        else {
             queryString.append(SELECT_COUNT_ROOT);
-
+                    
             queryString.append(this.buildFromClause());
-
+            
             queryString.append(this.buildWhereClause());
-
+            
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
         }
-
+        
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
-
+        
     }
-
+    
     /**
-     * Build a system level query or count query, based upon the encapsulated query
-     * segments and bind variables and
+     * Build a system level query or count query, based upon the encapsulated query segments and bind variables and
      * the passed select-root strings.
-     * A FHIR system level query spans multiple resource types, and therefore spans
-     * multiple tables in the database.
-     * 
-     * @param selectRoot      - The text of the outer SELECT ('SELECT' to 'FROM')
-     * @param subSelectRoot   - The text of the inner SELECT root to use in each
-     *                        sub-select
-     * @param addFinalClauses - Indicates whether or not ordering and pagination
-     *                        clauses should be generated.
-     * @return SqlQueryData - contains the complete SQL query string and any
-     *         associated bind variables.
+     * A FHIR system level query spans multiple resource types, and therefore spans multiple tables in the database. 
+     * @param selectRoot - The text of the outer SELECT ('SELECT' to 'FROM')
+     * @param subSelectRoot - The text of the inner SELECT root to use in each sub-select
+     * @param addFinalClauses - Indicates whether or not ordering and pagination clauses should be generated.
+     * @return SqlQueryData - contains the complete SQL query string and any associated bind variables.
      * @throws Exception
      */
-    protected SqlQueryData buildSystemLevelQuery(String selectRoot, String subSelectRoot, boolean addFinalClauses)
-            throws Exception {
+    protected SqlQueryData buildSystemLevelQuery(String selectRoot, String subSelectRoot, boolean addFinalClauses) 
+                                                    throws Exception {
         final String METHODNAME = "buildSystemLevelQuery";
         log.entering(CLASSNAME, METHODNAME);
-
+        
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
@@ -228,29 +192,28 @@ class QuerySegmentAggregator {
         boolean resourceTypeProcessed = false;
         Map<String, Integer> resourceNameIdMap = null;
         Map<Integer, String> resourceIdNameMap = null;
-
+        
         queryString.append(selectRoot).append(FROM).append("(");
-
+         
         resourceNameIdMap = this.resourceDao.readAllResourceTypeNames();
-        resourceTypeIds   = resourceNameIdMap.values();
-        resourceIdNameMap =
-                resourceNameIdMap.entrySet().stream()
-                        .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
-
-        for (Integer resourceTypeId : resourceTypeIds) {
-
-            resourceTypeName = resourceIdNameMap.get(resourceTypeId) + "_";
-
-            tempFromClause   = this.buildFromClause();
-            tempFromClause   = tempFromClause.replaceAll("Resource_", resourceTypeName);
+        resourceTypeIds = resourceNameIdMap.values();
+        resourceIdNameMap = resourceNameIdMap.entrySet().stream()
+                           .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+         
+        for(Integer resourceTypeId : resourceTypeIds) {
+             
+            resourceTypeName =  resourceIdNameMap.get(resourceTypeId) + "_";
+            
+            tempFromClause = this.buildFromClause();
+            tempFromClause = tempFromClause.replaceAll("Resource_", resourceTypeName);
             if (resourceTypeProcessed) {
                 queryString.append(UNION);
             }
             queryString.append(subSelectRoot).append(tempFromClause);
             resourceTypeProcessed = true;
 
-            tempFromClause        = this.buildWhereClause();
-            tempFromClause        = tempFromClause.replaceAll("Resource_", resourceTypeName);
+            tempFromClause = this.buildWhereClause();
+            tempFromClause = tempFromClause.replaceAll("Resource_", resourceTypeName);
             queryString.append(tempFromClause);
 
             for (SqlQueryData querySegment : this.querySegments) {
@@ -262,146 +225,110 @@ class QuerySegmentAggregator {
             queryString.append(" ORDER BY RESOURCE_ID ASC ");
             this.addPaginationClauses(queryString);
         }
-
+        
         queryData = new SqlQueryData(queryString.toString(), allBindVariables);
-
+        
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
     }
-
+    
     /**
-     * Builds the FROM clause for the SQL query being generated. The appropriate
-     * Resource and Parameter table names are included
+     * Builds the FROM clause for the SQL query being generated. The appropriate Resource and Parameter table names are included 
      * along with an alias for each table.
-     * 
      * @return A String containing the FROM clause
-     * @throws Exception
+     * @throws Exception 
      */
     protected String buildFromClause() throws Exception {
         final String METHODNAME = "buildFromClause";
         log.entering(CLASSNAME, METHODNAME);
-
+        
         StringBuilder fromClause = new StringBuilder();
-
-        // Create the Parameters are used in the format
-        // <code>{0}_RESOURCES </code><code> {1}_LOGICAL_RESOURCES</code>
-        String resourceTable = this.resourceType.getSimpleName() + "_RESOURCES";
-        String logicalResourceTable = this.resourceType.getSimpleName() + "_LOGICAL_RESOURCES";
-
-        // If this is not null, we need to do some machinations
-        // The order of these TWO if blocks is IMPORTANT
-        if (queryParamId != null) {
-            logicalResourceTable = "( SELECT * FROM " + logicalResourceTable + " ILR WHERE ILR.LOGICAL_ID = ? )";
-            searchQueryParameters.add(0, queryParamId);
-        }
-
-        if (queryParamLastUpdated != null) {
-            resourceTable = "( SELECT * FROM " + resourceTable + " IR WHERE IR.LAST_UPDATED = ? )";
-            searchQueryParameters.add(0, queryParamLastUpdated);
-        }
-
-        // IF AND ONLY if _id or _lastupdated is true. 
-        fromClause.append(MessageFormat.format(FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable));
+        fromClause.append(MessageFormat.format(FROM_CLAUSE_ROOT, this.resourceType.getSimpleName()));
         fromClause.append(" ");
-
+            
         log.exiting(CLASSNAME, METHODNAME);
         return fromClause.toString();
-
+        
     }
-
+    
     /**
-     * Builds the WHERE clause for the query being generated. This method aggregates
-     * the contained query segments, and ties those segments back
+     * Builds the WHERE clause for the query being generated. This method aggregates the contained query segments, and ties those segments back
      * to the appropriate parameter table alias.
-     * 
      * @return
      */
     protected String buildWhereClause() {
         final String METHODNAME = "buildWhereClause";
         log.entering(CLASSNAME, METHODNAME);
         boolean isLocationQuery;
-
+        
         StringBuilder whereClause = new StringBuilder();
         String whereClauseSegment;
-
+                         
         whereClause.append(WHERE_CLAUSE_ROOT);
         if (!this.querySegments.isEmpty()) {
-            for (int i = 0; i < this.querySegments.size(); i++) {
+            for(int i = 0; i < this.querySegments.size(); i++) {
                 SqlQueryData querySegment = this.querySegments.get(i);
                 Parameter param = this.searchQueryParameters.get(i);
 
-                // Being bold here... this part should NEVER get a NPE. 
-                // The parameter would not be parsed and passed successfully,
-                // the NPE would have occurred earlier in the stack. 
-                String name = param.getName();
-                if (!SKIP_WHERE.contains(name)) {
-
-                    whereClauseSegment = querySegment.getQueryString();
-                    if (Modifier.MISSING.equals(param.getModifier())) {
-                        whereClause.append(AND).append(whereClauseSegment);
-                    } else {
-
-                        whereClause.append(AND).append("R.LOGICAL_RESOURCE_ID IN (SELECT LOGICAL_RESOURCE_ID FROM ");
-                        whereClause.append(this.resourceType.getSimpleName());
-                        isLocationQuery =
-                                Location.class.equals(this.resourceType)
-                                        && param.getName().equals(AbstractQueryBuilder.NEAR);
-                        switch (param.getType()) {
-                        case URI:
-                        case REFERENCE:
-                        case STRING:
-                            whereClause.append("_STR_VALUES ");
-                            break;
-                        case NUMBER:
-                            whereClause.append("_NUMBER_VALUES ");
-                            break;
-                        case QUANTITY:
-                            whereClause.append("_QUANTITY_VALUES ");
-                            break;
-                        case DATE:
-                            whereClause.append("_DATE_VALUES ");
-                            break;
-                        case TOKEN:
-                            if (isLocationQuery) {
-                                whereClause.append("_LATLNG_VALUES ");
-                            } else {
-                                whereClause.append("_TOKEN_VALUES ");
-                            }
-                            break;
-                        }
-                        whereClauseSegment = whereClauseSegment.replaceAll(PARAMETER_TABLE_ALIAS + ".", "");
-                        whereClause.append(" WHERE ").append(whereClauseSegment).append(")");
+                whereClauseSegment = querySegment.getQueryString();
+                if (Modifier.MISSING.equals(param.getModifier())) {
+                    whereClause.append(AND).append(whereClauseSegment);
+                } else {
+                    
+                    whereClause.append(AND).append("R.LOGICAL_RESOURCE_ID IN (SELECT LOGICAL_RESOURCE_ID FROM ");
+                    whereClause.append(this.resourceType.getSimpleName());
+                    isLocationQuery = Location.class.equals(this.resourceType) && param.getName().equals(AbstractQueryBuilder.NEAR);
+                    switch(param.getType()) {
+                        case URI :
+                        case REFERENCE : 
+                        case STRING :   whereClause.append("_STR_VALUES ");
+                             break;
+                        case NUMBER :   whereClause.append("_NUMBER_VALUES "); 
+                             break;
+                        case QUANTITY : whereClause.append("_QUANTITY_VALUES ");
+                             break;
+                        case DATE :     whereClause.append("_DATE_VALUES ");
+                             break;
+                        case TOKEN :    if (isLocationQuery) {
+                                            whereClause.append("_LATLNG_VALUES ");
+                                        }
+                                        else {
+                                            whereClause.append("_TOKEN_VALUES ");
+                                        }
+                             break;
                     }
+                    whereClauseSegment = whereClauseSegment.replaceAll(PARAMETER_TABLE_ALIAS + ".", "");
+                    whereClause.append(" WHERE ").append(whereClauseSegment).append(")");
                 }
             }
         }
-
+        
         log.exiting(CLASSNAME, METHODNAME);
         return whereClause.toString();
     }
-
+    
     /**
+     * 
      * @return true if this instance represents a FHIR system level search
      */
     protected boolean isSystemLevelSearch() {
         return Resource.class.equals(this.resourceType);
     }
-
+    
     /**
-     * Adds the appropriate pagination clauses to the passed query string buffer,
-     * based on the type
+     * Adds the appropriate pagination clauses to the passed query string buffer, based on the type
      * of database we're running against.
-     * 
      * @param queryString A query string buffer.
      * @throws Exception
      */
     protected void addPaginationClauses(StringBuilder queryString) throws Exception {
-
-        if (this.parameterDao.isDb2Database()) {
+        
+        if(this.parameterDao.isDb2Database()) {
             queryString.append(" LIMIT ").append(this.pageSize).append(" OFFSET ").append(this.offset);
-        } else {
+        }
+        else {
             queryString.append(" OFFSET ").append(this.offset).append(" ROWS")
-                    .append(" FETCH NEXT ").append(this.pageSize).append(" ROWS ONLY");
+                       .append(" FETCH NEXT ").append(this.pageSize).append(" ROWS ONLY");
         }
     }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -8,9 +8,12 @@ package com.ibm.fhir.persistence.jdbc.util;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -23,21 +26,28 @@ import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.parameters.Parameter;
 
 /**
- * This class assists the JDBCQueryBuilder. Its purpose is to aggregate SQL query segments together to produce a well-formed FHIR Resource query or 
- * FHIR Resource count query. 
+ * This class assists the JDBCQueryBuilder. Its purpose is to aggregate SQL
+ * query segments together to produce a well-formed FHIR Resource query or
+ * FHIR Resource count query.
  */
 class QuerySegmentAggregator {
-    
+
     private static final String CLASSNAME = QuerySegmentAggregator.class.getName();
     private static final Logger log = java.util.logging.Logger.getLogger(CLASSNAME);
-    
-    protected static final String SELECT_ROOT = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
-    protected static final String SYSTEM_LEVEL_SELECT_ROOT = "SELECT RESOURCE_ID, LOGICAL_RESOURCE_ID, VERSION_ID, LAST_UPDATED, IS_DELETED, DATA, LOGICAL_ID ";
+
+    protected static final String SELECT_ROOT =
+            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
+    protected static final String SYSTEM_LEVEL_SELECT_ROOT =
+            "SELECT RESOURCE_ID, LOGICAL_RESOURCE_ID, VERSION_ID, LAST_UPDATED, IS_DELETED, DATA, LOGICAL_ID ";
     protected static final String SYSTEM_LEVEL_SUBSELECT_ROOT = SELECT_ROOT;
     private static final String SELECT_COUNT_ROOT = "SELECT COUNT(R.RESOURCE_ID) ";
     private static final String SYSTEM_LEVEL_SELECT_COUNT_ROOT = "SELECT COUNT(RESOURCE_ID) ";
     private static final String SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT = " SELECT R.RESOURCE_ID ";
-    protected static final String FROM_CLAUSE_ROOT = "FROM {0}_RESOURCES R JOIN {0}_LOGICAL_RESOURCES LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ";
+
+    // {0}_RESOURCES and {0}_LOGICAL_RESOURCES are replaced
+    // so derived tables can be used. 
+    protected static final String FROM_CLAUSE_ROOT =
+            "FROM {0} R JOIN {1} LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ";
     protected static final String WHERE_CLAUSE_ROOT = "WHERE R.IS_DELETED <> 'Y'";
     protected static final String PARAMETER_TABLE_ALIAS = "pX";
     private static final String FROM = " FROM ";
@@ -46,143 +56,169 @@ class QuerySegmentAggregator {
     private static final String AND = " AND ";
     protected static final String COMBINED_RESULTS = " COMBINED_RESULTS";
     private static final String DEFAULT_ORDERING = " ORDER BY R.RESOURCE_ID ASC ";
-        
+
+    private static final Set<String> SKIP_WHERE = new HashSet<>(Arrays.asList("_id", "_lastUpdated"));
+
     protected Class<?> resourceType;
 
     /**
      * querySegments and searchQueryParameters are used as parallel arrays
-     * and should be added to/removed together. 
+     * and should be added to/removed together.
      */
-    protected List<SqlQueryData> querySegments;
-    protected List<Parameter> searchQueryParameters;
-    
+    protected List<SqlQueryData> querySegments = new ArrayList<>();
+    protected List<Parameter> searchQueryParameters = new ArrayList<>();
+
+    protected Parameter queryParamId;
+    protected Parameter queryParamLastUpdated;
+
     private int offset;
     private int pageSize;
     protected ParameterDAO parameterDao;
     protected ResourceDAO resourceDao;
-    
 
     /**
      * Constructs a new QueryBuilderHelper
+     * 
      * @param resourceType - The type of FHIR Resource to be searched for.
-     * @param offset - The beginning index of the first search result.
-     * @param pageSize - The max number of requested search results.
+     * @param offset       - The beginning index of the first search result.
+     * @param pageSize     - The max number of requested search results.
      */
-    protected QuerySegmentAggregator(Class<?> resourceType, int offset, int pageSize, 
-                                    ParameterDAO parameterDao, ResourceDAO resourceDao) {
+    protected QuerySegmentAggregator(Class<?> resourceType, int offset, int pageSize,
+            ParameterDAO parameterDao, ResourceDAO resourceDao) {
         super();
-        this.resourceType = resourceType;
-        this.offset = offset;
-        this.pageSize = pageSize;
-        this.parameterDao = parameterDao;
-        this.resourceDao = resourceDao;
-        this.querySegments = new ArrayList<>();
+        this.resourceType          = resourceType;
+        this.offset                = offset;
+        this.pageSize              = pageSize;
+        this.parameterDao          = parameterDao;
+        this.resourceDao           = resourceDao;
+        this.querySegments         = new ArrayList<>();
         this.searchQueryParameters = new ArrayList<>();
-         
+
     }
-    
+
     /**
-     * Adds a query segment, which is a where clause segment corresponding to the passed query Parameter and its encapsulated search values.
-     * @param querySegment A piece of a SQL WHERE clause 
-     * @param queryParm - The corresponding query parameter
+     * Adds a query segment, which is a where clause segment corresponding to the
+     * passed query Parameter and its encapsulated search values.
+     * 
+     * @param querySegment A piece of a SQL WHERE clause
+     * @param queryParm    - The corresponding query parameter
      */
-    protected void addQueryData(SqlQueryData querySegment,Parameter queryParm) {
+    protected void addQueryData(SqlQueryData querySegment, Parameter queryParm) {
         final String METHODNAME = "addQueryData";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         //parallel arrays
         this.querySegments.add(querySegment);
-        this.searchQueryParameters.add(queryParm);
-        
+
+        String name = queryParm.getName();
+        if ("_id".compareTo(name) == 0) {
+            queryParamId = queryParm;
+        } else if ("_lastUpdated".compareTo(name) == 0) {
+            queryParamLastUpdated = queryParm;
+        } else {
+            this.searchQueryParameters.add(queryParm);
+        }
+
         log.exiting(CLASSNAME, METHODNAME);
-         
     }
-    
+
     /**
-     * Builds a complete SQL Query based upon the encapsulated query segments and bind variables.
-     * @return SqlQueryData - contains the complete SQL query string and any associated bind variables.
-     * @throws Exception 
+     * Builds a complete SQL Query based upon the encapsulated query segments and
+     * bind variables.
+     * 
+     * @return SqlQueryData - contains the complete SQL query string and any
+     *         associated bind variables.
+     * @throws Exception
      */
     protected SqlQueryData buildQuery() throws Exception {
         final String METHODNAME = "buildQuery";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
-        
+
         if (this.isSystemLevelSearch()) {
             queryData = this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_ROOT, SYSTEM_LEVEL_SUBSELECT_ROOT, true);
-        }
-        else {
+        } else {
             queryString.append(SELECT_ROOT);
-                    
+
             queryString.append(this.buildFromClause());
-            
+
             queryString.append(this.buildWhereClause());
-            
+
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
             // Add default ordering
             queryString.append(DEFAULT_ORDERING);
-            this.addPaginationClauses(queryString);        
+            this.addPaginationClauses(queryString);
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
         }
-        
+
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
     }
-    
+
     /**
-     *   Builds a complete SQL count query based upon the encapsulated query segments and bind variables.
-     * @return SqlQueryData - contains the complete SQL count query string and any associated bind variables.
-     * @throws Exception 
+     * Builds a complete SQL count query based upon the encapsulated query segments
+     * and bind variables.
+     * 
+     * @return SqlQueryData - contains the complete SQL count query string and any
+     *         associated bind variables.
+     * @throws Exception
      */
     protected SqlQueryData buildCountQuery() throws Exception {
         final String METHODNAME = "buildCountQuery";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
-        
+
         if (this.isSystemLevelSearch()) {
-            queryData = this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_COUNT_ROOT, SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT, false);
-        }
-        else {
+            queryData =
+                    this.buildSystemLevelQuery(SYSTEM_LEVEL_SELECT_COUNT_ROOT, SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT,
+                            false);
+        } else {
             queryString.append(SELECT_COUNT_ROOT);
-                    
+
             queryString.append(this.buildFromClause());
-            
+
             queryString.append(this.buildWhereClause());
-            
+
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
         }
-        
+
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
-        
+
     }
-    
+
     /**
-     * Build a system level query or count query, based upon the encapsulated query segments and bind variables and
+     * Build a system level query or count query, based upon the encapsulated query
+     * segments and bind variables and
      * the passed select-root strings.
-     * A FHIR system level query spans multiple resource types, and therefore spans multiple tables in the database. 
-     * @param selectRoot - The text of the outer SELECT ('SELECT' to 'FROM')
-     * @param subSelectRoot - The text of the inner SELECT root to use in each sub-select
-     * @param addFinalClauses - Indicates whether or not ordering and pagination clauses should be generated.
-     * @return SqlQueryData - contains the complete SQL query string and any associated bind variables.
+     * A FHIR system level query spans multiple resource types, and therefore spans
+     * multiple tables in the database.
+     * 
+     * @param selectRoot      - The text of the outer SELECT ('SELECT' to 'FROM')
+     * @param subSelectRoot   - The text of the inner SELECT root to use in each
+     *                        sub-select
+     * @param addFinalClauses - Indicates whether or not ordering and pagination
+     *                        clauses should be generated.
+     * @return SqlQueryData - contains the complete SQL query string and any
+     *         associated bind variables.
      * @throws Exception
      */
-    protected SqlQueryData buildSystemLevelQuery(String selectRoot, String subSelectRoot, boolean addFinalClauses) 
-                                                    throws Exception {
+    protected SqlQueryData buildSystemLevelQuery(String selectRoot, String subSelectRoot, boolean addFinalClauses)
+            throws Exception {
         final String METHODNAME = "buildSystemLevelQuery";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         StringBuilder queryString = new StringBuilder();
         SqlQueryData queryData;
         List<Object> allBindVariables = new ArrayList<>();
@@ -192,28 +228,29 @@ class QuerySegmentAggregator {
         boolean resourceTypeProcessed = false;
         Map<String, Integer> resourceNameIdMap = null;
         Map<Integer, String> resourceIdNameMap = null;
-        
+
         queryString.append(selectRoot).append(FROM).append("(");
-         
+
         resourceNameIdMap = this.resourceDao.readAllResourceTypeNames();
-        resourceTypeIds = resourceNameIdMap.values();
-        resourceIdNameMap = resourceNameIdMap.entrySet().stream()
-                           .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
-         
-        for(Integer resourceTypeId : resourceTypeIds) {
-             
-            resourceTypeName =  resourceIdNameMap.get(resourceTypeId) + "_";
-            
-            tempFromClause = this.buildFromClause();
-            tempFromClause = tempFromClause.replaceAll("Resource_", resourceTypeName);
+        resourceTypeIds   = resourceNameIdMap.values();
+        resourceIdNameMap =
+                resourceNameIdMap.entrySet().stream()
+                        .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+        for (Integer resourceTypeId : resourceTypeIds) {
+
+            resourceTypeName = resourceIdNameMap.get(resourceTypeId) + "_";
+
+            tempFromClause   = this.buildFromClause();
+            tempFromClause   = tempFromClause.replaceAll("Resource_", resourceTypeName);
             if (resourceTypeProcessed) {
                 queryString.append(UNION);
             }
             queryString.append(subSelectRoot).append(tempFromClause);
             resourceTypeProcessed = true;
 
-            tempFromClause = this.buildWhereClause();
-            tempFromClause = tempFromClause.replaceAll("Resource_", resourceTypeName);
+            tempFromClause        = this.buildWhereClause();
+            tempFromClause        = tempFromClause.replaceAll("Resource_", resourceTypeName);
             queryString.append(tempFromClause);
 
             for (SqlQueryData querySegment : this.querySegments) {
@@ -225,110 +262,146 @@ class QuerySegmentAggregator {
             queryString.append(" ORDER BY RESOURCE_ID ASC ");
             this.addPaginationClauses(queryString);
         }
-        
+
         queryData = new SqlQueryData(queryString.toString(), allBindVariables);
-        
+
         log.exiting(CLASSNAME, METHODNAME, queryData);
         return queryData;
     }
-    
+
     /**
-     * Builds the FROM clause for the SQL query being generated. The appropriate Resource and Parameter table names are included 
+     * Builds the FROM clause for the SQL query being generated. The appropriate
+     * Resource and Parameter table names are included
      * along with an alias for each table.
+     * 
      * @return A String containing the FROM clause
-     * @throws Exception 
+     * @throws Exception
      */
     protected String buildFromClause() throws Exception {
         final String METHODNAME = "buildFromClause";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         StringBuilder fromClause = new StringBuilder();
-        fromClause.append(MessageFormat.format(FROM_CLAUSE_ROOT, this.resourceType.getSimpleName()));
+
+        // Create the Parameters are used in the format
+        // <code>{0}_RESOURCES </code><code> {1}_LOGICAL_RESOURCES</code>
+        String resourceTable = this.resourceType.getSimpleName() + "_RESOURCES";
+        String logicalResourceTable = this.resourceType.getSimpleName() + "_LOGICAL_RESOURCES";
+
+        // If this is not null, we need to do some machinations
+        // The order of these TWO if blocks is IMPORTANT
+        if (queryParamId != null) {
+            logicalResourceTable = "( SELECT * FROM " + logicalResourceTable + " ILR WHERE ILR.LOGICAL_ID = ? )";
+            searchQueryParameters.add(0, queryParamId);
+        }
+
+        if (queryParamLastUpdated != null) {
+            resourceTable = "( SELECT * FROM " + resourceTable + " IR WHERE IR.LAST_UPDATED = ? )";
+            searchQueryParameters.add(0, queryParamLastUpdated);
+        }
+
+        // IF AND ONLY if _id or _lastupdated is true. 
+        fromClause.append(MessageFormat.format(FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable));
         fromClause.append(" ");
-            
+
         log.exiting(CLASSNAME, METHODNAME);
         return fromClause.toString();
-        
+
     }
-    
+
     /**
-     * Builds the WHERE clause for the query being generated. This method aggregates the contained query segments, and ties those segments back
+     * Builds the WHERE clause for the query being generated. This method aggregates
+     * the contained query segments, and ties those segments back
      * to the appropriate parameter table alias.
+     * 
      * @return
      */
     protected String buildWhereClause() {
         final String METHODNAME = "buildWhereClause";
         log.entering(CLASSNAME, METHODNAME);
         boolean isLocationQuery;
-        
+
         StringBuilder whereClause = new StringBuilder();
         String whereClauseSegment;
-                         
+
         whereClause.append(WHERE_CLAUSE_ROOT);
         if (!this.querySegments.isEmpty()) {
-            for(int i = 0; i < this.querySegments.size(); i++) {
+            for (int i = 0; i < this.querySegments.size(); i++) {
                 SqlQueryData querySegment = this.querySegments.get(i);
                 Parameter param = this.searchQueryParameters.get(i);
 
-                whereClauseSegment = querySegment.getQueryString();
-                if (Modifier.MISSING.equals(param.getModifier())) {
-                    whereClause.append(AND).append(whereClauseSegment);
-                } else {
-                    
-                    whereClause.append(AND).append("R.LOGICAL_RESOURCE_ID IN (SELECT LOGICAL_RESOURCE_ID FROM ");
-                    whereClause.append(this.resourceType.getSimpleName());
-                    isLocationQuery = Location.class.equals(this.resourceType) && param.getName().equals(AbstractQueryBuilder.NEAR);
-                    switch(param.getType()) {
-                        case URI :
-                        case REFERENCE : 
-                        case STRING :   whereClause.append("_STR_VALUES ");
-                             break;
-                        case NUMBER :   whereClause.append("_NUMBER_VALUES "); 
-                             break;
-                        case QUANTITY : whereClause.append("_QUANTITY_VALUES ");
-                             break;
-                        case DATE :     whereClause.append("_DATE_VALUES ");
-                             break;
-                        case TOKEN :    if (isLocationQuery) {
-                                            whereClause.append("_LATLNG_VALUES ");
-                                        }
-                                        else {
-                                            whereClause.append("_TOKEN_VALUES ");
-                                        }
-                             break;
+                // Being bold here... this part should NEVER get a NPE. 
+                // The parameter would not be parsed and passed successfully,
+                // the NPE would have occurred earlier in the stack. 
+                String name = param.getName();
+                if (!SKIP_WHERE.contains(name)) {
+
+                    whereClauseSegment = querySegment.getQueryString();
+                    if (Modifier.MISSING.equals(param.getModifier())) {
+                        whereClause.append(AND).append(whereClauseSegment);
+                    } else {
+
+                        whereClause.append(AND).append("R.LOGICAL_RESOURCE_ID IN (SELECT LOGICAL_RESOURCE_ID FROM ");
+                        whereClause.append(this.resourceType.getSimpleName());
+                        isLocationQuery =
+                                Location.class.equals(this.resourceType)
+                                        && param.getName().equals(AbstractQueryBuilder.NEAR);
+                        switch (param.getType()) {
+                        case URI:
+                        case REFERENCE:
+                        case STRING:
+                            whereClause.append("_STR_VALUES ");
+                            break;
+                        case NUMBER:
+                            whereClause.append("_NUMBER_VALUES ");
+                            break;
+                        case QUANTITY:
+                            whereClause.append("_QUANTITY_VALUES ");
+                            break;
+                        case DATE:
+                            whereClause.append("_DATE_VALUES ");
+                            break;
+                        case TOKEN:
+                            if (isLocationQuery) {
+                                whereClause.append("_LATLNG_VALUES ");
+                            } else {
+                                whereClause.append("_TOKEN_VALUES ");
+                            }
+                            break;
+                        }
+                        whereClauseSegment = whereClauseSegment.replaceAll(PARAMETER_TABLE_ALIAS + ".", "");
+                        whereClause.append(" WHERE ").append(whereClauseSegment).append(")");
                     }
-                    whereClauseSegment = whereClauseSegment.replaceAll(PARAMETER_TABLE_ALIAS + ".", "");
-                    whereClause.append(" WHERE ").append(whereClauseSegment).append(")");
                 }
             }
         }
-        
+
         log.exiting(CLASSNAME, METHODNAME);
         return whereClause.toString();
     }
-    
+
     /**
-     * 
      * @return true if this instance represents a FHIR system level search
      */
     protected boolean isSystemLevelSearch() {
         return Resource.class.equals(this.resourceType);
     }
-    
+
     /**
-     * Adds the appropriate pagination clauses to the passed query string buffer, based on the type
+     * Adds the appropriate pagination clauses to the passed query string buffer,
+     * based on the type
      * of database we're running against.
+     * 
      * @param queryString A query string buffer.
      * @throws Exception
      */
     protected void addPaginationClauses(StringBuilder queryString) throws Exception {
-        
-        if(this.parameterDao.isDb2Database()) {
+
+        if (this.parameterDao.isDb2Database()) {
             queryString.append(" LIMIT ").append(this.pageSize).append(" OFFSET ").append(this.offset);
-        }
-        else {
+        } else {
             queryString.append(" OFFSET ").append(this.offset).append(" ROWS")
-                       .append(" FETCH NEXT ").append(this.pageSize).append(" ROWS ONLY");
+                    .append(" FETCH NEXT ").append(this.pageSize).append(" ROWS ONLY");
         }
     }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -6,6 +6,9 @@
 
 package com.ibm.fhir.persistence.jdbc.util;
 
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
+
+import java.sql.Timestamp;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,16 +17,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.ibm.fhir.model.resource.Location;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.persistence.jdbc.JDBCConstants.JDBCOperator;
 import com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO;
 import com.ibm.fhir.persistence.jdbc.dao.api.ResourceDAO;
 import com.ibm.fhir.persistence.util.AbstractQueryBuilder;
 import com.ibm.fhir.search.SearchConstants.Modifier;
+import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.parameters.Parameter;
+import com.ibm.fhir.search.parameters.ParameterValue;
 
 /**
  * This class assists the JDBCQueryBuilder. Its purpose is to aggregate SQL
@@ -44,8 +52,8 @@ class QuerySegmentAggregator {
     private static final String SYSTEM_LEVEL_SELECT_COUNT_ROOT = "SELECT COUNT(RESOURCE_ID) ";
     private static final String SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT = " SELECT R.RESOURCE_ID ";
 
-    // {0}_RESOURCES and {0}_LOGICAL_RESOURCES are replaced
-    // so derived tables can be used. 
+    // The FROM_CLAUSE_ROOT is used in two classes - this, InclusionQuerySegmentAggregator
+    // The {0},{1} is used so the table is able to be replaced by a derived table.  
     protected static final String FROM_CLAUSE_ROOT =
             "FROM {0} R JOIN {1} LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ";
     protected static final String WHERE_CLAUSE_ROOT = "WHERE R.IS_DELETED <> 'Y'";
@@ -68,8 +76,8 @@ class QuerySegmentAggregator {
     protected List<SqlQueryData> querySegments = new ArrayList<>();
     protected List<Parameter> searchQueryParameters = new ArrayList<>();
 
-    protected Parameter queryParamId;
-    protected Parameter queryParamLastUpdated;
+    protected Parameter queryParamId = null;
+    protected Parameter queryParamLastUpdated = null;
 
     private int offset;
     private int pageSize;
@@ -283,30 +291,185 @@ class QuerySegmentAggregator {
 
         StringBuilder fromClause = new StringBuilder();
 
-        // Create the Parameters are used in the format
-        // <code>{0}_RESOURCES </code><code> {1}_LOGICAL_RESOURCES</code>
-        String resourceTable = this.resourceType.getSimpleName() + "_RESOURCES";
-        String logicalResourceTable = this.resourceType.getSimpleName() + "_LOGICAL_RESOURCES";
-
-        // If this is not null, we need to do some machinations
-        // The order of these TWO if blocks is IMPORTANT
-        if (queryParamId != null) {
-            logicalResourceTable = "( SELECT * FROM " + logicalResourceTable + " ILR WHERE ILR.LOGICAL_ID = ? )";
-            searchQueryParameters.add(0, queryParamId);
-        }
-
-        if (queryParamLastUpdated != null) {
-            resourceTable = "( SELECT * FROM " + resourceTable + " IR WHERE IR.LAST_UPDATED = ? )";
-            searchQueryParameters.add(0, queryParamLastUpdated);
-        }
-
         // IF AND ONLY if _id or _lastupdated is true. 
-        fromClause.append(MessageFormat.format(FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable));
+        fromClause.append(buildInterimFromForIdAndLastUpdated(this.resourceType.getSimpleName()));
         fromClause.append(" ");
 
         log.exiting(CLASSNAME, METHODNAME);
         return fromClause.toString();
 
+    }
+
+    /** 
+     * build interim from clause creates a DERIVED table when necessary. 
+     * The derived table is part of the LEFT INNER JOIN filtering down on the resources as the query is converted
+     * to a Query plan. 
+     * 
+     * @param tableType
+     * @return a combination of derived tables and JOINs. 
+     */
+    protected String buildInterimFromForIdAndLastUpdated(String tableType) {
+        // Create the Parameters are used in the format
+        // <code>{0}_RESOURCES </code><code> {1}_LOGICAL_RESOURCES</code>
+        String resourceTable =  tableType + "_RESOURCES";
+        String logicalResourceTable = tableType + "_LOGICAL_RESOURCES";
+
+        // If this is not null, we need to do some changes to the parameter (and the various values 1..* contained)
+        // The order of these subsequent TWO blocks is IMPORTANT
+        
+        // For the LOGICAL_ID the IN operator is used, as the value is a STRING
+        // The string value is treated as an exact match. 
+        if (queryParamId != null) {
+            StringBuilder logicalResourceTableBuilder = new StringBuilder();
+            logicalResourceTableBuilder.append("( SELECT * FROM ");
+            logicalResourceTableBuilder.append(logicalResourceTable);
+            logicalResourceTableBuilder.append(" ILR WHERE ILR.LOGICAL_ID IN ( ");
+            
+            int count = queryParamId.getValues().size();
+            for(int i = 0; i < count; i++){
+                if ( i != 0) {
+                    logicalResourceTableBuilder.append(",");
+                }
+                
+                logicalResourceTableBuilder.append("? ");
+                
+                searchQueryParameters.add(0, queryParamId);
+            }
+            logicalResourceTableBuilder.append(")) ");
+
+            if (log.isLoggable(Level.FINEST)) {
+                log.finest(logicalResourceTableBuilder.toString());
+            }
+            logicalResourceTable = logicalResourceTableBuilder.toString();
+        }
+
+        // The Date is compared in many different ways. 
+        if (queryParamLastUpdated  != null) {
+            StringBuilder resourceTableBuilder = new StringBuilder();
+            resourceTableBuilder.append("( SELECT * FROM ");
+            resourceTableBuilder.append(resourceTable);
+            resourceTableBuilder.append(" IR WHERE ");
+            
+            int count = queryParamLastUpdated.getValues().size();
+            List<ParameterValue> values = queryParamLastUpdated.getValues();
+            for(int i = 0; i < count; i++) {
+                if ( i != 0) {
+                    resourceTableBuilder.append(" OR ");
+                }
+                
+                // Get the Operand, and use it to switch between various behaviors. 
+                ParameterValue pValue = values.get(i);
+                Prefix operand = pValue.getPrefix();    
+                if (operand == null) {
+                    operand = Prefix.EQ;
+                } 
+                
+                handleComparisionOperators(queryParamLastUpdated, operand, resourceTableBuilder);
+                
+            }
+            
+            resourceTableBuilder.append(") ");
+            if (log.isLoggable(Level.FINEST)) {
+                log.finest(resourceTableBuilder.toString());
+            }
+            resourceTable = resourceTableBuilder.toString();
+        }
+
+        return MessageFormat.format(FROM_CLAUSE_ROOT, resourceTable, logicalResourceTable);
+    }
+    
+    public void handleComparisionOperators(Parameter queryParamLastUpdated, Prefix operand, StringBuilder whereClauseSegment) {
+        whereClauseSegment.append("(  IR.LAST_UPDATED ");
+        
+        searchQueryParameters.add(0, queryParamLastUpdated);
+        
+        switch (operand) {
+        case EB:
+            // the value for the parameter in the resource **ends before** the provided value
+            whereClauseSegment.append(JDBCOperator.LT.value()).append(BIND_VAR);
+            break;
+        case SA:
+            // the value for the parameter in the resource **starts after** the provided value
+            whereClauseSegment.append(JDBCOperator.GT.value()).append(BIND_VAR);
+            break;
+        case GE:
+            // the value for the parameter in the resource is greater or equal to the provided value
+            whereClauseSegment.append(JDBCOperator.GTE.value()).append(BIND_VAR);
+            break;
+        case GT:
+            // the value for the parameter in the resource is greater than the provided value
+            whereClauseSegment.append(JDBCOperator.GT.value()).append(BIND_VAR);
+            break;
+        case LE:
+            // the value for the parameter in the resource is less or equal to the provided value
+            whereClauseSegment.append(JDBCOperator.LTE.value()).append(BIND_VAR);
+            break;
+        case LT:
+            // the value for the parameter in the resource is less than the provided value
+            whereClauseSegment.append(JDBCOperator.LT.value()).append(BIND_VAR);
+            break;
+        case AP:
+            // the value for the parameter in the resource is approximately the same to the provided value.
+            // Note that the recommended value for the approximation is 10% of the stated value (or for a date, 
+            // 10% of the gap between now and the date), but systems may choose other values where appropriate
+
+//            // 1. search range fully contains the target period
+//            whereClauseSegment.append(LEFT_PAREN);
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_START).append(JDBCOperator.GTE.value()).append(BIND_VAR);
+//            whereClauseSegment.append(JDBCOperator.AND.value());
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_END).append(JDBCOperator.LT.value()).append(BIND_VAR);
+//            whereClauseSegment.append(RIGHT_PAREN);
+//
+//            whereClauseSegment.append(JDBCOperator.OR.value());
+//            // 2. search range begins during the target period
+//            whereClauseSegment.append(LEFT_PAREN);
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_START).append(JDBCOperator.LTE.value()).append(BIND_VAR);
+//            whereClauseSegment.append(JDBCOperator.AND.value());
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_END).append(JDBCOperator.GTE.value()).append(BIND_VAR);
+//            whereClauseSegment.append(RIGHT_PAREN);
+//
+//            whereClauseSegment.append(JDBCOperator.OR.value());
+//            // 3. search range ends during the target period
+//            whereClauseSegment.append(LEFT_PAREN);
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_START)
+//                // strictly less than because the implicit end of the search range is exclusive
+//                .append(JDBCOperator.LT.value()).append(BIND_VAR);
+//            whereClauseSegment.append(JDBCOperator.AND.value());
+//            whereClauseSegment.append(tableAlias + DOT).append(DATE_END).append(JDBCOperator.GTE.value()).append(BIND_VAR);
+//            whereClauseSegment.append(RIGHT_PAREN);
+            break;
+        case NE:
+            // the range of the search value does not fully contain the range of the target value
+            whereClauseSegment.append(JDBCOperator.LT.value()).append(BIND_VAR);
+            whereClauseSegment.append(")");
+            whereClauseSegment.append(JDBCOperator.OR.value());
+            whereClauseSegment.append("(  IR.LAST_UPDATED ");
+            whereClauseSegment.append(JDBCOperator.GTE.value()).append("'");
+            whereClauseSegment.append(translateDateTime(queryParamLastUpdated.getValues().get(0)));
+            whereClauseSegment.append("'");
+            break;
+        case EQ:
+        default:
+            // the value for the parameter in the resource is equal to the provided value
+            // GTE
+            whereClauseSegment.append(JDBCOperator.EQ.value()).append(BIND_VAR);
+            break;
+        }
+        whereClauseSegment.append(" )");
+    }
+    
+    public String translateDateTime(ParameterValue parameter){
+        DateTime dateTime = parameter.getValueDate();
+        
+        java.time.Instant time;
+        if (dateTime.isPartial()) {
+            time = QueryBuilderUtil.getInstantFromPartial(dateTime.getValue());
+        } else {
+            // fully specified time including zone, so we can interpret as an instant
+            time = java.time.Instant.from(dateTime.getValue());
+        }
+        
+        return Timestamp.from(time).toString();
     }
 
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -158,6 +158,7 @@ class QuerySegmentAggregator {
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
+            
             // Add default ordering
             queryString.append(DEFAULT_ORDERING);
             this.addPaginationClauses(queryString);
@@ -365,7 +366,6 @@ class QuerySegmentAggregator {
                 } 
                 
                 handleComparisionOperators(queryParamLastUpdated, operand, resourceTableBuilder);
-                
             }
             
             resourceTableBuilder.append(") ");
@@ -379,9 +379,9 @@ class QuerySegmentAggregator {
     }
     
     public void handleComparisionOperators(Parameter queryParamLastUpdated, Prefix operand, StringBuilder whereClauseSegment) {
-        whereClauseSegment.append("(  IR.LAST_UPDATED ");
-        
         searchQueryParameters.add(0, queryParamLastUpdated);
+        System.out.println("QUERY PARAM " + queryParamLastUpdated.getClass().getCanonicalName());
+        whereClauseSegment.append("(  IR.LAST_UPDATED ");
         
         switch (operand) {
         case EB:
@@ -451,7 +451,6 @@ class QuerySegmentAggregator {
         case EQ:
         default:
             // the value for the parameter in the resource is equal to the provided value
-            // GTE
             whereClauseSegment.append(JDBCOperator.EQ.value()).append(BIND_VAR);
             break;
         }
@@ -469,7 +468,12 @@ class QuerySegmentAggregator {
             time = java.time.Instant.from(dateTime.getValue());
         }
         
-        return Timestamp.from(time).toString();
+        
+        
+        Timestamp tstmp = Timestamp.from(time);
+        tstmp.setNanos(6);
+        System.out.println("HERE");
+        return tstmp.toString();
     }
 
     /**

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/MyTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/MyTest.java
@@ -1,0 +1,26 @@
+package com.ibm.fhir.persistence.jdbc.search.test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.type.DateTime;
+
+public class MyTest {
+
+    @Test
+    public void testMy(){
+        System.out.println();
+        
+        Instant instant = Instant.from(DateTime.PARSER_FORMATTER.parse("2019-11-18T23:27:45.003000Z"));
+        System.out.println(instant);
+        //java.time.Instant.now();
+        //2019-11-18 13:37:52.424918
+        
+        System.out.println(instant.truncatedTo(ChronoUnit.MILLIS));
+        System.out.println(instant);
+    }
+    
+    
+}

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
@@ -34,7 +34,7 @@ public class FHIRDbDAOTest {
         props.setProperty(FHIRDbDAO.PROPERTY_DB_DRIVER, "org.apache.derby.jdbc.EmbeddedDriver");
         props.setProperty(FHIRDbDAO.PROPERTY_DB_URL, "jdbc:derby:target/fhirDB;create=true");
         // Set the schemaName to the derby default so that it won't try using a non-existent FHIRDATA schema
-        props.setProperty("schemaName", "APP");
+
         FHIRDbDAO dao = new FHIRDbDAOImpl(props);
         Connection connection = dao.getConnection();
         assertNotNull(connection);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
@@ -34,7 +34,7 @@ public class FHIRDbDAOTest {
         props.setProperty(FHIRDbDAO.PROPERTY_DB_DRIVER, "org.apache.derby.jdbc.EmbeddedDriver");
         props.setProperty(FHIRDbDAO.PROPERTY_DB_URL, "jdbc:derby:target/fhirDB;create=true");
         // Set the schemaName to the derby default so that it won't try using a non-existent FHIRDATA schema
-
+        props.setProperty("schemaName", "APP");
         FHIRDbDAO dao = new FHIRDbDAOImpl(props);
         Connection connection = dao.getConnection();
         assertNotNull(connection);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/IdAndLastUpdatedSchemaTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/IdAndLastUpdatedSchemaTest.java
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.Device;
+import com.ibm.fhir.model.resource.Encounter;
+import com.ibm.fhir.model.resource.Observation;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Practitioner;
+import com.ibm.fhir.model.resource.RelatedPerson;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.MultiResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
+import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
+import com.ibm.fhir.persistence.test.common.AbstractPersistenceTest;
+import com.ibm.fhir.search.context.FHIRSearchContext;
+import com.ibm.fhir.search.util.SearchUtil;
+
+/**
+ * _id and _lastUpdated are first class citizens in the FHIR Schema. These first
+ * class citizens need to be tested under very specific conditions.
+ * <br>
+ * The following conditions are tested in the _id and _lastUpdated:
+ * <code>
+ * none
+ * _id
+ * _lastUpdated
+ * _id and _lastUpdated
+ * _lastUpdated and _id (intentionally in this order) 
+ * _id status
+ * _lastUpdated status
+ * _id and _lastUpdated status
+ * _lastUpdated and _id (intentionally in this order) status
+ * status _id (intentionally in this order)
+ * status _lastUpdated (intentionally in this order)
+ * </code>
+ * <br>
+ * The specific search types are also tested:
+ * <ul>
+ * <li>Resource</li>
+ * <li>Compartment</li>
+ * <li>Global</li>
+ * </ul>
+ */
+public class IdAndLastUpdatedSchemaTest extends AbstractPersistenceTest {
+
+    Patient savedPatient;
+    Device savedDevice;
+    Encounter savedEncounter;
+    Practitioner savedPractitioner;
+    RelatedPerson savedRelatedPerson;
+    Observation savedObservation;
+
+    @Override
+    public FHIRPersistence getPersistenceImpl() throws Exception {
+        Properties properties = TestUtil.readTestProperties("test.jdbc.properties");
+        return new FHIRPersistenceJDBCImpl(properties);
+    }
+
+    @Override
+    public void bootstrapDatabase() throws Exception {
+        Properties properties = TestUtil.readTestProperties("test.jdbc.properties");
+
+        DerbyInitializer derbyInit;
+        String dbDriverName = properties.getProperty("dbDriverName");
+        if (dbDriverName != null && dbDriverName.contains("derby")) {
+            derbyInit = new DerbyInitializer(properties);
+            derbyInit.bootstrapDb(false);
+        }
+    }
+
+    private Reference buildReference(Resource resource) {
+        assertNotNull(resource);
+        assertNotNull(resource.getId());
+        assertNotNull(resource.getId().getValue());
+
+        String resourceTypeName = FHIRUtil.getResourceTypeName(resource);
+        return Reference.builder()
+                .reference(string(resourceTypeName + "/" + resource.getId().getValue()))
+                .build();
+    }
+
+    @Test
+    public void testSearchId() throws Exception {
+        Observation.Builder observationBuilder =
+                ((Observation) TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json")).toBuilder();
+
+        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        savedPatient = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        observationBuilder.subject(buildReference(savedPatient));
+        observationBuilder.performer(buildReference(savedPatient));
+
+        Device device = TestUtil.readExampleResource("json/ibm/minimal/Device-1.json");
+        savedDevice = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        observationBuilder.device(buildReference(savedDevice));
+
+        Encounter encounter = TestUtil.readExampleResource("json/ibm/minimal/Encounter-1.json");
+        savedEncounter = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
+        observationBuilder.encounter(buildReference(savedEncounter));
+
+        Practitioner practitioner = TestUtil.readExampleResource("json/ibm/minimal/Practitioner-1.json");
+        savedPractitioner = persistence.create(getDefaultPersistenceContext(), practitioner).getResource();
+        observationBuilder.performer(buildReference(savedPractitioner));
+
+        RelatedPerson relatedPerson = TestUtil.readExampleResource("json/ibm/minimal/RelatedPerson-1.json");
+        savedRelatedPerson = persistence.create(getDefaultPersistenceContext(), relatedPerson).getResource();
+        observationBuilder.performer(buildReference(savedRelatedPerson));
+
+        savedObservation = persistence.create(getDefaultPersistenceContext(), observationBuilder.build()).getResource();
+        assertNotNull(savedObservation);
+        assertNotNull(savedObservation.getId());
+        assertNotNull(savedObservation.getId().getValue());
+        assertNotNull(savedObservation.getMeta());
+        assertNotNull(savedObservation.getMeta().getVersionId().getValue());
+        assertEquals("1", savedObservation.getMeta().getVersionId().getValue());
+
+        List<Resource> results =
+                runSearchTest(null, null,
+                        Observation.class, "_id", savedObservation.getId().getValue(), null);
+        assertTrue(results.size() > 0);
+        
+        results =
+                runSearchTest(null, null,
+                        Observation.class, "_lastUpdated", savedObservation.getMeta().getLastUpdated().getValue().toString(), null);
+        assertTrue(results.size() > 0);
+
+    }
+
+    protected List<Resource> runSearchTest(String compartmentName, String compartmentLogicalId,
+            Class<? extends Resource> resourceType, String parmName, String parmValue, Integer maxPageSize)
+            throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
+        if (parmName != null && parmValue != null) {
+            queryParms.put(parmName, Collections.singletonList(parmValue));
+        }
+
+        FHIRSearchContext searchContext =
+                SearchUtil.parseQueryParameters(compartmentName, compartmentLogicalId, resourceType, queryParms, null);
+
+        if (maxPageSize != null) {
+            searchContext.setPageSize(maxPageSize);
+        }
+        FHIRPersistenceContext persistenceContext = getPersistenceContextForSearch(searchContext);
+        MultiResourceResult<Resource> result = persistence.search(persistenceContext, resourceType);
+        assertNotNull(result.getResource());
+        return result.getResource();
+    }
+
+}

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -75,6 +75,9 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
         queryParms.put("_revinclude", Collections.singletonList("Composition:subject"));
         queryParms.put("boolean", Collections.singletonList("true"));
+        System.out.println("Basic --> "+savedResource);
+        System.out.println("Composition --> " + composition);
+        
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -86,9 +86,12 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
         List<String> savedId = Collections.singletonList(savedResource.getId().getValue());
         List<String> savedLastUpdated = Collections.singletonList(savedResource.getMeta().getLastUpdated().getValue().toString());
+        System.out.println(savedResource.getMeta().getLastUpdated().getValue().toString());
         queryParms.put("_id", savedId);
         queryParms.put("_lastUpdated", savedLastUpdated);
 
+        System.out.println(savedResource);
+        
         List<Resource> resources = runQueryTest(Resource.class, queryParms);
         assertNotNull(resources);
         assertEquals(resources.size(), 1, "Number of resources returned");

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -27,7 +27,7 @@ handlers= java.util.logging.ConsoleHandler
 # can be overriden by a facility specific level
 # Note that the ConsoleHandler also has a separate level
 # setting to limit messages printed to the console.
-.level= ALL
+.level= INFO
 
 ############################################################
 # Handler specific properties.

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -49,4 +49,4 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ############################################################
 
 # Set this to FINE or higher to output the SQL statements and related debug info
-com.ibm.fhir.persistence.level = FINE
+com.ibm.fhir.persistence.level = INFO

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -27,7 +27,7 @@ handlers= java.util.logging.ConsoleHandler
 # can be overriden by a facility specific level
 # Note that the ConsoleHandler also has a separate level
 # setting to limit messages printed to the console.
-.level= INFO
+.level= FINEST
 
 ############################################################
 # Handler specific properties.
@@ -49,4 +49,4 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ############################################################
 
 # Set this to FINE or higher to output the SQL statements and related debug info
-com.ibm.fhir.persistence.level = INFO
+com.ibm.fhir.persistence.level = FINEST

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -27,7 +27,7 @@ handlers= java.util.logging.ConsoleHandler
 # can be overriden by a facility specific level
 # Note that the ConsoleHandler also has a separate level
 # setting to limit messages printed to the console.
-.level= INFO
+.level= ALL
 
 ############################################################
 # Handler specific properties.

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/Parameter.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/Parameter.java
@@ -19,10 +19,6 @@ import com.ibm.fhir.search.SearchConstants.Type;
 
 /**
  * general type of parameter. 
- *  
- * @author markd
- * @author pbastide
- *
  */
 public class Parameter {
 
@@ -194,4 +190,5 @@ public class Parameter {
     public boolean isInclusionCriteria() {
         return isInclusionCriteria;
     }
+
 }


### PR DESCRIPTION
- adds a derived table for RESOURCE table and LOGICAL_RESOURCE table
- changes the order of parameters being set. 
- adds tests for the order of parameters _id and _lastUpdated

example query - _lastUpdated
```
FINE: Successfully retrieved count. SQL=SELECT COUNT(R.RESOURCE_ID) FROM ( SELECT * FROM Observation_RESOURCES IR WHERE IR.LAST_UPDATED = ? ) R JOIN Observation_LOGICAL_RESOURCES LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID  WHERE R.IS_DELETED <> 'Y'
  searchArgs=[2019-11-13 16:55:26.217]
  count=1 executionTime=1.660013ms
```

example query - _id
```
FINE: Successfully retrieved count. SQL=SELECT COUNT(R.RESOURCE_ID) FROM Observation_RESOURCES R JOIN ( SELECT * FROM Observation_LOGICAL_RESOURCES ILR WHERE ILR.LOGICAL_ID = ? ) LR ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID  WHERE R.IS_DELETED <> 'Y'
  searchArgs=[e07d9075-a466-4e81-8b59-e207c7f92f6b]
  count=1 executionTime=3.090915ms
```
