### PR TITLE
issue #103 #105 bulkdataExport multi-resType support with Res counts

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/CheckPointAlgorithm.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/CheckPointAlgorithm.java
@@ -17,8 +17,7 @@ import com.ibm.fhir.bulkcommon.Constants;
 
 /**
  * Bulk export Chunk implementation - custom checkpoint algorithm.
- * 
- * @author Albert Wang
+ *
  */
 
 public class CheckPointAlgorithm implements CheckpointAlgorithm {
@@ -44,34 +43,37 @@ public class CheckPointAlgorithm implements CheckpointAlgorithm {
      * Default constructor.
      */
     public CheckPointAlgorithm() {
-        // TODO Auto-generated constructor stub
+     // Nothing to do here at present
     }
 
     /**
      * @see CheckpointAlgorithm#checkpointTimeout()
      */
+    @Override
     public int checkpointTimeout() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
     /**
      * @see CheckpointAlgorithm#endCheckpoint()
      */
+    @Override
     public void endCheckpoint() {
-        // TODO Auto-generated method stub
+        // Nothing to do here at present
     }
 
     /**
      * @see CheckpointAlgorithm#beginCheckpoint()
      */
+    @Override
     public void beginCheckpoint() {
-        // TODO Auto-generated method stub
+        // Nothing to do here at present
     }
 
     /**
      * @see CheckpointAlgorithm#isReadyToCheckpoint()
      */
+    @Override
     public boolean isReadyToCheckpoint() {
         TransientUserData chunkData = (TransientUserData) jobContext.getTransientUserData();
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/CheckPointUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/CheckPointUserData.java
@@ -7,21 +7,23 @@
 package com.ibm.fhir.bulkexport;
 
 import java.util.List;
+
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 
 /**
  * Bulk export Chunk implementation - job check point data.
- * 
- * @author Albert Wang
+ *
  */
 public class CheckPointUserData implements java.io.Serializable {
     private static final long serialVersionUID = 5722923276076940517L;
-    protected int pageNum;
-    protected int lastPageNum;
-    protected int partNum;
-    protected String uploadId;
-    protected boolean isSingleCosObject = false;
-    protected List<PartETag> cosDataPacks;
+    private int pageNum;
+    private int lastPageNum;
+    private int partNum;
+    private String uploadId;
+    private boolean isSingleCosObject = false;
+    private List<PartETag> cosDataPacks;
+    private int indexOfCurrentResourceType;
+    private int currentPartResourceNum = 0;
 
     public CheckPointUserData(int pageNum, String uploadId, List<PartETag> cosDataPacks, int partNum) {
         super();
@@ -82,6 +84,22 @@ public class CheckPointUserData implements java.io.Serializable {
 
     public void setLastPageNum(int lastPageNum) {
         this.lastPageNum = lastPageNum;
+    }
+
+    public int getIndexOfCurrentResourceType() {
+        return indexOfCurrentResourceType;
+    }
+
+    public void setIndexOfCurrentResourceType(int indexOfCurrentResourceType) {
+        this.indexOfCurrentResourceType = indexOfCurrentResourceType;
+    }
+
+    public int getCurrentPartResourceNum() {
+        return currentPartResourceNum;
+    }
+
+    public void setCurrentPartResourceNum(int currentPartResourceNum) {
+        this.currentPartResourceNum = currentPartResourceNum;
     }
 
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/TransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/TransientUserData.java
@@ -13,8 +13,7 @@ import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 
 /**
  * Bulk export Chunk implementation - job cache data.
- * 
- * @author Albert Wang
+ *
  */
 public class TransientUserData extends CheckPointUserData {
     private static final long serialVersionUID = -5892726731783560418L;

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -142,7 +142,7 @@ public class BulkDataClient {
         // Need to push this into a property.
         WebTarget target = getWebTarget(properties.get(BulkDataConfigUtil.BATCH_URL));
 
-        System.out.println("-> " + properties.get(BulkDataConfigUtil.BATCH_URL));
+        log.info("-> " + properties.get(BulkDataConfigUtil.BATCH_URL));
 
         BulkExportJobInstanceRequest.Builder builder = BulkExportJobInstanceRequest.builder();
         builder.applicationName(properties.get(BulkDataConfigUtil.APPLICATION_NAME));

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -15,6 +15,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,10 +42,9 @@ import com.ibm.fhir.operation.bulkdata.util.BulkDataUtil;
 
 /**
  * BulkData Client to connect to the other server.
- * 
+ *
  * @link https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/rwlp_batch_rest_api.html#rwlp_batch_rest_api__http_return_codes
- * 
- * @author pbastide
+ *
  *
  */
 public class BulkDataClient {
@@ -141,7 +141,7 @@ public class BulkDataClient {
 
         // Need to push this into a property.
         WebTarget target = getWebTarget(properties.get(BulkDataConfigUtil.BATCH_URL));
-        
+
         System.out.println("-> " + properties.get(BulkDataConfigUtil.BATCH_URL));
 
         BulkExportJobInstanceRequest.Builder builder = BulkExportJobInstanceRequest.builder();
@@ -155,14 +155,14 @@ public class BulkDataClient {
         builder.cosCredentialIbm(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_IBM));
         builder.cosApiKey(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_KEY));
         builder.cosSrvInstId(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT));
-        
+
         String fhirTenant = FHIRRequestContext.get().getTenantId();
         builder.fhirTenant(fhirTenant);
-        
+
         String fhirDataStoreId = FHIRRequestContext.get().getDataStoreId();
         builder.fhirDataStoreId(fhirDataStoreId);
-        
-        String resourceType = types.get(0);
+
+        String resourceType = String.join(", ", types);
         builder.fhirResourceType(resourceType);
 
         if (since != null) {
@@ -257,24 +257,37 @@ public class BulkDataClient {
 
         // Assemble the URL
         String jobId = Integer.toString(response.getInstanceId());
-        String resourceType = response.getJobParameters().getFhirResourceType();
-        
+        String resourceTypes = response.getJobParameters().getFhirResourceType();
+
         String baseCosUrl = properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT);
         String bucket = properties.get(BulkDataConfigUtil.JOB_PARAMETERS_BUCKET);
-        String downloadUrl =
-                baseCosUrl + "/" + bucket + "/job" + jobId + "/" + resourceType + "_1.ndjson";
 
-        // Request 
-        String request = "/$export?_type=" + resourceType;
+
+        // Request
+        String request = "/$export?_type=" + resourceTypes;
         result.setRequest(request);
         result.setRequiresAccessToken(false);
-        
+
         // TODO: Convert to yyyy-MM-dd'T'HH:mm:ss
         result.setTransactionTime(response.getLastUpdatedTime());
-        
-        PollingLocationResponse.Output output = new PollingLocationResponse.Output(resourceType, downloadUrl);
-        result.setOutput(Arrays.asList(output));
-        
+        // Compose outputs for all exported ndjson files from the batch job exit status,
+        // e.g, Patient[1000,1000,200]:Observation[1000,1000,200]
+        String exitStatus = response.getExitStatus();
+        List<String> ResourceTypeInfs = Arrays.asList(exitStatus.split("\\s*:\\s*"));
+
+        List< PollingLocationResponse.Output> outPutList = new ArrayList< PollingLocationResponse.Output>();
+        for (String resourceTypeInf: ResourceTypeInfs) {
+            String resourceType = resourceTypeInf.substring(0, resourceTypeInf.indexOf("["));
+            String resourceCounts[] = resourceTypeInf.substring(resourceTypeInf.indexOf("[")+1, resourceTypeInf.indexOf("]"))
+                    .split("\\s*,\\s*");
+            for (int i = 0; i < resourceCounts.length; i++) {
+                String downloadUrl =
+                        baseCosUrl + "/" + bucket + "/job" + jobId + "/" + resourceType + "_" + (i+1) + ".ndjson";
+                outPutList.add(new PollingLocationResponse.Output(resourceType, downloadUrl, resourceCounts[i]));
+            }
+        }
+        result.setOutput(outPutList);
+
         return result;
     }
 }

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobExecutionResponse.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobExecutionResponse.java
@@ -152,6 +152,14 @@ public class BulkExportJobExecutionResponse {
         this._links.add(link);
     }
 
+    public String getExitStatus() {
+        return exitStatus;
+    }
+
+    public void setExitStatus(String exitStatus) {
+        this.exitStatus = exitStatus;
+    }
+
     public static class JobParameter {
 
         String fhirResourceType;
@@ -632,14 +640,6 @@ public class BulkExportJobExecutionResponse {
             return o;
         }
 
-    }
-
-    public String getExitStatus() {
-        return exitStatus;
-    }
-
-    public void setExitStatus(String exitStatus) {
-        this.exitStatus = exitStatus;
     }
 
 }

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobExecutionResponse.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobExecutionResponse.java
@@ -29,7 +29,7 @@ import com.ibm.fhir.exception.FHIROperationException;
 
 /**
  * BulkImportJob's JSON response
- * 
+ *
  * <pre>
  *  {
    “jobName”: “BulkImportJob”,
@@ -51,9 +51,7 @@ import com.ibm.fhir.exception.FHIROperationException;
        }
    ]
     }
- *  </pre>
- * 
- * @author pbastide
+ *  </pre
  *
  */
 public class BulkExportJobExecutionResponse {
@@ -62,13 +60,14 @@ public class BulkExportJobExecutionResponse {
     private String appName;
     private String submitter;
     private String batchStatus;
+    private String exitStatus;
     private String jobXMLName;
     private String instanceName;
     private String lastUpdatedTime;
     private List<Link> _links = new ArrayList<>();
-    
+
     private JobParameter jobParameters;
-    
+
     public JobParameter getJobParameters() {
         return jobParameters;
     }
@@ -152,7 +151,7 @@ public class BulkExportJobExecutionResponse {
     public void addLink(Link link) {
         this._links.add(link);
     }
-    
+
     public static class JobParameter {
 
         String fhirResourceType;
@@ -233,8 +232,6 @@ public class BulkExportJobExecutionResponse {
 
     /**
      * Link is a sub class reflecting the link to the parts of the Export Job.
-     * 
-     * @author pbastide
      *
      */
     public static class Link {
@@ -261,15 +258,13 @@ public class BulkExportJobExecutionResponse {
 
     /**
      * Builder is a convenience pattern to assemble to Java Object that reflects the BatchManagement pattern.
-     * 
-     * @author pbastide
      *
      */
     public static class Builder {
 
         private BulkExportJobExecutionResponse response = new BulkExportJobExecutionResponse();
         private JobParameter jobParameter = new JobParameter();
-        
+
         private Builder() {
             // Intentionally hiding from external callers.
         }
@@ -299,6 +294,11 @@ public class BulkExportJobExecutionResponse {
             return this;
         }
 
+        public Builder exitStatus(String exitStatus) {
+            response.setExitStatus(exitStatus);
+            return this;
+        }
+
         public Builder jobXMLName(String jobXMLName) {
             response.setJobXMLName(jobXMLName);
             return this;
@@ -313,7 +313,7 @@ public class BulkExportJobExecutionResponse {
             response.setLastUpdatedTime(lastUpdatedTime);
             return this;
         }
-        
+
         public Builder fhirResourceType(String fhirResourceType) {
             jobParameter.setFhirResourceType(fhirResourceType);
             return this;
@@ -373,25 +373,21 @@ public class BulkExportJobExecutionResponse {
         return new Builder();
     }
 
-    /**
-     * 
-     * @author pbastide
-     *
-     */
+
     public static class Parser {
-        
+
         private Parser() {
             // No Op
         }
 
         private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
-        
+
         public static BulkExportJobExecutionResponse parse(String jsonString) throws FHIROperationException {
-            
+
             try(InputStream in = new ByteArrayInputStream(jsonString.getBytes())){
-                
+
                 return BulkExportJobExecutionResponse.Parser.parse(in);
-                
+
             } catch(Exception e) {
                 throw new FHIROperationException("Problem parsing the Bulk Export Job's from jsonString response from the server", e);
             }
@@ -403,45 +399,49 @@ public class BulkExportJobExecutionResponse {
                 JsonObject jsonObject = jsonReader.readObject();
                 BulkExportJobExecutionResponse.Builder builder = BulkExportJobExecutionResponse.builder();
 
-                
+
                 if (jsonObject.containsKey("jobName")) {
                     String jobName = jsonObject.getString("jobName");
                     builder.jobName(jobName);
                 }
 
-                
+
                 if (jsonObject.containsKey("instanceId")) {
                     Integer instanceId = jsonObject.getInt("instanceId");
                     builder.instanceId(instanceId);
                 }
-                
+
                 if (jsonObject.containsKey("appName")) {
                     String appName = jsonObject.getString("appName");
                     builder.appName(appName);
                 }
-                
+
                 if (jsonObject.containsKey("batchStatus")) {
                     String batchStatus = jsonObject.getString("batchStatus");
                     builder.batchStatus(batchStatus);
                 }
 
-               
+                if (jsonObject.containsKey("exitStatus")) {
+                    String exitStatus = jsonObject.getString("exitStatus");
+                    builder.exitStatus(exitStatus);
+                }
+
                 if (jsonObject.containsKey("jobXMLName")) {
                     String jobXMLName = jsonObject.getString("jobXMLName");
                     builder.jobXMLName(jobXMLName);
                 }
-                
+
                 if (jsonObject.containsKey("instanceName")) {
                     String instanceName = jsonObject.getString("instanceName");
                     builder.instanceName(instanceName);
                 }
-                
+
                 if (jsonObject.containsKey("lastUpdatedTime")) {
                     String lastUpdatedTime = jsonObject.getString("lastUpdatedTime");
                     builder.lastUpdatedTime(lastUpdatedTime);
                 }
 
-               
+
                 if (jsonObject.containsKey("_links")) {
                     JsonArray arr = jsonObject.getJsonArray("_links");
                     ListIterator<JsonValue> iter = arr.listIterator();
@@ -457,8 +457,8 @@ public class BulkExportJobExecutionResponse {
                         }
                     }
                 }
-                
-                
+
+
                 if (jsonObject.containsKey("jobParameters")) {
                     JsonObject obj = jsonObject.getJsonObject("jobParameters");
                     String fhirResourceType = obj.getString("fhir.resourcetype");
@@ -513,8 +513,6 @@ public class BulkExportJobExecutionResponse {
 
     /**
      * Generates JSON from this object.
-     * 
-     * @author pbastide
      *
      */
     public static class Writer {
@@ -551,6 +549,10 @@ public class BulkExportJobExecutionResponse {
                         generator.write("batchStatus", obj.getBatchStatus());
                     }
 
+                    if (obj.getExitStatus() != null) {
+                        generator.write("exitStatus", obj.getExitStatus());
+                    }
+
                     if (obj.getJobXMLName() != null) {
                         generator.write("jobXMLName", obj.getJobXMLName());
                     }
@@ -577,7 +579,7 @@ public class BulkExportJobExecutionResponse {
                         generator.writeEnd();
                     }
 
-                    
+
                     generator.writeStartObject("jobParameters");
 
                     JobParameter parameter = obj.getJobParameters();
@@ -622,7 +624,7 @@ public class BulkExportJobExecutionResponse {
                     }
 
                     generator.writeEnd();
-                    
+
                     generator.writeEnd();
                 }
                 o = writer.toString();
@@ -630,6 +632,14 @@ public class BulkExportJobExecutionResponse {
             return o;
         }
 
+    }
+
+    public String getExitStatus() {
+        return exitStatus;
+    }
+
+    public void setExitStatus(String exitStatus) {
+        this.exitStatus = exitStatus;
     }
 
 }

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
@@ -9,10 +9,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * ResponseMetadata to manipulate the response back to the client. 
- * This response object is intent for the polling location. 
- * 
- * @author pbastide
+ * ResponseMetadata to manipulate the response back to the client.
+ * This response object is intent for the polling location.
+ *
  *
  */
 public class PollingLocationResponse {
@@ -56,14 +55,16 @@ public class PollingLocationResponse {
 
     public static class Output {
 
-        public Output(String type, String url) {
+        public Output(String type, String url, String count) {
             super();
             this.type = type;
             this.url = url;
+            this.count = count;
         }
 
         private String type;
         private String url;
+        private String count;
 
         public String getType() {
             return type;
@@ -81,9 +82,17 @@ public class PollingLocationResponse {
             this.url = url;
         }
 
+        public String getCount() {
+            return count;
+        }
+
+        public void setCount(String count) {
+            this.count = count;
+        }
+
         @Override
         public String toString() {
-            return "{ \"type\" : \"" + type + "\", \"url\": \"" + url + "\"}";
+            return "{ \"type\" : \"" + type + "\", \"url\": \"" + url + "\", \"count\": " + count + "}";
         }
 
     }

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
@@ -46,9 +46,9 @@ public class CosExportImpl implements ExportBulkData, ImportBulkData {
         try {
             log.info("Using the COS Implementation");
 
-            // More than one Resource type is being used.
-            if (types == null || types.size() != 1) {
-                throw BulkDataUtil.buildOperationException("We currently only support one type exported at a time");
+            // Resource type(s) is required.
+            if (types == null) {
+                throw BulkDataUtil.buildOperationException("Missing resource type(s)!");
             }
 
             Map<String, String> properties =
@@ -106,8 +106,8 @@ public class CosExportImpl implements ExportBulkData, ImportBulkData {
                 response =
                         Response.status(Status.OK).entity(pollingResponse.toJsonString()).type(MediaType.APPLICATION_JSON).build();
             } else {
-                // Technically we should also do 429 - Throttled when we get too many repeated requests. 
-                // We don't do that right now. 
+                // Technically we should also do 429 - Throttled when we get too many repeated requests.
+                // We don't do that right now.
                 response = Response.status(Status.ACCEPTED).header("Retry-After", "120").build();
             }
 

--- a/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponseTest.java
+++ b/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponseTest.java
@@ -16,9 +16,8 @@ import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.operation.bulkdata.model.PollingLocationResponse.Output;
 
 /**
- * Simple Test for the Rough Response defined in the BulkData Export 
- * 
- * @author pbastide
+ * Simple Test for the Rough Response defined in the BulkData Export
+ *
  *
  */
 public class PollingLocationResponseTest {
@@ -49,7 +48,8 @@ public class PollingLocationResponseTest {
     @Test
     public void testResponseMetadataJsonFullWithOutput() {
         List<Output> outputs = new ArrayList<>();
-        outputs.add(new Output("type", "url"));
+        outputs.add(new Output("type", "url", "1000"));
+        outputs.add(new Output("type2", "url2", "2000"));
 
         PollingLocationResponse metadata = new PollingLocationResponse();
         metadata.setRequest("request");
@@ -61,8 +61,8 @@ public class PollingLocationResponseTest {
                 +
                 "\"transactionTime\": \"{\n" +
                 "    \"instant\": \"\"\n" +
-                "}\",\"request\": \"request\",\"requiresAccessToken\": false,\"output\" : [{ \"type\" : \"type\", \"url\": \"url\"}]\n"
-                +
-                "}");
+                "}\",\"request\": \"request\",\"requiresAccessToken\": false,\"output\" : [{ \"type\" : \"type\", \"url\": \"url\", \"count\": 1000},"
+                + "{ \"type\" : \"type2\", \"url\": \"url2\", \"count\": 2000}]\n"
+                +"}");
     }
 }


### PR DESCRIPTION
Signed-off-by: Albert Wang <xuwang@us.ibm.com>
(1) Enhanced bulkexport job to support multiple resource types, and return the exported resource types and counts info in the exit status of the batch job, e.g, Patient[1000,1000,200]:Observation[1000,1000,200]
(2) Enhanced bulkdate export operation to parse the exit status of the batch job and generate the download Urls and resources counts for all the exported files of all the resource types like following:
...
[{ "type" : "Patient", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Patient_1.ndjson", "count": 400},{ "type" : "Patient", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Patient_2.ndjson", "count": 400},{ "type" : "Patient", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Patient_3.ndjson", "count": 205},{ "type" : "Observation", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Observation_1.ndjson", "count": 400},{ "type" : "Observation", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Observation_2.ndjson", "count": 400},{ "type" : "Observation", "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/fhir-r4-connectathon/job2/Observation_3.ndjson", "count": 200}]
...