### PR TITLE
Quantity searches update to consider implicit ranges #257

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterDAO.java
@@ -21,14 +21,6 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessExceptio
  * and retrieving rows in the IBM FHIR Server parameter-related tables.
  */
 public interface ParameterDAO extends FHIRDbDAO {
-    
-    /**
-     * Performs a batch insert of the passed Parameter objects into the FHIR database.
-     * @param parameters - A List of search parameters associated with a FHIR Resource.
-     * @throws FHIRPersistenceDataAccessException
-     * @throws FHIRPersistenceDBConnectException
-     */
-    void insert(List<Parameter> parameters) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException;
 
     /**
      * Deletes from the Parameter table all rows associated with the passed resource id.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterDAOImpl.java
@@ -8,9 +8,7 @@ package com.ibm.fhir.persistence.jdbc.dao.impl;
 
 import java.sql.Array;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.Struct;
-import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -23,8 +21,8 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.jdbc.dao.api.CodeSystemDAO;
-import com.ibm.fhir.persistence.jdbc.dao.api.ParameterNameDAO;
 import com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO;
+import com.ibm.fhir.persistence.jdbc.dao.api.ParameterNameDAO;
 import com.ibm.fhir.persistence.jdbc.dto.Parameter;
 import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDBConnectException;
 import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessException;
@@ -46,10 +44,6 @@ public class ParameterDAOImpl extends FHIRDbDAOImpl implements ParameterDAO {
     private static final String CLASSNAME = ParameterDAOImpl.class.getName(); 
     
     public static final String DEFAULT_TOKEN_SYSTEM = "default-token-system";
-    
-    private static final String SQL_INSERT = "INSERT INTO PARAMETERS_GTT (PARAMETER_NAME_ID, PARAMETER_TYPE, STR_VALUE, STR_VALUE_LCASE, DATE_VALUE, DATE_START, DATE_END, " +
-            "NUMBER_VALUE, NUMBER_VALUE_LOW, NUMBER_VALUE_HIGH, LATITUDE_VALUE, LONGITUDE_VALUE, TOKEN_VALUE, CODE_SYSTEM_ID, CODE) " +
-            "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
     
     private static final int SQL_INSERT_PARAMETERS_MAX_ARRAY_SIZE_DEFAULT = 512;
     private static final int SQL_INSERT_PARAMETERS_MAX_ARRAY_SIZE_STRINGS = 1024;
@@ -80,106 +74,6 @@ public class ParameterDAOImpl extends FHIRDbDAOImpl implements ParameterDAO {
      */
     public ParameterDAOImpl(Connection managedConnection) {
         super(managedConnection);
-    }
-
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO#insert(java.util.List)
-     */
-    @Override
-    public void insert(List<Parameter> parameters)
-                    throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
-        final String METHODNAME = "insert";
-        log.entering(CLASSNAME, METHODNAME);
-        
-        Connection connection = null;
-        PreparedStatement stmt = null;
-        String parameterName;
-        Integer parameterId;
-        String tokenSystem;
-        Integer tokenSystemId;
-        boolean acquiredFromCache;
-        long dbCallStartTime;
-        double dbCallDuration;
-                        
-        try {
-            connection = this.getConnection();
-            stmt = connection.prepareStatement(SQL_INSERT);
-            
-            for (Parameter parameter: parameters) {
-                parameterName = parameter.getName();
-                parameterId = ParameterNamesCache.getParameterNameId(parameterName);
-                if (parameterId == null) {
-                    acquiredFromCache = false;
-                    parameterId = this.readOrAddParameterNameId(parameterName);
-                    this.addParameterNamesCacheCandidate(parameterName, parameterId);
-                }
-                else {
-                    acquiredFromCache = true;
-                }
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("paramenterName=" + parameterName + "  parameterId=" + parameterId + 
-                              "  acquiredFromCache=" + acquiredFromCache + "  tenantDatastoreCacheName=" + ParameterNamesCache.getCacheNameForTenantDatastore());
-                }
-                stmt.setInt(1, parameterId);
-                stmt.setString(2, String.valueOf(this.determineParameterTypeChar(parameter)));
-                stmt.setString(3, parameter.getValueString());
-                stmt.setString(4, SearchUtil.normalizeForSearch(parameter.getValueString()));
-                stmt.setTimestamp(5, parameter.getValueDate());
-                stmt.setTimestamp(6, parameter.getValueDateStart());
-                stmt.setTimestamp(7, parameter.getValueDateEnd());
-                stmt.setObject(8, parameter.getValueNumber(), Types.DOUBLE);
-                stmt.setObject(9, parameter.getValueNumberLow(), Types.DOUBLE);
-                stmt.setObject(10, parameter.getValueNumberHigh(), Types.DOUBLE);
-                stmt.setObject(11, parameter.getValueLatitude(), Types.DOUBLE);
-                stmt.setObject(12, parameter.getValueLongitude(), Types.DOUBLE);
-                stmt.setString(13, parameter.getValueCode());
-                tokenSystem = parameter.getValueSystem();
-                if ((parameter.getType().equals(Type.TOKEN) || parameter.getType().equals(Type.QUANTITY)) &&
-                    (tokenSystem == null || tokenSystem.isEmpty())) {
-                        tokenSystem = DEFAULT_TOKEN_SYSTEM;
-                }
-                if(tokenSystem != null) {
-                    tokenSystemId = CodeSystemsCache.getCodeSystemId(tokenSystem);
-                    if (tokenSystemId == null) {
-                        acquiredFromCache = false;
-                        tokenSystem = SqlParameterEncoder.encode(tokenSystem);
-                        tokenSystemId = this.readOrAddCodeSystemId(tokenSystem);
-                        this.addCodeSystemsCacheCandidate(tokenSystem, tokenSystemId);
-                    }
-                    else {
-                        acquiredFromCache = true;
-                    }
-                    stmt.setInt(14, tokenSystemId);
-                    if (log.isLoggable(Level.FINE)) {
-                        log.fine("tokenSystem=" + tokenSystem + "  tokenSystemId=" + tokenSystemId + 
-                                  "  acquiredFromCache=" + acquiredFromCache + "  tenantDatastoreCacheName=" + CodeSystemsCache.getCacheNameForTenantDatastore());
-                    }
-                }
-                else {
-                    stmt.setObject(14, null, Types.INTEGER);
-                }
-                stmt.setString(15, parameter.getValueCode());
-                stmt.addBatch();
-            }
-            dbCallStartTime = System.nanoTime();
-            stmt.executeBatch();
-            dbCallDuration = (System.nanoTime()-dbCallStartTime)/1e6;
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Batch DB Parameter insert complete. executionTime=" + dbCallDuration + "ms");
-            }
-        }
-        catch(FHIRPersistenceDBConnectException e) {
-            throw e;
-        }
-        catch(Throwable e) {
-            FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure inserting Parameter batch.");
-            throw severe(log, fx, e);
-        }
-        finally {
-            this.cleanup(stmt, connection);
-            log.exiting(CLASSNAME, METHODNAME);
-        }
-
     }
 
     @Override
@@ -216,46 +110,6 @@ public class ParameterDAOImpl extends FHIRDbDAOImpl implements ParameterDAO {
             this.cleanup(null, connection);
             log.exiting(CLASSNAME, METHODNAME);
         }
