### PR TITLE
Number searches with implicit ranges #257

### DIFF
--- a/fhir-examples/src/main/resources/json/ibm/basic/BasicNumber.json
+++ b/fhir-examples/src/main/resources/json/ibm/basic/BasicNumber.json
@@ -11,6 +11,10 @@
     {
       "url": "http://example.org/decimal",
       "valueDecimal": 99.99
+    },
+    {
+      "url": "http://example.org/precision",
+      "valueDecimal": 100.25
     }
   ]
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -44,6 +44,7 @@ public class JDBCConstants {
     public static final String WHEN = " WHEN ";
     public static final String THEN = " THEN ";
     public static final String END = " END";
+    public static final char SPACE = ' ';
     
     /**
      * Maps Parameter modifiers to SQL operators.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -402,11 +402,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         int searchResultCount = 0;
         SqlQueryData countQuery;
         SqlQueryData query;
-                
+
         try {
             queryBuilder = new JDBCQueryBuilder((ParameterDAO)this.getParameterDao(),
                                                           (ResourceDAO)this.getResourceDao());
-             
+
             countQuery = queryBuilder.buildCountQuery(resourceType, searchContext);
             if (countQuery != null) {                
                 searchResultCount = this.getResourceDao().searchCount(countQuery);
@@ -416,7 +416,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                 searchContext.setTotalCount(searchResultCount);
                 
                 List<OperationOutcome.Issue> issues = validatePagingContext(searchContext);
-                
                 if (!issues.isEmpty()) {
                     resultBuilder.outcome(OperationOutcome.builder()
                         .issue(issues)
@@ -425,9 +424,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                         return resultBuilder.success(false).build();
                     }
                 }
-                                
+
                 // For _summary=count or pageSize == 0, we return only the count
-                if (searchResultCount > 0 && !SummaryValueSet.COUNT.equals(searchContext.getSummaryParameter()) && searchContext.getPageSize() > 0) {
+                if (searchResultCount > 0 
+                        && !SummaryValueSet.COUNT.equals(searchContext.getSummaryParameter()) 
+                        && searchContext.getPageSize() > 0) {
                     query = queryBuilder.buildQuery(resourceType, searchContext);
                     
                     List<String> elements = searchContext.getElementsParameters();
@@ -436,7 +437,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                     if (elements == null && searchContext.hasSummaryParameter()) {
                         Set<String> summaryElements = null;
                         SummaryValueSet summary = searchContext.getSummaryParameter();
-                        
+
                         switch (summary) {
                         case TRUE:
                             summaryElements = JsonSupport.getSummaryElementNames(resourceType);
@@ -449,15 +450,14 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                             break;
                         default:
                             break;
-                            
                         }
 
                         if (summaryElements != null) {
-                            elements = new ArrayList<String>();
+                            elements = new ArrayList<>();
                             elements.addAll(summaryElements);
                         }
                     }
-                    
+
                     if (searchContext.hasSortParameters()) {
                         // Sorting results of a system-level search is limited, and has a different logic path
                         // than other sorted searches.
@@ -475,7 +475,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                     }  
                 }
             }
-            
+
             return resultBuilder
                     .success(true)
                     .resource(resources)
@@ -502,9 +502,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         return resourceDao;
     }
 
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.persistence.FHIRPersistence#delete(com.ibm.fhir.persistence.context.FHIRPersistenceContext, Class<? extends Resource> resourceType, java.lang.String)
-     */
     @Override
     public <T extends Resource> SingleResourceResult<T> delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
         final String METHODNAME = "delete";
@@ -608,9 +605,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         }
     }
 
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.persistence.FHIRPersistence#read(com.ibm.fhir.persistence.context.FHIRPersistenceContext, java.lang.Class, java.lang.String)
-     */
     @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
                             throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
