### PR TITLE
Issue #453 - post refactor clean-up

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -174,12 +174,14 @@ public class FHIRUtil {
         Dosage.class));
     private static final Map<String, String> CONCRETE_TYPE_NAME_MAP = buildConcreteTypeNameMap();
     private static final OperationOutcome ALL_OK = OperationOutcome.builder()
-                                                            .issue(Issue.builder()
-                                                                    .severity(IssueSeverity.INFORMATION)
-                                                                    .code(IssueType.INFORMATIONAL)
-                                                                    .details(CodeableConcept.builder().text(string("All OK")).build())
-                                                                    .build())
-                                                            .build();
+        .issue(Issue.builder()
+        .severity(IssueSeverity.INFORMATION)
+        .code(IssueType.INFORMATIONAL)
+            .details(CodeableConcept.builder()
+                .text(string("All OK"))
+                .build())
+            .build())
+        .build();
 
     private FHIRUtil() { }
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
@@ -150,6 +150,39 @@ public final class ModelSupport {
         TriggerDefinition.class, 
         UsageContext.class, 
         Dosage.class));
+    private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
+        "$index", 
+        "$this", 
+        "$total", 
+        "and", 
+        "as", 
+        "contains", 
+        "day", 
+        "days", 
+        "div", 
+        "false", 
+        "hour", 
+        "hours", 
+        "implies", 
+        "in", 
+        "is", 
+        "millisecond", 
+        "milliseconds", 
+        "minute", 
+        "minutes", 
+        "mod", 
+        "month", 
+        "months", 
+        "or", 
+        "seconds", 
+        "true", 
+        "week", 
+        "weeks", 
+        "xor", 
+        "year", 
+        "years", 
+        "second"
+    ));
 
     private ModelSupport() { }
 
@@ -611,5 +644,13 @@ public final class ModelSupport {
         }
         
         return ta;
+    }
+    
+    public static boolean isKeyword(String identifier) {
+        return KEYWORDS.contains(identifier);
+    }
+    
+    public static String delimit(String identifier) {
+        return String.format("`%s`", identifier);
     }
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/visitor/PathAwareVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/visitor/PathAwareVisitor.java
@@ -6,6 +6,9 @@
 
 package com.ibm.fhir.model.visitor;
 
+import static com.ibm.fhir.model.util.ModelSupport.delimit;
+import static com.ibm.fhir.model.util.ModelSupport.isKeyword;
+
 import java.util.Stack;
 import java.util.stream.Collectors;
 