-    }
-    
-    /**
-     * Examines the type of the passed parameter and maps that enumerated Type to a char that can then be persisted
-     * in one of the parameter values tables.
-     * @param parameter A search Parameter containing a valid Type.
-     * @return char - A character indicating the search parameter type that can be persisted.
-     */
-    private char determineParameterTypeChar(Parameter parameter) {
-        final String METHODNAME = "determineParameterTypeChar";
-        log.entering(CLASSNAME, METHODNAME);
-        
-        char returnChar = 0;
-        if(AbstractQueryBuilder.NEAR.equals(parameter.getName()) || 
-           AbstractQueryBuilder.NEAR_DISTANCE.equals(parameter.getName())) {
-            returnChar = 'G';
-        }
-        else {
-            switch(parameter.getType()) {
-                case REFERENCE :
-                case URI: 
-                case STRING :     returnChar = 'S';
-                                  break;
-                              
-                case TOKEN :      returnChar = 'C';
-                                  break;
-                
-                case QUANTITY : returnChar = 'Q';  
-                                break;
-                              
-                case NUMBER :     returnChar = 'N';
-                                break;
-                    
-                case DATE :     returnChar = 'D'; 
-                                break;
-            }
-        }
-        
-        log.exiting(CLASSNAME, METHODNAME);
-        return returnChar;
     }
     
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCache.java
@@ -39,17 +39,16 @@ public class CodeSystemsCache {
      */
     public static Integer getCodeSystemId(String systemName) {
         
-        String tenantDatstoreCacheName = getCacheNameForTenantDatastore();
-        ConcurrentHashMap<String,Integer> currentDsMap;
+        String tenantDatastoreCacheName = getCacheNameForTenantDatastore();
         Integer systemId = null;
         String encodedSysName = SqlParameterEncoder.encode(systemName);
         
         if (enabled) {
-            currentDsMap = codeSystemIdMaps.putIfAbsent(tenantDatstoreCacheName, new ConcurrentHashMap<String,Integer>());
+            ConcurrentHashMap<String,Integer> currentDsMap = codeSystemIdMaps.putIfAbsent(tenantDatastoreCacheName, new ConcurrentHashMap<String,Integer>());
             if (currentDsMap == null) {
-                log.fine("getCodeSystemId() - Added new cache map for tennantDatastore=" + tenantDatstoreCacheName);
+                log.fine("getCodeSystemId() - Added new cache map for tennantDatastore=" + tenantDatastoreCacheName);
             }
-            currentDsMap = codeSystemIdMaps.get(tenantDatstoreCacheName);
+            currentDsMap = codeSystemIdMaps.get(tenantDatastoreCacheName);
             systemId = currentDsMap.get(encodedSysName);
         }
         return systemId;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/NumberParmBehaviorUtil.java
@@ -38,7 +38,7 @@ import com.ibm.fhir.search.valuetypes.ValueTypesFactory;
 public class NumberParmBehaviorUtil {
     private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtil.class.getName());
 
-    private static final BigDecimal FACTOR = new BigDecimal(".1");
+    protected static final BigDecimal FACTOR = new BigDecimal(".1");
 
     private NumberParmBehaviorUtil() {
         // No operation

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
@@ -185,7 +185,7 @@ public class QuantityParmBehaviorUtil {
      * @param value
      */
     public void buildCommonClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
-            String columnName, String columnNameLowOrHigh, String operator, BigDecimal value) {
+            String columnName, String columnNameLowOrHigh, String operator, BigDecimal value, BigDecimal bound) {
         whereClauseSegment
                 .append(LEFT_PAREN)
                 .append(tableAlias).append(DOT).append(columnName).append(operator).append(BIND_VAR)
@@ -194,7 +194,7 @@ public class QuantityParmBehaviorUtil {
                 .append(RIGHT_PAREN);
 
         bindVariables.add(value);
-        bindVariables.add(value);
+        bindVariables.add(bound);
     }
     
     public void buildEqualsRangeClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
@@ -286,40 +286,40 @@ public class QuantityParmBehaviorUtil {
             // the range of the search value does not overlap with the range of the target value,
             // and the range above the search value contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.LT.value(), lowerBound);
+                    JDBCOperator.LT.value(), value, lowerBound);
             break;
         case SA:
             // SA - Starts After
             // the range of the search value does not overlap with the range of the target value,
             // and the range below the search value contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.GT.value(), upperBound);
+                    JDBCOperator.GT.value(), value, upperBound);
             break;
         case GE:
             // GE - Greater Than Equal
             // the range above the search value intersects (i.e. overlaps) with the range of the target value,
             // or the range of the search value fully contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.GTE.value(), lowerBound);
+                    JDBCOperator.GTE.value(), value, lowerBound);
             break;
         case GT:
             // GT - Greater Than
             // the range above the search value intersects (i.e. overlaps) with the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.GT.value(), lowerBound);
+                    JDBCOperator.GT.value(), value, lowerBound);
             break;
         case LE:
             // LE - Less Than Equal
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             // or the range of the search value fully contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.LTE.value(), lowerBound);
+                    JDBCOperator.LTE.value(), value, lowerBound);
             break;
         case LT:
             // LT - Less Than
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.LT.value(), lowerBound);
+                    JDBCOperator.LT.value(), value, lowerBound);
             break;
         case AP:
             // AP - Approximate - Relative

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
@@ -299,26 +299,26 @@ public class QuantityParmBehaviorUtil {
             // GE - Greater Than Equal
             // the range above the search value intersects (i.e. overlaps) with the range of the target value,
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
                     JDBCOperator.GTE.value(), value, value);
             break;
         case GT:
             // GT - Greater Than
             // the range above the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
                     JDBCOperator.GT.value(), value, value);
             break;
         case LE:
             // LE - Less Than Equal
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
                     JDBCOperator.LTE.value(), value, value);
             break;
         case LT:
             // LT - Less Than
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
                     JDBCOperator.LT.value(), value, value);
             break;
         case AP:

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
@@ -1,0 +1,344 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.util.type;
+
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.AND;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.CODE;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.CODE_SYSTEM_ID;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.QUANTITY_VALUE;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.QUANTITY_VALUE_HIGH;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.QUANTITY_VALUE_LOW;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.jdbc.JDBCConstants.JDBCOperator;
+import com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO;
+import com.ibm.fhir.persistence.jdbc.util.CodeSystemsCache;
+import com.ibm.fhir.search.SearchConstants.Prefix;
+import com.ibm.fhir.search.parameters.Parameter;
+import com.ibm.fhir.search.parameters.ParameterValue;
+
+/**
+ * <a href="https://hl7.org/fhir/search.html#quantity>FHIR Specification: Search
+ * - Quantity</a>
+ * <br>
+ * This utility encapsulates the logic specific to fhir-search related to
+ * quantity.
+ */
+public class QuantityParmBehaviorUtil {
+
+    public QuantityParmBehaviorUtil() {
+        // No operation
+    }
+
+    public void executeBehavior(StringBuilder whereClauseSegment, Parameter queryParm, List<Object> bindVariables,
+            String tableAlias, ParameterDAO parameterDao)
+            throws Exception {
+        // Start the Clause 
+        // Query: AND ((
+        whereClauseSegment.append(AND).append(LEFT_PAREN).append(LEFT_PAREN);
+
+        // Process each parameter value in the query parameter
+        boolean parmValueProcessed = false;
+        Set<String> seen = new HashSet<>();
+        for (ParameterValue value : queryParm.getValues()) {
+
+            // Let's get the prefix. 
+            Prefix prefix = value.getPrefix();
+            if (prefix == null) {
+                // Default to EQ
+                prefix = Prefix.EQ;
+            }
+
+            // seen is used to optimize against a repeated value passed in. 
+            // the hash must use the prefix and original values (reassembled). 
+            String hash =
+                    prefix.value() + value.getValueNumber() + '|' + value.getValueSystem() + '|' + value.getValueCode();
+            if (!seen.contains(hash)) {
+                seen.add(hash);
+
+                // If multiple values are present, we need to OR them together.
+                if (parmValueProcessed) {
+                    // OR
+                    whereClauseSegment.append(RIGHT_PAREN).append(JDBCOperator.OR.value()).append(LEFT_PAREN);
+                } else {
+                    // Signal to the downstream to treat any subsequent value as an OR condition 
+                    parmValueProcessed = true;
+                }
+
+                addValue(whereClauseSegment, bindVariables, tableAlias, prefix, value.getValueNumber());
+                addSystemIfPresent(parameterDao, whereClauseSegment, tableAlias, bindVariables,
+                        value.getValueSystem());
+                addCodeIfPresent(whereClauseSegment, tableAlias, bindVariables,
+                        value.getValueCode());
+            }
+        }
+
+        // End the Clause started above, and closes the parameter expression. 
+        // Query: ))
+        whereClauseSegment.append(RIGHT_PAREN).append(RIGHT_PAREN).append(RIGHT_PAREN);
+    }
+
+    /**
+     * adds the system if present.
+     * 
+     * @param parameterDao
+     * @param whereClauseSegment
+     * @param tableAlias
+     * @param bindVariables
+     * @param system
+     * @throws FHIRPersistenceException
+     */
+    public void addSystemIfPresent(ParameterDAO parameterDao, StringBuilder whereClauseSegment, String tableAlias,
+            List<Object> bindVariables,
+            String system) throws FHIRPersistenceException {
+        /*
+         * <code>GET
+         * [base]/Observation?value-quantity=5.4|http://unitsofmeasure.org|mg</code>
+         * system -> http://unitsofmeasure.org
+         * <br>
+         * In the above example, the system is unitsofmeasure.org
+         * <br>
+         * When a system is present, the following sql is returned:
+         * <code>AND BASIC.CODE_SYSTEM_ID = ?</code>
+         * -1 indicates the system is not found (rather than returning null)
+         * 1 ... * - is used to indicate the key of the parameter in the parameters
+         * table,
+         * and to enable faster filtering.
+         * <br>
+         * This SQL is always an EXACT match unless a NOT modifier is used.
+         * When :not is used, the semantics are treated as:
+         * <code>value <> ? AND system = ? AND code = ?</code>
+         */
+        if (isPresent(system)) {
+            Integer systemId = CodeSystemsCache.getCodeSystemId(system);
+            if (systemId == null) {
+                systemId = parameterDao.readCodeSystemId(system);
+                if (systemId != null) {
+                    // If found, we want to cache it. 
+                    parameterDao.addCodeSystemsCacheCandidate(system, systemId);
+                } else {
+                    // This is an invalid number in the sequence. 
+                    // All of our sequences start with 1 and NO CYCLE. 
+                    systemId = -1;
+                }
+            }
+
+            // We shouldn't be adding to the query if it's NULL at this point. 
+            // What should we do? 
+            whereClauseSegment.append(JDBCOperator.AND.value()).append(tableAlias).append(DOT)
+                    .append(CODE_SYSTEM_ID)
+                    .append(JDBCOperator.EQ.value()).append(BIND_VAR);
+            bindVariables.add(systemId);
+        }
+    }
+
+    /**
+     * add code if present.
+     * 
+     * @param whereClauseSegment
+     * @param tableAlias
+     * @param bindVariables
+     * @param code
+     */
+    public void addCodeIfPresent(StringBuilder whereClauseSegment, String tableAlias, List<Object> bindVariables,
+            String code) {
+        // Include code if present.
+        if (isPresent(code)) {
+            whereClauseSegment.append(JDBCOperator.AND.value()).append(tableAlias + DOT).append(CODE)
+                    .append(JDBCOperator.EQ.value()).append(BIND_VAR);
+            bindVariables.add(code);
+        }
+    }
+
+    public boolean isPresent(String value) {
+        return value != null && !value.isEmpty();
+    }
+
+    /**
+     * the build common clause considers _VALUE_*** and _VALUE when querying the
+     * data.
+     * <br>
+     * The data should not result in a duplication as the OR condition short
+     * circuits double matches.
+     * If one exists, great, we'll return it, else we'll peek at the other column.
+     * <br>
+     * 
+     * @param whereClauseSegment
+     * @param bindVariables
+     * @param tableAlias
+     * @param columnName
+     * @param columnNameLowOrHigh
+     * @param operator
+     * @param value
+     */
+    public void buildCommonClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
+            String columnName, String columnNameLowOrHigh, String operator, BigDecimal value) {
+        whereClauseSegment
+                .append(LEFT_PAREN)
+                .append(tableAlias).append(DOT).append(columnName).append(operator).append(BIND_VAR)
+                .append(JDBCOperator.OR.value())
+                .append(tableAlias).append(DOT).append(columnNameLowOrHigh).append(operator).append(BIND_VAR)
+                .append(RIGHT_PAREN);
+
+        bindVariables.add(value);
+        bindVariables.add(value);
+    }
+    
+    public void buildEqualsRangeClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
+           BigDecimal lowerBound, BigDecimal upperBound, BigDecimal value) {
+        whereClauseSegment
+            .append(LEFT_PAREN)
+            .append(LEFT_PAREN)
+                    .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.GT.value()).append(BIND_VAR)
+                    .append(JDBCOperator.AND.value())
+                    .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.LTE.value()).append(BIND_VAR)
+                .append(RIGHT_PAREN)
+                .append(JDBCOperator.OR.value())
+                .append(LEFT_PAREN)
+                    .append(tableAlias).append(DOT).append(QUANTITY_VALUE_LOW).append(JDBCOperator.LT.value()).append(BIND_VAR)
+                    .append(JDBCOperator.AND.value())
+                    .append(tableAlias).append(DOT).append(QUANTITY_VALUE_HIGH).append(JDBCOperator.GTE.value()).append(BIND_VAR)
+                .append(RIGHT_PAREN).append(RIGHT_PAREN);
+
+        bindVariables.add(lowerBound);
+        bindVariables.add(upperBound);
+        bindVariables.add(value);
+        bindVariables.add(value);
+    }
+    
+    public void buildApproxRangeClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
+            BigDecimal lowerBound, BigDecimal upperBound, BigDecimal value) {
+         whereClauseSegment
+             .append(LEFT_PAREN)
+             .append(LEFT_PAREN)
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.GT.value()).append(BIND_VAR)
+                     .append(JDBCOperator.AND.value())
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.LTE.value()).append(BIND_VAR)
+                 .append(RIGHT_PAREN)
+                 .append(JDBCOperator.OR.value())
+                 .append(LEFT_PAREN)
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE_LOW).append(JDBCOperator.LTE.value()).append(BIND_VAR)
+                     .append(JDBCOperator.AND.value())
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE_HIGH).append(JDBCOperator.GTE.value()).append(BIND_VAR)
+                 .append(RIGHT_PAREN).append(RIGHT_PAREN);
+
+         bindVariables.add(lowerBound);
+         bindVariables.add(upperBound);
+         bindVariables.add(value);
+         bindVariables.add(value);
+     }
+    
+    public void buildNotEqualsRangeClause(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
+            BigDecimal lowerBound, BigDecimal upperBound, BigDecimal value) {
+         whereClauseSegment
+             .append(LEFT_PAREN)
+             .append(LEFT_PAREN)
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.LTE.value()).append(BIND_VAR)
+                     .append(JDBCOperator.OR.value())
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE).append(JDBCOperator.GT.value()).append(BIND_VAR)
+                 .append(RIGHT_PAREN)
+                 .append(JDBCOperator.OR.value())
+                 .append(LEFT_PAREN)
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE_LOW).append(JDBCOperator.LTE.value()).append(BIND_VAR)
+                     .append(JDBCOperator.OR.value())
+                     .append(tableAlias).append(DOT).append(QUANTITY_VALUE_HIGH).append(JDBCOperator.GT.value()).append(BIND_VAR)
+                 .append(RIGHT_PAREN).append(RIGHT_PAREN);
+
+         bindVariables.add(lowerBound);
+         bindVariables.add(upperBound);
+         bindVariables.add(value);
+         bindVariables.add(value);
+     }
+
+    /**
+     * Append the condition and bind the variables according to the semantics of the
+     * passed prefix
+     * adds the value to the whereClause.
+     * 
+     * @param whereClauseSegment
+     * @param bindVariables
+     * @param tableAlias
+     * @param prefix
+     * @param value
+     */
+    public void addValue(StringBuilder whereClauseSegment, List<Object> bindVariables, String tableAlias,
+            Prefix prefix, BigDecimal value) {
+
+        BigDecimal lowerBound = NumberParmBehaviorUtil.generateLowerBound(value);
+        BigDecimal upperBound = NumberParmBehaviorUtil.generateUpperBound(value);
+
+        switch (prefix) {
+        case EB:
+            // EB - Ends Before
+            // the range of the search value does not overlap with the range of the target value,
+            // and the range above the search value contains the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+                    JDBCOperator.LT.value(), lowerBound);
+            break;
+        case SA:
+            // SA - Starts After
+            // the range of the search value does not overlap with the range of the target value,
+            // and the range below the search value contains the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+                    JDBCOperator.GT.value(), upperBound);
+            break;
+        case GE:
+            // GE - Greater Than Equal
+            // the range above the search value intersects (i.e. overlaps) with the range of the target value,
+            // or the range of the search value fully contains the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+                    JDBCOperator.GTE.value(), lowerBound);
+            break;
+        case GT:
+            // GT - Greater Than
+            // the range above the search value intersects (i.e. overlaps) with the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+                    JDBCOperator.GT.value(), lowerBound);
+            break;
+        case LE:
+            // LE - Less Than Equal
+            // the range below the search value intersects (i.e. overlaps) with the range of the target value
+            // or the range of the search value fully contains the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+                    JDBCOperator.LTE.value(), lowerBound);
+            break;
+        case LT:
+            // LT - Less Than
+            // the range below the search value intersects (i.e. overlaps) with the range of the target value
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+                    JDBCOperator.LT.value(), lowerBound);
+            break;
+        case AP:
+            // AP - Approximate - Relative
+            // -10% of the Lower Bound
+            // +10% of the Upper Bound
+            BigDecimal factor = value.multiply(NumberParmBehaviorUtil.FACTOR);
+            buildApproxRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound.subtract(factor), upperBound.add(factor), value);
+            break;
+        case NE:
+            // NE:  Upper and Lower Bounds - Range Based Search
+            // the range of the search value does not fully contain the range of the target value
+            buildNotEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound, upperBound, value);
+            break;
+        case EQ:
+        default:
+            // EQ:  Upper and Lower Bounds - Range Based Search
+            // the range of the search value fully contains the range of the target value
+            buildEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound, upperBound, value);
+            break;
+        }
+    }
+}

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/QuantityParmBehaviorUtil.java
@@ -285,41 +285,41 @@ public class QuantityParmBehaviorUtil {
             // EB - Ends Before
             // the range of the search value does not overlap with the range of the target value,
             // and the range above the search value contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.LT.value(), value, lowerBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
+                    JDBCOperator.LT.value(), value, value);
             break;
         case SA:
             // SA - Starts After
             // the range of the search value does not overlap with the range of the target value,
             // and the range below the search value contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.GT.value(), value, upperBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