@@ -32,8 +32,8 @@ import com.ibm.fhir.search.valuetypes.ValueTypesFactory;
 
 /**
  * Number Parameter Behavior Util encapsulates the logic specific to Prefix
- * treatment of the
- * Search queries related to numbers, and the implied ranges therein.
+ * treatment of the Search queries related to numbers, and the implied ranges
+ * therein.
  */
 public class NumberParmBehaviorUtil {
     private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtil.class.getName());

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
@@ -139,10 +139,12 @@ public class NumberParmBehaviorUtil {
                     break;
                 case AP:
                     // ap - approximate
-                    // -10%
-                    bindVariables.add(originalNumber.multiply(LOWER_BOUND));
-                    // +10%
-                    bindVariables.add(originalNumber.multiply(UPPER_BOUND));
+                    // -10% of the Lower Bound
+                    BigDecimal lowerBound = generateLowerBound(originalNumber);
+                    BigDecimal upperBound = generateUpperBound(originalNumber);
+                    bindVariables.add(lowerBound.multiply(LOWER_BOUND));
+                    // +10% of the UPPER Bound
+                    bindVariables.add(upperBound.multiply(UPPER_BOUND));
 
                     // <CODE>BASIC_NUMBER_VALUE >= ? AND BASIC_NUMBER_VALUE <= ?</CODE> 
                     whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
@@ -38,8 +38,7 @@ import com.ibm.fhir.search.valuetypes.ValueTypesFactory;
 public class NumberParmBehaviorUtil {
     private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtil.class.getName());
 
-    private static final BigDecimal LOWER_BOUND = new BigDecimal(".9");
-    private static final BigDecimal UPPER_BOUND = new BigDecimal("1.1");
+    private static final BigDecimal FACTOR = new BigDecimal(".1");
 
     private NumberParmBehaviorUtil() {
         // No operation
@@ -142,9 +141,10 @@ public class NumberParmBehaviorUtil {
                     // -10% of the Lower Bound
                     BigDecimal lowerBound = generateLowerBound(originalNumber);
                     BigDecimal upperBound = generateUpperBound(originalNumber);
-                    bindVariables.add(lowerBound.multiply(LOWER_BOUND));
+                    BigDecimal factor = originalNumber.multiply(FACTOR);
+                    bindVariables.add(lowerBound.subtract(factor));
                     // +10% of the UPPER Bound
-                    bindVariables.add(upperBound.multiply(UPPER_BOUND));
+                    bindVariables.add(upperBound.add(factor));
 
                     // <CODE>BASIC_NUMBER_VALUE >= ? AND BASIC_NUMBER_VALUE <= ?</CODE> 
                     whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
@@ -1,0 +1,289 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.util.type;
+
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.AND;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.NUMBER_VALUE;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.jdbc.JDBCConstants;
+import com.ibm.fhir.persistence.jdbc.JDBCConstants.JDBCOperator;
+import com.ibm.fhir.persistence.jdbc.util.JDBCQueryBuilder;
+import com.ibm.fhir.search.SearchConstants.Prefix;
+import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.search.parameters.Parameter;
+import com.ibm.fhir.search.parameters.ParameterValue;
+import com.ibm.fhir.search.valuetypes.ValueTypesFactory;
+
+/**
+ * Number Parameter Behavior Util encapsulates the logic specific to Prefix
+ * treatment of the
+ * Search queries related to numbers, and the implied ranges therein.
+ */
+public class NumberParmBehaviorUtil {
+    private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtil.class.getName());
+
+    private static final BigDecimal LOWER_BOUND = new BigDecimal(".9");
+    private static final BigDecimal UPPER_BOUND = new BigDecimal("1.1");
+
+    private NumberParmBehaviorUtil() {
+        // No operation
+    }
+
+    public static void executeBehavior(StringBuilder whereClauseSegment, Parameter queryParm,
+            List<Object> bindVariables, Class<?> resourceType, String tableAlias, JDBCQueryBuilder queryBuilder)
+            throws FHIRPersistenceException {
+        // Start the Clause 
+        // Query: AND (
+        whereClauseSegment.append(AND).append(LEFT_PAREN);
+
+        // Process each parameter value in the query parameter
+        boolean parmValueProcessed = false;
+        Set<String> seen = new HashSet<>();
+        for (ParameterValue value : queryParm.getValues()) {
+
+            Prefix prefix = value.getPrefix();
+
+            // Default to EQ
+            if (prefix == null) {
+                prefix = Prefix.EQ;
+            }
+            BigDecimal originalNumber = value.getValueNumber();
+
+            // seen is used to optimize against a repeated value passed in. 
+            // the hash must use the prefix and original number. 
+            String hash = prefix.value() + originalNumber.toPlainString();
+            if (!seen.contains(hash)) {
+                seen.add(hash);
+                // Check for valid conditions and return if it needs to be treated as an INTEGER:
+                boolean isInteger = checkIntegerSearchWithSaEb(prefix, resourceType, queryParm, originalNumber);
+
+                // If multiple values are present, we need to OR them together.
+                if (parmValueProcessed) {
+                    // ) OR (
+                    whereClauseSegment.append(RIGHT_PAREN)
+                            .append(JDBCOperator.OR.value())
+                            .append(LEFT_PAREN);
+                } else {
+                    // Signal to the downstream to treat any subsequent value as an OR condition 
+                    parmValueProcessed = true;
+                }
+
+                // Branch behavior based on the type of prefix. 
+                // EQ/NE/AP have special handling
+                switch (prefix) {
+                case EQ:
+                    // eq - equals is a specific range search.
+                    if (isInteger) {
+                        bindVariables.add(originalNumber);
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.EQ.value())
+                                .append(BIND_VAR);
+
+                    } else {
+                        // Not an Integer search. 
+                        // Bounds are based on precision.
+                        bindVariables.add(generateLowerBound(originalNumber));
+                        bindVariables.add(generateUpperBound(originalNumber));
+
+                        // <CODE>BASIC_NUMBER_VALUE > ? AND BASIC_NUMBER_VALUE <= ?</CODE> 
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.GT.value())
+                                .append(BIND_VAR);
+                        whereClauseSegment.append(JDBCConstants.SPACE).append(JDBCOperator.AND)
+                                .append(JDBCConstants.SPACE);
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.LTE.value())
+                                .append(BIND_VAR);
+                    }
+
+                    break;
+                case NE:
+                    // ne - not equals is a specific not in range search.
+                    if (isInteger) {
+                        bindVariables.add(originalNumber);
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.NE.value())
+                                .append(BIND_VAR);
+                    } else {
+                        // Bounds are based on precision.
+
+                        bindVariables.add(generateLowerBound(originalNumber));
+                        bindVariables.add(generateUpperBound(originalNumber));
+
+                        // <CODE>BASIC_NUMBER_VALUE <= ? OR BASIC_NUMBER_VALUE > ?</CODE> 
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.LTE.value())
+                                .append(BIND_VAR);
+                        whereClauseSegment.append(JDBCConstants.SPACE).append(JDBCOperator.OR)
+                                .append(JDBCConstants.SPACE);
+                        whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                        whereClauseSegment.append(JDBCOperator.GT.value())
+                                .append(BIND_VAR);
+                    }
+                    break;
+                case AP:
+                    // ap - approximate
+                    // -10%
+                    bindVariables.add(originalNumber.multiply(LOWER_BOUND));
+                    // +10%
+                    bindVariables.add(originalNumber.multiply(UPPER_BOUND));
+
+                    // <CODE>BASIC_NUMBER_VALUE >= ? AND BASIC_NUMBER_VALUE <= ?</CODE> 
+                    whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                    whereClauseSegment.append(JDBCOperator.GTE.value())
+                            .append(BIND_VAR);
+                    whereClauseSegment.append(JDBCConstants.SPACE).append(JDBCOperator.AND).append(JDBCConstants.SPACE);
+                    whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE);
+                    whereClauseSegment.append(JDBCOperator.LTE.value())
+                            .append(BIND_VAR);
+                    break;
+                default:
+                    // gt, lt, ge, le, sa, eb
+                    // take the default behavior.
+                    // Build this piece: p1.value_string {operator} search-attribute-value
+                    JDBCOperator operator = queryBuilder.getPrefixOperator(value);
+                    whereClauseSegment.append(tableAlias + DOT).append(NUMBER_VALUE).append(operator.value())
+                            .append(BIND_VAR);
+                    bindVariables.add(originalNumber);
+                    break;
+                }
+            }
+        }
+
+        // End the Clause started above, and closes the parameter expression. 
+        // Query: )) 
+        whereClauseSegment.append(RIGHT_PAREN).append(RIGHT_PAREN);
+    }
+
+    public static BigDecimal generateLowerBound(BigDecimal original) {
+
+        int factor = calculateSignificantFigures(original);
+        if (factor < 0) {
+            factor = Math.abs(factor) - 1;
+        } else {
+            factor = original.scale() + 1;
+
+            // Mutate it to the ORIGINAL string
+            String t = "" + original;
+            int loc = t.indexOf('E');
+            if (loc > -1) {
+                factor = -1 * (loc - 2);
+            }
+        }
+
+        BigDecimal scaleFactor = new BigDecimal("5e" + -1 * factor);
+        return original.subtract(scaleFactor);
+    }
+
+    public static BigDecimal generateUpperBound(BigDecimal original) {
+        int factor = calculateSignificantFigures(original);
+        if (factor < 0) {
+            factor = Math.abs(factor) - 1;
+        } else {
+            factor = original.scale() + 1;
+
+            // Mutate it to the ORIGINAL string
+            String t = "" + original;
+            int loc = t.indexOf('E');
+            if (loc > -1) {
+                factor = -1 * (loc - 2);
+            }
+        }
+        BigDecimal scaleFactor = new BigDecimal("5e" + -1 * factor);
+        return original.add(scaleFactor);
+    }
+
+    /**
+     * calculates the significant figures
+     * based on
+     * <a href="https://en.wikipedia.org/wiki/Significant_figures">Significant
+     * Figures</a>
+     * 
+     * @param original
+     * @return
+     */
+    public static int calculateSignificantFigures(BigDecimal original) {
+        int count = original.precision();
+        if (original.scale() <= 0) {
+            // Common pattern is to strip zeros... <code>.stripTrailingZeros()</code> 
+            // We don't per the pattern in FHIR. 
+            count += original.scale();
+        }
+        return count;
+    }
+
+    /**
+     * per the specification we DO NOT process EB/SA integers.
+     * <a href="https://hl7.org/fhir/search.html#prefix">FHIR Specification: Search
+     * - Prefixes</a>
+     * <code> 
+     * sa (starts-after) and eb (ends-before) are not used with integer values but are used for decimals. 
+     * </code>
+     * 
+     * @param prefix
+     * @param resourceType
+     * @param queryParm
+     * @param originalNumber
+     * @return boolean indicating that an integer search is being run.
+     * @throws FHIRPersistenceException
+     */
+    public static boolean checkIntegerSearchWithSaEb(Prefix prefix, Class<?> resourceType, Parameter queryParm,
+            BigDecimal originalNumber)
+            throws FHIRPersistenceException {
+        boolean isIntegerSearch = false;
+        try {
+            isIntegerSearch = ValueTypesFactory.getValueTypesProcessor().isIntegerSearch(resourceType, queryParm);
+        } catch (FHIRSearchException e) {
+            log.log(Level.INFO, "Caught exception while checking the value types for parameter '"
+                    + queryParm.getCode() + "'; continuing...", e);
+            // do nothing
+        }
+
+        if (isIntegerSearch) {
+            if (prefix == Prefix.EB || prefix == Prefix.SA) {
+                throw new FHIRPersistenceException(
+                        "Search prefixes '" + Prefix.EB.value() + "' and '" + Prefix.SA.value()
+                                + "' are not supported for integer searches.");
+            } else {
+                /*
+                 * Per Specification: <br>
+                 * When a number search is used against a resource element that stores a simple
+                 * integer (e.g. ImmunizationRecommendation.recommendation.doseNumber), and the
+                 * search parameter is not expressed using the exponential forms, and does not
+                 * include any non-zero digits after a decimal point, the significance issues
+                 * cancel out and searching is based on exact matches. Note that if there are
+                 * non-zero digits after a decimal point, there cannot be any matches
+                 */
+
+                // Conditions:
+                // We know the target is an integer.
+                // if integer and ! exponential form ('E') and no non-zero
+                // if indexOf 'E' and indexOf '.' are zero... then it's a specific equals search
+
+                // we need to mutate into a string to test the conditions
+                String num = "" + originalNumber;
+                if (num.indexOf('E') > -1 || num.indexOf('.') > -1) {
+                    isIntegerSearch = false;
+                }
+            }
+        }
+
+        return isIntegerSearch;
+    }
+}

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
@@ -275,12 +275,12 @@ public class NumberParmBehaviorUtilTest {
 
         // expectedBindVariables are pivoted on 100
         // Precision is implied by the use of ap
-        // Implied Range: (89.55 ... 110.55)
+        // Implied Range: (89.5 ... 110.5)
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "100");
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("89.55"));
-        expectedBindVariables.add(new BigDecimal("110.55"));
+        expectedBindVariables.add(new BigDecimal("89.5"));
+        expectedBindVariables.add(new BigDecimal("110.5"));
         String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,
                 expectedBindVariables,
