### PR TITLE
WIP:  issue #255 - start handling even more datetimes as ranges

### DIFF
--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QueryBuilderUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QueryBuilderUtilTest.java
@@ -61,7 +61,7 @@ public class QueryBuilderUtilTest {
         Instant start = QueryBuilderUtil.getStart(dt);
         assertEquals(startRef, start, "getStart failed");
         
-        Instant end = QueryBuilderUtil.getEnd(dt);
+        Instant end = QueryBuilderUtil.getEnd(dt, true);
         assertEquals(endRef, end, "getEnd failed");
     }
     
@@ -70,11 +70,11 @@ public class QueryBuilderUtilTest {
         Instant startRef = Instant.parse("2018-01-01T00:00:00Z");
         Instant endRef = Instant.parse("2018-02-01T00:00:00Z");
         
-        DateTime dt = DateTime.builder().value("2018-01").build();        
+        DateTime dt = DateTime.builder().value("2018-01").build();
         Instant start = QueryBuilderUtil.getStart(dt);
         assertEquals(startRef, start, "getStart failed");
         
-        Instant end = QueryBuilderUtil.getEnd(dt);
+        Instant end = QueryBuilderUtil.getEnd(dt, true);
         assertEquals(endRef, end, "getEnd failed");
     }
     
@@ -87,7 +87,7 @@ public class QueryBuilderUtilTest {
         Instant start = QueryBuilderUtil.getStart(dt);
         assertEquals(startRef, start, "getStart failed");
 
-        Instant end = QueryBuilderUtil.getEnd(dt);
+        Instant end = QueryBuilderUtil.getEnd(dt, true);
         assertEquals(endRef, end, "getEnd failed");
     }
     
@@ -101,7 +101,7 @@ public class QueryBuilderUtilTest {
         Instant start = QueryBuilderUtil.getStart(date);
         assertEquals(startRef, start, "getStart failed");
         
-        Instant end = QueryBuilderUtil.getEnd(date);
+        Instant end = QueryBuilderUtil.getEnd(date, true);
         assertEquals(endRef, end, "getEnd failed");
     }
     
@@ -110,11 +110,11 @@ public class QueryBuilderUtilTest {
         Instant startRef = Instant.parse("2018-01-01T00:00:00Z");
         Instant endRef = Instant.parse("2018-02-01T00:00:00Z");
         
-        Date date = Date.builder().value("2018-01").build();        
+        Date date = Date.builder().value("2018-01").build();
         Instant start = QueryBuilderUtil.getStart(date);
         assertEquals(startRef, start, "getStart failed");
         
-        Instant end = QueryBuilderUtil.getEnd(date);
+        Instant end = QueryBuilderUtil.getEnd(date, true);
         assertEquals(endRef, end, "getEnd failed");
     }
     
@@ -127,7 +127,7 @@ public class QueryBuilderUtilTest {
         Instant start = QueryBuilderUtil.getStart(date);
         assertEquals(startRef, start, "getStart failed");
 
-        Instant end = QueryBuilderUtil.getEnd(date);
+        Instant end = QueryBuilderUtil.getEnd(date, true);
         assertEquals(endRef, end, "getEnd failed");
     }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -39,30 +39,33 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         
         assertSearchReturnsSavedResource("date", "2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29");
