### PR TITLE
Remove unnecessary complexity in db utils Table/ColumnDefBuilder

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/ColumnDefBuilder.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/ColumnDefBuilder.java
@@ -156,11 +156,7 @@ public class ColumnDefBuilder {
                 column = new DoubleColumn(cd.getName(), cd.isNullable());
                 break;
             case TIMESTAMP:
-                if (cd.getPrecision() == null) {
-                    column = new TimestampColumn(cd.getName(), cd.isNullable());
-                } else {
-                    column = new TimestampColumn(cd.getName(), cd.isNullable(), cd.getPrecision());
-                }
+                column = new TimestampColumn(cd.getName(), cd.isNullable(), cd.getPrecision());
                 break;
             case VARCHAR:
                 if (cd.getSize() > Integer.MAX_VALUE) {

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
@@ -532,11 +532,7 @@ public class Table extends BaseObject {
                     column = new DoubleColumn(cd.getName(), cd.isNullable());
                     break;
                 case TIMESTAMP:
-                    if (cd.getPrecision() == null) {
-                        column = new TimestampColumn(cd.getName(), cd.isNullable());
-                    } else {
-                        column = new TimestampColumn(cd.getName(), cd.isNullable(), cd.getPrecision());
-                    }
+                    column = new TimestampColumn(cd.getName(), cd.isNullable(), cd.getPrecision());
                     break;
                 case VARCHAR:
                     if (cd.getSize() > Integer.MAX_VALUE) {

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/TimestampColumn.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/TimestampColumn.java
@@ -22,7 +22,7 @@ public class TimestampColumn extends ColumnBase {
         this.precision = null;
     }
     
-    public TimestampColumn(String name, boolean nullable, int precision) {
+    public TimestampColumn(String name, boolean nullable, Integer precision) {
         super(name, nullable);
         this.precision = precision;
     }


### PR DESCRIPTION
I added the original if logic because it was throwing a NullPointer and
I didn't understand why...now I realize it was just from "auto-boxing"
of the Integer to an int. Now I switched the parameter to type Integer
so we can remove the extra branching logic.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>