@@ -294,12 +294,12 @@ public class NumberParmBehaviorUtilTest {
 
         // expectedBindVariables are pivoted on 100
         // Precision is implied by the use of ap
-        // Implied Range: (.45 ... 1.65)
+        // Implied Range: (.4 ... 1.6)
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "1");
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("0.45"));
-        expectedBindVariables.add(new BigDecimal("1.65"));
+        expectedBindVariables.add(new BigDecimal("0.4"));
+        expectedBindVariables.add(new BigDecimal("1.6"));
         String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,
                 expectedBindVariables,
@@ -319,8 +319,8 @@ public class NumberParmBehaviorUtilTest {
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100" });
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("89.55"));
-        expectedBindVariables.add(new BigDecimal("110.55"));
+        expectedBindVariables.add(new BigDecimal("89.5"));
+        expectedBindVariables.add(new BigDecimal("110.5"));
         String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,
                 expectedBindVariables,
@@ -333,17 +333,14 @@ public class NumberParmBehaviorUtilTest {
         //  [parameter]=ap100,ap100.00
 
         // expectedBindVariables are pivoted on 100
-        // Precision is implied by the use of ap
-        // Implied Range: (90 ... 110)
-
         // It should NOT de-dupe
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100.00" });
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("89.55"));
-        expectedBindVariables.add(new BigDecimal("110.55"));
-        expectedBindVariables.add(new BigDecimal("89.9955"));
-        expectedBindVariables.add(new BigDecimal("110.0055"));
+        expectedBindVariables.add(new BigDecimal("89.5"));
+        expectedBindVariables.add(new BigDecimal("110.5"));
+        expectedBindVariables.add(new BigDecimal("89.995"));
+        expectedBindVariables.add(new BigDecimal("110.005"));
         String expectedSql =
                 " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?) OR (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