+                    JDBCOperator.GT.value(), value, value);
             break;
         case GE:
             // GE - Greater Than Equal
             // the range above the search value intersects (i.e. overlaps) with the range of the target value,
             // or the range of the search value fully contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.GTE.value(), value, lowerBound);
+                    JDBCOperator.GTE.value(), value, value);
             break;
         case GT:
             // GT - Greater Than
             // the range above the search value intersects (i.e. overlaps) with the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_LOW,
-                    JDBCOperator.GT.value(), value, lowerBound);
+                    JDBCOperator.GT.value(), value, value);
             break;
         case LE:
             // LE - Less Than Equal
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             // or the range of the search value fully contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.LTE.value(), value, lowerBound);
+                    JDBCOperator.LTE.value(), value, value);
             break;
         case LT:
             // LT - Less Than
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, QUANTITY_VALUE, QUANTITY_VALUE_HIGH,
-                    JDBCOperator.LT.value(), value, lowerBound);
+                    JDBCOperator.LT.value(), value, value);
             break;
         case AP:
             // AP - Approximate - Relative

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/NumberParmBehaviorUtilTest.java
@@ -31,7 +31,7 @@ import com.ibm.fhir.search.parameters.ParameterValue;
 
 public class NumberParmBehaviorUtilTest {
     private static final Logger log = java.util.logging.Logger.getLogger(NumberParmBehaviorUtilTest.class.getName());
-    private static final Level LOG_LEVEL = Level.INFO;
+    private static final Level LOG_LEVEL = Level.FINE;
 
     private ParameterValue generateParameterValue(String value, SearchConstants.Prefix prefix) {
         ParameterValue parameterValue = new ParameterValue();

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -391,7 +391,7 @@ public class QuantityParmBehaviorUtilTest {
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         String expectedSql =
-                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_LOW > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_HIGH > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);
@@ -404,7 +404,7 @@ public class QuantityParmBehaviorUtilTest {
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
-                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_HIGH < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_LOW < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);
@@ -417,7 +417,7 @@ public class QuantityParmBehaviorUtilTest {
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
-                " AND (((Basic.QUANTITY_VALUE >= ? OR Basic.QUANTITY_VALUE_LOW >= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE >= ? OR Basic.QUANTITY_VALUE_HIGH >= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);
@@ -430,7 +430,7 @@ public class QuantityParmBehaviorUtilTest {
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
-                " AND (((Basic.QUANTITY_VALUE <= ? OR Basic.QUANTITY_VALUE_HIGH <= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE <= ? OR Basic.QUANTITY_VALUE_LOW <= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -127,10 +127,9 @@ public class QuantityParmBehaviorUtilTest {
         QuantityParmBehaviorUtil behavior = new QuantityParmBehaviorUtil();
         behavior.addSystemIfPresent(parameterDao, actualWhereClauseSegment, tableAlias, actualBindVariables, system);
 
-        if (log.isLoggable(LOG_LEVEL)) {
-            log.info("whereClauseSegment -> " + actualWhereClauseSegment.toString());
-            log.info("bind variables -> " + actualBindVariables);
-        }
+        log.fine("whereClauseSegment -> " + actualWhereClauseSegment.toString());
+        log.fine("bind variables -> " + actualBindVariables);
+
         assertEquals(actualWhereClauseSegment.toString(), expectedSql);
 
         for (Object o : expectedBindVariables) {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -36,7 +36,7 @@ import com.ibm.fhir.search.parameters.ParameterValue;
 
 public class QuantityParmBehaviorUtilTest {
     private static final Logger log = java.util.logging.Logger.getLogger(QuantityParmBehaviorUtilTest.class.getName());
-    private static final Level LOG_LEVEL = Level.INFO;
+    private static final Level LOG_LEVEL = Level.FINE;
 
     //---------------------------------------------------------------------------------------------------------
     // Supporting Methods: 

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -1,0 +1,701 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.test.util;
+
+import static org.testng.Assert.assertEquals;
+
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.exception.FHIRException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO;
+import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDBConnectException;
+import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessException;
+import com.ibm.fhir.persistence.jdbc.util.CodeSystemsCache;
+import com.ibm.fhir.persistence.jdbc.util.type.NumberParmBehaviorUtil;
+import com.ibm.fhir.persistence.jdbc.util.type.QuantityParmBehaviorUtil;
+import com.ibm.fhir.search.SearchConstants;
+import com.ibm.fhir.search.parameters.Parameter;
+import com.ibm.fhir.search.parameters.ParameterValue;
+
+public class QuantityParmBehaviorUtilTest {
+    private static final Logger log = java.util.logging.Logger.getLogger(QuantityParmBehaviorUtilTest.class.getName());
+    private static final Level LOG_LEVEL = Level.INFO;
+
+    //---------------------------------------------------------------------------------------------------------
+    // Supporting Methods: 
+    @BeforeClass
+    public static void before() throws FHIRException {
+        FHIRRequestContext.get().setTenantId("quantity");
+    }
+
+    @AfterClass
+    public static void after() throws FHIRException {
+        FHIRRequestContext.get().setTenantId("default");
+    }
+
+    private ParameterValue generateParameterValue(String value, SearchConstants.Prefix prefix) {
+        ParameterValue parameterValue = new ParameterValue();
+        parameterValue.setPrefix(prefix);
+        parameterValue.setValueNumber(new BigDecimal(value));
+        parameterValue.setValueCode("code");
+        parameterValue.setValueSystem("system");
+        return parameterValue;
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String code, String... values) {
+        Parameter parameter = new Parameter(SearchConstants.Type.QUANTITY, code, modifier, null);
+        for (String value : values) {
+            parameter.getValues().add(generateParameterValue(value, prefix));
+        }
+        return parameter;
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String value) {
+        return generateParameter(prefix, modifier, "Quantity", new String[] { value });
+    }
+
+    private Parameter generateParameter(SearchConstants.Prefix prefix, SearchConstants.Modifier modifier,
+            String... values) {
+        return generateParameter(prefix, modifier, "Quantity", values);
+    }
+
+    private void runTest(Parameter queryParm, List<Object> expectedBindVariables, String expectedSql, boolean sendNull)
+            throws Exception {
+        runTest(queryParm, expectedBindVariables, expectedSql, "Basic", sendNull);
+    }
+
+    public void runSignificantDigitsTest(String value, int significantDigits) {
+        assertEquals(NumberParmBehaviorUtil.calculateSignificantFigures(new BigDecimal(value)), significantDigits);
+    }
+
+    private void runTest(Parameter queryParm, List<Object> expectedBindVariables, String expectedSql,
+            String tableAlias, boolean sendNull)
+            throws Exception {
+        StringBuilder actualWhereClauseSegment = new StringBuilder();
+        List<Object> actualBindVariables = new ArrayList<>();
+
+        QuantityParmBehaviorUtil behavior = new QuantityParmBehaviorUtil();
+        behavior.executeBehavior(actualWhereClauseSegment, queryParm, actualBindVariables,
+                tableAlias, generateDao(sendNull));
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("whereClauseSegment -> " + actualWhereClauseSegment.toString());
+            log.info("bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualWhereClauseSegment.toString(), expectedSql);
+
+        for (Object o : expectedBindVariables) {
+            actualBindVariables.remove(o);
+        }
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("leftover - bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualBindVariables.size(), 0);
+
+    }
+
+    /*
+     * checks the generated sql
+     */
+    public void runSystemTest(boolean sendNull, String system, List<Object> expectedBindVariables, String expectedSql)
+            throws FHIRPersistenceException {
+        ParameterDAO parameterDao = generateDao(sendNull);
+        StringBuilder actualWhereClauseSegment = new StringBuilder();
+        String tableAlias = "BASIC";
+        List<Object> actualBindVariables = new ArrayList<>();
+
+        QuantityParmBehaviorUtil behavior = new QuantityParmBehaviorUtil();
+        behavior.addSystemIfPresent(parameterDao, actualWhereClauseSegment, tableAlias, actualBindVariables, system);
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("whereClauseSegment -> " + actualWhereClauseSegment.toString());
+            log.info("bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualWhereClauseSegment.toString(), expectedSql);
+
+        for (Object o : expectedBindVariables) {
+            actualBindVariables.remove(o);
+        }
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("leftover - bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualBindVariables.size(), 0);
+    }
+
+    /*
+     * checks the generated sql
+     */
+    public void runCodeTest(String code, List<Object> expectedBindVariables, String expectedSql)
+            throws FHIRPersistenceException {
+        StringBuilder actualWhereClauseSegment = new StringBuilder();
+        String tableAlias = "BASIC";
+        List<Object> actualBindVariables = new ArrayList<>();
+
+        QuantityParmBehaviorUtil behavior = new QuantityParmBehaviorUtil();
+        behavior.addCodeIfPresent(actualWhereClauseSegment, tableAlias, actualBindVariables, code);
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("whereClauseSegment -> " + actualWhereClauseSegment.toString());
+            log.info("bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualWhereClauseSegment.toString(), expectedSql);
+
+        for (Object o : expectedBindVariables) {
+            actualBindVariables.remove(o);
+        }
+
+        if (log.isLoggable(LOG_LEVEL)) {
+            log.info("leftover - bind variables -> " + actualBindVariables);
+        }
+        assertEquals(actualBindVariables.size(), 0);
+    }
+
+    //------------------------------------------------------------------
+    // To enable mock replacement the method generateDao is here 
+    private ParameterDAO generateDao(boolean sendNull) {
+        return new ParameterDAO() {
+
+            @Override
+            public Connection getConnection() throws FHIRPersistenceDBConnectException {
+                return null;
+            }
+
+            @Override
+            public Connection getExternalConnection() {
+                return null;
+            }
+
+            @Override
+            public boolean isDb2Database() throws Exception {
+                return false;
+            }
+
+            @Override
+            public Map<String, Integer> readAllSearchParameterNames()
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                return null;
+            }
+
+            @Override
+            public Map<String, Integer> readAllCodeSystems()
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                return null;
+            }
+
+            @Override
+            public int readOrAddParameterNameId(String parameterName)
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                return 0;
+            }
+
+            @Override
+            public Integer readParameterNameId(String parameterName)
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                return null;
+            }
+
+            @Override
+            public int readOrAddCodeSystemId(String systemName)
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                return 0;
+            }
+
+            @Override
+            public Integer readCodeSystemId(String systemName)
+                    throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+                if (sendNull) {
+                    return null;
+                }
+                return 1;
+            }
+
+            @Override
+            public int acquireParameterNameId(String parameterName) throws FHIRPersistenceException {
+                return 0;
+            }
+
+            @Override
+            public int acquireCodeSystemId(String codeSystemName) throws FHIRPersistenceException {
+                return 0;
+            }
+
+            @Override
+            public void addCodeSystemsCacheCandidate(String codeSystemName, Integer codeSystemId)
+                    throws FHIRPersistenceException {
+
+            }
+
+            @Override
+            public void addParameterNamesCacheCandidate(String parameterName, Integer parameterId)
+                    throws FHIRPersistenceException {
+
+            }
+
+            @Override
+            public Array transformStringParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+                return null;
+            }
+
+            @Override
+            public Array transformNumberParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+                return null;
+            }
+
+            @Override
+            public Array transformDateParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+                return null;
+            }
+
+            @Override
+            public Array transformLatLongParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+                return null;
+            }
+
+            @Override
+            public Array transformTokenParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+                return null;
+            }
+
+            @Override
+            public Array transformQuantityParameters(Connection connection, String schemaName,
+                    List<com.ibm.fhir.persistence.jdbc.dto.Parameter> parameters)
+                    throws FHIRPersistenceException {
+
+                return null;
+            }
+
+            @Override
+            public void setExternalConnection(Connection connection) {
+
+            }
+        };
+    }
+
+    //---------------------------------------------------------------------------------------------------------
+    @Test
+    public void testPrecisionWithExact() throws Exception {
+
+    }
+
+    @Test
+    public void testAddSystemIfPresent() throws FHIRPersistenceException {
+        String expectedSql = " AND BASIC.CODE_SYSTEM_ID = ?";
+        boolean sendNull = false;
+        String system = "target";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(1);
+        runSystemTest(sendNull, system, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddSystemIfPresentNotFound() throws FHIRPersistenceException {
+        String expectedSql = " AND BASIC.CODE_SYSTEM_ID = ?";
+        boolean sendNull = true;
+        String system = "target";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(-1);
+        runSystemTest(sendNull, system, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddSystemIfPresentEmpty() throws FHIRPersistenceException {
+        String expectedSql = "";
+        boolean sendNull = true;
+        String system = "";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        runSystemTest(sendNull, system, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddSystemIfPresentNull() throws FHIRPersistenceException {
+        String expectedSql = "";
+        boolean sendNull = true;
+        String system = null;
+        List<Object> expectedBindVariables = new ArrayList<>();
+        runSystemTest(sendNull, system, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddSystemIfPresentWithNonNullCache() throws FHIRPersistenceException {
+        CodeSystemsCache.putCodeSystemId("quantity~default", "system-example-quantity", 1);
+        String expectedSql = " AND BASIC.CODE_SYSTEM_ID = ?";
+        boolean sendNull = true;
+        String system = "system-example-quantity";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(1);
+        runSystemTest(sendNull, system, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddCodeIfPresent() throws FHIRPersistenceException {
+        String expectedSql = " AND BASIC.CODE = ?";
+        String code = "target";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add("target");
+        runCodeTest(code, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddCodeIfPresentEmpty() throws FHIRPersistenceException {
+        String expectedSql = "";
+        String code = "";
+        List<Object> expectedBindVariables = new ArrayList<>();
+        runCodeTest(code, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testAddCodeIfPresentNull() throws FHIRPersistenceException {
+        String expectedSql = "";
+        String code = null;
+        List<Object> expectedBindVariables = new ArrayList<>();
+        runCodeTest(code, expectedBindVariables, expectedSql);
+    }
+
+    @Test
+    public void testHandleQuantityRangeComparisonWithExact() throws Exception {
+        // gt - Greater Than
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.GT, null, "1e3");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_LOW > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+
+        // lt - Less Than
+        queryParm             = generateParameter(SearchConstants.Prefix.LT, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        expectedSql =
+                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_HIGH < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+
+        // ge - Greater than Equal
+        queryParm             = generateParameter(SearchConstants.Prefix.GE, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        expectedSql =
+                " AND (((Basic.QUANTITY_VALUE >= ? OR Basic.QUANTITY_VALUE_LOW >= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+
+        // le - Less than Equal
+        queryParm             = generateParameter(SearchConstants.Prefix.LE, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        expectedSql =
+                " AND (((Basic.QUANTITY_VALUE <= ? OR Basic.QUANTITY_VALUE_HIGH <= ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+
+        // sa - starts after
+        queryParm             = generateParameter(SearchConstants.Prefix.SA, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("1000.5"));
+        expectedBindVariables.add(new BigDecimal("1000.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        expectedSql =
+                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_HIGH > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+
+        // eb - Ends before
+        queryParm             = generateParameter(SearchConstants.Prefix.EB, null, "1e3");
+        expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        expectedSql =
+                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_LOW < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithEqual() throws Exception {
+        // in this case, our code if missing Prefix, it injects EQ.
+        // therefore this test case tests two conditions 
+        // Condition:
+        //  [parameter]=100
+        //  [parameter]=eq100
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(99.5));
+        expectedBindVariables.add(new BigDecimal(100.5));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW < ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleValuesForEqual() throws Exception {
+        // in this case, our code if missing Prefix, it injects EQ.
+        // therefore this test case tests two conditions 
+        // Condition:
+        //  [parameter]=100,1.00
+        //  [parameter]=eq100,1.00
+
+        /*
+         * We want this SQL generated which appropriately conditions the multiple values
+         * together.
+         * 
+         * <pre>
+         * AND (
+         * (
+         * (
+         * (
+         * Basic.QUANTITY_VALUE > ?
+         * AND Basic.QUANTITY_VALUE <= ?
+         * )
+         * OR (
+         * Basic.QUANTITY_VALUE_LOW < ?
+         * AND Basic.QUANTITY_VALUE_HIGH >= ?
+         * )
+         * )
+         * AND Basic.CODE_SYSTEM_ID = ?
+         * AND Basic.CODE = ?
+         * )
+         * OR (
+         * (
+         * (
+         * Basic.QUANTITY_VALUE > ?
+         * AND Basic.QUANTITY_VALUE <= ?
+         * )
+         * OR (
+         * Basic.QUANTITY_VALUE_LOW < ?
+         * AND Basic.QUANTITY_VALUE_HIGH >= ?
+         * )
+         * )
+         * AND Basic.CODE_SYSTEM_ID = ?
+         * AND Basic.CODE = ?
+         * )
+         * )
+         * </pre>
+         */
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.EQ, null, new String[] { "100", "1.00" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("99.5"));
+        expectedBindVariables.add(new BigDecimal("100.5"));
+        expectedBindVariables.add(new BigDecimal("100"));
+        expectedBindVariables.add(new BigDecimal("100"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+
+        expectedBindVariables.add(new BigDecimal("0.995"));
+        expectedBindVariables.add(new BigDecimal("1.005"));
+        expectedBindVariables.add(new BigDecimal("1.00"));
+        expectedBindVariables.add(new BigDecimal("1.00"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW < ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?) OR (((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW < ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    /*
+     * we want to make sure the equalclause is well balanced
+     * <pre>
+     * (
+     * (
+     * Basic.QUANTITY_VALUE > ?
+     * AND Basic.QUANTITY_VALUE <= ?
+     * )
+     * OR (
+     * Basic.QUANTITY_VALUE_LOW < ?
+     * AND Basic.QUANTITY_VALUE_HIGH >= ?
+     * )
+     * )
+     * </pre>
+     */
+    @Test
+    public void testEqualsClauseBuilder() {
+        StringBuilder whereClauseSegment = new StringBuilder();
+        List<Object> bindVariables = new ArrayList<>();
+        String tableAlias = "Basic";
+        BigDecimal lowerBound = new BigDecimal("1");
+        BigDecimal upperBound = new BigDecimal("2");
+        BigDecimal value = new BigDecimal("3");
+        QuantityParmBehaviorUtil util = new QuantityParmBehaviorUtil();
+        util.buildEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias,
+                lowerBound, upperBound, value);
+
+        assertEquals(whereClauseSegment.toString(),
+                "((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW < ? AND Basic.QUANTITY_VALUE_HIGH >= ?))");
+    }
+
+    @Test
+    public void testPrecisionWithNotEqual() throws Exception {
+        // Condition:
+        //  [parameter]=ne100
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.NE, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(99.5));
+        expectedBindVariables.add(new BigDecimal(100.5));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE <= ? OR Basic.QUANTITY_VALUE > ?) OR (Basic.QUANTITY_VALUE_LOW <= ? OR Basic.QUANTITY_VALUE_HIGH > ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithApprox() throws Exception {
+        // Condition:
+        //  [parameter]=ap100
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "100");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(89.5));
+        expectedBindVariables.add(new BigDecimal(110.5));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW <= ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithApproxNumberOne() throws Exception {
+        // Condition:
+        //  [parameter]=ap1
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, "1");
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal("0.4"));
+        expectedBindVariables.add(new BigDecimal("1.6"));
+        expectedBindVariables.add(new BigDecimal("1"));
+        expectedBindVariables.add(new BigDecimal("1"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW <= ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleSameApprox() throws Exception {
+        // Condition:
+        //  [parameter]=ap100,ap100
+        // It should de-dupe
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(89.5));
+        expectedBindVariables.add(new BigDecimal(110.5));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW <= ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+
+    @Test
+    public void testPrecisionWithMultipleDifferentApprox() throws Exception {
+        // Condition:
+        //  [parameter]=ap100,ap100.00
+
+        // expectedBindVariables are pivoted on 100
+        // It should NOT de-dupe
+
+        Parameter queryParm = generateParameter(SearchConstants.Prefix.AP, null, new String[] { "100", "100.00" });
+        List<Object> expectedBindVariables = new ArrayList<>();
+        expectedBindVariables.add(new BigDecimal(89.5));
+        expectedBindVariables.add(new BigDecimal(110.5));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(new BigDecimal(100));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+
+        expectedBindVariables.add(new BigDecimal("89.995"));
+        expectedBindVariables.add(new BigDecimal("110.005"));
+        expectedBindVariables.add(new BigDecimal("100.00"));
+        expectedBindVariables.add(new BigDecimal("100.00"));
+        expectedBindVariables.add(1);
+        expectedBindVariables.add("code");
+
+        String expectedSql =
+                " AND ((((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW <= ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?) OR (((Basic.QUANTITY_VALUE > ? AND Basic.QUANTITY_VALUE <= ?) OR (Basic.QUANTITY_VALUE_LOW <= ? AND Basic.QUANTITY_VALUE_HIGH >= ?)) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+        runTest(queryParm,
+                expectedBindVariables,
+                expectedSql, false);
+    }
+}

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -387,7 +387,7 @@ public class QuantityParmBehaviorUtilTest {
         Parameter queryParm = generateParameter(SearchConstants.Prefix.GT, null, "1e3");
         List<Object> expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("999.5"));
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         String expectedSql =
@@ -400,7 +400,7 @@ public class QuantityParmBehaviorUtilTest {
         queryParm             = generateParameter(SearchConstants.Prefix.LT, null, "1e3");
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("999.5"));
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
@@ -413,7 +413,7 @@ public class QuantityParmBehaviorUtilTest {
         queryParm             = generateParameter(SearchConstants.Prefix.GE, null, "1e3");
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("999.5"));
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
@@ -426,7 +426,7 @@ public class QuantityParmBehaviorUtilTest {
         queryParm             = generateParameter(SearchConstants.Prefix.LE, null, "1e3");
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("999.5"));
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
@@ -439,7 +439,7 @@ public class QuantityParmBehaviorUtilTest {
         queryParm             = generateParameter(SearchConstants.Prefix.SA, null, "1e3");
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("1000.5"));
-        expectedBindVariables.add(new BigDecimal("1000.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
@@ -452,7 +452,7 @@ public class QuantityParmBehaviorUtilTest {
         queryParm             = generateParameter(SearchConstants.Prefix.EB, null, "1e3");
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(new BigDecimal("999.5"));
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/QuantityParmBehaviorUtilTest.java
@@ -386,7 +386,7 @@ public class QuantityParmBehaviorUtilTest {
         // gt - Greater Than
         Parameter queryParm = generateParameter(SearchConstants.Prefix.GT, null, "1e3");
         List<Object> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
@@ -399,7 +399,7 @@ public class QuantityParmBehaviorUtilTest {
         // lt - Less Than
         queryParm             = generateParameter(SearchConstants.Prefix.LT, null, "1e3");
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
@@ -412,7 +412,7 @@ public class QuantityParmBehaviorUtilTest {
         // ge - Greater than Equal
         queryParm             = generateParameter(SearchConstants.Prefix.GE, null, "1e3");
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
@@ -425,7 +425,7 @@ public class QuantityParmBehaviorUtilTest {
         // le - Less than Equal
         queryParm             = generateParameter(SearchConstants.Prefix.LE, null, "1e3");
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
@@ -438,12 +438,12 @@ public class QuantityParmBehaviorUtilTest {
         // sa - starts after
         queryParm             = generateParameter(SearchConstants.Prefix.SA, null, "1e3");
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("1000.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
-                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_HIGH > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE > ? OR Basic.QUANTITY_VALUE_LOW > ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);
@@ -451,12 +451,12 @@ public class QuantityParmBehaviorUtilTest {
         // eb - Ends before
         queryParm             = generateParameter(SearchConstants.Prefix.EB, null, "1e3");
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(new BigDecimal("999.5"));
+        expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(new BigDecimal("1E+3"));
         expectedBindVariables.add(1);
         expectedBindVariables.add("code");
         expectedSql =
-                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_LOW < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
+                " AND (((Basic.QUANTITY_VALUE < ? OR Basic.QUANTITY_VALUE_HIGH < ?) AND Basic.CODE_SYSTEM_ID = ? AND Basic.CODE = ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, false);

--- a/fhir-persistence-jdbc/src/test/java/testng.xml
+++ b/fhir-persistence-jdbc/src/test/java/testng.xml
@@ -7,6 +7,7 @@
             <class name="com.ibm.fhir.persistence.jdbc.test.util.ParameterExtractionTest" />
             <class name="com.ibm.fhir.persistence.jdbc.test.util.UriModifierUtilTest" />
             <class name="com.ibm.fhir.persistence.jdbc.test.util.NumberParmBehaviorUtilTest" />
+            <class name="com.ibm.fhir.persistence.jdbc.test.util.QuantityParmBehaviorUtilTest" />
         </classes>
     </test>
     <test name="JDBCSpecTest">

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -232,6 +232,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "lt2||gt"); // > 3 is not < 2
         assertSearchReturnsSavedResource("Quantity-greaterThan", "gt2||gt"); // > 3 may be > 2
         assertSearchReturnsSavedResource("Quantity-greaterThan", "lt4||gt"); // > 3 may be < 4
+
         // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
         // assertSearchReturnsSavedResource("Quantity-greaterThan", "gt4||gt");      // > 3 may be > 4
     }
@@ -242,12 +243,11 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "3||lte");
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "4||lte");
 
-        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte");      // <= 3 may be < 2
+        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte"); // <= 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "gt2||lte"); // <= 3 may be > 2
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
-        
-        // As we have added implict ranges to the prefix processing, we need to add precision 
+
         // >= 3 may be <= 3 uses precision and bounding for the range. 
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3||lte");
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte"); // <= 3 may be >= 3
@@ -262,11 +262,10 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "lt2||gte"); // >= 3 is not < 2
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "gt2||gte"); // >= 3 may be > 2
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte"); // >= 3 may be < 4 
-        assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "gt4||gte");      // >= 3 may be > 4
-        
-        // As we have added implict ranges to the prefix processing, we need to add precision 
+        assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "gt4||gte"); // >= 3 may be > 4
+
         // >= 3 may be <= 3 uses precision and bounding for the range. 
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3||gte"); 
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3||gte");
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "ge3||gte"); // >= 3 is >= 3
     }
 
@@ -309,14 +308,14 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_LT() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "lt4||s");
         assertSearchDoesntReturnSavedResource("Range", "lt5||s");
-        assertSearchDoesntReturnSavedResource("Range", "lt10||s");
+        assertSearchReturnsSavedResource("Range", "lt10||s");
         assertSearchReturnsSavedResource("Range", "lt11||s");
     }
 
     @Test
     public void testSearchQuantity_Range_GT() throws Exception {
         assertSearchReturnsSavedResource("Range", "gt4||s");
-        assertSearchDoesntReturnSavedResource("Range", "gt5||s");
+        assertSearchReturnsSavedResource("Range", "gt5||s");
         assertSearchDoesntReturnSavedResource("Range", "gt10||s");
         assertSearchDoesntReturnSavedResource("Range", "gt11||s");
     }
@@ -337,19 +336,19 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Range", "sa10.0||s");
         assertSearchDoesntReturnSavedResource("Range", "sa11||s");
     }
-    
+
     @Test
     public void testSearchQuantity_Range_GE() throws Exception {
         assertSearchReturnsSavedResource("Range", "ge4||s");
         assertSearchReturnsSavedResource("Range", "ge5||s");
-        assertSearchDoesntReturnSavedResource("Range", "ge10||s");
+        assertSearchReturnsSavedResource("Range", "ge10||s");
         assertSearchDoesntReturnSavedResource("Range", "ge11||s");
     }
 
     @Test
     public void testSearchQuantity_Range_LE() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "le4||s");
-        assertSearchDoesntReturnSavedResource("Range", "le5||s");
+        assertSearchReturnsSavedResource("Range", "le5||s");
         assertSearchReturnsSavedResource("Range", "le10||s");
         assertSearchReturnsSavedResource("Range", "le10.01||s");
         assertSearchReturnsSavedResource("Range", "le11||s");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -120,7 +120,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         // For the following test, as the upper bound is now the lower bound of the range
         // the following must use a lower value of the range/precision 
         // To keep from hitting, we have to make it more precise. 
-        assertSearchDoesntReturnSavedResource("Quantity", "gt25.05||s");
+        assertSearchDoesntReturnSavedResource("Quantity", "gt25||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt26|http://unitsofmeasure.org|s");
@@ -134,7 +134,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity", "le24.5||s");
 
         // We have to make the following test more precise since the implied range is used. 
-        assertSearchReturnsSavedResource("Quantity", "le25.01||s");
+        assertSearchReturnsSavedResource("Quantity", "le25||s");
         assertSearchReturnsSavedResource("Quantity", "le25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "le25.5||s");
         assertSearchReturnsSavedResource("Quantity", "le26|http://unitsofmeasure.org|s");
@@ -168,17 +168,17 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity", "eb24.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "eb24.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "eb25||s");
-        assertSearchDoesntReturnSavedResource("Quantity", "eb24.4999||s");
+        assertSearchReturnsSavedResource("Quantity", "eb25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "eb25.5||s");
         assertSearchReturnsSavedResource("Quantity", "eb26|http://unitsofmeasure.org|s");
     }
 
     @Test
     public void testSearchQuantity_Quantity_withPrefixes_chained() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.Quantity", "lt26.0|http://unitsofmeasure.org|s");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "lt26|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "gt24|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "le26|http://unitsofmeasure.org|s");
-        assertSearchReturnsComposition("subject:Basic.Quantity", "le25.02|http://unitsofmeasure.org|s");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "le25|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "ge25|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "ge24|http://unitsofmeasure.org|s");
     }
@@ -214,7 +214,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "4||lt");
 
         // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
-        // With implicit ranges, 3 (+/-0.5) actually might be < 3
         // assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
         // assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThan", "gt2||lt"); // < 3 may be > 2
@@ -249,14 +248,14 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "3||lte");
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "4||lte");
 
-        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte");      // <= 2 may be < 2
+        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte");      // <= 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "gt2||lte"); // <= 3 may be > 2
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
         
         // As we have added implict ranges to the prefix processing, we need to add precision 
         // >= 3 may be <= 3 uses precision and bounding for the range. 
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3.01||lte");
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3||lte");
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte"); // <= 3 may be >= 3
     }
 
@@ -273,7 +272,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         
         // As we have added implict ranges to the prefix processing, we need to add precision 
         // >= 3 may be <= 3 uses precision and bounding for the range. 
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3.01||gte"); 
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3||gte"); 
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "ge3||gte"); // >= 3 is >= 3
     }
 
@@ -317,9 +316,10 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Range", "lt4||s");
         assertSearchDoesntReturnSavedResource("Range", "lt5||s");
 
-        // Lower Bound is 9.5 for 11, therefore adding precision. 
+        // Lower Bound is 9.5 for 11, therefore adding precision.
+        // And this is still a RANGE search.
         assertSearchReturnsSavedResource("Range", "lt10.05||s");
-        assertSearchReturnsSavedResource("Range", "lt11.0||s");
+        assertSearchReturnsSavedResource("Range", "lt11||s");
     }
 
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         //  assertSearchReturnsComposition("Quantity", "25");
 
         // I think this should return the resource but it currently doesn't.
-        // https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
+        // https://jira.hl7.org/browse/FHIR-19597
         // assertSearchReturnsComposition("Quantity", "25||sec");
     }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -209,7 +209,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
     /***
      * FHIR Server does not yet use quantity comparator to calculate search results.
-     * *
      *********************************************************************************/
     // Quantity search is of the form <prefix><number>|<unit_system>|<unit>.
     // We use custom units to mark the quantity comparators so we can scope our searches in the tests.

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -63,14 +63,8 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Quantity_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.Quantity", "25|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "25||s");
-
-        // DSTU2 does not say if this is allowed or not, but we do not support it.
-        // In more recent versions, they clarified that it should work:  https://build.fhir.org/search.html#quantity
-        //  assertSearchReturnsComposition("Quantity", "25");
-
-        // I think this should return the resource but it currently doesn't.
-        // https://jira.hl7.org/browse/FHIR-19597
-        // assertSearchReturnsComposition("Quantity", "25||sec");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "25");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "25||sec");
     }
 
     @Test
@@ -84,11 +78,11 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchQuantity_Quantity_withPrefix_NE() throws Exception {
-        //assertSearchReturnsSavedResource("Quantity", "ne24|http://unitsofmeasure.org|s");
+        assertSearchReturnsSavedResource("Quantity", "ne24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "ne24.4999||s");
-        //        assertSearchDoesntReturnSavedResource("Quantity", "ne24.5||s");
+        assertSearchReturnsSavedResource("Quantity", "ne24.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "ne25||s");
-        //        assertSearchDoesntReturnSavedResource("Quantity", "ne25.4999||s");
+        assertSearchReturnsSavedResource("Quantity", "ne25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "ne25.5||s");
         assertSearchReturnsSavedResource("Quantity", "ne26|http://unitsofmeasure.org|s");
     }
@@ -215,16 +209,14 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchQuantity_Quantity_LessThan() throws Exception {
-        // Later versions of the spec indicate that there is an implicit precision 
-        // of .5 of the next least significant digit.  We don't support that now, but 
-        // lets use numbers far enough away that it won't matter.
-        //        assertSearchReturnsSavedResource("Quantity-lessThan", "2||lt");
+        // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
+        // assertSearchReturnsSavedResource("Quantity-lessThan", "2||lt");
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "4||lt");
 
+        // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
         // With implicit ranges, 3 (+/-0.5) actually might be < 3
-        //      assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
-
-        //        assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
+        // assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
+        // assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThan", "gt2||lt"); // < 3 may be > 2
         assertSearchReturnsSavedResource("Quantity-lessThan", "lt4||lt"); // < 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "gt4||lt"); // < 3 is not > 4
@@ -232,19 +224,23 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchQuantity_Quantity_GreaterThan() throws Exception {
-        // Later versions of the spec indicate that there is an implicit precision 
-        // of .5 of the next least significant digit.  We don't support that now, but 
-        // lets use numbers far enough away that it won't matter.
         assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "2||gt");
-        //        assertSearchReturnsSavedResource("Quantity-greaterThan", "4||gt");
 
+        // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
+        // In this test, the comparator should be from the DB
+        // assertSearchReturnsSavedResource("Quantity-greaterThan", "4||gt");
+
+        // In this test, the comparator should be from the DB
         // With implicit ranges, 3 (+/-0.5) actually might be > 3
-        //      assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "3||gt");
+        // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
+        //assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "3||gt");
+        assertSearchReturnsSavedResource("Quantity-greaterThan", "3||gt");
 
         assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "lt2||gt"); // > 3 is not < 2
         assertSearchReturnsSavedResource("Quantity-greaterThan", "gt2||gt"); // > 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-greaterThan", "lt4||gt"); // > 3 may be < 4 
-        //        assertSearchReturnsSavedResource("Quantity-greaterThan", "gt4||gt");      // > 3 may be > 4
+        assertSearchReturnsSavedResource("Quantity-greaterThan", "lt4||gt"); // > 3 may be < 4
+        // For more details, please see Quantity search does not consider the quantity comparator field #493 https://github.com/IBM/FHIR/issues/493
+        // assertSearchReturnsSavedResource("Quantity-greaterThan", "gt4||gt");      // > 3 may be > 4
     }
 
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -116,10 +116,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity", "gt24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "gt24.4999||s");
         assertSearchReturnsSavedResource("Quantity", "gt24.5||s");
-
-        // For the following test, as the upper bound is now the lower bound of the range
-        // the following must use a lower value of the range/precision 
-        // To keep from hitting, we have to make it more precise. 
         assertSearchDoesntReturnSavedResource("Quantity", "gt25||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.5||s");
@@ -132,8 +128,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity", "le24|http://unitsofmeasure.org|s");
         assertSearchDoesntReturnSavedResource("Quantity", "le24.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "le24.5||s");
-
-        // We have to make the following test more precise since the implied range is used. 
         assertSearchReturnsSavedResource("Quantity", "le25||s");
         assertSearchReturnsSavedResource("Quantity", "le25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "le25.5||s");
@@ -315,17 +309,14 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_LT() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "lt4||s");
         assertSearchDoesntReturnSavedResource("Range", "lt5||s");
-
-        // Lower Bound is 9.5 for 11, therefore adding precision.
-        // And this is still a RANGE search.
-        assertSearchReturnsSavedResource("Range", "lt10.05||s");
+        assertSearchDoesntReturnSavedResource("Range", "lt10||s");
         assertSearchReturnsSavedResource("Range", "lt11||s");
     }
 
     @Test
     public void testSearchQuantity_Range_GT() throws Exception {
         assertSearchReturnsSavedResource("Range", "gt4||s");
-        assertSearchReturnsSavedResource("Range", "gt5||s");
+        assertSearchDoesntReturnSavedResource("Range", "gt5||s");
         assertSearchDoesntReturnSavedResource("Range", "gt10||s");
         assertSearchDoesntReturnSavedResource("Range", "gt11||s");
     }
@@ -334,14 +325,14 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_EB() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "eb4||s");
         assertSearchDoesntReturnSavedResource("Range", "eb5||s");
-        // We use the range, so we actually return the value here. 
-        assertSearchReturnsSavedResource("Range", "eb10||s");
+        assertSearchDoesntReturnSavedResource("Range", "eb10||s");
         assertSearchReturnsSavedResource("Range", "eb11||s");
     }
 
     @Test
     public void testSearchQuantity_Range_SA() throws Exception {
         assertSearchReturnsSavedResource("Range", "sa4||s");
+        assertSearchDoesntReturnSavedResource("Range", "sa5||s");
         assertSearchDoesntReturnSavedResource("Range", "sa10||s");
         assertSearchDoesntReturnSavedResource("Range", "sa10.0||s");
         assertSearchDoesntReturnSavedResource("Range", "sa11||s");
@@ -351,7 +342,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_GE() throws Exception {
         assertSearchReturnsSavedResource("Range", "ge4||s");
         assertSearchReturnsSavedResource("Range", "ge5||s");
-        // We're using the lowerbound to trigger the range search
         assertSearchDoesntReturnSavedResource("Range", "ge10||s");
         assertSearchDoesntReturnSavedResource("Range", "ge11||s");
     }
@@ -359,9 +349,8 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     @Test
     public void testSearchQuantity_Range_LE() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "le4||s");
-        assertSearchDoesntReturnSavedResource("Range", "le5.01||s");
-        // the upper bound is actually higher than the valueRange we inserted. 
-        assertSearchDoesntReturnSavedResource("Range", "le10||s");
+        assertSearchDoesntReturnSavedResource("Range", "le5||s");
+        assertSearchReturnsSavedResource("Range", "le10||s");
         assertSearchReturnsSavedResource("Range", "le10.01||s");
         assertSearchReturnsSavedResource("Range", "le11||s");
     }
@@ -370,7 +359,6 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_missing() throws Exception {
         assertSearchReturnsSavedResource("Range:missing", "false");
         assertSearchDoesntReturnSavedResource("Range:missing", "true");
-
         assertSearchReturnsSavedResource("missing-Range:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Range:missing", "false");
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -20,8 +20,8 @@ import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.test.TestUtil;
 
 /**
- * @author lmsurpre
- * @see https://hl7.org/fhir/r4/search.html#quantity
+ * <a href="https://hl7.org/fhir/r4/search.html#quantity">FHIR Specification:
+ * Search - quantity</a>
  */
 public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
@@ -38,42 +38,41 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity", "25|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "25||s");
         assertSearchReturnsSavedResource("Quantity", "25");
-        
+
         // https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
         assertSearchReturnsSavedResource("Quantity", "25||sec");
-        
-        assertSearchDoesntReturnSavedResource("Quantity", "24.4999||s");
 
-//        assertSearchReturnsSavedResource("Quantity", "24.5||s");
-//        assertSearchReturnsSavedResource("Quantity", "25.4999||s");
+        assertSearchDoesntReturnSavedResource("Quantity", "24.4999||s");
+        assertSearchDoesntReturnSavedResource("Quantity", "24.5||s");
+        assertSearchDoesntReturnSavedResource("Quantity", "25.019||s");
         assertSearchDoesntReturnSavedResource("Quantity", "25.5||s");
     }
-    
+
     @Test
     public void testSearchToken_Quantity_or() throws Exception {
         assertSearchReturnsSavedResource("Quantity", "10||a,25||s,30||z");
     }
-    
+
     @Test
     public void testSearchToken_Quantity_escaped() throws Exception {
         assertSearchReturnsSavedResource("Quantity", "25|http://unitsofmeasure.org|s");
         assertSearchDoesntReturnSavedResource("Quantity", "25|http://unitsofmeasure.org\\||s");
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.Quantity", "25|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "25||s");
-        
+
         // DSTU2 does not say if this is allowed or not, but we do not support it.
         // In more recent versions, they clarified that it should work:  https://build.fhir.org/search.html#quantity
-//        assertSearchReturnsComposition("Quantity", "25");
-        
+        //  assertSearchReturnsComposition("Quantity", "25");
+
         // I think this should return the resource but it currently doesn't.
         // https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
-//        assertSearchReturnsComposition("Quantity", "25||sec");
+        // assertSearchReturnsComposition("Quantity", "25||sec");
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -82,25 +81,32 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-    
+
     @Test
-    public void testSearchQuantity_Quantity_withPrefixes() throws Exception {
-        assertSearchReturnsSavedResource("Quantity", "ne24|http://unitsofmeasure.org|s");
+    public void testSearchQuantity_Quantity_withPrefix_NE() throws Exception {
+        //assertSearchReturnsSavedResource("Quantity", "ne24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "ne24.4999||s");
-//        assertSearchDoesntReturnSavedResource("Quantity", "ne24.5||s");
+        //        assertSearchDoesntReturnSavedResource("Quantity", "ne24.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "ne25||s");
-//        assertSearchDoesntReturnSavedResource("Quantity", "ne25.4999||s");
+        //        assertSearchDoesntReturnSavedResource("Quantity", "ne25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "ne25.5||s");
         assertSearchReturnsSavedResource("Quantity", "ne26|http://unitsofmeasure.org|s");
-        
-//        assertSearchReturnsSavedResource("Quantity", "ap24|http://unitsofmeasure.org|s");
-//        assertSearchReturnsSavedResource("Quantity", "ap24.4999||s");
-//        assertSearchReturnsSavedResource("Quantity", "ap24.5||s");
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_AP() throws Exception {
+        assertSearchReturnsSavedResource("Quantity", "ap24|http://unitsofmeasure.org|s");
+        assertSearchReturnsSavedResource("Quantity", "ap24.4999||s");
+        assertSearchReturnsSavedResource("Quantity", "ap24.5||s");
         assertSearchReturnsSavedResource("Quantity", "ap25||s");
-//        assertSearchReturnsSavedResource("Quantity", "ap25.4999||s");
-//        assertSearchReturnsSavedResource("Quantity", "ap25.5||s");
-//        assertSearchReturnsSavedResource("Quantity", "ap26|http://unitsofmeasure.org|s");
-        
+        assertSearchReturnsSavedResource("Quantity", "ap25.4999||s");
+        assertSearchReturnsSavedResource("Quantity", "ap25.5||s");
+        assertSearchReturnsSavedResource("Quantity", "ap26|http://unitsofmeasure.org|s");
+        assertSearchDoesntReturnSavedResource("Quantity", "ap30|http://unitsofmeasure.org|s");
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_LT() throws Exception {
         assertSearchDoesntReturnSavedResource("Quantity", "lt24|http://unitsofmeasure.org|s");
         assertSearchDoesntReturnSavedResource("Quantity", "lt24.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "lt24.5||s");
@@ -108,23 +114,40 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity", "lt25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "lt25.5||s");
         assertSearchReturnsSavedResource("Quantity", "lt26|http://unitsofmeasure.org|s");
-        
+
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_GT() throws Exception {
         assertSearchReturnsSavedResource("Quantity", "gt24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "gt24.4999||s");
         assertSearchReturnsSavedResource("Quantity", "gt24.5||s");
-        assertSearchDoesntReturnSavedResource("Quantity", "gt25||s");
+
+        // For the following test, as the upper bound is now the lower bound of the range
+        // the following must use a lower value of the range/precision 
+        // To keep from hitting, we have to make it more precise. 
+        assertSearchDoesntReturnSavedResource("Quantity", "gt25.05||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt25.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "gt26|http://unitsofmeasure.org|s");
-        
+
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_LE() throws Exception {
         assertSearchDoesntReturnSavedResource("Quantity", "le24|http://unitsofmeasure.org|s");
         assertSearchDoesntReturnSavedResource("Quantity", "le24.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "le24.5||s");
-        assertSearchReturnsSavedResource("Quantity", "le25||s");
+
+        // We have to make the following test more precise since the implied range is used. 
+        assertSearchReturnsSavedResource("Quantity", "le25.01||s");
         assertSearchReturnsSavedResource("Quantity", "le25.4999||s");
         assertSearchReturnsSavedResource("Quantity", "le25.5||s");
         assertSearchReturnsSavedResource("Quantity", "le26|http://unitsofmeasure.org|s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_GE() throws Exception {
         assertSearchReturnsSavedResource("Quantity", "ge24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "ge24.4999||s");
         assertSearchReturnsSavedResource("Quantity", "ge24.5||s");
@@ -132,30 +155,36 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Quantity", "ge25.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "ge25.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "ge26|http://unitsofmeasure.org|s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_SA() throws Exception {
         assertSearchReturnsSavedResource("Quantity", "sa24|http://unitsofmeasure.org|s");
         assertSearchReturnsSavedResource("Quantity", "sa24.4999||s");
-//        assertSearchDoesntReturnSavedResource("Quantity", "sa24.5||s");
+        assertSearchReturnsSavedResource("Quantity", "sa24.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "sa25||s");
         assertSearchDoesntReturnSavedResource("Quantity", "sa25.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "sa25.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "sa26|http://unitsofmeasure.org|s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Quantity_withPrefix_EB() throws Exception {
         assertSearchDoesntReturnSavedResource("Quantity", "eb24|http://unitsofmeasure.org|s");
         assertSearchDoesntReturnSavedResource("Quantity", "eb24.4999||s");
         assertSearchDoesntReturnSavedResource("Quantity", "eb24.5||s");
         assertSearchDoesntReturnSavedResource("Quantity", "eb25||s");
-//        assertSearchDoesntReturnSavedResource("Quantity", "eb25.4999||s");
+        assertSearchDoesntReturnSavedResource("Quantity", "eb24.4999||s");
         assertSearchReturnsSavedResource("Quantity", "eb25.5||s");
         assertSearchReturnsSavedResource("Quantity", "eb26|http://unitsofmeasure.org|s");
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_withPrefixes_chained() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.Quantity", "lt26|http://unitsofmeasure.org|s");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "lt26.0|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "gt24|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "le26|http://unitsofmeasure.org|s");
-        assertSearchReturnsComposition("subject:Basic.Quantity", "le25|http://unitsofmeasure.org|s");
+        assertSearchReturnsComposition("subject:Basic.Quantity", "le25.02|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "ge25|http://unitsofmeasure.org|s");
         assertSearchReturnsComposition("subject:Basic.Quantity", "ge24|http://unitsofmeasure.org|s");
     }
@@ -170,163 +199,200 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Quantity_NoCode() throws Exception {
         assertSearchReturnsSavedResource("Quantity-noCode", "1||eq");
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_NoCodeOrUnit() throws Exception {
         // spec isn't clear about whether quantities with no unit should be indexed
         // but since we require the unit while searching, it doesn't really matter
         assertSearchDoesntReturnSavedResource("Quantity-noCodeOrUnit", "1||eq");
     }
-    
+
     /***
-     * FHIR Server does not yet use quantity comparator to calculate search results. *
+     * FHIR Server does not yet use quantity comparator to calculate search results.
+     * *
      *********************************************************************************/
     // Quantity search is of the form <prefix><number>|<unit_system>|<unit>.
     // We use custom units to mark the quantity comparators so we can scope our searches in the tests.
-    
+
     @Test
     public void testSearchQuantity_Quantity_LessThan() throws Exception {
         // Later versions of the spec indicate that there is an implicit precision 
         // of .5 of the next least significant digit.  We don't support that now, but 
         // lets use numbers far enough away that it won't matter.
-//        assertSearchReturnsSavedResource("Quantity-lessThan", "2||lt");
+        //        assertSearchReturnsSavedResource("Quantity-lessThan", "2||lt");
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "4||lt");
-        
+
         // With implicit ranges, 3 (+/-0.5) actually might be < 3
-//      assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
-        
-//        assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
-        assertSearchReturnsSavedResource("Quantity-lessThan", "gt2||lt");      // < 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-lessThan", "lt4||lt");      // < 3 may be < 4 
+        //      assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
+
+        //        assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
+        assertSearchReturnsSavedResource("Quantity-lessThan", "gt2||lt"); // < 3 may be > 2
+        assertSearchReturnsSavedResource("Quantity-lessThan", "lt4||lt"); // < 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "gt4||lt"); // < 3 is not > 4
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_GreaterThan() throws Exception {
         // Later versions of the spec indicate that there is an implicit precision 
         // of .5 of the next least significant digit.  We don't support that now, but 
         // lets use numbers far enough away that it won't matter.
         assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "2||gt");
-//        assertSearchReturnsSavedResource("Quantity-greaterThan", "4||gt");
-        
+        //        assertSearchReturnsSavedResource("Quantity-greaterThan", "4||gt");
+
         // With implicit ranges, 3 (+/-0.5) actually might be > 3
-//      assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "3||gt");
-        
+        //      assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "3||gt");
+
         assertSearchDoesntReturnSavedResource("Quantity-greaterThan", "lt2||gt"); // > 3 is not < 2
-        assertSearchReturnsSavedResource("Quantity-greaterThan", "gt2||gt");      // > 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-greaterThan", "lt4||gt");      // > 3 may be < 4 
-//        assertSearchReturnsSavedResource("Quantity-greaterThan", "gt4||gt");      // > 3 may be > 4
+        assertSearchReturnsSavedResource("Quantity-greaterThan", "gt2||gt"); // > 3 may be > 2
+        assertSearchReturnsSavedResource("Quantity-greaterThan", "lt4||gt"); // > 3 may be < 4 
+        //        assertSearchReturnsSavedResource("Quantity-greaterThan", "gt4||gt");      // > 3 may be > 4
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_LessThanOrEqual() throws Exception {
-//        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "2||lte");
+        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "2||lte");
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "3||lte");
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "4||lte");
-        
-//        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt2||lte");      // <= 3 may be < 2
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "gt2||lte");      // <= 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte");      // <= 3 may be < 4 
+
+        assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte");      // <= 2 may be < 2
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "gt2||lte"); // <= 3 may be > 2
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3||lte");      // <= 3 is <= 3
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte");      // <= 3 may be >= 3
+        
+        // As we have added implict ranges to the prefix processing, we need to add precision 
+        // >= 3 may be <= 3 uses precision and bounding for the range. 
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3.01||lte");
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte"); // <= 3 may be >= 3
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_GreaterThanOrEqual() throws Exception {
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "2||gte");
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "3||gte");
-//        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "4||gte");
-        
+        assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "4||gte");
+
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "lt2||gte"); // >= 3 is not < 2
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "gt2||gte");      // >= 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte");      // >= 3 may be < 4 
-//        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "gt4||gte");      // >= 3 may be > 4
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3||gte");         // >= 3 may be <= 3
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "ge3||gte");         // >= 3 is >= 3
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "gt2||gte"); // >= 3 may be > 2
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte"); // >= 3 may be < 4 
+        assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "gt4||gte");      // >= 3 may be > 4
+        
+        // As we have added implict ranges to the prefix processing, we need to add precision 
+        // >= 3 may be <= 3 uses precision and bounding for the range. 
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3.01||gte"); 
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "ge3||gte"); // >= 3 is >= 3
     }
-    
+
     @Test
     public void testSearchQuantity_Quantity_missing() throws Exception {
         assertSearchReturnsSavedResource("Quantity:missing", "false");
         assertSearchDoesntReturnSavedResource("Quantity:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-Quantity:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Quantity:missing", "false");
     }
-    
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    
-//    @Test
-//    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.Quantity:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.Quantity:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-Quantity:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-Quantity:missing", "false");
-//    }
-    
+
+    // Range is 5-10 seconds
     @Test
-    public void testSearchQuantity_Range() throws Exception {
-        // Range is 5-10 seconds
-        
-        // the range of the search value doesn't fully contain the range of the target value
-        assertSearchDoesntReturnSavedResource("Range", "4||s");
-        assertSearchDoesntReturnSavedResource("Range", "5||s");
-        assertSearchDoesntReturnSavedResource("Range", "10||s");
-        assertSearchDoesntReturnSavedResource("Range", "11||s");
-        
+    public void testSearchQuantity_Range_NE() throws Exception {
         assertSearchReturnsSavedResource("Range", "ne4||s");
         assertSearchReturnsSavedResource("Range", "ne5||s");
         assertSearchReturnsSavedResource("Range", "ne10||s");
         assertSearchReturnsSavedResource("Range", "ne11||s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Range_AP() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "ap4||s");
         assertSearchReturnsSavedResource("Range", "ap5||s");
         assertSearchReturnsSavedResource("Range", "ap10||s");
         assertSearchDoesntReturnSavedResource("Range", "ap11||s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Range_EQ_Implied() throws Exception {
+        // the range of the search value doesn't fully contain the range of the target value
+        assertSearchDoesntReturnSavedResource("Range", "4||s");
+        assertSearchDoesntReturnSavedResource("Range", "5||s");
+        assertSearchReturnsSavedResource("Range", "10||s");
+        assertSearchDoesntReturnSavedResource("Range", "11||s");
+    }
+
+    @Test
+    public void testSearchQuantity_Range_LT() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "lt4||s");
         assertSearchDoesntReturnSavedResource("Range", "lt5||s");
-        assertSearchReturnsSavedResource("Range", "lt10||s");
-        assertSearchReturnsSavedResource("Range", "lt11||s");
-        
+
+        // Lower Bound is 9.5 for 11, therefore adding precision. 
+        assertSearchReturnsSavedResource("Range", "lt10.05||s");
+        assertSearchReturnsSavedResource("Range", "lt11.0||s");
+    }
+
+    @Test
+    public void testSearchQuantity_Range_GT() throws Exception {
         assertSearchReturnsSavedResource("Range", "gt4||s");
         assertSearchReturnsSavedResource("Range", "gt5||s");
         assertSearchDoesntReturnSavedResource("Range", "gt10||s");
         assertSearchDoesntReturnSavedResource("Range", "gt11||s");
-        
-        assertSearchDoesntReturnSavedResource("Range", "le4||s");
-        assertSearchReturnsSavedResource("Range", "le5||s");
-        assertSearchReturnsSavedResource("Range", "le10||s");
-        assertSearchReturnsSavedResource("Range", "le11||s");
-        
-        assertSearchReturnsSavedResource("Range", "ge4||s");
-        assertSearchReturnsSavedResource("Range", "ge5||s");
-        assertSearchReturnsSavedResource("Range", "ge10||s");
-        assertSearchDoesntReturnSavedResource("Range", "ge11||s");
-        
-        assertSearchReturnsSavedResource("Range", "sa4||s");
-        assertSearchDoesntReturnSavedResource("Range", "sa5||s");
-        assertSearchDoesntReturnSavedResource("Range", "sa10||s");
-        assertSearchDoesntReturnSavedResource("Range", "sa11||s");
-        
+    }
+
+    @Test
+    public void testSearchQuantity_Range_EB() throws Exception {
         assertSearchDoesntReturnSavedResource("Range", "eb4||s");
         assertSearchDoesntReturnSavedResource("Range", "eb5||s");
-        assertSearchDoesntReturnSavedResource("Range", "eb10||s");
+        // We use the range, so we actually return the value here. 
+        assertSearchReturnsSavedResource("Range", "eb10||s");
         assertSearchReturnsSavedResource("Range", "eb11||s");
     }
+
+    @Test
+    public void testSearchQuantity_Range_SA() throws Exception {
+        assertSearchReturnsSavedResource("Range", "sa4||s");
+        assertSearchDoesntReturnSavedResource("Range", "sa10||s");
+        assertSearchDoesntReturnSavedResource("Range", "sa10.0||s");
+        assertSearchDoesntReturnSavedResource("Range", "sa11||s");
+    }
     
+    @Test
+    public void testSearchQuantity_Range_GE() throws Exception {
+        assertSearchReturnsSavedResource("Range", "ge4||s");
+        assertSearchReturnsSavedResource("Range", "ge5||s");
+        // We're using the lowerbound to trigger the range search
+        assertSearchDoesntReturnSavedResource("Range", "ge10||s");
+        assertSearchDoesntReturnSavedResource("Range", "ge11||s");
+    }
+
+    @Test
+    public void testSearchQuantity_Range_LE() throws Exception {
+        assertSearchDoesntReturnSavedResource("Range", "le4||s");
+        assertSearchDoesntReturnSavedResource("Range", "le5.01||s");
+        // the upper bound is actually higher than the valueRange we inserted. 
+        assertSearchDoesntReturnSavedResource("Range", "le10||s");
+        assertSearchReturnsSavedResource("Range", "le10.01||s");
+        assertSearchReturnsSavedResource("Range", "le11||s");
+    }
+
     @Test
     public void testSearchQuantity_Range_missing() throws Exception {
         assertSearchReturnsSavedResource("Range:missing", "false");
         assertSearchDoesntReturnSavedResource("Range:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-Range:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Range:missing", "false");
     }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+
+    //    @Test
+    //    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
+    //        assertSearchReturnsComposition("subject:Basic.Quantity:missing", "false");
+    //        assertSearchDoesntReturnComposition("subject:Basic.Quantity:missing", "true");
+    //        
+    //        assertSearchReturnsComposition("subject:Basic.missing-Quantity:missing", "true");
+    //        assertSearchDoesntReturnComposition("subject:Basic.missing-Quantity:missing", "false");
+    //    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity", "25||s");
         assertSearchReturnsSavedResource("Quantity", "25");
 
-        // https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
+        // https://jira.hl7.org/browse/FHIR-19597
         assertSearchReturnsSavedResource("Quantity", "25||sec");
 
         assertSearchDoesntReturnSavedResource("Quantity", "24.4999||s");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -248,7 +248,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
 
-        // >= 3 may be <= 3
+        // <= 3 may be <= 3
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3||lte");
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte"); // <= 3 may be >= 3
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -248,7 +248,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
 
-        // >= 3 may be <= 3 uses precision and bounding for the range. 
+        // >= 3 may be <= 3
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "le3||lte");
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "ge3||lte"); // <= 3 may be >= 3
     }
@@ -264,7 +264,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte"); // >= 3 may be < 4 
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "gt4||gte"); // >= 3 may be > 4
 
-        // >= 3 may be <= 3 uses precision and bounding for the range. 
+        // >= 3 may be <= 3
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "le3||gte");
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "ge3||gte"); // >= 3 is >= 3
     }


### PR DESCRIPTION
- Remove reference to PARAMETERS_GTT which is not used and also removed
insert method from the interface and impl
- Refactor JDBCQueryBuilder to move QuantityParameter processing into a
Specific Utility related to the processing
- Add QuantityParmBehaviorUtil
- Add tests for QuantityParmBehaviorUtil and the various methods and
prefixes
- Add QuantityParmBehaviorUtilTest to testng.xml
- Reset NumberParmBehaviorUtilTest to FINE (avoids needless logs at
INFO)

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>