### PR TITLE
Search modifier refactoring and doc update

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -80,11 +80,11 @@ For information on how to specify custom search parameters, see [FHIRSearchConfi
 FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#modifiers and vary by search parameter type. The IBM FHIR Server implements a subset of the spec-defined search modifiers that is defined in the following table:
 
 |FHIR Search Parameter Type|Supported Modifiers|"Default" search behavior when no Modifier or Prefix is present|
-|--------------------------|-------------------|-----------------------------------------------------|
+|--------------------------|-------------------|---------------------------------------------------------------|
 |String                    |`:exact`,`:contains`,`:missing` |"starts with" search that is case-insensitive and accent-insensitive|
 |Reference                 |`:[type]`,`:missing`            |exact match search|
 |URI                       |`:below`,`:above`,`:missing`    |exact match search|
-|Token                     |`:below`,`:not`,`:missing`      |exact match search|
+|Token                     |`:missing`                      |exact match search|
 |Number                    |`:missing`                      |exact match search|
 |Date                      |`:missing`                      |exact match search|
 |Quantity                  |`:missing`                      |implicit range search (see http://hl7.org/fhir/R4/search.html#quantity)|

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -5,10 +5,14 @@
  */
 package com.ibm.fhir.persistence.jdbc;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.SearchConstants.Prefix;
+import com.ibm.fhir.search.SearchConstants.Type;
 
 public class JDBCConstants {
     /**
@@ -57,24 +61,40 @@ public class JDBCConstants {
     public static final String JOIN = " JOIN ";
     public static final String LEFT_JOIN = " LEFT JOIN ";
     public static final String COMBINED_RESULTS = " COMBINED_RESULTS";
-    
+
+    /**
+     * Maps search parameter types to the currently supported list of modifiers for that type.
+     */
+    public static Map<Type, List<Modifier>> supportedModifiersMap;
+
     /**
      * Maps Parameter modifiers to SQL operators.
      */
-    public static HashMap<Modifier, JDBCOperator> modifierMap;
+    public static Map<Modifier, JDBCOperator> modifierOperatorMap;
 
     /**
      * Maps Parameter value prefix operators to SQL operators.
      */
-    public static HashMap<Prefix, JDBCOperator> prefixOperatorMap;
+    public static Map<Prefix, JDBCOperator> prefixOperatorMap;
 
     static {
-        modifierMap = new HashMap<>();
-        modifierMap.put(Modifier.ABOVE, JDBCOperator.GT);
-        modifierMap.put(Modifier.BELOW, JDBCOperator.LT);
-        modifierMap.put(Modifier.CONTAINS, JDBCOperator.LIKE);
-        modifierMap.put(Modifier.EXACT, JDBCOperator.EQ);
-        modifierMap.put(Modifier.NOT, JDBCOperator.NE);
+        supportedModifiersMap = new HashMap<Type, List<Modifier>>();
+        supportedModifiersMap.put(Type.STRING, Arrays.asList(Modifier.EXACT, Modifier.CONTAINS, Modifier.MISSING));
+        supportedModifiersMap.put(Type.REFERENCE, Arrays.asList(Modifier.TYPE, Modifier.MISSING));
+        supportedModifiersMap.put(Type.URI, Arrays.asList(Modifier.BELOW, Modifier.ABOVE, Modifier.MISSING));
+        supportedModifiersMap.put(Type.TOKEN, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.NUMBER, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.DATE, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.QUANTITY, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.COMPOSITE, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.SPECIAL, Arrays.asList(Modifier.MISSING));
+
+        modifierOperatorMap = new HashMap<>();
+        modifierOperatorMap.put(Modifier.ABOVE, JDBCOperator.GT);
+        modifierOperatorMap.put(Modifier.BELOW, JDBCOperator.LT);
+        modifierOperatorMap.put(Modifier.CONTAINS, JDBCOperator.LIKE);
+        modifierOperatorMap.put(Modifier.EXACT, JDBCOperator.EQ);
+        modifierOperatorMap.put(Modifier.NOT, JDBCOperator.NE);
 
         prefixOperatorMap = new HashMap<>();
         prefixOperatorMap.put(Prefix.EQ, JDBCOperator.EQ);
@@ -87,7 +107,7 @@ public class JDBCConstants {
         prefixOperatorMap.put(Prefix.EB, JDBCOperator.LT);
         prefixOperatorMap.put(Prefix.AP, JDBCOperator.EQ);
     }
-    
+
     /**
      * An enumeration of SQL query operators.
      */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -7,8 +7,6 @@
 package com.ibm.fhir.persistence.jdbc.util;
 
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.AND;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ON;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.OR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.CODE_SYSTEM_ID;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_END;
@@ -19,7 +17,12 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_EXPR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_PERCENT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_UNDERSCORE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.FROM;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.JOIN;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_JOIN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.MAX_NUM_OF_COMPOSITE_COMPONENTS;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ON;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.OR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.PARAMETER_TABLE_ALIAS;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.PERCENT_WILDCARD;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
@@ -28,11 +31,8 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.STR_VALUE_LCASE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.TOKEN_VALUE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.UNDERSCORE_WILDCARD;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.WHERE;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.modifierMap;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.modifierOperatorMap;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.prefixOperatorMap;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.JOIN;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_JOIN;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.MAX_NUM_OF_COMPOSITE_COMPONENTS;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -257,7 +257,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData, JDBCOpe
                 operator = JDBCOperator.EQ;
             }
         } else if (modifier != null) {
-            operator = modifierMap.get(modifier);
+            operator = modifierOperatorMap.get(modifier);
         }
         
         if (operator == null) {
@@ -287,7 +287,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData, JDBCOpe
         Modifier modifier = queryParm.getModifier();
 
         if (modifier != null) {
-            operator = modifierMap.get(modifier);
+            operator = modifierOperatorMap.get(modifier);
         }
         if (operator == null) {
             if (defaultOverride != null) {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
@@ -116,13 +116,13 @@ public class SearchConstants {
     
     public static final String WILDCARD = "*";
     
-    public static final char AND_CHAR = '&';    
+    public static final char AND_CHAR = '&';
     
     public static final char EQUALS_CHAR = '=';
     
     public static final String JOIN_STR = ",";
     
-    public static final String AND_CHAR_STR = "&";    
+    public static final String AND_CHAR_STR = "&";
     
     // Filter
     public static final String WILDCARD_FILTER = "*";
@@ -141,9 +141,10 @@ public class SearchConstants {
 
                 {
                     put(SearchConstants.Type.STRING, Arrays.asList(Modifier.EXACT, Modifier.CONTAINS, Modifier.MISSING));
-                    put(SearchConstants.Type.REFERENCE, Arrays.asList(Modifier.TYPE, Modifier.MISSING));
+                    put(SearchConstants.Type.REFERENCE, Arrays.asList(Modifier.TYPE, Modifier.IDENTIFIER, Modifier.MISSING));
                     put(SearchConstants.Type.URI, Arrays.asList(Modifier.BELOW, Modifier.ABOVE, Modifier.MISSING));
-                    put(SearchConstants.Type.TOKEN, Arrays.asList(Modifier.BELOW, Modifier.NOT, Modifier.MISSING));
+                    put(SearchConstants.Type.TOKEN, Arrays.asList(Modifier.TEXT, Modifier.NOT, 
+                            Modifier.ABOVE, Modifier.BELOW, Modifier.IN, Modifier.NOT_IN, Modifier.OF_TYPE, Modifier.MISSING));
                     put(SearchConstants.Type.NUMBER, Arrays.asList(Modifier.MISSING));
                     put(SearchConstants.Type.DATE, Arrays.asList(Modifier.MISSING));
                     put(SearchConstants.Type.QUANTITY, Arrays.asList(Modifier.MISSING));
@@ -235,7 +236,9 @@ public class SearchConstants {
         ABOVE("above"),
         NOT("not"),
         NOT_IN("not-in"),
-        TYPE("[type]");
+        TYPE("[type]"), 
+        OF_TYPE("of-type"), 
+        IDENTIFIER("identifier");
 
         private String value = null;
 


### PR DESCRIPTION
1. Added more search modifiers to map of allowed modifiers in
fhir-search  SearchConstants

2. Introduced a new "supportedModifiersMap" in the fhir-persistence-jdbc
layer, added a method called `checkModifiers` which checks all
QueryParameters passed to the search method

3. Updated the Conformance.md doc to state that we don't support
`:below` or `:not` modifiers for token search

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>