+        
+        // lt2018-10-29 is handled like lt[2018-10-29,2018-10-30) and so, confusingly, it overlaps with [2018-10-29,2018-10-30)
+        assertSearchReturnsSavedResource("date", "lt2018-10-29");
+        // gt2018-10-29 is handled like gt[2018-10-29,2018-10-30) and so, confusingly, it overlaps with [2018-10-29,2018-10-30)
+        assertSearchReturnsSavedResource("date", "gt2018-10-29");
         assertSearchReturnsSavedResource("date", "le2018-10-29");
         assertSearchReturnsSavedResource("date", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29");
         assertSearchReturnsSavedResource("date", "ap2018-10-29");
         
-        // This should return the resource but does not
-//      assertSearchReturnsSavedResource("date", "2018-10-29T17:12:00-04:00");
-//      assertSearchDoesntReturnSavedResource("date", "ne2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("date", "ne2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
-//      assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-//      assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
-//      assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
-//      assertSearchReturnsSavedResource("date", "ap2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("date", "ap2018-10-29T17:12:00-04:00");
         
         assertSearchDoesntReturnSavedResource("date", "2018-10-28");
         assertSearchReturnsSavedResource("date", "ne2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "lt2018-10-28");
         assertSearchReturnsSavedResource("date", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
+        // this shouldn't return the resource but does.  le[2018-10-28,2018-10-29) shouldn't overlap with [2018-10-29,2018-10-30)
+//        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
         assertSearchReturnsSavedResource("date", "ge2018-10-28");
         assertSearchReturnsSavedResource("date", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28");
@@ -137,8 +140,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         //assertSearchReturnsSavedResource("date", "9999-01-01,2018-10-29");
         
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29,9999-01-01");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29,9999-01-01");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29,9999-01-01");
+        assertSearchReturnsSavedResource("date", "lt2018-10-29,9999-01-01");
+        assertSearchReturnsSavedResource("date", "gt2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "le2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "ge2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29,9999-01-01");
@@ -170,7 +173,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         
         assertSearchReturnsSavedResource("dateTime", "2018-10-29");
 //        assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-29");
+        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29");
 //        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-29");
 //        assertSearchReturnsSavedResource("dateTime", "le2018-10-29");
         assertSearchReturnsSavedResource("dateTime", "ge2018-10-29");
@@ -180,8 +183,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         
         assertSearchReturnsSavedResource("dateTime", "2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("dateTime", "le2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("dateTime", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-29T17:12:00-04:00");
@@ -364,7 +367,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T17:18:00-04:00");
@@ -431,7 +434,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period-noStart", "gt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
@@ -577,7 +580,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         //assertSearchDoesntReturnSavedResource("Period", "9999-01-01,le2018-10-28");
         //assertSearchReturnsSavedResource("Period", "9999-01-01,ge2018-10-28");
         //assertSearchReturnsSavedResource("Period", "9999-01-01,sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period", "9999-01-01,eb2018-10-28");
+        //assertSearchDoesntReturnSavedResource("Period", "9999-01-01,eb2018-10-28");
         //assertSearchDoesntReturnSavedResource("Period", "9999-01-01,ap2018-10-28");
     }
 

--- a/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/IValueTypes.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/IValueTypes.java
@@ -22,24 +22,14 @@ import com.ibm.fhir.search.parameters.Parameter;
 public interface IValueTypes {
 
     /**
-     * checks the resource value types against the indicators of the search type DateRange search.
+     * checks whether the resource value type must be an Instant
      * 
      * @param resourceType
      * @param queryParm
-     * @return
+     * @return false if the resource value type contains any type other than Instant (even if Instant is present as well)
      * @throws FHIRSearchException
      */
-    public boolean isDateRangeSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException;
-
-    /**
-     * checks the resource value types against the indicators of the search type Date search.
-     * 
-     * @param resourceType
-     * @param queryParm
-     * @return
-     * @throws FHIRSearchException
-     */
-    public boolean isDateSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException;
+    public boolean isInstantSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException;
 
     /**
      * checks the resource value types against the indicators of the search type Range search.

--- a/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/impl/ValueTypesR4Impl.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/valuetypes/impl/ValueTypesR4Impl.java
@@ -29,23 +29,17 @@ import javax.json.JsonValue;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.model.type.Count;
-import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Instant;
-import com.ibm.fhir.model.type.Period;
 import com.ibm.fhir.model.type.PositiveInt;
 import com.ibm.fhir.model.type.Range;
 import com.ibm.fhir.model.type.UnsignedInt;
-import com.ibm.fhir.search.SearchConstants.Type;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.parameters.Parameter;
 import com.ibm.fhir.search.valuetypes.IValueTypes;
 import com.ibm.fhir.search.valuetypes.cache.TenantSpecificValueTypesCache;
 
 /**
- * ValueTypes R4 Impl
- * 
- * @author pbastide
- *
+ * ValueTypes Implementation for FHIR R4
  */
 public class ValueTypesR4Impl implements IValueTypes {
 
@@ -76,17 +70,9 @@ public class ValueTypesR4Impl implements IValueTypes {
     }
 
     @Override
-    public boolean isDateRangeSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException {
-        return getValueTypes(resourceType, queryParm.getName()).contains(Period.class);
-    }
-
-    @Override
-    public boolean isDateSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException {
-        // Date Search does not support Date and Partial DateTime in a Range Search.
-
+    public boolean isInstantSearch(Class<?> resourceType, Parameter queryParm) throws FHIRSearchException {
         Set<Class<?>> valueTypes = getValueTypes(resourceType, queryParm.getName());
-        return Type.TOKEN.compareTo(queryParm.getType()) == 0 || valueTypes.contains(com.ibm.fhir.model.type.Date.class)
-                || valueTypes.contains(DateTime.class) || valueTypes.contains(Instant.class);
+        return valueTypes.size() == 1 && valueTypes.iterator().next().equals(Instant.class);
     }
 
     @Override

--- a/fhir-search/src/test/java/com/ibm/fhir/search/valuetypes/ValueTypesTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/valuetypes/ValueTypesTest.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.FHIRRequestContext;
-import com.ibm.fhir.model.resource.Account;
 import com.ibm.fhir.model.resource.ActivityDefinition;
 import com.ibm.fhir.model.resource.AdverseEvent;
 import com.ibm.fhir.model.resource.Appointment;
@@ -179,50 +178,32 @@ public class ValueTypesTest extends BaseSearchTest {
     }
 
     @Test
-    public void testDateRangeSearch() throws FHIRSearchException {
-        Class<?> resourceType = Account.class;
-
-        String name = "period";
-        Parameter queryParm = new Parameter(Type.DATE, name, null, name);
-        assertTrue(ValueTypesFactory.getValueTypesProcessor().isDateRangeSearch(resourceType, queryParm));
-
-        name = "subject";
-        queryParm = new Parameter(Type.REFERENCE, name, null, name);
-        assertFalse(ValueTypesFactory.getValueTypesProcessor().isDateRangeSearch(resourceType, queryParm));
-
-    }
-
-    @Test
     public void testDateSearch() throws FHIRSearchException {
         Class<?> resourceType = ActivityDefinition.class;
 
         String name = "date";
         Parameter queryParm = new Parameter(Type.DATE, name, null, name);
-        assertTrue(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
+        assertFalse(ValueTypesFactory.getValueTypesProcessor().isInstantSearch(resourceType, queryParm));
 
         name = "depends-on";
         queryParm = new Parameter(Type.REFERENCE, name, null, name);
-        assertFalse(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
+        assertFalse(ValueTypesFactory.getValueTypesProcessor().isInstantSearch(resourceType, queryParm));
 
-        resourceType = Account.class;
-        name = "subject";
-        queryParm = new Parameter(Type.REFERENCE, name, null, name);
-        assertFalse(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
-
+        // Appointment-date selects Appointment.start which is of type Instant
         resourceType = Appointment.class;
         name = "date";
         queryParm = new Parameter(Type.DATE, name, null, name);
-        assertTrue(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
+        assertTrue(ValueTypesFactory.getValueTypesProcessor().isInstantSearch(resourceType, queryParm));
 
         resourceType = CapabilityStatement.class;
         name = "date";
         queryParm = new Parameter(Type.DATE, name, null, name);
-        assertTrue(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
+        assertFalse(ValueTypesFactory.getValueTypesProcessor().isInstantSearch(resourceType, queryParm));
 
         resourceType = ClaimResponse.class;
         name = "payment-date";
         queryParm = new Parameter(Type.DATE, name, null, name);
-        assertTrue(ValueTypesFactory.getValueTypesProcessor().isDateSearch(resourceType, queryParm));
+        assertFalse(ValueTypesFactory.getValueTypesProcessor().isInstantSearch(resourceType, queryParm));
 
     }
 


### PR DESCRIPTION
on call with Paul and John, we identified about 7 other related things
that need to get done, but hopefully these changes are a step in the right direcation

TODO:
* remove DATE column and always use DATE_START and DATE_END (even for instants)
* handle date search parameter query params as instants when prefixed by lt, gt, le, or ge
* handle date search parameter query params as implicit ranges in all other cases (when no fractional seconds are passed)

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>