@@ -1,0 +1,485 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.test.util;
+
+import static org.testng.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.exception.FHIRException;
+import com.ibm.fhir.model.resource.Basic;
+import com.ibm.fhir.model.resource.MolecularSequence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.jdbc.util.JDBCQueryBuilder;
+import com.ibm.fhir.persistence.jdbc.util.type.NumberParmBehaviorUtil;
+import com.ibm.fhir.search.SearchConstants;
+import com.ibm.fhir.search.parameters.Parameter;
+import com.ibm.fhir.search.parameters.ParameterValue;
+
+public class NumberParmBehaviorUtilTest {
+    private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtilTest.class.getName());
+    private static final Level LOG_LEVEL = Level.INFO;
+
+    private ParameterValue generateParameterValue(String value, SearchConstants.Prefix prefix) {
+        ParameterValue parameterValue = new ParameterValue();
+        parameterValue.setPrefix(prefix);
+        parameterValue.setValueNumber(new BigDecimal(value));
+        return parameterValue;
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String code, String... values) {
+        Parameter parameter = new Parameter(SearchConstants.Type.NUMBER, code, modifier, null);
+        for (String value : values) {
+            parameter.getValues().add(generateParameterValue(value, prefix));
+        }
+        return parameter;
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String value) {
+        return generateParameter(prefix, modifier, "precision", new String[] { value });
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String... values) {
+        return generateParameter(prefix, modifier, "precision", values);
+    }
+
+    private void runTest(Parameter queryParm, List<Object> expectedBindVariables, String expectedSql)
+            throws FHIRPersistenceException {
+        runTest(queryParm, expectedBindVariables, expectedSql, "Basic", Basic.class);
+    }
+
+    private void runLowerUpperTest(String value, String lower, String upper) {
+        BigDecimal decimal = new BigDecimal(value);
+        String actualLower = Double.toString(NumberParmBehaviorUtil.generateLowerBound(decimal).doubleValue());
+        assertEquals(actualLower, lower);
+
+        String actualUpper = Double.toString(NumberParmBehaviorUtil.generateUpperBound(decimal).doubleValue());
+        assertEquals(actualUpper, upper);
+    }
+
+    public void runSignificantDigitsTest(String value, int significantDigits) {
+        assertEquals(NumberParmBehaviorUtil.calculateSignificantFigures(new BigDecimal(value)), significantDigits);
+    }
+
+    private void runTest(Parameter queryParm, List<Object> expectedBindVariables, String expectedSql,
+            String tableAlias, Class<?> resourceType)
+            throws FHIRPersistenceException {
+        StringBuilder actualWhereClauseSegment = new StringBuilder();
+        List<Object> actualBindVariables = new ArrayList<>();
+
+        JDBCQueryBuilder queryBuilder = new JDBCQueryBuilder(null, null);
+        NumberParmBehaviorUtil.executeBehavior(actualWhereClauseSegment, queryParm, actualBindVariables, resourceType,
+                tableAlias, queryBuilder);
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("whereClauseSegment -> " + actualWhereClauseSegment.toString());
+            log.info("bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualWhereClauseSegment.toString(), expectedSql);
+
+        for (Object o : expectedBindVariables) {
+            actualBindVariables.remove(o);
+        }
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("leftover - bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualBindVariables.size(), 0);
+
+    }
+
+    @BeforeClass
+    public static void before() throws FHIRException {
+        FHIRRequestContext.get().setTenantId("number");
+    }
+
+    @AfterClass
+    public static void after() throws FHIRException {
+        FHIRRequestContext.get().setTenantId("default");
+    }
+
+    @Test
+    public void testPrecisionWithExact() throws FHIRPersistenceException {
+        // The spec states: 
+        // When a comparison prefix in the set lgt, lt, ge, le, sa & eb is provided, 
+        // the implicit precision of the number is ignored, and they are treated as 
+        // if they have arbitrarily high precision
+        // However there is no 'lgt', means gt? (documented in https://jira.hl7.org/browse/FHIR-21216) 
+
+        // gt - Greater Than
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.GT, null, "1e3");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        String expectedSql = " AND (Basic.NUMBER_VALUE > ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+
+        // lt - Less Than
+        queryParm             = generateParameter(SearchConstants.Prefix.LT, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        expectedSql = " AND (Basic.NUMBER_VALUE < ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+
+        // ge - Greater than Equal
+        queryParm             = generateParameter(SearchConstants.Prefix.GE, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        expectedSql = " AND (Basic.NUMBER_VALUE >= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+
+        // le - Less than Equal
+        queryParm             = generateParameter(SearchConstants.Prefix.LE, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        expectedSql = " AND (Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+
+        // sa - starts after
+        queryParm             = generateParameter(SearchConstants.Prefix.SA, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        expectedSql = " AND (Basic.NUMBER_VALUE > ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+
+        // eb - Ends before
+        queryParm             = generateParameter(SearchConstants.Prefix.EB, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1E+3"));
+        expectedSql = " AND (Basic.NUMBER_VALUE < ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test(expectedExceptions = { FHIRPersistenceException.class })
+    public void testPrecisionIntegerWithStartsAfter() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.SA, null, "window-end", new String[] { "1" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        String expectedSql = "THROWS EXCEPTION";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test(expectedExceptions = { FHIRPersistenceException.class })
+    public void testPrecisionIntegerWithEndsBefore() throws FHIRPersistenceException {
+        // eb - ends before with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.SA, null, "window-end", new String[] { "1" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        String expectedSql = "THROWS EXCEPTION";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test
+    public void testPrecisionWithEqual() throws FHIRPersistenceException {
+        // in this case, our code if missing Prefix, it injects EQ.
+        // therefore this test case tests two conditions 
+        // Condition:
+        //  [parameter]=100
+        //  [parameter]=eq100
+
+        // expectedBindVariables are pivoted on 100
+        // Precision: 3 
+        // Implied Range: [99.5 ... 100.5)
+        // Exclusive and Inclusive
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(99.5));
+        expectedBindVariables.add(new BigDecimal(100.5));
+        String expectedSql = " AND (Basic.NUMBER_VALUE > ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleValuesForEqual() throws FHIRPersistenceException {
+        // in this case, our code if missing Prefix, it injects EQ.
+        // therefore this test case tests two conditions 
+        // Condition:
+        //  [parameter]=100,1.00
+        //  [parameter]=eq100,1.00
+
+        // expectedBindVariables are pivoted on 100 and 1.00
+        // Precision: 3 and 5
+        // Implied Range: [99.5 ... 100.5) [0.995 ... 1.005)
+        // Exclusive and Inclusive
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, new String[] { "100", "1.00" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("99.5"));
+        expectedBindVariables.add(new BigDecimal("100.5"));
+        expectedBindVariables.add(new BigDecimal("0.995"));
+        expectedBindVariables.add(new BigDecimal("1.005"));
+        String expectedSql =
+                " AND (Basic.NUMBER_VALUE > ? AND Basic.NUMBER_VALUE <= ?) OR (Basic.NUMBER_VALUE > ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testPrecisionWithNotEqual() throws FHIRPersistenceException {
+        // Condition:
+        //  [parameter]=ne100
+
+        // expectedBindVariables are pivoted on 100
+        // Precision: 3 
+        // Implied Range: <= 99.5 OR 100.5 >
+        // Exclusive and Inclusive
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.NE, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(99.5));
+        expectedBindVariables.add(new BigDecimal(100.5));
+        String expectedSql = " AND (Basic.NUMBER_VALUE <= ? OR Basic.NUMBER_VALUE > ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testPrecisionWithApprox() throws FHIRPersistenceException {
+        // Condition:
+        //  [parameter]=ap100
+
+        // expectedBindVariables are pivoted on 100
+        // Precision is implied by the use of ap
+        // Implied Range: (90 ... 110)
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("90.0"));
+        expectedBindVariables.add(new BigDecimal("110.0"));
+        String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleSameApprox() throws FHIRPersistenceException {
+        // Condition:
+        //  [parameter]=ap100,ap100
+
+        // expectedBindVariables are pivoted on 100
+        // Precision is implied by the use of ap
+        // Implied Range: (90 ... 110)
+
+        // It should de-dupe
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("90.0"));
+        expectedBindVariables.add(new BigDecimal("110.0"));
+        String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleDifferentApprox() throws FHIRPersistenceException {
+        // Condition:
+        //  [parameter]=ap100,ap100.00
+
+        // expectedBindVariables are pivoted on 100
+        // Precision is implied by the use of ap
+        // Implied Range: (90 ... 110)
+
+        // It should NOT de-dupe
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100.00" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("90.0"));
+        expectedBindVariables.add(new BigDecimal("110.0"));
+        expectedBindVariables.add(new BigDecimal("90.000"));
+        expectedBindVariables.add(new BigDecimal("110.000"));
+        String expectedSql =
+                " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?) OR (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+
+    @Test
+    public void testLowerAndUpperBounds() {
+        // [parameter]=1.00
+        // range [0.005 ... 1.005)
+        runLowerUpperTest("1.00", "0.995", "1.005");
+
+        // [parameter]=100.00
+        // significant figures precision = 5
+        // range [99.995 ... 100.005)
+        runLowerUpperTest("100.00", "99.995", "100.005");
+
+        // [parameter]=100
+        // significant figures precision = 3 
+        // range [99.5 ... 100.5)
+        runLowerUpperTest("100", "99.5", "100.5");
+
+        // [parameter]=1e2
+        // Value: 1e2
+        // significant figures precision = 1
+        // Implied Range: [95 ... 105)
+        runLowerUpperTest("1e2", "95.0", "105.0");
+
+        // [parameter]=1e3
+        // Value: 1e3
+        // Implied Range: [999.5 ... 100.5)
+        runLowerUpperTest("1e3", "999.5", "1000.5");
+
+        // [parameter]=1.0e2
+        // Value: 1.0e2
+        // Implied Range: [50 ... 150)
+        runLowerUpperTest("1.0e2", "50.0", "150.0");
+
+        // [parameter]=1.00e2
+        // Value: 1.00e2
+        // Implied Range: [99.5 ... 100.5)
+        runLowerUpperTest("1.00e2", "99.5", "100.5");
+
+        // [parameter]=1.02e2
+        // Value: 1.02e2
+        // Implied Range: [105.0 ... 115.0)
+        runLowerUpperTest("1.1e2", "60.0", "160.0");
+    }
+
+    @Test
+    public void testSignificantFiguresPrecision() {
+        runSignificantDigitsTest("100.00", 5);
+        runSignificantDigitsTest("100", 3);
+
+        // Based on examples from https://en.wikipedia.org/wiki/Significant_figures
+        runSignificantDigitsTest("12.3450", 6);
+        runSignificantDigitsTest("12.345", 5);
+        runSignificantDigitsTest("12.34", 4);
+        runSignificantDigitsTest("12.3", 3);
+        runSignificantDigitsTest("12.", 2);
+
+        // Different than the standard approach, we're going for 2. 
+        runSignificantDigitsTest("10", 2);
+
+        runSignificantDigitsTest("0.01234500", 7);
+        runSignificantDigitsTest("0.0123450", 6);
+        runSignificantDigitsTest("0.012345", 5);
+        runSignificantDigitsTest("0.01234", 4);
+        runSignificantDigitsTest("0.0123", 3);
+        runSignificantDigitsTest("0.012", 2);
+        runSignificantDigitsTest("0.01", 1);
+        runSignificantDigitsTest("0.0", 1);
+        runSignificantDigitsTest("0", 1);
+
+        // Demonstrates significant digits as in the specification.
+        runSignificantDigitsTest("1e1", 0);
+        runSignificantDigitsTest("1e2", -1);
+        runSignificantDigitsTest("1e3", -2);
+        runSignificantDigitsTest("1e4", -3);
+    }
+
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithEQ() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, "window-end", new String[] { "1" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE = ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithNE() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.NE, null, "window-end", new String[] { "1" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE <> ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithEQNotInt() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, "window-end", new String[] { "1.0" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("0.95"));
+        expectedBindVariables.add(new BigDecimal("1.05"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE > ? AND MolecularSequence.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithNENotInt() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.NE, null, "window-end", new String[] { "1.0" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("0.95"));
+        expectedBindVariables.add(new BigDecimal("1.05"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE <= ? OR MolecularSequence.NUMBER_VALUE > ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+    
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithEQNotIntExp() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, "window-end", new String[] { "1e2" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("95"));
+        expectedBindVariables.add(new BigDecimal("105"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE > ? AND MolecularSequence.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+
+    @Test(expectedExceptions = {})
+    public void testPrecisionIntegerWithNENotIntExp() throws FHIRPersistenceException {
+        // sa - starts after with integer, and it's not supported
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.NE, null, "window-end", new String[] { "1e2" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("95"));
+        expectedBindVariables.add(new BigDecimal("105"));
+        String expectedSql = " AND (MolecularSequence.NUMBER_VALUE <= ? OR MolecularSequence.NUMBER_VALUE > ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, "MolecularSequence", MolecularSequence.class);
+    }
+}

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
@@ -275,12 +275,31 @@ public class NumberParmBehaviorUtilTest {
 
         // expectedBindVariables are pivoted on 100
         // Precision is implied by the use of ap
-        // Implied Range: (90 ... 110)
+        // Implied Range: (89.55 ... 110.55)
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "100");
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("90.0"));
-        expectedBindVariables.add(new BigDecimal("110.0"));
+        expectedBindVariables.add(new BigDecimal("89.55"));
+        expectedBindVariables.add(new BigDecimal("110.55"));
+        String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql);
+    }
+    
+    @Test
+    public void testPrecisionWithApproxNumberOne() throws FHIRPersistenceException {
+        // Condition:
+        //  [parameter]=ap1
+
+        // expectedBindVariables are pivoted on 100
+        // Precision is implied by the use of ap
+        // Implied Range: (.45 ... 1.65)
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "1");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("0.45"));
+        expectedBindVariables.add(new BigDecimal("1.65"));
         String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,
                 expectedBindVariables,
@@ -294,14 +313,14 @@ public class NumberParmBehaviorUtilTest {
 
         // expectedBindVariables are pivoted on 100
         // Precision is implied by the use of ap
-        // Implied Range: (90 ... 110)
+        // Implied Range: (89.55 ... 110.55)
 
         // It should de-dupe
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100" });
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("90.0"));
-        expectedBindVariables.add(new BigDecimal("110.0"));
+        expectedBindVariables.add(new BigDecimal("89.55"));
+        expectedBindVariables.add(new BigDecimal("110.55"));
         String expectedSql = " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,
                 expectedBindVariables,
@@ -321,10 +340,10 @@ public class NumberParmBehaviorUtilTest {
 
         Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100.00" });
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("90.0"));
-        expectedBindVariables.add(new BigDecimal("110.0"));
-        expectedBindVariables.add(new BigDecimal("90.000"));
-        expectedBindVariables.add(new BigDecimal("110.000"));
+        expectedBindVariables.add(new BigDecimal("89.55"));
+        expectedBindVariables.add(new BigDecimal("110.55"));
+        expectedBindVariables.add(new BigDecimal("89.9955"));
+        expectedBindVariables.add(new BigDecimal("110.0055"));
         String expectedSql =
                 " AND (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?) OR (Basic.NUMBER_VALUE >= ? AND Basic.NUMBER_VALUE <= ?))";
         runTest(queryParm,

--- a/fhir-persistence-jdbc/src/test/java/testng.xml
+++ b/fhir-persistence-jdbc/src/test/java/testng.xml
@@ -5,6 +5,8 @@
             <class name="com.ibm.fhir.persistence.jdbc.test.util.CacheUtilTest" />
             <class name="com.ibm.fhir.persistence.jdbc.test.util.QueryBuilderUtilTest" />
             <class name="com.ibm.fhir.persistence.jdbc.test.util.ParameterExtractionTest" />
+            <class name="com.ibm.fhir.persistence.jdbc.test.util.UriModifierUtilTest" />
+            <class name="com.ibm.fhir.persistence.jdbc.test.util.NumberParmBehaviorUtilTest" />
         </classes>
     </test>
     <test name="JDBCSpecTest">

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -155,6 +155,12 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         //assertSearchReturnsSavedResource("date", "9999-01-01,ap2018-10-29");
     }
 
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchDate_date_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.date:missing", "false");
@@ -308,6 +314,12 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-instant:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-instant:missing", "false");
     }
+    
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
     
 //    @Test
 //    public void testSearchDate_instant_chained_missing() throws Exception {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
@@ -302,12 +302,12 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
     }
 
     /*
-     * <PRE>
+     * <pre>
      * {
      * "url": "http://example.org/precision",
      * "valueDecimal": 100.25
      * }
-     * </PRE>
+     * </pre>
      */
     @Test
     public void testSearchNumber_Precision() throws Exception {
@@ -337,11 +337,9 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("precision", "1e2");
         assertSearchDoesntReturnSavedResource("precision", "1.05e2");
 
-        // [parameter]=1e3
-        // Value: 1e3
-        // Precision: 0
-        // Implied Range: [50 ... 150)
-        assertSearchReturnsSavedResource("precision", "100");
+        // [parameter]=1e2
+        // Implied Range: [50 to 150)
+        assertSearchReturnsSavedResource("precision", "1.0e2");
     }
 
     /*

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
@@ -22,8 +22,8 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 
 /**
- * @author lmsurpre
- * @see https://hl7.org/fhir/r4/search.html#number
+ * <a href="https://hl7.org/fhir/r4/search.html#number"> FHIR Specification:
+ * Search - Number</a>
  */
 public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
 
@@ -39,47 +39,49 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
     public void testSearchNumber_integer() throws Exception {
         assertSearchReturnsSavedResource("integer", "12");
         assertSearchReturnsSavedResource("integer", "1.2e1");
-        
+
         assertSearchReturnsSavedResource("integer", "lt13");
         assertSearchReturnsSavedResource("integer", "gt11");
         assertSearchReturnsSavedResource("integer", "le12");
         assertSearchReturnsSavedResource("integer", "le13");
         assertSearchReturnsSavedResource("integer", "ge12");
         assertSearchReturnsSavedResource("integer", "ge11");
-        
+
         assertSearchReturnsSavedResource("integer", "ne13");
         assertSearchReturnsSavedResource("integer", "ap12");
     }
-    
+
     @Test(expectedExceptions = { FHIRPersistenceException.class })
     public void testSearchNumber_integer_eb() throws Exception {
         assertSearchReturnsSavedResource("integer", "eb12");
     }
+
     @Test(expectedExceptions = { FHIRPersistenceException.class })
     public void testSearchNumber_integer_sa() throws Exception {
         assertSearchReturnsSavedResource("integer", "sa12");
     }
+
     @Test(expectedExceptions = { FHIRSearchException.class })
     public void testSearchNumber_integer_invalidPrefix() throws Exception {
         assertSearchReturnsSavedResource("integer", "zz12");
     }
-    
+
     @Test
     public void testSearchNumber_integer_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.integer", "12");
         assertSearchReturnsComposition("subject:Basic.integer", "1.2e1");
-        
+
         assertSearchReturnsComposition("subject:Basic.integer", "lt13");
         assertSearchReturnsComposition("subject:Basic.integer", "gt11");
         assertSearchReturnsComposition("subject:Basic.integer", "le12");
         assertSearchReturnsComposition("subject:Basic.integer", "le13");
         assertSearchReturnsComposition("subject:Basic.integer", "ge12");
         assertSearchReturnsComposition("subject:Basic.integer", "ge11");
-        
+
         assertSearchReturnsComposition("subject:Basic.integer", "ne13");
         assertSearchReturnsComposition("subject:Basic.integer", "ap12");
     }
-    
+
     @Test
     public void testSearchNumber_integer_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -88,23 +90,23 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-    
+
     @Test
     public void testSearchNumber_integer_missing() throws Exception {
         assertSearchReturnsSavedResource("integer:missing", "false");
         assertSearchDoesntReturnSavedResource("integer:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-integer:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-integer:missing", "false");
     }
-    
+
     @Test
     public void testSearchNumber_integer_or() throws Exception {
         assertSearchReturnsSavedResource("integer", "12,99");
         assertSearchReturnsSavedResource("integer", "1.2e1,99");
         assertSearchReturnsSavedResource("integer", "99,12");
         assertSearchReturnsSavedResource("integer", "99,1.2e1");
-        
+
         assertSearchReturnsSavedResource("integer", "lt13,99");
         assertSearchReturnsSavedResource("integer", "gt11,99");
         assertSearchReturnsSavedResource("integer", "le12,99");
@@ -117,58 +119,76 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("integer", "99,le13");
         assertSearchReturnsSavedResource("integer", "99,ge12");
         assertSearchReturnsSavedResource("integer", "99,ge11");
-        
+
         assertSearchReturnsSavedResource("integer", "ne13,99");
         assertSearchReturnsSavedResource("integer", "ap12,99");
         assertSearchReturnsSavedResource("integer", "99,ne13");
         assertSearchReturnsSavedResource("integer", "99,ap12");
     }
 
-//    @Test
-//    public void testSearchNumber_integer_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.integer:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.integer:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-integer:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-integer:missing", "false");
-//    }
-    
     @Test
     public void testSearchNumber_decimal() throws Exception {
+        // Targeted Value is 99.99
+
+        // Range: 98.5, 99.5 
         assertSearchDoesntReturnSavedResource("decimal", "99");
+
+        // Range: 99.984985, 99.984995
         assertSearchDoesntReturnSavedResource("decimal", "99.98499");
 
-//        assertSearchReturnsSavedResource("decimal", "99.985");
+        // Range: 99.9845, 99.9855
+        assertSearchDoesntReturnSavedResource("decimal", "99.985");
+
+        // Range: 99.985, 99.995
         assertSearchReturnsSavedResource("decimal", "99.99");
+
+        // Range: 99.45, 99.55
+        assertSearchDoesntReturnSavedResource("decimal", "99.5");
+
+        // Range: 99.985, 99.995
         assertSearchReturnsSavedResource("decimal", "9999e-2");
 
-//        assertSearchReturnsSavedResource("decimal", "99.99499");
+        // Range: 99.994985, 99.994995
+        assertSearchDoesntReturnSavedResource("decimal", "99.99499");
+
+        // Range: 99.9945, 99.9955
         assertSearchDoesntReturnSavedResource("decimal", "99.995");
-        assertSearchDoesntReturnSavedResource("decimal", "100");
-        
+
+        // Range: 99.5, 100.5
+        assertSearchReturnsSavedResource("decimal", "100");
+
+        // Range: Not in 98.5, 99.5
         assertSearchReturnsSavedResource("decimal", "ne99");
+
+        // Range: Not in 99.984985, 99.984995
         assertSearchReturnsSavedResource("decimal", "ne99.98499");
-//        assertSearchDoesntReturnSavedResource("decimal", "ne99.985");
+
+        // Range: 99.85, 99.95
+        assertSearchReturnsSavedResource("decimal", "ne99.9");
+
+        // Range: 99.985, 99.995
         assertSearchDoesntReturnSavedResource("decimal", "ne99.99");
         assertSearchDoesntReturnSavedResource("decimal", "ne9999e-2");
 
-//        assertSearchDoesntReturnSavedResource("decimal", "ne99.99499");
+        // Not in Range: 99.994985, 99.994995
+        assertSearchReturnsSavedResource("decimal", "ne99.99499");
         assertSearchReturnsSavedResource("decimal", "ne99.995");
-        assertSearchReturnsSavedResource("decimal", "ne100");
-        
-        // Currently "ap" prefix works just like "eq" for non-ranges
-//      assertSearchReturnsSavedResource("decimal", "ap99");
-//      assertSearchReturnsSavedResource("decimal", "ap99.98499");
-//      assertSearchReturnsSavedResource("decimal", "ap99.985");
+
+        // Not in Range: 99.5, 100.5
+        assertSearchDoesntReturnSavedResource("decimal", "ne100");
+
+        // ap does +/- 10% range
+        assertSearchReturnsSavedResource("decimal", "ap99");
+        assertSearchReturnsSavedResource("decimal", "ap99.98499");
+        assertSearchReturnsSavedResource("decimal", "ap99.985");
         assertSearchReturnsSavedResource("decimal", "ap99.99");
         assertSearchReturnsSavedResource("decimal", "ap9999e-2");
-//      assertSearchReturnsSavedResource("decimal", "ap99.99499");
-//      assertSearchReturnsSavedResource("decimal", "ap99.995");
-//      assertSearchReturnsSavedResource("decimal", "ap100");
-      
+        assertSearchReturnsSavedResource("decimal", "ap99.99499");
+        assertSearchReturnsSavedResource("decimal", "ap99.995");
+        assertSearchReturnsSavedResource("decimal", "ap100");
+
         // For gt, lt, ge, le, sa, & eb, numbers are treated as if they have arbitrarily high precision
-        // Question:  does that apply to just the search parameter value, or to the target values too?
-        
+        // Applies to just the search parameter value
         assertSearchDoesntReturnSavedResource("decimal", "lt99");
         assertSearchDoesntReturnSavedResource("decimal", "lt99.98499");
         assertSearchDoesntReturnSavedResource("decimal", "lt99.985");
@@ -177,7 +197,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("decimal", "lt99.99499");
         assertSearchReturnsSavedResource("decimal", "lt99.995");
         assertSearchReturnsSavedResource("decimal", "lt100");
-        
+
         assertSearchReturnsSavedResource("decimal", "gt99");
         assertSearchReturnsSavedResource("decimal", "gt99.98499");
         assertSearchReturnsSavedResource("decimal", "gt99.985");
@@ -187,7 +207,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("decimal", "gt99.99499");
         assertSearchDoesntReturnSavedResource("decimal", "gt99.995");
         assertSearchDoesntReturnSavedResource("decimal", "gt100");
-        
+
         assertSearchDoesntReturnSavedResource("decimal", "le99");
         assertSearchDoesntReturnSavedResource("decimal", "le99.98499");
         assertSearchDoesntReturnSavedResource("decimal", "le99.985");
@@ -196,7 +216,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("decimal", "le99.99499");
         assertSearchReturnsSavedResource("decimal", "le99.995");
         assertSearchReturnsSavedResource("decimal", "le100");
-        
+
         assertSearchReturnsSavedResource("decimal", "ge99");
         assertSearchReturnsSavedResource("decimal", "ge99.98499");
         assertSearchReturnsSavedResource("decimal", "ge99.985");
@@ -205,7 +225,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("decimal", "ge99.99499");
         assertSearchDoesntReturnSavedResource("decimal", "ge99.995");
         assertSearchDoesntReturnSavedResource("decimal", "ge100");
-        
+
         assertSearchReturnsSavedResource("decimal", "sa99");
         assertSearchReturnsSavedResource("decimal", "sa99.98499");
         assertSearchReturnsSavedResource("decimal", "sa99.985");
@@ -214,7 +234,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("decimal", "sa99.99499");
         assertSearchDoesntReturnSavedResource("decimal", "sa99.995");
         assertSearchDoesntReturnSavedResource("decimal", "sa100");
-        
+
         assertSearchDoesntReturnSavedResource("decimal", "eb99");
         assertSearchDoesntReturnSavedResource("decimal", "eb99.98499");
         assertSearchDoesntReturnSavedResource("decimal", "eb99.985");
@@ -224,44 +244,44 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("decimal", "eb99.995");
         assertSearchReturnsSavedResource("decimal", "eb100");
     }
-    
+
     @Test(expectedExceptions = { FHIRSearchException.class })
     public void testSearchNumber_decimal_invalidPrefix() throws Exception {
         assertSearchReturnsSavedResource("decimal", "zz99.99");
     }
-    
+
     @Test
     public void testSearchNumber_decimal_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.decimal", "99.99");
         assertSearchReturnsComposition("subject:Basic.decimal", "9999e-2");
-        
+
         assertSearchReturnsComposition("subject:Basic.decimal", "lt100");
         assertSearchReturnsComposition("subject:Basic.decimal", "gt99");
         assertSearchReturnsComposition("subject:Basic.decimal", "le99.99");
         assertSearchReturnsComposition("subject:Basic.decimal", "le100");
         assertSearchReturnsComposition("subject:Basic.decimal", "ge99.99");
         assertSearchReturnsComposition("subject:Basic.decimal", "ge99");
-        
+
         assertSearchReturnsComposition("subject:Basic.decimal", "ne13");
         assertSearchReturnsComposition("subject:Basic.decimal", "ap99.99");
     }
-    
+
     @Test
     public void testSearchNumber_decimal_missing() throws Exception {
         assertSearchReturnsSavedResource("decimal:missing", "false");
         assertSearchDoesntReturnSavedResource("decimal:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-decimal:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-decimal:missing", "false");
     }
-    
+
     @Test
     public void testSearchNumber_decimal_or() throws Exception {
         assertSearchReturnsComposition("subject:Basic.decimal", "99.99,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "9999e-2,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,99.99");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,9999e-2");
-        
+
         assertSearchReturnsComposition("subject:Basic.decimal", "lt100,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "gt99,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "le99.99,1");
@@ -274,19 +294,77 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsComposition("subject:Basic.decimal", "1,le100");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,ge99.99");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,ge99");
-        
+
         assertSearchReturnsComposition("subject:Basic.decimal", "ne13,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "ap99.99,1");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,ne13");
         assertSearchReturnsComposition("subject:Basic.decimal", "1,ap99.99");
     }
-    
-//    @Test
-//    public void testSearchNumber_decimal_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.decimal:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.decimal:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-decimal:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-decimal:missing", "false");
-//    }
+
+    /*
+     * <PRE>
+     * {
+     * "url": "http://example.org/precision",
+     * "valueDecimal": 100.25
+     * }
+     * </PRE>
+     */
+    @Test
+    public void testSearchNumber_Precision() throws Exception {
+        // [parameter]=100
+        // Value: 100
+        // Precision: 3 
+        // Implied Range: [99.5 ... 100.5)
+        // Target: 100.25
+        assertSearchReturnsSavedResource("precision", "100");
+        assertSearchDoesntReturnSavedResource("precision", "101");
+        assertSearchDoesntReturnSavedResource("precision", "99");
+        assertSearchDoesntReturnSavedResource("precision", "99.99");
+
+        // [parameter]=100.00
+        // Value: 100.00
+        // Precision: 5
+        // Implied Range: [99.995 ... 100.005)
+        assertSearchReturnsSavedResource("precision", "100");
+        assertSearchDoesntReturnSavedResource("precision", "100.005");
+        assertSearchDoesntReturnSavedResource("precision", "99");
+        assertSearchDoesntReturnSavedResource("precision", "99.999999990");
+
+        // [parameter]=1e2
+        // Value: 1e2
+        // Precision: 1
+        // Implied Range: [95 ... 105)
+        assertSearchReturnsSavedResource("precision", "1e2");
+        assertSearchDoesntReturnSavedResource("precision", "1.05e2");
+
+        // [parameter]=1e3
+        // Value: 1e3
+        // Precision: 0
+        // Implied Range: [50 ... 150)
+        assertSearchReturnsSavedResource("precision", "100");
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+
+    //    @Test
+    //    public void testSearchNumber_integer_chained_missing() throws Exception {
+    //        assertSearchReturnsComposition("subject:Basic.integer:missing", "false");
+    //        assertSearchDoesntReturnComposition("subject:Basic.integer:missing", "true");
+    //
+    //        assertSearchReturnsComposition("subject:Basic.missing-integer:missing", "true");
+    //        assertSearchDoesntReturnComposition("subject:Basic.missing-integer:missing", "false");
+    //    }
+    //
+    //    @Test
+    //    public void testSearchNumber_decimal_chained_missing() throws Exception {
+    //        assertSearchReturnsComposition("subject:Basic.decimal:missing", "false");
+    //        assertSearchDoesntReturnComposition("subject:Basic.decimal:missing", "true");
+    //
+    //        assertSearchReturnsComposition("subject:Basic.missing-decimal:missing", "true");
+    //        assertSearchDoesntReturnComposition("subject:Basic.missing-decimal:missing", "false");
+    //    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -255,7 +255,12 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-Quantity:missing", "false");
     }
     
-
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.Quantity:missing", "false");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
@@ -110,6 +110,12 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-Reference:missing", "false");
     }
     
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchReference_Reference_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.Reference:missing", "false");
@@ -137,6 +143,12 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-uri:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-uri:missing", "false");
     }
+    
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
     
 //    @Test
 //    public void testSearchReference_uri_chained_missing() throws Exception {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
@@ -108,6 +108,12 @@ public abstract class AbstractSearchStringTest extends AbstractPLSearchTest {
         runQueryTest(Basic.class, "string", "\\", Integer.MAX_VALUE);
     }
     
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchString_string_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.string:missing", "false");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -119,6 +119,12 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-code:missing", "false");
     }
 
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchToken_code_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.code:missing", "false");
@@ -182,6 +188,12 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-Coding:missing", "false");
     }
 
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchToken_Coding_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.Coding:missing", "false");
@@ -231,6 +243,12 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-Identifier:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Identifier:missing", "false");
     }