@@ -48,7 +51,7 @@ public class PathAwareVisitor extends DefaultVisitor {
      */
     public final void reset() {
         if (!pathStack.isEmpty()) {
-            pathStack.removeAllElements();
+            pathStack.clear();
         }
     }
 
@@ -81,6 +84,9 @@ public class PathAwareVisitor extends DefaultVisitor {
     }
     
     private void pathStackPush(String elementName, int index) {
+        if (isKeyword(elementName)) {
+            elementName = delimit(elementName);
+        }
         if (index != -1) {
             pathStack.push(elementName + "[" + index + "]");
         } else {

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
@@ -55,39 +55,6 @@ import com.ibm.fhir.path.TupleTypeInfo;
 import com.ibm.fhir.path.TupleTypeInfoElement;
 
 public final class FHIRPathUtil {
-    private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
-        "$index", 
-        "$this", 
-        "$total", 
-        "and", 
-        "as", 
-        "contains", 
-        "day", 
-        "days", 
-        "div", 
-        "false", 
-        "hour", 
-        "hours", 
-        "implies", 
-        "in", 
-        "is", 
-        "millisecond", 
-        "milliseconds", 
-        "minute", 
-        "minutes", 
-        "mod", 
-        "month", 
-        "months", 
-        "or", 
-        "seconds", 
-        "true", 
-        "week", 
-        "weeks", 
-        "xor", 
-        "year", 
-        "years", 
-        "second"
-    ));
     public static final Set<String> STRING_TRUE_VALUES = new HashSet<>(Arrays.asList("true", "t", "yes", "y", "1", "1.0"));
     public static final Set<String> STRING_FALSE_VALUES = new HashSet<>(Arrays.asList("false", "f", "no", "n", "0", "0.0"));
     public static final Integer INTEGER_TRUE = 1;
@@ -110,14 +77,6 @@ public final class FHIRPathUtil {
 
     public static boolean isTypeCompatible(FHIRPathSystemValue leftValue, FHIRPathSystemValue rightValue) {
         return TYPE_COMPATIBILITY_MAP.get(leftValue.type()).contains(rightValue.type());
-    }
-    
-    public static boolean isKeyword(String identifier) {
-        return KEYWORDS.contains(identifier);
-    }
-    
-    public static String delimit(String identifier) {
-        return String.format("`%s`", identifier);
     }
     
     public static boolean hasResourceNode(Collection<FHIRPathNode> nodes) {

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathCacheSizeEstimator.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathCacheSizeEstimator.java
@@ -6,11 +6,14 @@
 
 package com.ibm.fhir.path.test;
 
+import static com.ibm.fhir.model.util.ModelSupport.delimit;
+import static com.ibm.fhir.model.util.ModelSupport.isKeyword;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 
 import com.ibm.fhir.model.annotation.Constraint;
@@ -18,30 +21,29 @@ import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.path.FHIRPathBaseVisitor;
 import com.ibm.fhir.path.FHIRPathLexer;
 import com.ibm.fhir.path.FHIRPathParser;
-import com.ibm.fhir.path.FHIRPathVisitor;
 import com.ibm.fhir.path.FHIRPathParser.ExpressionContext;
+import com.ibm.fhir.path.FHIRPathVisitor;
 import com.ibm.fhir.path.function.FHIRPathFunction;
-import com.ibm.fhir.path.util.FHIRPathUtil;
 
 public class FHIRPathCacheSizeEstimator {
     public static void main(String[] args) {        
         Set<String> identifiers = new HashSet<>();
         for (Class<?> modelClass : ModelSupport.getModelClasses()) {
             String typeName = ModelSupport.getTypeName(modelClass);
-            if (FHIRPathUtil.isKeyword(typeName)) {
-                typeName = FHIRPathUtil.delimit(typeName);
+            if (isKeyword(typeName)) {
+                typeName = delimit(typeName);
             }
             identifiers.add(typeName);
             for (String elementName : ModelSupport.getElementNames(modelClass)) {
-                if (FHIRPathUtil.isKeyword(elementName)) {
-                    elementName = FHIRPathUtil.delimit(elementName);
+                if (isKeyword(elementName)) {
+                    elementName = delimit(elementName);
                 }
                 identifiers.add(elementName);
             }
         }
         for (String functionName : FHIRPathFunction.registry().getFunctionNames()) {   
-            if (FHIRPathUtil.isKeyword(functionName)) {
-                functionName = FHIRPathUtil.delimit(functionName);
+            if (isKeyword(functionName)) {
+                functionName = delimit(functionName);
             }
             identifiers.add(functionName);
         }
@@ -73,7 +75,7 @@ public class FHIRPathCacheSizeEstimator {
     }
     
     private static ExpressionContext compile(String expr) {
-        FHIRPathLexer lexer = new FHIRPathLexer(new ANTLRInputStream(expr));
+        FHIRPathLexer lexer = new FHIRPathLexer(CharStreams.fromString(expr));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         FHIRPathParser parser = new FHIRPathParser(tokens);
         return parser.expression();

--- a/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
+++ b/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
@@ -32,7 +32,6 @@ import com.ibm.fhir.registry.FHIRRegistry;
 public final class ProfileSupport {
     public static final String HL7_STRUCTURE_DEFINITION_URL_PREFIX = "http://hl7.org/fhir/StructureDefinition/";
     public static final String HL7_VALUE_SET_URL_PREFIX = "http://hl7.org/fhir/ValueSet/";
-    
     private static final Set<String> KEYWORDS = new HashSet<>(Arrays.asList(
         "$index", 
         "$this", 
@@ -78,14 +77,6 @@ public final class ProfileSupport {
     };
 
     private ProfileSupport() { }
-    
-    public static boolean isKeyword(String identifier) {
-        return KEYWORDS.contains(identifier);
-    }
-    
-    public static String delimit(String identifier) {
-        return String.format("`%s`", identifier);
-    }
 
     private static Map<String, Binding> computeBindingMap(String url) {
         StructureDefinition structureDefinition = getStructureDefinition(url);
@@ -318,5 +309,13 @@ public final class ProfileSupport {
     
     public static boolean isProfile(StructureDefinition structureDefinition) {
         return structureDefinition != null && TypeDerivationRule.CONSTRAINT.equals(structureDefinition.getDerivation());
+    }
+    
+    public static boolean isKeyword(String identifier) {
+        return KEYWORDS.contains(identifier);
+    }
+    
+    public static String delimit(String identifier) {
+        return String.format("`%s`", identifier);
     }
 }


### PR DESCRIPTION
- Clean up `implies` logic
- Clean up external constant handling
- Add logic to unescape additional characters
- Re-introduce keyword checking into PathAwareVisitor

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>