### PR TITLE
issue #519 - QueryParameterValue.toString should use query string format

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameterValue.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameterValue.java
@@ -145,11 +145,13 @@ public class QueryParameterValue {
         outputBuilder(returnString, valueDate);
         
         if (component != null && !component.isEmpty()) {
-            returnString.append("composite[");
-            // temporarily change the delimiter; NOT thread-safe
             String componentDelim = "";
             for (QueryParameter componentParam : component) {
-                returnString.append(componentDelim).append(componentParam);
+                List<QueryParameterValue> componentValues = componentParam.getValues();
+                if (componentValues.size() != 1) {
+                    throw new IllegalStateException("Components of a composite search parameter may only have a single value");
+                }
+                returnString.append(componentDelim).append(componentValues.get(0));
                 componentDelim = "$";
             }
         }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/uri/UriBuilder.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/uri/UriBuilder.java
@@ -239,7 +239,7 @@ public class UriBuilder {
         return returnString.toString();
     }
 
-    /*
+    /**
      * creates a normal parameter and string.
      * 
      * @param param


### PR DESCRIPTION
I didn't realize that we were using QueryParameterValue.toString to
write the self URI for the response messages, so I added a generic
toString capability for composite values.
Now, I've updated this to return the data in a format that is consistent
with the query string value we parsed to get it.

Note: there is no known syntax for a single component within a composite
value to itself have multiple values; we'll throw an
IllegalStateException if we ever see it.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>