+    
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
 
 //    @Test
 //    public void testSearchToken_Identifier_chained_missing() throws Exception {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
@@ -98,6 +98,12 @@ public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-uri:missing", "false");
     }
 
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    
 //    @Test
 //    public void testSearchURI_uri_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.uri:missing", "false");

--- a/fhir-persistence/src/test/resources/config/number/extension-search-parameters.json
+++ b/fhir-persistence/src/test/resources/config/number/extension-search-parameters.json
@@ -324,5 +324,22 @@
             "xpath": "f:Basic/f:extension[@url='http://example.org/missing-decimal']/f:valueDecimal",
             "xpathUsage": "normal"
         }
+    },
+    {
+        "fullUrl": "http://ibm.com/fhir/SearchParameter/Basic-precision",
+        "resource": {
+            "resourceType": "SearchParameter",
+            "id": "Basic-precision",
+            "url": "http://ibm.com/fhir/SearchParameter/Basic-precision",
+            "name": "precision",
+            "status": "active",
+            "description": "test param",
+            "code": "precision",
+            "base": ["Basic"],
+            "type": "number",
+            "expression": "Basic.extension.where(url='http://example.org/precision').value",
+            "xpath": "f:Basic/f:extension[@url='http://example.org/precision']/f:valueDecimal",
+            "xpathUsage": "normal"
+        }
     }]
 }

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -49,4 +49,4 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ############################################################
 
 # Set this to FINE or higher to output the SQL statements and related debug info
