### PR TITLE
Issue #389 - re-enable FHIRPath spec tests

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -497,12 +497,9 @@ public class FHIRPathEvaluator {
                     result = singleton(leftNode.subtract(rightNode));
                     break;
                 }
-            }
-            /*
-            else {
+            } else if (!left.isEmpty() && !right.isEmpty()){
                 throw new IllegalArgumentException("Invalid argument(s) for '" + operator + "' operator");
             }
-            */
                                     
             indentLevel--;
             return result;
@@ -1261,11 +1258,5 @@ public class FHIRPathEvaluator {
         public boolean hasExternalConstant(String name) {
             return externalConstantMap.containsKey(name);
         }
-    }
-    
-    public static void main(String[] args) throws Exception {
-        FHIRPathEvaluator.DEBUG = true;
-        Collection<FHIRPathNode> result = FHIRPathEvaluator.evaluator().evaluate("{} or {}");
-        System.out.println("result: " + result);
     }
 }

--- a/fhir-path/src/test/resources/FHIRPath/tests-fhir-r4.xml
+++ b/fhir-path/src/test/resources/FHIRPath/tests-fhir-r4.xml
@@ -224,8 +224,8 @@
 		<test name="testLiteralTimeMillisecond" inputfile="patient-example.xml"><expression>@T14:34:28.123.is(Time)</expression><output type="boolean">true</output></test>
         <!--
 		<test name="testLiteralTimeUTC" inputfile="patient-example.xml"><expression invalid="true">@T14:34:28Z.is(Time)</expression></test>
-		<test name="testLiteralTimeTimezoneOffset" inputfile="patient-example.xml"><expression invalid="true">@T14:34:28+10:00.is(Time)</expression></test>
 		-->
+		<test name="testLiteralTimeTimezoneOffset" inputfile="patient-example.xml"><expression invalid="true">@T14:34:28+10:00.is(Time)</expression></test>
 
 		<test name="testLiteralQuantityDecimal" inputfile="patient-example.xml"><expression>10.1 'mg'.convertsToQuantity()</expression><output type="boolean">true</output></test>
 		<test name="testLiteralQuantityInteger" inputfile="patient-example.xml"><expression>10 'mg'.convertsToQuantity()</expression><output type="boolean">true</output></test>
@@ -965,9 +965,7 @@
 		<test name="testConcatenate1" inputfile="patient-example.xml"><expression>'a' &amp; 'b' = 'ab'</expression><output type="boolean">true</output></test>
 		<test name="testConcatenate2" inputfile="patient-example.xml"><expression>'1' &amp; {} = '1'</expression><output type="boolean">true</output></test>
 		<test name="testConcatenate3" inputfile="patient-example.xml"><expression>{} &amp; 'b' = 'b'</expression><output type="boolean">true</output></test>
-		<!--
 		<test name="testConcatenate4" inputfile="patient-example.xml"><expression invalid="semantic">(1 | 2 | 3) &amp; 'b' = '1,2,3b'</expression></test>
-		-->
 	</group>
 
 	<group name="testMinus">


### PR DESCRIPTION
Changed error handling logic in `FHIRPathEvaluator.EvaluatingVisitor.visitAdditiveExpression`
Re-enabled a couple of FHIRPath spec tests

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>