### PR TITLE
Support _pretty query parameter #269

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -24,7 +24,7 @@ The IBM FHIR Server implements a linear versioning scheme for resources and full
 ### General parameters
 The `_format` parameter is supported and provides a useful mechanism for requesting a specific format (`XML` or `JSON`) in requests made from a browser. In the absence of either an `Accept` header or a `_format` query parameter, the server defaults to `application/fhir+json`.
 
-The `_pretty` parameter is not currently supported, but should be added as part of https://github.com/IBM/FHIR/issues/269.
+The `_pretty` parameter is also supported. 
 
 The `_summary` and `_elements` parameters are supported on the search interaction as documented.
 

--- a/fhir-provider/src/test/java/com/ibm/fhir/provider/FHIRProviderTest.java
+++ b/fhir-provider/src/test/java/com/ibm/fhir/provider/FHIRProviderTest.java
@@ -6,41 +6,261 @@
 
 package com.ibm.fhir.provider;
 
-import org.testng.annotations.Test;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
-import com.ibm.fhir.config.FHIRConfiguration;
-import com.ibm.fhir.provider.FHIRProvider;
-
-import static org.testng.AssertJUnit.*;
-
-import javax.ws.rs.core.*;
+import java.net.URI;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-/**
- * Created by rick.boyd on 11/19/18.
- */
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.PathSegment;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRConfiguration;
 
 public class FHIRProviderTest {
+    
+    /*
+     * generate multivalued map
+     * @param value
+     * @return
+     */
+    public MultivaluedMap<String, String> generateMulivaluedMap(String value) {
+        return new MultivaluedMap<String, String>() {
+
+            @Override
+            public int size() {
+                return 0;
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return false;
+            }
+
+            @Override
+            public boolean containsKey(Object key) {
+                return false;
+            }
+
+            @Override
+            public boolean containsValue(Object value) {
+                return false;
+            }
+
+            @Override
+            public List<String> get(Object key) {
+                return null;
+            }
+
+            @Override
+            public List<String> put(String key, List<String> value) {
+                return null;
+            }
+
+            @Override
+            public List<String> remove(Object key) {
+                return null;
+            }
+
+            @Override
+            public void putAll(Map<? extends String, ? extends List<String>> m) {
+
+            }
+
+            @Override
+            public void clear() {
+
+            }
+
+            @Override
+            public Set<String> keySet() {
+                return null;
+            }
+
+            @Override
+            public Collection<List<String>> values() {
+                return null;
+            }
+
+            @Override
+            public Set<Entry<String, List<String>>> entrySet() {
+                return null;
+            }
+
+            @Override
+            public void putSingle(String key, String value) {
+
+            }
+
+            @Override
+            public void add(String key, String value) {
+
+            }
+
+            @Override
+            public String getFirst(String key) {
+                return value;
+            }
+
+            @Override
+            public void addAll(String key, String... newValues) {
+
+            }
+
+            @Override
+            public void addAll(String key, List<String> valueList) {
+
+            }
+
+            @Override
+            public void addFirst(String key, String value) {
+
+            }
+
+            @Override
+            public boolean equalsIgnoreValueOrder(MultivaluedMap<String, String> otherMap) {
+                return false;
+            }
+
+        };
+    }
+
+    /*
+     * generate uri info
+     */
+    public UriInfo generatePrettyParameterUriInfo(String value) {
+        return new UriInfo() {
+
+            @Override
+            public String getPath() {
+                return null;
+            }
+
+            @Override
+            public String getPath(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public List<PathSegment> getPathSegments() {
+                return null;
+            }
+
+            @Override
+            public List<PathSegment> getPathSegments(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public URI getRequestUri() {
+                return null;
+            }
+
+            @Override
+            public UriBuilder getRequestUriBuilder() {
+                return null;
+            }
+
+            @Override
+            public URI getAbsolutePath() {
+                return null;
+            }
+
+            @Override
+            public UriBuilder getAbsolutePathBuilder() {
+                return null;
+            }
+
+            @Override
+            public URI getBaseUri() {
+                return null;
+            }
+
+            @Override
+            public UriBuilder getBaseUriBuilder() {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getPathParameters() {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getPathParameters(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getQueryParameters() {
+                return generateMulivaluedMap(value);
+            }
+
+            @Override
+            public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
+                return generateMulivaluedMap(value);
+            }
+
+            @Override
+            public List<String> getMatchedURIs() {
+                return null;
+            }
+
+            @Override
+            public List<String> getMatchedURIs(boolean decode) {
+                return null;
+            }
+
+            @Override
+            public List<Object> getMatchedResources() {
+
+                return null;
+            }
+
+            @Override
+            public URI resolve(URI uri) {
+                return null;
+            }
+
+            @Override
+            public URI relativize(URI uri) {
+                return null;
+            }
+
+        };
+    }
 
     @Test
     public void isPrettyDefaultsFalse() {
+
         HttpHeaders headers = createHeaders();
+
         // when empty
-        assertFalse(FHIRProvider.isPretty(headers));
+        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
         // when populated but misspelled
         headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "nottrue");
-        assertFalse(FHIRProvider.isPretty(headers));
+        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     @Test
     public void isPrettyTrueForTrue() {
         HttpHeaders headers = createHeaders();
         headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "true");
-        assertTrue(FHIRProvider.isPretty(headers));
+        assertTrue(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     @Test
@@ -48,12 +268,13 @@ public class FHIRProviderTest {
         HttpHeaders headers = createHeaders();
         headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "false");
 
-        assertFalse(FHIRProvider.isPretty(headers));
+        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     private static HttpHeaders createHeaders() {
         return new HttpHeaders() {
             private MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+
             @Override
             public List<String> getRequestHeader(String s) {
                 return headers.get(s);

--- a/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
@@ -87,13 +87,15 @@ public class SearchConstants {
     // _count
     public static final String COUNT = "_count";
     
-    
-    //_summary
+    // _summary
     public static final String SUMMARY = "_summary";
+    
+    // _pretty
+    public static final String PRETTY = "_pretty";
 
     // set as unmodifiable
     public static final List<String> SEARCH_RESULT_PARAMETER_NAMES =
-            Collections.unmodifiableList(Arrays.asList(SORT, "_sort:asc", "_sort:desc", COUNT, PAGE, INCLUDE, REVINCLUDE, ELEMENTS, SUMMARY));
+            Collections.unmodifiableList(Arrays.asList(PRETTY, SORT, "_sort:asc", "_sort:desc", COUNT, PAGE, INCLUDE, REVINCLUDE, ELEMENTS, SUMMARY));
     
     // set as unmodifiable
     public static final List<String> SYSTEM_LEVEL_SORT_PARAMETER_NAMES = Collections.unmodifiableList(Arrays.asList("_id", "_lastUpdated"));

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PrettyServerFormatTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PrettyServerFormatTest.java
@@ -1,0 +1,64 @@
+/*
+ * (C) Copyright IBM Corp. 2017,2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+
+/**
+ * Basic Test of the _pretty
+ */
+public class PrettyServerFormatTest extends FHIRServerTestBase {
+
+    /**
+     * Create a minimal Patient, then make sure we can retrieve it with varying
+     * format
+     */
+    @Test(groups = { "server-pretty" })
+    public void testPrettyFormatting() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_DavidOrtiz.json");
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request().post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        String patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response =
+                target.queryParam("_pretty", "true").path("Patient/" + patientId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON).header("_format", "application/fhir+json").get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+
+        String prettyOutput = response.readEntity(String.class);
+
+        response =
+                target.queryParam("_pretty", "false").path("Patient/" + patientId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON).header("_format", "application/fhir+json").get();
+
+        String notPrettyOutput = response.readEntity(String.class);
+        
+        assertNotEquals(prettyOutput, notPrettyOutput);
+        assertFalse(notPrettyOutput.contains("\n"));
+        assertTrue(prettyOutput.contains("\n"));
+    }
+}


### PR DESCRIPTION
- Update conformance.md statements on _pretty
- Update Provider to support Pretty from CDI injected URIInfo
- Introduce new test for Pretty
- Update SearchConstants to avoid processing _pretty as a Search
Parameter

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>