### PR TITLE
add link to fhir-persistence-schema project

### DIFF
--- a/fhir-install/README-DB2.md
+++ b/fhir-install/README-DB2.md
@@ -38,7 +38,7 @@ db2 CREATE DB ref using codeset UTF-8 territory us PAGESIZE 32768
 db2 CREATE DB profile using codeset UTF-8 territory us PAGESIZE 32768
 ```
 
-For the created databases fhirdb, study, ref and profile, please use the db schema tool in fhir-persistence-schema project to deploy new schema and grant privileges to data access user "fhiruser". And then add "default" and "tenant1" tenants for fhirdb database, and add "tenant1" tenant for the other 3 databases.  
+For the created databases fhirdb, study, ref and profile, please use the [db schema tool](https://github.com/IBM/FHIR/tree/master/fhir-persistence-schema) in fhir-persistence-schema project to deploy new schema and grant privileges to data access user "fhiruser". And then add "default" and "tenant1" tenants for fhirdb database, and add "tenant1" tenant for the other 3 databases.  
 
 Configure to use db2 for the default tenant in fhir-server-config.json, e.g:
 


### PR DESCRIPTION
previously, it just said to use the "db schema tool" in the fhir-persistence-schema project; now it links to a page that will show the README of how that works

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>