### PR TITLE
Issue #389 - fixed issues related to failing FHIRPathSpec tests

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathDateTimeValue.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathDateTimeValue.java
@@ -11,6 +11,7 @@ import static com.ibm.fhir.model.path.util.FHIRPathUtil.getTemporalAccessor;
 import static com.ibm.fhir.model.path.util.FHIRPathUtil.getTemporalAmount;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.YearMonth;
 import java.time.ZonedDateTime;
@@ -32,15 +33,26 @@ public class FHIRPathDateTimeValue extends FHIRPathAbstractNode implements FHIRP
                 .appendPattern("-MM")
                 .optionalStart()
                     .appendPattern("-dd")
+                    .appendLiteral("T")
                     .optionalStart()
-                        .appendPattern("'T'HH:mm:ss")
+                        .appendPattern("HH")
                         .optionalStart()
-                            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                            .appendPattern(":mm")
+                            .optionalStart()
+                                .appendPattern(":ss")
+                                .optionalStart()
+                                    .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                                .optionalEnd()
+                            .optionalEnd()
                         .optionalEnd()
-                        .appendPattern("XXX")
+                        .optionalStart()
+                            .appendPattern("XXX")
+                        .optionalEnd()
                     .optionalEnd()
                 .optionalEnd()
             .optionalEnd()
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
             .toFormatter();
 
     private final TemporalAccessor dateTime;
@@ -71,7 +83,7 @@ public class FHIRPathDateTimeValue extends FHIRPathAbstractNode implements FHIRP
     }
     
     public static FHIRPathDateTimeValue dateTimeValue(String dateTime) {
-        return FHIRPathDateTimeValue.builder(DATE_TIME_PARSER_FORMATTER.parseBest(dateTime, ZonedDateTime::from, LocalDate::from, YearMonth::from, Year::from)).build();
+        return FHIRPathDateTimeValue.builder(DATE_TIME_PARSER_FORMATTER.parseBest(dateTime, ZonedDateTime::from, LocalDateTime::from, LocalDate::from, YearMonth::from, Year::from)).build();
     }
     
     public static FHIRPathDateTimeValue dateTimeValue(TemporalAccessor dateTime) {
@@ -170,6 +182,9 @@ public class FHIRPathDateTimeValue extends FHIRPathAbstractNode implements FHIRP
         }
         if (dateTime instanceof LocalDate || value.dateTime instanceof LocalDate) {
             return LocalDate.from(dateTime).compareTo(LocalDate.from(value.dateTime));
+        }
+        if (dateTime instanceof LocalDateTime || value.dateTime instanceof LocalDateTime) {
+            return LocalDateTime.from(dateTime).compareTo(LocalDateTime.from(value.dateTime));
         }
         return ZonedDateTime.from(dateTime).compareTo(ZonedDateTime.from(value.dateTime));
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathNumberValue.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/FHIRPathNumberValue.java
@@ -52,7 +52,8 @@ public interface FHIRPathNumberValue extends FHIRPathSystemValue {
 
     @Override
     default boolean isComparableTo(FHIRPathNode other) {
-        return other instanceof FHIRPathQuantityValue || 
+        return (other instanceof FHIRPathQuantityNode && ((FHIRPathQuantityNode) other).getQuantityValue() != null) || 
+                other instanceof FHIRPathQuantityValue || 
                 other.getValue() instanceof FHIRPathQuantityValue || 
                 other instanceof FHIRPathNumberValue || 
                 other.getValue() instanceof FHIRPathNumberValue;
@@ -62,6 +63,9 @@ public interface FHIRPathNumberValue extends FHIRPathSystemValue {
     default int compareTo(FHIRPathNode other) {
         if (!isComparableTo(other)) {
             throw new IllegalArgumentException();
+        }
+        if (other instanceof FHIRPathQuantityNode) {
+            return decimal().compareTo(((FHIRPathQuantityNode) other).getQuantityValue());
         }
         if (other instanceof FHIRPathQuantityValue) {
             return decimal().compareTo(((FHIRPathQuantityValue) other).value());

--- a/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/path/evaluator/FHIRPathEvaluator.java
@@ -906,13 +906,11 @@ public class FHIRPathEvaluator {
         @Override
         public Collection<FHIRPathNode> visitNumberLiteral(FHIRPathParser.NumberLiteralContext ctx) {
             debug(ctx);
-            // TODO: needs alternative to using exception for control flow
-            BigDecimal decimal = new BigDecimal(ctx.getText());
-            try {
-                Integer integer = decimal.intValueExact();
-                return singleton(integerValue(integer));
-            } catch (ArithmeticException e) {
-                return singleton(decimalValue(decimal));
+            String text = ctx.getText();
+            if (text.contains(".")) {
+                return singleton(decimalValue(new BigDecimal(text)));
+            } else {
+                return singleton(integerValue(Integer.parseInt(text)));
             }
         }
         


### PR DESCRIPTION
* Updated visitNumberLiteral to use presence of a decimal point instead of exceptions to control logic flow
* Updated FHIRPathNumberValue.isComparableTo/compareTo to accommodate newly introduced FHIRPathQuantityNode
* Updated FHIRPathDateTimeValue and FHIRPathTimeValue classes with new patterns per the updated FHIRPath grammar

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>