-com.ibm.fhir.persistence.level = INFO
+com.ibm.fhir.persistence.level = FINE

--- a/fhir-persistence/src/test/resources/logging.unitTest.properties
+++ b/fhir-persistence/src/test/resources/logging.unitTest.properties
@@ -49,4 +49,4 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ############################################################
 
 # Set this to FINE or higher to output the SQL statements and related debug info
-com.ibm.fhir.persistence.level = FINE
+com.ibm.fhir.persistence.level = INFO

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParameterValue.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParameterValue.java
@@ -14,9 +14,6 @@ import com.ibm.fhir.search.SearchConstants.Prefix;
 
 /**
  * Refactored the code to more consistently apply the output patterns.<br/>
- * 
- * @author paulbastide
- * @author markd
  */
 public class ParameterValue {
 
@@ -25,7 +22,9 @@ public class ParameterValue {
     private String valueString = null;
     private DateTime valueDate = null;
 
+    // Used with Number
     private BigDecimal valueNumber = null;
+
     private String valueSystem = null;
     private String valueCode = null;
 


### PR DESCRIPTION
- Add precision value to BasicNumber.json
- Extend the extension-search-parameters.json to add precision
SearchParameter
- Enhance AbstractSearchNumberTest.java to include precision
- Update testng.xml to include new tests that were not specifically
included
- Cleanup formatting in FHIRPersistenceJDBCImpl
- Implement variable precision in the search
- Add guard to the Null Prefix.
- Added a conformance related commentary to the Abstract Tests

Reference: https://hl7.org/fhir/search.html#number

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>