### PR TITLE
more swagger tweaks and update OpenApiGenerator to match

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
@@ -507,10 +507,24 @@ public final class ModelSupport {
         return Element.class.isAssignableFrom(modelClass);
     }
     
+    public static boolean isMetadataType(Class<?> type) {
+        return ContactDetail.class.equals(type) ||
+                Contributor.class.equals(type) ||
+                DataRequirement.class.isAssignableFrom(type) || 
+                RelatedArtifact.class.isAssignableFrom(type) ||
+                UsageContext.class.equals(type) || 
+                ParameterDefinition.class.equals(type) ||
+                Expression.class.equals(type) || 
+                TriggerDefinition.class.equals(type);
+    }
+    
     public static boolean isModelClass(Class<?> type) {
         return isResourceType(type) || isElementType(type);
     }
 
+    /**
+     * @implNote xhtml is considered a primitive type
+     */
     public static boolean isPrimitiveType(Class<?> type) {
         return Base64Binary.class.equals(type) ||
             com.ibm.fhir.model.type.Boolean.class.equals(type) ||

--- a/fhir-swagger-generator/.gitignore
+++ b/fhir-swagger-generator/.gitignore
@@ -1,0 +1,2 @@
+src/main/resources/swagger/
+src/main/resources/openapi/

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.openapi.generator;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -14,10 +15,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.time.ZonedDateTime;
-import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -39,22 +36,78 @@ import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.annotation.Required;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.ActivityDefinition;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
+import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.resource.DeviceDefinition;
 import com.ibm.fhir.model.resource.DomainResource;
+import com.ibm.fhir.model.resource.EventDefinition;
+import com.ibm.fhir.model.resource.EvidenceVariable;
+import com.ibm.fhir.model.resource.GuidanceResponse;
+import com.ibm.fhir.model.resource.Library;
+import com.ibm.fhir.model.resource.Measure;
+
+import com.ibm.fhir.model.resource.MedicationDispense;
+import com.ibm.fhir.model.resource.MedicationKnowledge;
+import com.ibm.fhir.model.resource.MedicationRequest;
+import com.ibm.fhir.model.resource.MedicationStatement;
+import com.ibm.fhir.model.resource.MedicinalProductContraindication;
+import com.ibm.fhir.model.resource.MedicinalProductIndication;
+import com.ibm.fhir.model.resource.MedicinalProductManufactured;
+import com.ibm.fhir.model.resource.MedicinalProductPackaged;
+import com.ibm.fhir.model.resource.MedicinalProductUndesirableEffect;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.PlanDefinition;
+import com.ibm.fhir.model.resource.RequestGroup;
+import com.ibm.fhir.model.resource.ResearchElementDefinition;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.resource.StructureDefinition;
+import com.ibm.fhir.model.resource.StructureMap;
+import com.ibm.fhir.model.resource.SubstancePolymer;
+import com.ibm.fhir.model.resource.Task;
 import com.ibm.fhir.model.type.BackboneElement;
 import com.ibm.fhir.model.type.Code;
-import com.ibm.fhir.model.type.Date;
-import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.ContactDetail;
+import com.ibm.fhir.model.type.Contributor;
+import com.ibm.fhir.model.type.DataRequirement;
+import com.ibm.fhir.model.type.Dosage;
 import com.ibm.fhir.model.type.ElementDefinition;
+import com.ibm.fhir.model.type.Expression;
+import com.ibm.fhir.model.type.MarketingStatus;
+import com.ibm.fhir.model.type.Oid;
+import com.ibm.fhir.model.type.ParameterDefinition;
+import com.ibm.fhir.model.type.Population;
+import com.ibm.fhir.model.type.ProdCharacteristic;
+import com.ibm.fhir.model.type.ProductShelfLife;
+import com.ibm.fhir.model.type.RelatedArtifact;
+import com.ibm.fhir.model.type.SubstanceAmount;
+import com.ibm.fhir.model.type.TriggerDefinition;
+import com.ibm.fhir.model.type.UsageContext;
+import com.ibm.fhir.model.type.Uuid;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.visitor.AbstractVisitable;
 import com.ibm.fhir.search.util.SearchUtil;
+import com.ibm.fhir.swagger.generator.APIConnectAdapter;
 
+/**
+ * Generate OpenAPI 3.0 from the HL7 FHIR R4 artifacts and IBM FHIR object model.
+ * 
+ * <p>
+ * By default, this class will create a separate OpenAPI definition for each and every resource type;
+ * each with all HTTP interactions enabled.
+ * 
+ * <p>
+ * To limit the output to a given set of resources and/or interactions, pass a set of semicolon-delimited
+ * filter strings of the form {@code ResourceType1(interaction1,interaction2)}.
+ *  
+ * For example: 
+ * <pre>
+ * Patient(create,update,read,vread,history,search);Contract(create,read,vread,history,search);RiskAssessment(read)
+ * </pre>
+ */
 public class FHIROpenApiGenerator {
     private static final JsonBuilderFactory factory = Json.createBuilderFactory(null);
     private static final Map<Class<?>, StructureDefinition> structureDefinitionMap = buildStructureDefinitionMap();
@@ -63,112 +116,234 @@ public class FHIROpenApiGenerator {
     public static final String RESOURCEPACKAGENAME = "com.ibm.fhir.model.resource";
 
     public static void main(String[] args) throws Exception {
-        /*
-         * for (Class<?> key : structureDefinitionMap.keySet()) { StructureDefinition
-         * structureDefinition = structureDefinitionMap.get(key);
-         * System.out.println("key: " + key + ", value: " +
-         * structureDefinition.getUrl().getValue()); }
-         */
-
+        File file = new File("./src/main/resources/openapi");
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+        
         Filter filter = null;
         if (args.length == 1) {
             filter = createFilter(args[0]);
         } else {
             filter = createAcceptAllFilter();
         }
-        // filter =
-        // createFilter("Patient(create,read);Contract(create,read);Questionnaire(create,read),QuestionnaireResponse(create,read);RiskAssessment(read,search)");
-        // filter =
-        // createFilter("Patient(create,read,vread,update,delete,search,history)");
+        filter = createFilter("Patient(create,read,vread,update,delete,search,history)");
 
+        List<String> classNames = getClassNames();
+        for (String resourceClassName : classNames) {
+            Class<?> resourceModelClass = Class.forName(RESOURCEPACKAGENAME + "." + resourceClassName);
+            if (DomainResource.class.isAssignableFrom(resourceModelClass) && filter.acceptResourceType(resourceModelClass)) {
+                
+                JsonObjectBuilder swagger = factory.createObjectBuilder();
+                swagger.add("openapi", "3.0.0");
+        
+                JsonObjectBuilder info = factory.createObjectBuilder();
+                info.add("title", resourceClassName + " API");
+                info.add("description", "The IBM FHIR Server API for " + resourceClassName + " resources.");
+                info.add("version", "4.0.0");
+                swagger.add("info", info);
+
+                /**
+                 * "servers": [ { "url": "/fhir-server/api/v4" } ]
+                 */
+                JsonArrayBuilder servers = factory.createArrayBuilder();
+                JsonObjectBuilder server = factory.createObjectBuilder();
+                server.add("url", "/fhir-server/api/v4");
+                servers.add(server);
+                swagger.add("servers", servers);
+
+                // Set the hostname in APIConnectAdapter and uncomment this to add "x-ibm-configuration"
+                // with a default ExecuteInvoke Assembly
+                APIConnectAdapter.addApiConnectStuff(swagger);
+
+                JsonArrayBuilder tags = factory.createArrayBuilder();
+                JsonObjectBuilder paths = factory.createObjectBuilder();
+                JsonObjectBuilder definitions = factory.createObjectBuilder();
+                JsonObjectBuilder requestBodies = factory.createObjectBuilder();
+
+                // generate Resource and DomainResource definitions
+                generateDefinition(Resource.class, definitions);
+                generateDefinition(DomainResource.class, definitions);
+                
+                generatePaths(resourceModelClass, paths, filter);
+                JsonObjectBuilder tag = factory.createObjectBuilder();
+                tag.add("name", resourceModelClass.getSimpleName());
+                tags.add(tag);
+                generateRequestBody(resourceModelClass, requestBodies);
+                generateDefinition(resourceModelClass, definitions);
+                // for search response
+                generateDefinition(Bundle.class, definitions);
+                // for error response
+                generateDefinition(OperationOutcome.class, definitions);
+                
+                // generate definition for all the applicable data types.
+                for (String typeClassName : getAllTypesList()) {
+                    Class<?> typeModelClass = Class.forName(TYPEPACKAGENAME + "." + typeClassName);
+                    // System.out.println("Type:  " + className);
+                    if (isApplicableForClass(typeModelClass, resourceModelClass)) {
+                        generateDefinition(typeModelClass, definitions);
+                    }
+                }
+                
+                
+                // generate definition for all inner classes inside the top level resources.
+                for (String innerClassName : getAllResourceInnerClasses()) {
+                    String parentClassName = innerClassName.split("\\$")[0];
+                    if (resourceClassName.equals(parentClassName) ||
+                            "DomainResource".equals(parentClassName) ||
+                            "Resource".equals(parentClassName) ||
+                            "Bundle".equals(parentClassName) ||
+                            "OperationOutcome".equals(parentClassName)) {
+                        Class<?> innerModelClass = Class.forName(RESOURCEPACKAGENAME + "." + innerClassName);
+                        // System.out.println("Resource:  " + className);
+                        generateDefinition(innerModelClass, definitions);
+                    }
+                }
+
+                swagger.add("tags", tags);
+                swagger.add("paths", paths);
+        
+                JsonObjectBuilder components = factory.createObjectBuilder();
+                JsonObjectBuilder parameters = factory.createObjectBuilder();
+                generateSearchParameters(parameters, filter);
+                JsonObject parametersObject = parameters.build();
+                if (!parametersObject.isEmpty()) {
+                    components.add("parameters", parametersObject);
+                }
+                components.add("requestBodies", requestBodies);
+                components.add("schemas", definitions);
+        
+                swagger.add("components", components);
+        
+                Map<String, Object> config = new HashMap<String, Object>();
+                config.put(JsonGenerator.PRETTY_PRINTING, true);
+                JsonWriterFactory factory = Json.createWriterFactory(config);
+                
+                File outFile = new File("./src/main/resources/openapi/" + resourceClassName + "-openapi.json");
+                try (JsonWriter writer = factory.createWriter(new FileWriter(outFile))) {
+                    writer.writeObject(swagger.build());
+                } catch (Exception e) {
+                    throw new Error(e);
+                }
+            }
+        }
+        
+        generateMetadataOpenApi();
+        generateBatchTransactionOpenApi();
+    }
+    
+    
+
+    private static void generateMetadataOpenApi() throws Exception, ClassNotFoundException, Error {
         JsonObjectBuilder swagger = factory.createObjectBuilder();
-        swagger.add("openapi", "3.0.0");
-
+        swagger.add("swagger", "2.0");
+        
         JsonObjectBuilder info = factory.createObjectBuilder();
-        info.add("title", "FHIR REST API");
-        info.add("description", "IBM FHIR Server API");
+        info.add("title", "Capabilities");
+        info.add("description", "The capabilities interaction retrieves the information about a server's capabilities - which portions of the HL7 FHIR specification it supports.");
         info.add("version", "4.0.0");
         swagger.add("info", info);
 
-        /**
-         * "servers": [ { "url": "/fhir-server/api/v4" } ]
-         */
-        JsonArrayBuilder servers = factory.createArrayBuilder();
-        JsonObjectBuilder server = factory.createObjectBuilder();
-        server.add("url", "/fhir-server/api/v4");
-        servers.add(server);
-        swagger.add("servers", servers);
+        swagger.add("basePath", "/fhir-server/api/v4");
 
-        JsonArrayBuilder tags = factory.createArrayBuilder();
         JsonObjectBuilder paths = factory.createObjectBuilder();
         JsonObjectBuilder definitions = factory.createObjectBuilder();
-        JsonObjectBuilder requestBodies = factory.createObjectBuilder();
-
-        List<String> classNames = getClassNames();
-        // generation for all the top level resource.
-        for (String className : classNames) {
-            Class<?> modelClass = Class.forName(RESOURCEPACKAGENAME + "." + className);
-            if (DomainResource.class.isAssignableFrom(modelClass) && filter.acceptResourceType(modelClass)) {
-                generatePaths(modelClass, paths, filter);
-                JsonObjectBuilder tag = factory.createObjectBuilder();
-                tag.add("name", modelClass.getSimpleName());
-                tags.add(tag);
-            }
-            generateRequestBody(modelClass, requestBodies);
-            generateDefinition(modelClass, definitions);
-        }
         
-        // generate definition for all the defined Types.
-        classNames = getAllTypesList();
-        for (String className : classNames) {
-            Class<?> modelClass = Class.forName(TYPEPACKAGENAME + "." + className);
-            // System.out.println("Type:  " + className);
-            generateDefinition(modelClass, definitions);
-        }
-        
-        // generate definition for all inner classes inside the top level resources.
-        for (String className : getAllResourceInnerClasses()) {
-            Class<?> modelClass = Class.forName(RESOURCEPACKAGENAME + "." + className);
-            // System.out.println("Resource:  " + className);
-            generateDefinition(modelClass, definitions);
-        }
-
-        JsonObjectBuilder tag = factory.createObjectBuilder();
-        tag.add("name", "Other");
-        tags.add(tag);
-
-        // FHIR metadata operation
+        // FHIR capabilities interaction
         JsonObjectBuilder path = factory.createObjectBuilder();
         generateMetadataPathItem(path);
         paths.add("/metadata", path);
-
-        // FHIR batch operation
-        path = factory.createObjectBuilder();
-        generateBatchPathItem(path);
-        paths.add("/", path);
-
-        // TODO: FHIR transaction operation
-
-        swagger.add("tags", tags);
         swagger.add("paths", paths);
-
-        JsonObjectBuilder components = factory.createObjectBuilder();
-        JsonObjectBuilder parameters = factory.createObjectBuilder();
-        generateParameters(parameters, filter);
-        JsonObject parametersObject = parameters.build();
-        if (!parametersObject.isEmpty()) {
-            components.add("parameters", parametersObject);
+        
+        
+        generateDefinition(CapabilityStatement.class, definitions);
+        
+        // generate definition for all the defined Types.
+        for (String typeClassName : getAllTypesList()) {
+            Class<?> typeModelClass = Class.forName(TYPEPACKAGENAME + "." + typeClassName);
+            // System.out.println("Type:  " + className);
+            generateDefinition(typeModelClass, definitions);
         }
-        components.add("requestBodies", requestBodies);
-        components.add("schemas", definitions);
-
-        swagger.add("components", components);
-
+        
+        // generate definition for all inner classes inside the top level resources.
+        for (String innerClassName : getAllResourceInnerClasses()) {
+            Class<?> parentClass = Class.forName(RESOURCEPACKAGENAME + "." + innerClassName.split("\\$")[0]);
+            if (CapabilityStatement.class.equals(parentClass)) {
+                Class<?> innerModelClass = Class.forName(RESOURCEPACKAGENAME + "." + innerClassName);
+                // System.out.println("Resource:  " + className);
+                generateDefinition(innerModelClass, definitions);
+            }
+        }
+        
+        swagger.add("definitions", definitions);
+        
+        
         Map<String, Object> config = new HashMap<String, Object>();
         config.put(JsonGenerator.PRETTY_PRINTING, true);
         JsonWriterFactory factory = Json.createWriterFactory(config);
-        JsonWriter writer = factory.createWriter(System.out);
-        writer.writeObject(swagger.build());
+        
+        File outFile = new File("./src/main/resources/swagger/metadata-swagger.json");
+        try (JsonWriter writer = factory.createWriter(new FileWriter(outFile))) {
+            writer.writeObject(swagger.build());
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+
+    private static void generateBatchTransactionOpenApi() throws Exception, ClassNotFoundException, Error {
+        JsonObjectBuilder swagger = factory.createObjectBuilder();
+        swagger.add("swagger", "2.0");
+        
+        JsonObjectBuilder info = factory.createObjectBuilder();
+        info.add("title", "Batch/Transaction");
+        info.add("description", "The batch and transaction interactions submit a set of actions to perform on a server in a single HTTP request/response.");
+        info.add("version", "4.0.0");
+        swagger.add("info", info);
+
+        swagger.add("basePath", "/fhir-server/api/v4");
+
+        JsonObjectBuilder paths = factory.createObjectBuilder();
+        JsonObjectBuilder definitions = factory.createObjectBuilder();
+        
+        // FHIR batch/transaction interaction
+        JsonObjectBuilder path = factory.createObjectBuilder();
+        generateBatchPathItem(path);
+        paths.add("/", path);
+        swagger.add("paths", paths);
+        
+        
+        generateDefinition(CapabilityStatement.class, definitions);
+        
+        // generate definition for all the defined Types.
+        for (String typeClassName : getAllTypesList()) {
+            Class<?> typeModelClass = Class.forName(TYPEPACKAGENAME + "." + typeClassName);
+            // System.out.println("Type:  " + className);
+            generateDefinition(typeModelClass, definitions);
+        }
+        
+        // generate definition for all inner classes inside the top level resources.
+        for (String innerClassName : getAllResourceInnerClasses()) {
+            Class<?> parentClass = Class.forName(RESOURCEPACKAGENAME + "." + innerClassName.split("\\$")[0]);
+            if (CapabilityStatement.class.equals(parentClass)) {
+                Class<?> innerModelClass = Class.forName(RESOURCEPACKAGENAME + "." + innerClassName);
+                // System.out.println("Resource:  " + className);
+                generateDefinition(innerModelClass, definitions);
+            }
+        }
+        
+        swagger.add("definitions", definitions);
+        
+        
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(JsonGenerator.PRETTY_PRINTING, true);
+        JsonWriterFactory factory = Json.createWriterFactory(config);
+        
+        File outFile = new File("./src/main/resources/swagger/batch-swagger.json");
+        try (JsonWriter writer = factory.createWriter(new FileWriter(outFile))) {
+            writer.writeObject(swagger.build());
+        } catch (Exception e) {
+            throw new Error(e);
+        }
     }
 
     private static Map<Class<?>, StructureDefinition> buildStructureDefinitionMap() {
@@ -185,6 +360,7 @@ public class FHIROpenApiGenerator {
     private static void populateStructureDefinitionMap(Map<Class<?>, StructureDefinition> structureDefinitionMap,
             String structureDefinitionFile) throws Exception {
         InputStream stream = FHIROpenApiGenerator.class.getClassLoader().getResourceAsStream(structureDefinitionFile);
+        
         Bundle bundle = FHIRParser.parser(Format.JSON).parse(stream);
         for (Entry entry : bundle.getEntry()) {
             if (entry.getResource() instanceof StructureDefinition) {
@@ -210,40 +386,12 @@ public class FHIROpenApiGenerator {
                             structureDefinitionMap.put(modelClass, structureDefinition);
                         }
                     }
-
                 }
             }
         }
     }
 
-    private static void generateParameters(JsonObjectBuilder parameters, Filter filter) throws Exception {
-        if (filter.acceptOperation("read") || filter.acceptOperation("vread") || filter.acceptOperation("update")
-                || filter.acceptOperation("delete") || filter.acceptOperation("history")) {
-            JsonObjectBuilder id = factory.createObjectBuilder();
-            id.add("name", "id");
-            id.add("description", "logical identifier");
-            id.add("in", "path");
-            id.add("required", true);
-
-            JsonObjectBuilder schema = factory.createObjectBuilder();
-            schema.add("type", "string");
-            id.add("schema", schema);
-
-            parameters.add("idParam", id);
-        }
-        if (filter.acceptOperation("vread")) {
-            JsonObjectBuilder vid = factory.createObjectBuilder();
-            vid.add("name", "vid");
-            vid.add("description", "version identifier");
-            vid.add("in", "path");
-            vid.add("required", true);
-
-            JsonObjectBuilder schema = factory.createObjectBuilder();
-            schema.add("type", "string");
-            vid.add("schema", schema);
-
-            parameters.add("vidParam", vid);
-        }
+    private static void generateSearchParameters(JsonObjectBuilder parameters, Filter filter) throws Exception {
         if (filter.acceptOperation("search")) {
             for (SearchParameter searchParameter : SearchUtil.getSearchParameters(Resource.class)) {
                 JsonObjectBuilder parameter = factory.createObjectBuilder();
@@ -357,7 +505,7 @@ public class FHIROpenApiGenerator {
 
         JsonArrayBuilder parameters = factory.createArrayBuilder();
         JsonObjectBuilder idParamRef = factory.createObjectBuilder();
-        idParamRef.add("$ref", "#/components/parameters/idParam");
+        addIdPathParam(idParamRef);
         parameters.add(idParamRef);
 
         get.add("parameters", parameters);
@@ -398,11 +546,11 @@ public class FHIROpenApiGenerator {
 
         JsonArrayBuilder parameters = factory.createArrayBuilder();
         JsonObjectBuilder idParamRef = factory.createObjectBuilder();
-        idParamRef.add("$ref", "#/components/parameters/idParam");
+        addIdPathParam(idParamRef);
         parameters.add(idParamRef);
 
         JsonObjectBuilder vidParamRef = factory.createObjectBuilder();
-        vidParamRef.add("$ref", "#/components/parameters/vidParam");
+        addVidParamRef(vidParamRef);
         parameters.add(vidParamRef);
 
         get.add("parameters", parameters);
@@ -430,6 +578,26 @@ public class FHIROpenApiGenerator {
         path.add("get", get);
     }
 
+    private static void addIdPathParam(JsonObjectBuilder idParamRef) {
+        idParamRef.add("name", "id");
+        idParamRef.add("in", "path");
+        idParamRef.add("required", true);
+        idParamRef.add("description", "logical identifier");
+        JsonObjectBuilder schema = factory.createObjectBuilder();
+        schema.add("type", "string");
+        idParamRef.add("schema", schema);
+    }
+
+    private static void addVidParamRef(JsonObjectBuilder vidParamRef) {
+        vidParamRef.add("name", "vid");
+        vidParamRef.add("in", "path");
+        vidParamRef.add("required", true);
+        vidParamRef.add("description", "version identifier");
+        JsonObjectBuilder schema = factory.createObjectBuilder();
+        schema.add("type", "string");
+        vidParamRef.add("schema", schema);
+    }
+
     private static void generateUpdatePathItem(Class<?> modelClass, JsonObjectBuilder path) {
         JsonObjectBuilder put = factory.createObjectBuilder();
 
@@ -443,7 +611,7 @@ public class FHIROpenApiGenerator {
         JsonArrayBuilder parameters = factory.createArrayBuilder();
 
         JsonObjectBuilder idParamRef = factory.createObjectBuilder();
-        idParamRef.add("$ref", "#/components/parameters/idParam");
+        addIdPathParam(idParamRef);
         parameters.add(idParamRef);
 
         put.add("parameters", parameters);
@@ -485,7 +653,7 @@ public class FHIROpenApiGenerator {
         JsonArrayBuilder parameters = factory.createArrayBuilder();
 
         JsonObjectBuilder idParamRef = factory.createObjectBuilder();
-        idParamRef.add("$ref", "#/parameters/idParam");
+        addIdPathParam(idParamRef);
         parameters.add(idParamRef);
 
         delete.add("parameters", parameters);
@@ -577,7 +745,7 @@ public class FHIROpenApiGenerator {
 
         JsonArrayBuilder parameters = factory.createArrayBuilder();
         JsonObjectBuilder idParamRef = factory.createObjectBuilder();
-        idParamRef.add("$ref", "#/components/parameters/idParam");
+        addIdPathParam(idParamRef);
         parameters.add(idParamRef);
 
         get.add("parameters", parameters);
@@ -608,10 +776,6 @@ public class FHIROpenApiGenerator {
     private static void generateMetadataPathItem(JsonObjectBuilder path) {
         JsonObjectBuilder get = factory.createObjectBuilder();
 
-        JsonArrayBuilder tags = factory.createArrayBuilder();
-        tags.add("Other");
-
-        get.add("tags", tags);
         get.add("summary", "Get the FHIR Capability statement for this endpoint");
         get.add("operationId", "metadata");
 
@@ -715,7 +879,7 @@ public class FHIROpenApiGenerator {
     }
 
     private static void generateDefinition(Class<?> modelClass, JsonObjectBuilder definitions) throws Exception {
-        if (!isEnumerationWrapperClass(modelClass)) {
+        if (!ModelSupport.isPrimitiveType(modelClass)) {
             JsonObjectBuilder definition = factory.createObjectBuilder();
             JsonObjectBuilder properties = factory.createObjectBuilder();
             JsonArrayBuilder required = factory.createArrayBuilder();
@@ -729,7 +893,8 @@ public class FHIROpenApiGenerator {
             
             for (Field field : modelClass.getDeclaredFields()) {
                 if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isVolatile(field.getModifiers())) {
-                    if (!ModelSupport.isChoiceElement(modelClass, ModelSupport.getElementName(field)) && field.isAnnotationPresent(Required.class)) {
+                    if (!ModelSupport.isChoiceElement(modelClass, ModelSupport.getElementName(field)) && 
+                            field.isAnnotationPresent(Required.class)) {
                         required.add(ModelSupport.getElementName(field));
                     }
                     generateProperties(structureDefinition, modelClass, field, properties);
@@ -836,8 +1001,10 @@ public class FHIROpenApiGenerator {
             ElementDefinition elementDefinition = getElementDefinition(structureDefinition, modelClass, elementName + "[x]");
             String description = elementDefinition.getDefinition().getValue();
             for (Class<?> choiceType : choiceElementTypes) {
-                String choiceElementName = ModelSupport.getChoiceElementName(elementName, choiceType);
-                generateProperty(structureDefinition, modelClass, field, properties, choiceElementName, choiceType, many, description);
+                if (isApplicableForClass(choiceType, modelClass)) {
+                    String choiceElementName = ModelSupport.getChoiceElementName(elementName, choiceType);
+                    generateProperty(structureDefinition, modelClass, field, properties, choiceElementName, choiceType, many, description);
+                }
             }
         } else {
             ElementDefinition elementDefinition = getElementDefinition(structureDefinition, modelClass, elementName);
@@ -851,6 +1018,7 @@ public class FHIROpenApiGenerator {
 
         JsonObjectBuilder property = factory.createObjectBuilder();
 
+        // Convert all the primitive types to json types.
         if (isEnumerationWrapperClass(fieldClass)) {
             property.add("type", "string");
             JsonArrayBuilder constants = factory.createArrayBuilder();
@@ -861,38 +1029,60 @@ public class FHIROpenApiGenerator {
                 constants.add(value);
             }
             property.add("enum", constants);
-        // Convert all the java types to according json types based on FHIR spec.
-        } else if (String.class.equals(fieldClass)) {
+        } else if (com.ibm.fhir.model.type.String.class.isAssignableFrom(fieldClass)) {
             property.add("type", "string");
-        } else if (Boolean.class.equals(fieldClass)) {
+            if (com.ibm.fhir.model.type.Code.class.isAssignableFrom(fieldClass)) {
+                property.add("pattern", "[^\\s]+(\\s[^\\s]+)*");
+            } else if (com.ibm.fhir.model.type.Id.class.equals(fieldClass)) {
+                property.add("pattern", "[A-Za-z0-9\\-\\.]{1,64}");
+            } else {
+                property.add("pattern", "[ \\r\\n\\t\\S]+");
+            }
+        } else if (com.ibm.fhir.model.type.Uri.class.isAssignableFrom(fieldClass)) {
+            property.add("type", "string");
+            if (Oid.class.equals(fieldClass)) {
+                property.add("pattern", "urn:oid:[0-2](\\.(0|[1-9][0-9]*))+");
+            } else if (Uuid.class.equals(fieldClass)) {
+                property.add("pattern", "urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
+            } else {
+                property.add("pattern", "\\S*");
+            }
+        } else if (com.ibm.fhir.model.type.Boolean.class.equals(fieldClass)) {
             property.add("type", "boolean");
-        } else if (ZonedDateTime.class.equals(fieldClass)) {
+        } else if (com.ibm.fhir.model.type.Instant.class.equals(fieldClass)) {
             property.add("type", "string");
             property.add("pattern", "([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)-(0[1-9]"
                     + "|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]"
                     + "|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))");
-        } else if (BigDecimal.class.equals(fieldClass)) {
-            property.add("type", "number");
-            property.add("pattern","-?(0|[1-9][0-9]*)(\\.[0-9]+)?([eE][+-]?[0-9]+)?");
-        } else if (LocalTime.class.equals(fieldClass)) {
+        } else if (com.ibm.fhir.model.type.Time.class.equals(fieldClass)) {
             property.add("type", "string");
             property.add("pattern","([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\\.[0-9]+)?");
-        } else if (TemporalAccessor.class.equals(fieldClass)) {
+        } else if (com.ibm.fhir.model.type.Date.class.equals(fieldClass)) {
             property.add("type", "string");
-            if (Date.class.equals(modelClass)) {
-                property.add("pattern","([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)"
-                        + "|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?");
-            } else if (DateTime.class.equals(modelClass)) {
-                property.add("pattern","([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]"
-                        + "|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]"
-                        + "|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?");
-            }
-        } else if (fieldClass.getSimpleName().equalsIgnoreCase("byte[]")) {
+            property.add("pattern","([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)"
+                    + "|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1]))?)?");
+        } else if (com.ibm.fhir.model.type.DateTime.class.equals(fieldClass)) {
+            property.add("type", "string");
+            property.add("pattern","([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]"
+                    + "|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]"
+                    + "|60)(\\.[0-9]+)?(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?");
+        } else if (com.ibm.fhir.model.type.Decimal.class.equals(fieldClass)) {
+            property.add("type", "number");
+        } else if (com.ibm.fhir.model.type.Integer.class.isAssignableFrom(fieldClass)) {
+            property.add("type", "integer");
+            property.add("format", "int32");
+        } else if (com.ibm.fhir.model.type.Base64Binary.class.equals(fieldClass)) {
             property.add("type", "string");
             property.add("pattern","(\\s*([0-9a-zA-Z\\+\\=]){4}\\s*)+");
-        } else if (fieldClass.getSimpleName().equalsIgnoreCase("int")) {
-            property.add("type", "integer");
-            property.add("pattern","[0]|[-+]?[1-9][0-9]*");
+        } else if (String.class.equals(fieldClass)) {
+            property.add("type", "string");
+            if ("id".equals(elementName)) {
+                property.add("pattern", "[A-Za-z0-9\\-\\.]{1,64}");
+            } else if ("url".equals(elementName)) {
+                property.add("pattern", "\\S*");
+            }
+        } else if (com.ibm.fhir.model.type.Xhtml.class.equals(fieldClass)) {
+            property.add("type", "string");
         } else {
             property.add("$ref", "#/components/schemas/" + getSimpleNameWithEnclosingNames(fieldClass));
         }
@@ -1074,6 +1264,7 @@ public class FHIROpenApiGenerator {
 
         for (int i = 0; i < listOfFiles.length; i++) {
             if (listOfFiles[i].isFile()) {
+                // strip the ".java"
                 allTypesList.add(listOfFiles[i].getName().substring(0, listOfFiles[i].getName().length() - 5));
             }
         }
@@ -1110,5 +1301,119 @@ public class FHIROpenApiGenerator {
         return allResourceInnerClassList;
     }
     
-
+    /**
+     * @return true if the type model class is applicable for the outer model class
+     */
+    public static boolean isApplicableForClass(Class<?> typeModelClass, Class<?> outerModelClass) {
+        // if the resource class has a choice element (other than Extension.value[x])
+        // with a type of "*" (any), then include it
+        if (StructureMap.class == outerModelClass ||
+                Task.class == outerModelClass) {
+            return true;
+        }
+        
+        boolean isApplicable = true;
+        
+        if (Dosage.class == typeModelClass ||
+                Dosage.class == typeModelClass.getEnclosingClass()) {
+            // Special case for Dosage
+            if (outerModelClass != ActivityDefinition.class &&
+                    outerModelClass != MedicationDispense.class &&
+                    outerModelClass != MedicationKnowledge.class &&
+                    outerModelClass != MedicationRequest.class &&
+                    outerModelClass != MedicationStatement.class) {
+                isApplicable = false;
+            }
+        } else if (ElementDefinition.class == typeModelClass ||
+                ElementDefinition.class.equals(typeModelClass.getEnclosingClass()) ||
+                ElementDefinition.Slicing.Discriminator.class == typeModelClass) {
+            if (outerModelClass != StructureDefinition.class) {
+                isApplicable = false;
+            }
+        } else if (ContactDetail.class == typeModelClass) {
+            // TODO: introspect the resourceModelClass to tell if its truly applicable or not
+            isApplicable = true;
+        } else if (Contributor.class == typeModelClass) {
+            // Not used anywhere yet
+            isApplicable = false;
+        } else if (DataRequirement.class == typeModelClass ||
+                DataRequirement.class == typeModelClass.getEnclosingClass()) {
+            if (outerModelClass != TriggerDefinition.class &&
+                    outerModelClass != EvidenceVariable.class &&
+                    outerModelClass != GuidanceResponse.class &&
+                    outerModelClass != Library.class &&
+                    outerModelClass != PlanDefinition.class &&
+                    outerModelClass != ResearchElementDefinition.class) {
+                isApplicable = false;
+            }
+        } else if (ParameterDefinition.class == typeModelClass ||
+                ParameterDefinition.class == typeModelClass.getEnclosingClass()) {
+            if (outerModelClass != ActivityDefinition.class &&
+                    outerModelClass != MedicationDispense.class &&
+                    outerModelClass != MedicationKnowledge.class &&
+                    outerModelClass != MedicationRequest.class &&
+                    outerModelClass != MedicationStatement.class) {
+                isApplicable = false;
+            }
+        } else if (RelatedArtifact.class == typeModelClass) {
+            // TODO: introspect the resourceModelClass to tell if its truly applicable or not
+            isApplicable = true;
+        } else if (TriggerDefinition.class == typeModelClass ||
+                TriggerDefinition.class == typeModelClass.getEnclosingClass()) {
+            if (outerModelClass != EventDefinition.class &&
+                    outerModelClass != EvidenceVariable.class &&
+                    outerModelClass != PlanDefinition.class) {
+                isApplicable = false;
+            }
+        } else if (Expression.class == typeModelClass ||
+                Expression.class == typeModelClass.getEnclosingClass()) {
+            if (outerModelClass != ActivityDefinition.class &&
+                    outerModelClass != TriggerDefinition.class &&
+                    outerModelClass != ActivityDefinition.class &&
+                    outerModelClass != EvidenceVariable.class &&
+                    outerModelClass != Measure.class &&
+                    outerModelClass != PlanDefinition.class &&
+                    outerModelClass != RequestGroup.class &&
+                    outerModelClass != ResearchElementDefinition.class) {
+                isApplicable = false;
+            }
+        } else if (UsageContext.class == typeModelClass ||
+                UsageContext.class == typeModelClass.getEnclosingClass()) {
+            // TODO: introspect the resourceModelClass to tell if its truly applicable or not
+            isApplicable = true;
+        } else if (SubstanceAmount.class == typeModelClass ||
+                SubstanceAmount.class == typeModelClass.getEnclosingClass()) {
+            if (SubstancePolymer.class != outerModelClass) {
+                isApplicable = false;
+            }
+        } else if (ProdCharacteristic.class == typeModelClass ||
+                ProdCharacteristic.class == typeModelClass.getEnclosingClass()) {
+            if (DeviceDefinition.class != outerModelClass &&
+                    MedicinalProductManufactured.class != outerModelClass &&
+                    MedicinalProductPackaged.class != outerModelClass) {
+                isApplicable = false;
+            }
+        } else if (ProductShelfLife.class == typeModelClass ||
+                ProductShelfLife.class == typeModelClass.getEnclosingClass()) {
+            if (DeviceDefinition.class != outerModelClass &&
+                    MedicinalProductPackaged.class != outerModelClass) {
+                isApplicable = false;
+            }
+        } else if (MarketingStatus.class == typeModelClass ||
+                MarketingStatus.class == typeModelClass.getEnclosingClass()) {
+            if (DeviceDefinition.class != outerModelClass &&
+                    MedicinalProductPackaged.class != outerModelClass) {
+                isApplicable = false;
+            }
+        } else if (Population.class == typeModelClass ||
+                Population.class == typeModelClass.getEnclosingClass()) {
+            if (MedicinalProductContraindication.class != outerModelClass &&
+                    MedicinalProductIndication.class != outerModelClass &&
+                    MedicinalProductUndesirableEffect.class != outerModelClass) {
+                isApplicable = false;
+            }
+        }
+        
+        return isApplicable;
+    }
 }

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/APIConnectAdapter.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/APIConnectAdapter.java
@@ -1,9 +1,10 @@
-package com.ibm.fhir.swagger.generator;
 /*
  * (C) Copyright IBM Corp. 2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+package com.ibm.fhir.swagger.generator;
 
 import javax.json.Json;
 import javax.json.JsonArrayBuilder;
@@ -11,18 +12,18 @@ import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
 
 /**
- * 
+ *
  */
 public class APIConnectAdapter {
-    
+
     /**
      * Set this to the hostname of your FHIR Server and the generated assembly will proxy this
      */
     private static final String HOST = "localhost";
-    
+
     private static final JsonBuilderFactory factory = Json.createBuilderFactory(null);
-    
-    static void addApiConnectStuff(JsonObjectBuilder swagger) {
+
+    public static void addApiConnectStuff(JsonObjectBuilder swagger) {
         JsonObjectBuilder ibmConfig = factory.createObjectBuilder()
                                         .add("gateway", "datapower-api-gateway")
                                         .add("type", "rest")
@@ -41,12 +42,12 @@ public class APIConnectAdapter {
                                         .add("catalogs", factory.createObjectBuilder());
         swagger.add("x-ibm-configuration", ibmConfig);
     }
-    
+
     private static JsonObjectBuilder buildAssembly() {
         JsonObjectBuilder executeInvoke = factory.createObjectBuilder().add("invoke", buildExecuteInvoke());
-        
+
         JsonArrayBuilder execute = factory.createArrayBuilder().add(executeInvoke);
-        
+
         return factory.createObjectBuilder()
                 .add("execute", execute)
                 .add("catch", factory.createArrayBuilder());
@@ -71,13 +72,13 @@ public class APIConnectAdapter {
                                     .add("stop-on-error", factory.createArrayBuilder())
                                     .add("target-url", "$(target-url)$(api.operation.path)$(request.search)");
     }
-    
+
     private static JsonObjectBuilder buildProperties() {
         JsonObjectBuilder targetUrl = factory.createObjectBuilder()
                                             .add("value", "https://" + HOST + "/fhir-server/api/v4/")
                                             .add("description", "The URL of the target service")
                                             .add("encoded", false);
-        
+
         return factory.createObjectBuilder().add("target-url", targetUrl);
     }
 }

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -979,6 +979,8 @@ public class FHIRSwaggerGenerator {
             } else if ("url".equals(elementName)) {
                 property.add("pattern", "\\S*");
             }
+        } else if (com.ibm.fhir.model.type.Xhtml.class.equals(fieldClass)) {
+            property.add("type", "string");
         } else {
             property.add("$ref", "#/definitions/" + getSimpleNameWithEnclosingNames(fieldClass));
         }


### PR DESCRIPTION
1. Updated FHIROpenApiGenerator to match the recent changes to
FHIRSwaggerGenerator (e.g. one file per resource type)

2. utilize the Liberty mpOpenAPI-1.0 feature to validate the updated
OpenAPI definition; this helped to find and a number of issues that were
applicable to both the OpenAPI and the Swagger 2.0 definitions, includ
ing:

* Problem:  Complex datatypes and wildcard choice elements are
referencing non-existent primitive elements.
    * Solution:  add isApplicableForClass guard to the loops for adding
the choice type properties and the data type and definitions...this
simplifies the schema by skipping both special types like Dosage and
ElementDefinition and metadata types like ContactDetail, Contributor,
DataRequirement, and ParameterDefinition (unless they are explicitly
referenced from the resource type being generated). Although technically
these types are allowed values for the Extension.value[x] element that
is always applicable, they are almost never desired here.

* Problem:  String definitions for Element.id and Extension.url are not
properly inlined.
    * Found and fixed the issue; I had accidentally left a conditional
clause (`&& !"id".equals(elementName) && !"url".equals(elementName)`)
which needed to be removed for proper functioning.

* Problem:  Date and DateTime are not properly inlined; instead we have
stale references*
    * Found and fixed the issue; the logic for these 2 primitives (and
only these primitives) was using `modelClass` where it should have used
`fieldClass`.

3. To appease the Liberty OpenAPI validation, path parameters `id` and
`vid` are now defined inline in the OpenAPI. I did *not* make the
corresponding change to the Swagger 2.0 generator, but its possible to
make this change there as well if needed.