### PR TITLE
Set timezone to UTC for all storedprocedure timestamps

### DIFF
--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRUtilities.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRUtilities.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.core;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Date;
 import java.util.TimeZone;
@@ -118,7 +117,7 @@ public class FHIRUtilities {
      * @return
      */
     public static Timestamp convertToTimestamp(java.time.ZonedDateTime zdt) {
-        return Timestamp.from(zdt.withZoneSameInstant(ZoneId.of("UTC")).toInstant());
+        return Timestamp.from(zdt.toInstant());
     }
 
 

--- a/fhir-examples/src/main/resources/json/ibm/basic/BasicDate.json
+++ b/fhir-examples/src/main/resources/json/ibm/basic/BasicDate.json
@@ -14,7 +14,7 @@
     },
     {
       "url": "http://example.org/dateTime",
-      "valueDateTime": "2018-10-29T17:12:00-04:00"
+      "valueDateTime": "2019-12-31T20:00:00-04:00"
     },
     {
       "url": "http://example.org/time",

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -6,9 +6,11 @@
 package com.ibm.fhir.persistence.jdbc;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.SearchConstants.Type;
@@ -64,34 +66,38 @@ public class JDBCConstants {
     public static final char COMMA_CHAR = ',';
     public static final char QUOTE = '\'';
     public static final char PATH_CHAR = '/';
-    
+
     // JDBC Operators
     public static final String EQ = " = ";
     public static final String LIKE = " LIKE ";
     public static final String IN =" IN ";
     public static final String LT = " < ";
     public static final String LTE = " <= ";
-    public static final String GT = " > "; 
+    public static final String GT = " > ";
     public static final String GTE = " >= ";
     public static final String NE = " <> ";
     public static final String OR = " OR ";
     public static final String AND = " AND ";
-    
+
     // ASC/DESC
     public static final String ORDER_BY = " ORDER BY ";
     public static final String ASCENDING = "ASC";
     public static final String DESCENDING = "DESC";
-    
+
     public static final String DEFAULT_ORDERING = " ORDER BY RESOURCE_ID ASC ";
     public static final String DEFAULT_ORDERING_WITH_TABLE = " ORDER BY R.RESOURCE_ID ASC ";
-    
-    // MIN / MAX 
+
+    // MIN / MAX
     public static final String MAX = "MAX";
     public static final String MIN = "MIN";
 
     /**
-     * Maps search parameter types to the currently supported list of modifiers for
-     * that type.
+     * Calendar object to use while inserting Timestamp objects into the database.
+     */
+    public static final Calendar UTC = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+
+    /**
+     * Maps search parameter types to the currently supported list of modifiers for that type.
      */
     public static final Map<Type, List<Modifier>> supportedModifiersMap;
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -6,6 +6,8 @@
 
 package com.ibm.fhir.persistence.jdbc.dao.impl;
 
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.UTC;
+
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -324,11 +326,7 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
                 }
 
                 // Insert record into the base level date attribute table
-                resourceDates.setInt(1, parameterNameId);
-                resourceDates.setTimestamp(2, date);
-                resourceDates.setTimestamp(3, dateStart);
-                resourceDates.setTimestamp(4, dateEnd);
-                resourceDates.setLong(5, logicalResourceId);
+                setDateParms(resourceDates, parameterNameId, date, dateStart, dateEnd);
                 resourceDates.addBatch();
 
                 if (++resourceDateCount == this.batchSize) {
@@ -359,9 +357,9 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
 
     private void setDateParms(PreparedStatement insert, int parameterNameId, Timestamp date, Timestamp dateStart, Timestamp dateEnd) throws SQLException {
         insert.setInt(1, parameterNameId);
-        insert.setTimestamp(2, date);
-        insert.setTimestamp(3, dateStart);
-        insert.setTimestamp(4, dateEnd);
+        insert.setTimestamp(2, date, UTC);
+        insert.setTimestamp(3, dateStart, UTC);
+        insert.setTimestamp(4, dateEnd, UTC);
         insert.setLong(5, logicalResourceId);
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -6,6 +6,8 @@
 
 package com.ibm.fhir.persistence.jdbc.derby;
 
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.UTC;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -309,7 +311,7 @@ public class DerbyResourceDAO {
             stmt.setLong(2, v_logical_resource_id);
             stmt.setInt(3, v_insert_version);
             stmt.setBytes(4, p_payload);
-            stmt.setTimestamp(5, p_last_updated);
+            stmt.setTimestamp(5, p_last_updated, UTC);
             stmt.setString(6, p_is_deleted ? "Y" : "N");
             stmt.executeUpdate();
         }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/DateParmVal.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/DateParmVal.java
@@ -97,4 +97,10 @@ public class DateParmVal implements ExtractedParameterValue {
     public void setBase(String base) {
         this.base = base;
     }
+
+    @Override
+    public String toString() {
+        return "DateParmVal [resourceType=" + resourceType + ", name=" + name + ", valueDate=" + valueDate
+                + ", valueDateStart=" + valueDateStart + ", valueDateEnd=" + valueDateEnd + ", base=" + base + "]";
+    }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -651,6 +651,8 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
             inst = DateTimeHandler.generateUpperBound(date.getValue());
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
+            
+            System.out.println(p);
         }
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -648,6 +648,9 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         if (date.getValue() != null) {
             java.time.Instant inst = DateTimeHandler.generateValue(date.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
+            p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
+            inst = DateTimeHandler.generateUpperBound(date.getValue());
+            p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }
 
@@ -664,6 +667,9 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         if (dateTime.getValue() != null) {
             java.time.Instant inst = DateTimeHandler.generateValue(dateTime.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
+            p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
+            inst = DateTimeHandler.generateUpperBound(dateTime.getValue());
+            p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -75,14 +75,11 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
     // Datetime Limits from
     // DB2: https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0001029.html
     // Derby: https://db.apache.org/derby/docs/10.0/manuals/reference/sqlj271.html
-    private static final Timestamp SMALLEST_TIMESTAMP =
-            Timestamp.from(
-                    ((ZonedDateTime) DateTimeHandler.parseQuiet("0001-01-01T00:00:00.000000+00:00")).toInstant());
-
+    private static final Timestamp SMALLEST_TIMESTAMP = Timestamp.from(
+            ZonedDateTime.parse("0001-01-01T00:00:00.000000Z").toInstant());
     // 23:59:59.999999 used instead of 24:00:00.000000 to ensure it could be represented in FHIR if needed
-    private static final Timestamp LARGEST_TIMESTAMP =
-            Timestamp.from(
-                    ((ZonedDateTime) DateTimeHandler.parseQuiet("9999-12-31T23:59:59.999999+00:00")).toInstant());
+    private static final Timestamp LARGEST_TIMESTAMP = Timestamp.from(
+            ZonedDateTime.parse("9999-12-31T23:59:59.999999Z").toInstant());
 
     // We only need the SearchParameter type and code, so just store those directly as members
     private final String searchParamCode;
@@ -612,7 +609,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         LocationParmVal p = new LocationParmVal();
         p.setName(searchParamCode);
 
-        // The following code ensures that the lat/lon is only added when there is a pair. 
+        // The following code ensures that the lat/lon is only added when there is a pair.
         boolean add = false;
         if (position.getLatitude() != null && position.getLatitude().getValue() != null) {
             Double lat = position.getLatitude().getValue().doubleValue();
@@ -667,7 +664,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         if (dateTime.getValue() != null) {
             java.time.Instant inst = DateTimeHandler.generateValue(dateTime.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
-        } 
+        }
     }
 
     private IllegalArgumentException invalidComboException(SearchParamType paramType, Element value) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -652,7 +652,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             java.time.Instant inst = DateTimeHandler.generateValue(date.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
-            inst = DateTimeHandler.generateUpperBound(date.getValue());
+            inst = DateTimeHandler.generateUpperBound(date);
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }
@@ -671,7 +671,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             java.time.Instant inst = DateTimeHandler.generateValue(dateTime.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
-            inst = DateTimeHandler.generateUpperBound(dateTime.getValue());
+            inst = DateTimeHandler.generateUpperBound(dateTime);
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -231,7 +231,10 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
                 throw invalidComboException(searchParamType, instant);
             }
             p.setName(searchParamCode);
-            p.setValueDate(generateTimestamp(instant.getValue().toInstant()));
+            Timestamp t = generateTimestamp(instant.getValue().toInstant());
+            p.setValueDate(t);
+            p.setValueDateStart(t);
+            p.setValueDateEnd(t);
             result.add(p);
         }
         return false;
@@ -651,8 +654,6 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
             inst = DateTimeHandler.generateUpperBound(date.getValue());
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
-            
-            System.out.println(p);
         }
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -99,7 +99,7 @@ public class DateParmBehaviorUtil {
             // the value for the parameter in the resource is equal to the provided value
             // the range of the search value fully contains the range of the target value
             buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
-                    LT, value, value);
+                    LT, lowerBound, lowerBound);
             break;
         case SA:
             // SA - Starts After
@@ -112,27 +112,27 @@ public class DateParmBehaviorUtil {
             // GE - Greater Than Equal
             // the range above the search value intersects (i.e. overlaps) with the range of the target value,
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
-                    GTE, value, value);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
+                    GTE, lowerBound, lowerBound);
             break;
         case GT:
             // GT - Greater Than
             // the range above the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
-                    GT, upperBound, upperBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
+                    GT, lowerBound, lowerBound);
             break;
         case LE:
             // LE - Less Than Equal
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
                     LTE, upperBound, upperBound);
             break;
         case LT:
             // LT - Less Than
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
-                    LT, value, value);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
+                    LT, upperBound, upperBound);
             break;
         case AP:
             // AP - Approximate - Relative
@@ -143,13 +143,13 @@ public class DateParmBehaviorUtil {
         case NE:
             // NE:  Upper and Lower Bounds - Range Based Search
             // the range of the search value does not fully contain the range of the target value
-            buildNotEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, value, upperBound);
+            buildNotEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound, upperBound);
             break;
         case EQ:
         default:
             // EQ:  Upper and Lower Bounds - Range Based Search
             // the range of the search value fully contains the range of the target value
-            buildEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, value, upperBound);
+            buildEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound, upperBound);
             break;
         }
     }
@@ -163,21 +163,14 @@ public class DateParmBehaviorUtil {
      * @param columnName
      * @param columnNameLowOrHigh
      * @param operator
-     * @param value
+     * @param value TODO: remove this
      * @param bound
      */
     public void buildCommonClause(StringBuilder whereClauseSegment, List<Timestamp> bindVariables, String tableAlias,
             String columnName, String columnNameLowOrHigh, String operator, Instant value, Instant bound) {
-        // @formatter:off
         whereClauseSegment
-                .append(LEFT_PAREN)
-                    .append(tableAlias).append(DOT).append(columnName).append(operator).append(BIND_VAR)
-                .append(OR)
-                    .append(tableAlias).append(DOT).append(columnNameLowOrHigh).append(operator).append(BIND_VAR)
-                .append(RIGHT_PAREN);
-        // @formatter:on
+                    .append(tableAlias).append(DOT).append(columnNameLowOrHigh).append(operator).append(BIND_VAR);
 
-        bindVariables.add(generateTimestamp(value));
         bindVariables.add(generateTimestamp(bound));
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -11,7 +11,6 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_END;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_START;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EQ;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GTE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
@@ -172,25 +171,17 @@ public class DateParmBehaviorUtil {
      */
     public void buildEqualsRangeClause(StringBuilder whereClauseSegment, List<Timestamp> bindVariables,
             String tableAlias, Instant lowerBound, Instant upperBound) {
-        bindVariables.add(generateTimestamp(lowerBound));
+        // @formatter:off
+        whereClauseSegment
+                .append(LEFT_PAREN)
+                    .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
+                .append(AND)
+                    .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
+                .append(RIGHT_PAREN);
+        // @formatter:on
 
-        if (!lowerBound.equals(upperBound)) {
-            // @formatter:off
-            whereClauseSegment
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
-                    .append(AND)
-                        .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
-                    .append(RIGHT_PAREN);
-            // @formatter:on
-            bindVariables.add(generateTimestamp(upperBound));
-        } else {
-            // Exact match of an instant. 
-            whereClauseSegment
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_START).append(EQ).append(BIND_VAR)
-                    .append(RIGHT_PAREN);
-        }
+        bindVariables.add(generateTimestamp(lowerBound));
+        bindVariables.add(generateTimestamp(upperBound));
     }
 
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -188,7 +188,7 @@ public class DateParmBehaviorUtil {
             // Exact match of an instant. 
             whereClauseSegment
                     .append(LEFT_PAREN)
-                    .append(tableAlias).append(DOT).append(DATE_START).append(EQ).append(BIND_VAR)
+                        .append(tableAlias).append(DOT).append(DATE_START).append(EQ).append(BIND_VAR)
                     .append(RIGHT_PAREN);
         }
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -10,8 +10,8 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.AND;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_END;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_START;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_VALUE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EQ;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GTE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
@@ -44,8 +44,7 @@ public class DateParmBehaviorUtil {
 
     public void executeBehavior(StringBuilder whereClauseSegment, QueryParameter queryParm,
             List<Timestamp> bindVariables,
-            String tableAlias)
-            throws Exception {
+            String tableAlias) {
         // Start the Clause 
         // Query: AND ((
         whereClauseSegment.append(AND).append(LEFT_PAREN).append(LEFT_PAREN);
@@ -69,10 +68,9 @@ public class DateParmBehaviorUtil {
                 prefix = Prefix.EQ;
             }
 
-            Instant v = value.getValueDate();
             Instant lowerBound = value.getValueDateLowerBound();
             Instant upperBound = value.getValueDateUpperBound();
-            buildPredicates(whereClauseSegment, bindVariables, tableAlias, prefix, v, lowerBound, upperBound);
+            buildPredicates(whereClauseSegment, bindVariables, tableAlias, prefix, lowerBound, upperBound);
         }
 
         // End the Clause started above, and closes the parameter expression. 
@@ -87,52 +85,45 @@ public class DateParmBehaviorUtil {
      * @param bindVariables
      * @param tableAlias
      * @param prefix
-     * @param value
      * @param lowerBound
      * @param upperBound
      */
     public void buildPredicates(StringBuilder whereClauseSegment, List<Timestamp> bindVariables, String tableAlias,
-            Prefix prefix, Instant value, Instant lowerBound, Instant upperBound) {
+            Prefix prefix, Instant lowerBound, Instant upperBound) {
         switch (prefix) {
         case EB:
             // EB - Ends Before
             // the value for the parameter in the resource is equal to the provided value
             // the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
-                    LT, lowerBound, lowerBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_END, LT, lowerBound);
             break;
         case SA:
             // SA - Starts After
             // the range of the search value does not overlap with the range of the target value,
             // and the range below the search value contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
-                    GT, upperBound, upperBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_START, GT, upperBound);
             break;
         case GE:
             // GE - Greater Than Equal
             // the range above the search value intersects (i.e. overlaps) with the range of the target value,
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
-                    GTE, lowerBound, lowerBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_END, GTE, lowerBound);
             break;
         case GT:
             // GT - Greater Than
             // the range above the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_END,
-                    GT, lowerBound, lowerBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_END, GT, lowerBound);
             break;
         case LE:
             // LE - Less Than Equal
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
             // or the range of the search value fully contains the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
-                    LTE, upperBound, upperBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_START, LTE, upperBound);
             break;
         case LT:
             // LT - Less Than
             // the range below the search value intersects (i.e. overlaps) with the range of the target value
-            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_VALUE, DATE_START,
-                    LT, upperBound, upperBound);
+            buildCommonClause(whereClauseSegment, bindVariables, tableAlias, DATE_START, LT, upperBound);
             break;
         case AP:
             // AP - Approximate - Relative
@@ -160,17 +151,13 @@ public class DateParmBehaviorUtil {
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias
-     * @param columnName
      * @param columnNameLowOrHigh
      * @param operator
-     * @param value TODO: remove this
      * @param bound
      */
     public void buildCommonClause(StringBuilder whereClauseSegment, List<Timestamp> bindVariables, String tableAlias,
-            String columnName, String columnNameLowOrHigh, String operator, Instant value, Instant bound) {
-        whereClauseSegment
-                    .append(tableAlias).append(DOT).append(columnNameLowOrHigh).append(operator).append(BIND_VAR);
-
+            String columnNameLowOrHigh, String operator, Instant bound) {
+        whereClauseSegment.append(tableAlias).append(DOT).append(columnNameLowOrHigh).append(operator).append(BIND_VAR);
         bindVariables.add(generateTimestamp(bound));
     }
 
@@ -185,26 +172,25 @@ public class DateParmBehaviorUtil {
      */
     public void buildEqualsRangeClause(StringBuilder whereClauseSegment, List<Timestamp> bindVariables,
             String tableAlias, Instant lowerBound, Instant upperBound) {
-        //  buildEqualsRangeClause(whereClauseSegment, bindVariables, tableAlias, value, upperBound, value);
-        // @formatter:off
-        whereClauseSegment
-                .append(LEFT_PAREN).append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(GTE).append(BIND_VAR)
-                        .append(AND)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(LTE).append(BIND_VAR)
-                    .append(RIGHT_PAREN)
-                    .append(OR)
+        bindVariables.add(generateTimestamp(lowerBound));
+
+        if (!lowerBound.equals(upperBound)) {
+            // @formatter:off
+            whereClauseSegment
                     .append(LEFT_PAREN)
                         .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
-                        .append(AND)
+                    .append(AND)
                         .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
-                .append(RIGHT_PAREN).append(RIGHT_PAREN);
-        // @formatter:on
-
-        bindVariables.add(generateTimestamp(lowerBound));
-        bindVariables.add(generateTimestamp(upperBound));
-        bindVariables.add(generateTimestamp(lowerBound));
-        bindVariables.add(generateTimestamp(upperBound));
+                    .append(RIGHT_PAREN);
+            // @formatter:on
+            bindVariables.add(generateTimestamp(upperBound));
+        } else {
+            // Exact match of an instant. 
+            whereClauseSegment
+                    .append(LEFT_PAREN)
+                    .append(tableAlias).append(DOT).append(DATE_START).append(EQ).append(BIND_VAR)
+                    .append(RIGHT_PAREN);
+        }
     }
 
     /**
@@ -221,22 +207,12 @@ public class DateParmBehaviorUtil {
         // @formatter:off
         whereClauseSegment
                 .append(LEFT_PAREN)
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(GTE).append(BIND_VAR)
-                    .append(AND)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(LTE).append(BIND_VAR)
-                    .append(RIGHT_PAREN)
-                    .append(OR)
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
-                    .append(AND)
-                        .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
-                    .append(RIGHT_PAREN)
+                     .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
+                .append(AND)
+                     .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
                 .append(RIGHT_PAREN);
         // @formatter:on
 
-        bindVariables.add(generateTimestamp(lowerBound));
-        bindVariables.add(generateTimestamp(upperBound));
         bindVariables.add(generateTimestamp(lowerBound));
         bindVariables.add(generateTimestamp(upperBound));
     }
@@ -255,22 +231,12 @@ public class DateParmBehaviorUtil {
         // @formatter:off
         whereClauseSegment
                 .append(LEFT_PAREN)
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(LT).append(BIND_VAR)
-                        .append(OR)
-                        .append(tableAlias).append(DOT).append(DATE_VALUE).append(GT).append(BIND_VAR)
-                    .append(RIGHT_PAREN)
-                    .append(OR)
-                    .append(LEFT_PAREN)
                         .append(tableAlias).append(DOT).append(DATE_START).append(LT).append(BIND_VAR)
                         .append(OR)
                         .append(tableAlias).append(DOT).append(DATE_END).append(GT).append(BIND_VAR)
-                    .append(RIGHT_PAREN)
                 .append(RIGHT_PAREN);
         // @formatter:on
 
-        bindVariables.add(generateTimestamp(lowerBound));
-        bindVariables.add(generateTimestamp(upperBound));
         bindVariables.add(generateTimestamp(lowerBound));
         bindVariables.add(generateTimestamp(upperBound));
     }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DateParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DateParmBehaviorUtilTest.java
@@ -32,7 +32,7 @@ import com.ibm.fhir.search.parameters.QueryParameterValue;
 
 public class DateParmBehaviorUtilTest {
     private static final Logger log = java.util.logging.Logger.getLogger(DateParmBehaviorUtilTest.class.getName());
-    private static final Level LOG_LEVEL = Level.INFO;
+    private static final Level LOG_LEVEL = Level.FINE;
 
     //---------------------------------------------------------------------------------------------------------
     // Supporting Methods: 
@@ -122,10 +122,9 @@ public class DateParmBehaviorUtilTest {
         // gt - Greater Than
         QueryParameter queryParm = generateQueryParameter(SearchConstants.Prefix.GT, null, vTime);
         List<Timestamp> expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(upper);
-        expectedBindVariables.add(upper);
+        expectedBindVariables.add(value);
         String expectedSql =
-                " AND (((Date.DATE_VALUE > ? OR Date.DATE_START > ?))))";
+                " AND ((Date.DATE_END > ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -133,10 +132,9 @@ public class DateParmBehaviorUtilTest {
         // lt - Less Than
         queryParm             = generateQueryParameter(SearchConstants.Prefix.LT, null, vTime);
         expectedBindVariables = new ArrayList<>();
-        expectedBindVariables.add(value);
-        expectedBindVariables.add(value);
+        expectedBindVariables.add(upper);
         expectedSql =
-                " AND (((Date.DATE_VALUE < ? OR Date.DATE_END < ?))))";
+                " AND ((Date.DATE_START < ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -145,9 +143,8 @@ public class DateParmBehaviorUtilTest {
         queryParm             = generateQueryParameter(SearchConstants.Prefix.GE, null, vTime);
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(value);
-        expectedBindVariables.add(value);
         expectedSql =
-                " AND (((Date.DATE_VALUE >= ? OR Date.DATE_START >= ?))))";
+                " AND ((Date.DATE_END >= ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -156,9 +153,8 @@ public class DateParmBehaviorUtilTest {
         queryParm             = generateQueryParameter(SearchConstants.Prefix.LE, null, vTime);
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(upper);
-        expectedBindVariables.add(upper);
         expectedSql =
-                " AND (((Date.DATE_VALUE <= ? OR Date.DATE_END <= ?))))";
+                " AND ((Date.DATE_START <= ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -167,9 +163,8 @@ public class DateParmBehaviorUtilTest {
         queryParm             = generateQueryParameter(SearchConstants.Prefix.SA, null, vTime);
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(upper);
-        expectedBindVariables.add(upper);
         expectedSql =
-                " AND (((Date.DATE_VALUE > ? OR Date.DATE_START > ?))))";
+                " AND ((Date.DATE_START > ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -178,9 +173,8 @@ public class DateParmBehaviorUtilTest {
         queryParm             = generateQueryParameter(SearchConstants.Prefix.EB, null, vTime);
         expectedBindVariables = new ArrayList<>();
         expectedBindVariables.add(value);
-        expectedBindVariables.add(value);
         expectedSql =
-                " AND (((Date.DATE_VALUE < ? OR Date.DATE_END < ?))))";
+                " AND ((Date.DATE_END < ?)))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -200,7 +194,7 @@ public class DateParmBehaviorUtilTest {
         expectedBindVariables.add(value);
         expectedBindVariables.add(value);
         String expectedSql =
-                " AND ((((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?)))))";
+                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -225,7 +219,7 @@ public class DateParmBehaviorUtilTest {
         expectedBindVariables.add(value);
 
         String expectedSql =
-                " AND ((((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?))) OR (((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?)))))";
+                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?)) OR ((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -248,7 +242,7 @@ public class DateParmBehaviorUtilTest {
         expectedBindVariables.add(value);
 
         String expectedSql =
-                " AND ((((Date.DATE_VALUE < ? OR Date.DATE_VALUE > ?) OR (Date.DATE_START < ? OR Date.DATE_END > ?)))))";
+                " AND (((Date.DATE_START < ? OR Date.DATE_END > ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql);
@@ -262,7 +256,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND ((((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?)))))";
+                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);
@@ -277,7 +271,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND ((((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?))) OR (((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?)))))";
+                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?)) OR ((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);
@@ -292,7 +286,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND ((((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?))) OR (((Date.DATE_VALUE >= ? AND Date.DATE_VALUE <= ?) OR (Date.DATE_START >= ? AND Date.DATE_END <= ?)))))";
+                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?)) OR ((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/LocationParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/LocationParmBehaviorUtilTest.java
@@ -27,7 +27,7 @@ import com.ibm.fhir.search.location.bounding.BoundingRadius;
 
 public class LocationParmBehaviorUtilTest {
     private static final Logger log = java.util.logging.Logger.getLogger(LocationParmBehaviorUtilTest.class.getName());
-    private static final Level LOG_LEVEL = Level.INFO;
+    private static final Level LOG_LEVEL = Level.FINE;
 
     private void runTestBoundingBox(List<Object> expectedBindVariables, String expectedSql,
             BoundingBox boundingBox)

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -8,10 +8,12 @@ package com.ibm.fhir.persistence.search.test;
 
 import static org.testng.Assert.assertTrue;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.testng.annotations.Test;
 
@@ -20,111 +22,531 @@ import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.test.TestUtil;
 
 /**
- * <a href="https://hl7.org/fhir/search.html#date>FHIR Specification: Search
+ * <a href="https://hl7.org/fhir/search.html#date">FHIR Specification: Search
  * - Date</a> Tests
  */
 public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
-
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
     }
-
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("date");
-    }
-
-    @Test
-    public void testSearchDate_date_UTC() throws Exception {
-        // "date" is 2018-10-29
-        // The following tests use 2018-10-28
-        assertSearchDoesntReturnSavedResource("date", "2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ne2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ge2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "sa2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ap2018-10-28T23:59:59.999999Z");
-    }
-
-    @Test
-    public void testSearchDate_date() throws Exception {
-        // "date" is 2018-10-29
-        assertSearchReturnsSavedResource("date", "2018-10-29");
-        assertSearchReturnsSavedResource("date", "lt2018-10-29");
-        assertSearchReturnsSavedResource("date", "gt2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
-
-        assertSearchReturnsSavedResource("date", "le2018-10-29");
-        assertSearchReturnsSavedResource("date", "ge2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29");
-        assertSearchReturnsSavedResource("date", "ap2018-10-29");
-
-        // Specificity, says the EQ range does not overlap. 
-        assertSearchDoesntReturnSavedResource("date", "2018-10-29T17:12:00-04:00");
-
-        // Not equals is the inverse of the previous. 
-        assertSearchReturnsSavedResource("date", "ne2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "ap2018-10-29T17:12:00-04:00");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-28");
-        assertSearchReturnsSavedResource("date", "ne2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28");
-        assertSearchReturnsSavedResource("date", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
-        assertSearchReturnsSavedResource("date", "ge2018-10-28");
-        assertSearchReturnsSavedResource("date", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28");
-        assertSearchReturnsSavedResource("date", "ap2018-10-28");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-30");
-        assertSearchReturnsSavedResource("date", "ne2018-10-30");
-        assertSearchReturnsSavedResource("date", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30");
-        assertSearchReturnsSavedResource("date", "le2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30");
-        assertSearchReturnsSavedResource("date", "eb2018-10-30");
-        assertSearchReturnsSavedResource("date", "ap2018-10-30");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "ne2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "lt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "le2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "ap2018-10-30T00:00:00.000001Z");
-
-        // The test is checking against ... valueDate": "2018-10-29"
-        // As this test is using an implied range with SECONDS, it's the proper behavior. 
-        assertSearchDoesntReturnSavedResource("date", "2018-10-29T21:12:00");
+        
+        // this might deserve its own method, but just use setTenant for now 
+        // since its called before creating any resources
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-4:00"));
+        System.out.println(ZoneId.systemDefault());
     }
     
     @Test
-    public void testSearchDateExactPrecision() throws Exception {
+    public void testSearchDate_date_Day_noTZ() throws Exception {
         // "date" is 2018-10-29
-        assertSearchReturnsSavedResource("date", "2018-10-29T00:00:00.000000Z");
-    }
+        
+        // the day before
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28");
 
+        // the exact day
+        assertSearchReturnsSavedResource(     "date",   "2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29");
+
+        // the day after
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_noTZ() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59");
+        
+        // the first second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00");
+        // This one returns the resource because we consider this a range from 00:00:00 to 00:00:01 and the ranges overlap
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59");
+        // This one returns the resource because there are fractions of a second between 23:59:59 and 23:59:59.999999
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_EDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59-04:00");
+        
+        // the first second of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00-04:00");
+        // This one returns the resource because 00:00:00 is converted into a range of [00:00:00, 00:00:01) which overlaps the day
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00-04:00");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00-04:00");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59-04:00");
+        // This one returns the resource because there are fractional seconds between 23:59:59 and 23:59:59.999999
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59-04:00");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00-04:00");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_UTC() throws Exception {
+        // "date" is 2018-10-29
+        
+        // we set the system time to GMT-4, so this is really [2018-10-29T04:00:00Z, 2018-10-30T03:59:59.999999]
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T03:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T03:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-29T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-29T03:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T03:59:59Z");
+        
+        // the first second of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T04:00:00Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T04:00:00Z");
+        // This one returns the resource because we consider this a range from 00:00:00 to 00:00:01 and the ranges overlap
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T04:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T04:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T04:00:00Z");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00Z");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T03:59:59Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T03:59:59Z");
+        // This one returns the resource because there are fractions of a second between 23:59:59 and 23:59:59.999999
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-30T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-30T03:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T03:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-30T03:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T03:59:59Z");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T04:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T04:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T04:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T04:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T04:00:00Z");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_noTZ() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999");
+        
+        // the first instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_EDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999-04:00");
+        
+        // the first instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0-04:00");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0-04:00");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999-04:00");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0-04:00");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_IDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999+03:00");
+        
+        // the first instant of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0+03:00");
+//        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0+03:00");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0+03:00");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999+03:00");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0+03:00");
+//        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0+03:00");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_UTC() throws Exception {
+        // "date" is 2018-10-29
+        
+        // we set the system time to GMT-4, so this is really [2018-10-29T04:00:00Z, 2018-10-30T03:59:59.999999]
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-29T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-29T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T03:59:59.999999Z");
+        
+        // the first instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T04:00:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T04:00:00.0Z");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0Z");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T03:59:59.999999Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-30T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T03:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-30T03:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T03:59:59.999999Z");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T04:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T04:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T04:00:00.0Z");
+    }
     @Test
     public void testSearchDate_date_missing() throws Exception {
         assertSearchReturnsSavedResource("date:missing", "false");
         assertSearchDoesntReturnSavedResource("date:missing", "true");
-
         assertSearchReturnsSavedResource("missing-date:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-date:missing", "false");
     }
-
     @Test
     public void testSearchDate_date_chained() throws Exception {
         // Date is specific - 2018-10-29
@@ -133,7 +555,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnComposition("subject:Basic.date", "2018-10-29T17:12:00");
         assertSearchDoesntReturnComposition("subject:Basic.date", "2025-10-29");
     }
-
     @Test
     public void testSearchDate_date_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -142,7 +563,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-
     @Test
     public void testSearchDate_date_or() throws Exception {
         // Date is 2018-10-29
@@ -156,7 +576,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("date", "ge2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29,9999-01-01");
-
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,lt2018-10-28");
         assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-30");
         assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-29");
@@ -166,110 +585,233 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
         assertSearchReturnsSavedResource("date", "9999-01-01,le2018-10-29");
         assertSearchReturnsSavedResource("date", "9999-01-01,ge2018-10-29");
-
         assertSearchReturnsSavedResource("date", "9999-01-01,sa2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,sa2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,eb2018-10-29");
     }
-
     @Test
     public void testSearchDate_date_or_NE() throws Exception {
         // "date" is 2018-10-29
         assertSearchReturnsSavedResource("date", "9999-10-29,ne2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,ne2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29,ne2018-10-29");
-
     }
-
     @Test
     public void testSearchDate_date_or_AP() throws Exception {
         assertSearchReturnsSavedResource("date", "ap2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "9999-01-01,ap2018-10-29");
     }
-
     @Test
-    public void testSearchDate_dateTime() throws Exception {
-        // "dateTime" is 2018-10-29T17:12:00-04:00
-        assertSearchReturnsSavedResource("dateTime", "2018-10-29");
-        assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-29");
-
-        assertSearchReturnsSavedResource("dateTime", "2018-10-29T17:12:00.000000-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-29T17:12:00-04:00");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "le2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-28");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "le2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-28T23:59:59.999999Z");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "ge2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "eb2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-30");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "ge2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-30T00:00:00.000001Z");
+    public void testSearchDate_dateTime_Day_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
+        
+        // the day before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-30");
+//        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-30");
+        
+        // the day of
+        assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
+        assertSearchDoesntReturnSavedResource("dateTime", "ne2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31");
+        
+        // the day after
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01");
+        assertSearchDoesntReturnSavedResource("dateTime", "gt2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01");
+        assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
+    @Test
+    public void testSearchDate_dateTime_Seconds_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
 
+        // we set the system to GMT-4, so it should match the timezone of the target dateTime
+        
+        // the second before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T19:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T19:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T19:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T19:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T19:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T19:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T19:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T19:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T19:59:59");
+        
+        // the exact second
+        assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31T20:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "ne2019-12-31T20:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2019-12-31T20:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T20:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31T20:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T20:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T20:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:00");
+        
+        // the next second
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T20:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T20:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2019-12-31T20:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "gt2019-12-31T20:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31T20:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "ge2019-12-31T20:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "eb2019-12-31T20:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:01");
+    }
+    @Test
+    public void testSearchDate_dateTime_Seconds_UTC() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
+        
+        // the second before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59Z");
+        
+        // the exact second
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00Z");
+        
+        // the next second
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "gt2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:01Z");
+    }
+    @Test
+    public void testSearchDate_dateTime_Fractions_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+
+        // we set the system to GMT-4, so it should match the timezone of the target dateTime
+
+        // the instant before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T19:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T19:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T19:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T19:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T19:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T19:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T19:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T19:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T19:59:59.999999");
+        
+        // the exact instant
+        // This one does not return the resource because the search value is a single point
+        // and the target value is a range from 2019-12-31T20:00:00-04:00 to 2019-12-31T20:00:01-04:00
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T20:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T20:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T20:00:00.0");
+        // This one returns the resource because 20:00:00-04:00 is saved as a range [00:00:00,00:00:01)
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T20:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31T20:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T20:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T20:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:00.0");
+        
+        // the next instant
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T20:00:00.000001");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:00.000001");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T20:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:00.000001");
+    }
+    @Test
+    public void testSearchDate_dateTime_Fractions_UTC() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+
+        // the instant before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59.999999Z");
+        
+        // the exact instant
+        // This one does not return the resource because the search value is a single point
+        // and the target value is a range from 2019-12-31T20:00:00-04:00 to 2019-12-31T20:00:01-04:00
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource("dateTime", "ne2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2020-01-01T00:00:00.0Z");
+        // This one returns the resource because 20:00:00-04:00 is saved as a range [00:00:00,00:00:01)
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.0Z");
+        
+        // the next instant
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.000001Z");
+    }
     @Test
     public void testSearchDate_dateTime_chained() throws Exception {
-        // dateTime is 2018-10-29T17:12:00-04:00
-        // Add precision, otherwise a range .000000 
-        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29T17:12:00.000000-04:00");
-        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29");
-
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        
+        assertSearchReturnsComposition("subject:Basic.dateTime", "2019-12-31T20:00:00-04:00");
         assertSearchDoesntReturnSavedResource("subject:Basic.dateTime", "2025-10-29");
     }
-
     @Test
     public void testSearchDate_dateTime_missing() throws Exception {
         assertSearchReturnsSavedResource("dateTime:missing", "false");
         assertSearchDoesntReturnSavedResource("dateTime:missing", "true");
-
         assertSearchReturnsSavedResource("missing-dateTime:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-dateTime:missing", "false");
     }
-
     @Test
     public void testSearchDate_instant() throws Exception {
         // instant is 2018-10-29T17:12:44-04:00
@@ -279,32 +821,24 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44-00:00");
         assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44Z");
     }
-
     @Test
     public void testSearchDate_instant_precise() throws Exception {
         // Searching by second should include all instants within that second (regardless of sub-seconds)
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:02Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01.1Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:01.12Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.12Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0002-02-02T02:02:02.123Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.123Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0003-03-03T03:03:03.1234Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.1234Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0004-04-04T04:04:04.12345Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0005-05-05T05:05:05.123456Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06Z");
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123456Z");
     }
-
     @Test
     public void testSearchDate_dateTime_precise() throws Exception {
         assertSearchReturnsSavedResource("dateTime-precise", "0001-01-01T01:01:01.1Z");
@@ -314,26 +848,21 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("dateTime-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchReturnsSavedResource("dateTime-precise", "0006-06-06T06:06:06.123456Z");
     }
-
     @Test
     public void testSearchDate_instant_chained() throws Exception {
         // Instant - 2018-10-29T17:12:44-04:00
         assertSearchReturnsComposition("subject:Basic.instant", "2018-10-29T17:12:44.000000-04:00");
     }
-
     @Test
     public void testSearchDate_instant_missing() throws Exception {
         assertSearchReturnsSavedResource("instant:missing", "false");
         assertSearchDoesntReturnSavedResource("instant:missing", "true");
-
         assertSearchReturnsSavedResource("missing-instant:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-instant:missing", "false");
     }
-
     ///////////////
     // Period tests
     ///////////////
-
     /*
      * <pre>
      * "url": "http://example.org/Period",
@@ -345,120 +874,131 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
      * 2018-10-29T21:18:00
      * </pre>
      */
-
     @Test
     public void testSearchDate_Period_EQ_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018");
         assertSearchDoesntReturnSavedResource("Period", "2017");
         assertSearchDoesntReturnSavedResource("Period", "2019");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10");
         assertSearchDoesntReturnSavedResource("Period", "2018-09");
         assertSearchDoesntReturnSavedResource("Period", "2018-11");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "2018-10-29T21");
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T11");
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17");
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T20");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "2018-10-29T21Z");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T11Z");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17Z");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T22Z");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T20Z");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Minutes() throws Exception {
-        // The Search Value of the implied range DOES NOT contain the start/end fully. 
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        // The Search Value of the implied range DOES NOT contain the start/end fully.
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13Z");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         // The Search Value of the implied range DOES NOT contain the start/end fully.
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00.000123");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00.000123Z");
     }
-
     @Test
     public void testSearchDate_Period_EQ_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "2018-10-29T17-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17-05:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:12:44-04:00");
-
         assertSearchReturnsSavedResource("Period", "eq2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "eq2018-10-29T17-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17-05:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17:12:44-04:00");
-
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28T23:59:59.999999Z");
-
     }
-
     @Test
     public void testSearchDate_Period_LT_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "lt2017");
         assertSearchReturnsSavedResource("Period", "lt2018");
         assertSearchReturnsSavedResource("Period", "lt2019");
         assertSearchReturnsSavedResource("Period", "lt2020");
     }
-
     @Test
     public void testSearchDate_Period_LT_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "lt2018-09");
         assertSearchReturnsSavedResource("Period", "lt2018-10");
         assertSearchReturnsSavedResource("Period", "lt2018-11");
     }
-
     @Test
     public void testSearchDate_Period_LT_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28");
     }
-
     @Test
     public void testSearchDate_Period_LT_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17");
-        assertSearchDoesntReturnSavedResource("Period", "lt2017-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T20");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21Z");
+        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17Z");
+        assertSearchDoesntReturnSavedResource("Period", "lt2017-10-29T22Z");
+        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T20Z");
     }
-
     @Test
     public void testSearchDate_Period_LT_Minutes() throws Exception {
-        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21:00:00");
-        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:18:01");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19Z");
+        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21:00:00Z");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:18:01Z");
     }
-
     @Test
     public void testSearchDate_Period_LT_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00.000123");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_LT_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T15-05:00");
@@ -468,50 +1008,56 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:11:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_LE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2017");
         assertSearchReturnsSavedResource("Period", "le2018");
         assertSearchReturnsSavedResource("Period", "le2019");
         assertSearchReturnsSavedResource("Period", "le2020");
     }
-
     @Test
     public void testSearchDate_Period_LE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2018-09");
         assertSearchReturnsSavedResource("Period", "le2018-10");
         assertSearchReturnsSavedResource("Period", "le2018-11");
     }
-
     @Test
     public void testSearchDate_Period_LE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-27");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28");
         assertSearchReturnsSavedResource("Period", "le2018-10-29");
         assertSearchReturnsSavedResource("Period", "le2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_LE_Hours() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "le2017-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T17");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T20");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T21");
-        assertSearchReturnsSavedResource("Period", "le2018-10-29T21");
-        assertSearchReturnsSavedResource("Period", "le2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "le2018-10-29T23");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchDoesntReturnSavedResource("Period", "le2017-10-29T22Z");
+        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T17Z");
+        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T20Z");
+        assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T21Z");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T21Z");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T23Z");
     }
-
     @Test
     public void testSearchDate_Period_LE_Minutes() throws Exception {
-        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T21:00:00");
-        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:18:01");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19Z");
+        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T21:00:00Z");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:18:01Z");
     }
-
     @Test
     public void testSearchDate_Period_LE_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00.000123");
@@ -519,9 +1065,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_LE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "le2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T15-05:00");
@@ -530,60 +1077,65 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:12:44-04:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_GE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge1901");
         assertSearchReturnsSavedResource("Period", "ge2018");
         assertSearchDoesntReturnSavedResource("Period", "ge2019");
         assertSearchDoesntReturnSavedResource("Period", "ge2020");
     }
-
     @Test
     public void testSearchDate_Period_GE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge2018-09");
         assertSearchReturnsSavedResource("Period", "ge2018-10");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-11");
-
     }
-
     @Test
     public void testSearchDate_Period_GE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge2018-10-28");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_GE_Hours() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "ge2019-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T17");
-        assertSearchReturnsSavedResource("Period", "ge2017-10-29T22");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T20");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchDoesntReturnSavedResource("Period", "ge2019-10-29T22Z");
+        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T17Z");
+        assertSearchReturnsSavedResource("Period", "ge2017-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T20Z");
     }
-
     @Test
     public void testSearchDate_Period_GE_Minutes() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:19");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:17");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:18");
-        assertSearchReturnsSavedResource("Period", "ge2017-10-29T21:12:00");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:19Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:17Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:18Z");
     }
-
     @Test
     public void testSearchDate_Period_GE_Seconds() throws Exception {
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:12:00");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00");
-        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00.000123");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:12:00Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00Z");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00.000123Z");
         assertSearchReturnsSavedResource("Period", "ge2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ge2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_GE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17-04:00");
@@ -594,58 +1146,65 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_GT_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2017");
         assertSearchReturnsSavedResource("Period", "gt2018");
         assertSearchDoesntReturnSavedResource("Period", "gt2019");
         assertSearchDoesntReturnSavedResource("Period", "gt2020");
     }
-
     @Test
     public void testSearchDate_Period_GT_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-09");
         assertSearchReturnsSavedResource("Period", "gt2018-10");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-11");
     }
-
     @Test
     public void testSearchDate_Period_GT_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-28");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_GT_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T20");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T17");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "gt2017-10-29T22");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T20Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T17Z");
+        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "gt2017-10-29T22Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21Z");
     }
-
     @Test
     public void testSearchDate_Period_GT_Minutes() throws Exception {
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:18");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13Z");
+        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:18Z");
     }
-
     @Test
     public void testSearchDate_Period_GT_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11:00");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:12:00");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00.000123");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11:00Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:12:00Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00.000123Z");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_GT_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T20-00:00");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T18-04:00");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T15-05:00");
@@ -655,60 +1214,66 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T17:12:00-03:00");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T17:18:00-05:00");
     }
-
     @Test
     public void testSearchDate_Period_SA_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2017");
         assertSearchDoesntReturnSavedResource("Period", "sa2018");
         assertSearchDoesntReturnSavedResource("Period", "sa2019");
         assertSearchDoesntReturnSavedResource("Period", "sa2020");
     }
-
     @Test
     public void testSearchDate_Period_SA_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-09");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-11");
     }
-
     @Test
     public void testSearchDate_Period_SA_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_SA_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "sa2018-10-29T17");
-        assertSearchReturnsSavedResource("Period", "sa2018-10-29T20");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30T20");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "sa2018-10-29T17Z");
+        assertSearchReturnsSavedResource("Period", "sa2018-10-29T20Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T22Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30T20Z");
     }
-
     @Test
     public void testSearchDate_Period_SA_Minutes() throws Exception {
-        assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:11");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:11Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19Z");
     }
-
     @Test
     public void testSearchDate_Period_SA_Seconds() throws Exception {
-        assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:00:00");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19:00");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:00:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19:00Z");
         assertSearchReturnsSavedResource("Period", "sa2018-10-28T20:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:12:01");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19:00");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00.000123");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:12:01Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00.000123Z");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30T00:00:00.000001Z");
-
     }
-
     @Test
     public void testSearchDate_Period_SA_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T18-02:00");
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T15-05:00");
@@ -717,105 +1282,114 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T17:12:44-04:00");
     }
-
     @Test
     public void testSearchDate_Period_EB_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018");
         assertSearchReturnsSavedResource("Period", "eb2019");
         assertSearchReturnsSavedResource("Period", "eb2020");
     }
-
     @Test
     public void testSearchDate_Period_EB_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10");
         assertSearchReturnsSavedResource("Period", "eb2018-11");
     }
-
     @Test
     public void testSearchDate_Period_EB_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29");
         assertSearchReturnsSavedResource("Period", "eb2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_EB_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "eb2018-10-29T22");
-        assertSearchReturnsSavedResource("Period", "eb2018-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17");
-        assertSearchDoesntReturnSavedResource("Period", "eb2017-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T20");
-    }
+//      EDT: [2018-10-29T17:12:00-04:00, 2018-10-29T17:18:00-04:00]
+        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17-04:00");
+        assertSearchReturnsSavedResource(     "Period", "eb2018-10-29T18-04:00");
 
+//      UTC: [2018-10-29T21:12:00Z, 2018-10-30T21:18:00-04:00]
+        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21Z");
+        assertSearchReturnsSavedResource(     "Period", "eb2018-10-29T22Z");
+    }
     @Test
     public void testSearchDate_Period_EB_Minutes() throws Exception {
-        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:00:00");
-        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:18:01");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19Z");
+        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:00:00Z");
+        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:18:01Z");
     }
-
     @Test
     public void testSearchDate_Period_EB_Seconds() throws Exception {
-        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19:00");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00.000123");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00Z");
+        assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00.000123Z");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28T23:59:59.999999Z");
-
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "eb2018-10-30T00:00:00.000001Z");
-
     }
-
     @Test
     public void testSearchDate_Period_EB_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T15-05:00");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T17:18:01-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:18:00-04:00");
-
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:12:44-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_NE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018");
         assertSearchReturnsSavedResource("Period", "ne2019");
         assertSearchReturnsSavedResource("Period", "ne2020");
     }
-
     @Test
     public void testSearchDate_Period_NE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10");
         assertSearchReturnsSavedResource("Period", "ne2018-11");
     }
-
     @Test
     public void testSearchDate_Period_NE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29");
         assertSearchReturnsSavedResource("Period", "ne2018-10-30");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28");
     }
-
     @Test
     public void testSearchDate_Period_NE_Hours() throws Exception {
-        assertSearchReturnsSavedResource("Period", "ne2018-10-29T20");
-        assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29T21");
-        assertSearchReturnsSavedResource("Period", "ne2018-10-29T22");
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        assertSearchReturnsSavedResource("Period", "ne2018-10-29T20Z");
+        assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29T21Z");
+        assertSearchReturnsSavedResource("Period", "ne2018-10-29T22Z");
     }
-
     @Test
     public void testSearchDate_Period_NE_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:12");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:12");
     }
-
     @Test
     public void testSearchDate_Period_NE_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:18:01");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:13:00");
@@ -823,9 +1397,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_NE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29T16-05:00");
@@ -835,50 +1410,56 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_AP_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018");
         assertSearchDoesntReturnSavedResource("Period", "ap2100");
         assertSearchDoesntReturnSavedResource("Period", "ap2000");
         assertSearchDoesntReturnSavedResource("Period", "ap2025");
     }
-
     @Test
     public void testSearchDate_Period_AP_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10");
         assertSearchReturnsSavedResource("Period", "ap2018-11");
         assertSearchDoesntReturnSavedResource("Period", "ap2018-01");
     }
-
     @Test
     public void testSearchDate_Period_AP_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ap2018-01-01");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29");
         assertSearchReturnsSavedResource("Period", "ap2018-10-30");
         assertSearchDoesntReturnSavedResource("Period", "ap2019-01-01");
     }
-
     @Test
     public void testSearchDate_Period_AP_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T20");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T22");
     }
-
     @Test
     public void testSearchDate_Period_AP_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:19");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:00:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:18:01");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21:00:00");
     }
-
     @Test
     public void testSearchDate_Period_AP_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:13:00");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21:13:00.000123");
@@ -886,18 +1467,17 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ap2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_AP_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:12:44-04:00");
     }
-
     @Test
     public void testSearchDate_Period_NoStart() throws Exception {
         // "Period-noStart" has end=2018-10-29T17:18:00-04:00
-
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29");
@@ -912,21 +1492,20 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29");
-
+        
         // search on the dateTime at the end of the Period-noStart
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29T17:18:00+04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:01-04:00");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28");
@@ -938,7 +1517,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28T23:59:59.999999Z");
@@ -950,7 +1529,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30");
@@ -960,7 +1539,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30T00:00:00.000001Z");
@@ -971,12 +1550,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_NoEnd() throws Exception {
         // "Period-noEnd" has start=2018-10-29T17:12:00-04:00
-        // No End -  A missing upper boundary is "greater than" any actual date. 
-
+        // No End -  A missing upper boundary is "greater than" any actual date.
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-29");
@@ -989,7 +1566,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29");
-
+        
         // search on the dateTime at the start of the Period-noEnd
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29T17:12:00-04:00");
@@ -1003,7 +1580,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29T17:12:00-04:00");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1013,7 +1590,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28T23:59:59.999999Z");
@@ -1023,7 +1600,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28T23:59:59.999999Z");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1038,7 +1615,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30");
-
+        
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-30T00:00:00.000001Z");
@@ -1053,23 +1630,25 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T00:00:00.000000Z");
     }
-
     @Test
     public void testSearchDate_Period_chained() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsComposition("subject:Basic.Period", "2018-10-29");
     }
-
     @Test
     public void testSearchDate_Period_missing() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period:missing", "false");
         assertSearchDoesntReturnSavedResource("Period:missing", "true");
-
         assertSearchReturnsSavedResource("missing-Period:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Period:missing", "false");
     }
-
     @Test
     public void testSearchDate_Period_or() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28,9999-01-01");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28,9999-01-01");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28,9999-01-01");
@@ -1080,7 +1659,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28,9999-01-01");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28,9999-01-01");
         assertSearchDoesntReturnSavedResource("Period", "ap2010-10-28,9999-01-01");
-
+        
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,2018-10-28");
         assertSearchReturnsSavedResource("Period", "9999-01-01,ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,lt2018-10-28");
@@ -1091,13 +1670,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,ap2010-10-28");
     }
-
-    // We decided that Periods with no start or end should not even be indexed 
+    // We decided that Periods with no start or end should not even be indexed
     //    @Test
     //    public void testSearchDate_Period_NoStartOrEnd() throws Exception {
     //        assertSearchReturnsSavedResource("Period-noStartOrEnd", "2018-10-29T17:12:44-04:00");
     //    }
-
     // Timing search is not working properly.
     //    @Test
     //    public void testSearchDate_Timing_EventsOnly() throws Exception {
@@ -1115,53 +1692,47 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     //    public void testSearchDate_Timing_BoundPeriod() throws Exception {
     //        testSearchDateReturnsResourceWithExtension("Timing-boundPeriod", "2018-10-29T17:18:00-04:00", "http://example.org/TimingBoundsPeriod");
     //    }
-
     /*
      * Currently, documented in our conformance statement. We do not support
      * modifiers on chained parameters.
      * https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
      */
-
     //    @Test
     //    public void testSearchDate_instant_chained_missing() throws Exception {
     //        assertSearchReturnsSavedResource("subject:Basic.instant:missing", "false");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.instant:missing", "true");
-    //        
+    //
     //        assertSearchReturnsSavedResource("subject:Basic.missing-instant:missing", "true");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-instant:missing", "false");
     //    }
-
     //  @Test
     //  public void testSearchDate_Period_chained_missing() throws Exception {
     //      assertSearchReturnsComposition("subject:Basic.Period:missing", "false");
     //      assertSearchDoesntReturnComposition("subject:Basic.Period:missing", "true");
-    //      
+    //
     //      assertSearchReturnsComposition("subject:Basic.missing-Period:missing", "true");
     //      assertSearchDoesntReturnComposition("subject:Basic.missing-Period:missing", "false");
     //  }
-
     /*
      * Currently, documented in our conformance statement. We do not support
      * modifiers on chained parameters.
      * https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
      */
-
     //    @Test
     //    public void testSearchDate_date_chained_missing() throws Exception {
     //        assertSearchReturnsComposition("subject:Basic.date:missing", "false");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.date:missing", "true");
-    //        
+    //
     //        assertSearchReturnsComposition("subject:Basic.missing-date:missing", "true");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-date:missing", "false");
     //    }
-
     //    @Test
     //    public void testSearchDate_dateTime_chained_missing() throws Exception {
     //        assertSearchReturnsComposition("subject:Basic.dateTime:missing", "false");
     //        assertSearchDoesntReturnComposition("subject:Basic.dateTime:missing", "true");
-    //        
+    //
     //        assertSearchReturnsComposition("subject:Basic.missing-dateTime:missing", "true");
     //        assertSearchDoesntReturnComposition("subject:Basic.missing-dateTime:missing", "false");
     //    }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -70,7 +70,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -266,6 +266,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_instant() throws Exception {
+        // instant is 2018-10-29T17:12:44-04:00
         assertSearchReturnsSavedResource("instant", "2018-10-29T17:12:44-04:00");
     }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -50,11 +50,16 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_date() throws Exception {
+//        assertSearchReturnsSavedResource("date", "2018-10-29+04:00");
+        
+        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
+        
         // "date" is 2018-10-29
         assertSearchReturnsSavedResource("date", "2018-10-29");
+        assertSearchReturnsSavedResource("date", "lt2018-10-29");
+        assertSearchReturnsSavedResource("date", "gt2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29");
+        
         assertSearchReturnsSavedResource("date", "le2018-10-29");
         assertSearchReturnsSavedResource("date", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
@@ -67,15 +72,12 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // Not equals is the inverse of the previous. 
         assertSearchReturnsSavedResource("date", "ne2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
-        // Date is actually 2018-10-29, so this would not be true, a second test is added to show a true.
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "gt2018-10-28T17:12:00-04:00");
+        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-        // Date is actually 2018-10-29, so this would not be true, a second test is added to show a true. 
-        assertSearchDoesntReturnSavedResource("date", "ge2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "ge2018-10-28T17:12:00-04:00");
+        
+        assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "eb2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "ap2018-10-29T17:12:00-04:00");
 
         assertSearchDoesntReturnSavedResource("date", "2018-10-28");
@@ -268,6 +270,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     public void testSearchDate_instant() throws Exception {
         // instant is 2018-10-29T17:12:44-04:00
         assertSearchReturnsSavedResource("instant", "2018-10-29T17:12:44-04:00");
+        assertSearchReturnsSavedResource("instant", "2018-10-30T01:12:44+04:00");
+        assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44+00:00");
+        assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44-00:00");
+        assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44Z");
     }
 
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -50,16 +50,12 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_date() throws Exception {
-//        assertSearchReturnsSavedResource("date", "2018-10-29+04:00");
-        
-        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
-        
         // "date" is 2018-10-29
         assertSearchReturnsSavedResource("date", "2018-10-29");
         assertSearchReturnsSavedResource("date", "lt2018-10-29");
         assertSearchReturnsSavedResource("date", "gt2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
-        
+
         assertSearchReturnsSavedResource("date", "le2018-10-29");
         assertSearchReturnsSavedResource("date", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
@@ -74,7 +70,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-        
+        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
@@ -113,6 +109,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // The test is checking against ... valueDate": "2018-10-29"
         // As this test is using an implied range with SECONDS, it's the proper behavior. 
         assertSearchDoesntReturnSavedResource("date", "2018-10-29T21:12:00");
+    }
+    
+    @Test
+    public void testSearchDateExactPrecision() throws Exception {
+        // "date" is 2018-10-29
         assertSearchReturnsSavedResource("date", "2018-10-29T00:00:00.000000Z");
     }
 
@@ -149,9 +150,9 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("date", "2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "9999-01-01,2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29,9999-01-01");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29,9999-01-01");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28,9999-01-01");
 
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29,9999-01-01");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30,9999-01-01");
         assertSearchReturnsSavedResource("date", "le2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "ge2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29,9999-01-01");
@@ -159,8 +160,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,lt2018-10-28");
         assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "9999-01-01,lt2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "9999-01-01,gt2018-10-29");
+        assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "9999-01-01,lt2018-10-28");
+        assertSearchReturnsSavedResource("date", "9999-01-01,gt2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "9999-01-01,gt2018-10-30");
 
         assertSearchReturnsSavedResource("date", "9999-01-01,le2018-10-29");
         assertSearchReturnsSavedResource("date", "9999-01-01,ge2018-10-29");
@@ -190,18 +193,18 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // "dateTime" is 2018-10-29T17:12:00-04:00
         assertSearchReturnsSavedResource("dateTime", "2018-10-29");
         assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-29");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-29");
+        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29");
+        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29");
         assertSearchReturnsSavedResource("dateTime", "le2018-10-29");
         assertSearchReturnsSavedResource("dateTime", "ge2018-10-29");
         assertSearchReturnsSavedResource("dateTime", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-29");
         assertSearchReturnsSavedResource("dateTime", "ap2018-10-29");
 
-        assertSearchReturnsSavedResource("dateTime", "2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("dateTime", "2018-10-29T17:12:00.000000-04:00");
+        assertSearchReturnsSavedResource("dateTime", "ne2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("dateTime", "le2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("dateTime", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-29T17:12:00-04:00");
@@ -251,7 +254,9 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_dateTime_chained() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29T17:12:00-04:00");
+        // dateTime is 2018-10-29T17:12:00-04:00
+        // Add precision, otherwise a range .000000 
+        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29T17:12:00.000000-04:00");
         assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29");
 
         assertSearchDoesntReturnSavedResource("subject:Basic.dateTime", "2025-10-29");
@@ -313,7 +318,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_instant_chained() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.instant", "2018-10-29T17:12:44-04:00");
+        // Instant - 2018-10-29T17:12:44-04:00
+        assertSearchReturnsComposition("subject:Basic.instant", "2018-10-29T17:12:44.000000-04:00");
     }
 
     @Test
@@ -406,20 +412,22 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_Period_LT_Year() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "lt2018");
+        assertSearchDoesntReturnSavedResource("Period", "lt2017");
+        assertSearchReturnsSavedResource("Period", "lt2018");
         assertSearchReturnsSavedResource("Period", "lt2019");
         assertSearchReturnsSavedResource("Period", "lt2020");
     }
 
     @Test
     public void testSearchDate_Period_LT_Month() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10");
+        assertSearchDoesntReturnSavedResource("Period", "lt2018-09");
+        assertSearchReturnsSavedResource("Period", "lt2018-10");
         assertSearchReturnsSavedResource("Period", "lt2018-11");
     }
 
     @Test
     public void testSearchDate_Period_LT_Day() throws Exception {
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28");
     }
@@ -428,7 +436,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     public void testSearchDate_Period_LT_Hours() throws Exception {
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17");
         assertSearchDoesntReturnSavedResource("Period", "lt2017-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T20");
@@ -444,8 +452,8 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_Period_LT_Seconds() throws Exception {
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19:00");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21:13:00.000123");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00.000123");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30T00:00:00.000001Z");
     }
@@ -455,9 +463,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T15-05:00");
+
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:18:01-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:11:00-04:00");
     }
 
     @Test
@@ -504,10 +514,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_Period_LE_Seconds() throws Exception {
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19:00");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T21:13:00.000123");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00.000123");
         assertSearchReturnsSavedResource("Period", "le2018-10-30T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
     }
 
@@ -518,7 +528,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T15-05:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:18:01-04:00");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T17:00:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T17:12:44-04:00");
+        assertSearchReturnsSavedResource("Period", "le2018-10-29T17:12:44-04:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:18:00-04:00");
     }
 
@@ -558,16 +568,16 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_Period_GE_Minutes() throws Exception {
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:19");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:17");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:18");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:17");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:18");
         assertSearchReturnsSavedResource("Period", "ge2017-10-29T21:12:00");
     }
 
     @Test
     public void testSearchDate_Period_GE_Seconds() throws Exception {
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:12:00");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:13:00.000123");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00.000123");
         assertSearchReturnsSavedResource("Period", "ge2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ge2018-10-28T23:59:59.999999Z");
@@ -577,21 +587,19 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     public void testSearchDate_Period_GE_ZonedDateTime() throws Exception {
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21-00:00");
-
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T15-05:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:11:01-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:00:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T18:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T17:12:44-04:00");
-        assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:18:00-04:00");
     }
 
     @Test
     public void testSearchDate_Period_GT_Year() throws Exception {
         assertSearchReturnsSavedResource("Period", "gt2017");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018");
+        assertSearchReturnsSavedResource("Period", "gt2018");
         assertSearchDoesntReturnSavedResource("Period", "gt2019");
         assertSearchDoesntReturnSavedResource("Period", "gt2020");
     }
@@ -599,15 +607,14 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_Period_GT_Month() throws Exception {
         assertSearchReturnsSavedResource("Period", "gt2018-09");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10");
+        assertSearchReturnsSavedResource("Period", "gt2018-10");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-11");
     }
 
     @Test
     public void testSearchDate_Period_GT_Day() throws Exception {
         assertSearchReturnsSavedResource("Period", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30");
     }
 
@@ -617,25 +624,24 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T17");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "gt2017-10-29T22");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21");
     }
 
     @Test
     public void testSearchDate_Period_GT_Minutes() throws Exception {
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:12");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:13");
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:00");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13");
+        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:18");
     }
 
     @Test
     public void testSearchDate_Period_GT_Seconds() throws Exception {
-        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11:00");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:12:00");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:13:00");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:13:00.000123");
-        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "gt2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11:00");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:12:00");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00");
+        assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13:00.000123");
+        assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30T00:00:00.000001Z");
     }
 
@@ -897,10 +903,13 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "lt2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29");
+        assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29");
+        assertSearchReturnsSavedResource("Period-noStart", "gt2018-10-29");
+        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-30");
+
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-29");
+        assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29");
+        assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29");
@@ -909,36 +918,36 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29T17:18:00+04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "lt2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:01-04:00");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "lt2018-10-28");
+        assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "le2018-10-28");
+        assertSearchReturnsSavedResource("Period-noStart", "gt2018-10-28");
+        assertSearchReturnsSavedResource("Period-noStart", "le2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-28");
+        assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "lt2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "le2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "gt2018-10-28T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "le2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
@@ -972,9 +981,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29");
+        assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-29");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-29");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-28");
+        assertSearchReturnsSavedResource("Period-noEnd", "le2018-10-29");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29");
@@ -984,9 +995,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29T17:11:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-29T17:11:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-29T17:11:00-04:00");
+        assertSearchReturnsSavedResource("Period-noEnd", "le2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29T17:12:00-04:00");
@@ -1014,31 +1027,31 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "gt2018-10-30");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
+        assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-29");
+        assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-30");
+        assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "gt2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ge2018-10-30");
-        assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29");
+        assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-29");
+        assertSearchReturnsSavedResource("Period-noEnd", "le2018-10-30");
+        assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30");
+        assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "gt2018-10-30T00:00:00.000000Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "gt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "le2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-30T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-29T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-30T00:00:00.000000Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "gt2018-10-30T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "le2018-10-30T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30T00:00:00.000001Z");
-
-        // FINE: dateValue: Period-noEnd[12], value: [null], period: [2018-10-29 21:12:00.0, 9999-12-31 05:00:00.0]
-        // "2018-10-29T17:12:00-04:00"
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T00:00:00.000000Z");
     }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -19,6 +19,7 @@ import java.util.logging.LogManager;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
@@ -102,7 +103,7 @@ public abstract class AbstractPersistenceTest {
         }
     }
     
-    @AfterClass(alwaysRun = true)
+    @AfterSuite(alwaysRun = true)
     public void tearDown() throws Exception {
         shutdownDatabase();
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.LogManager;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.LogManager;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -55,6 +56,9 @@ public abstract class AbstractPersistenceTest {
 
     // A hook for subclasses to override and provide specific test database setup functionality if required.
     protected void bootstrapDatabase() throws Exception {}
+    
+    // A hook for subclasses to override and provide specific test database shutdown functionality if required.
+    protected void shutdownDatabase() throws Exception {}
 
     // The following persistence context-related methods can be overridden in subclasses to
     // provide a more specific instance of the FHIRPersistenceContext if necessary.
@@ -96,6 +100,11 @@ public abstract class AbstractPersistenceTest {
         if (persistence != null && persistence.isTransactional()) {
             persistence.getTransaction().commit();
         }
+    }
+    
+    @AfterClass(alwaysRun = true)
+    public void tearDown() throws Exception {
+        shutdownDatabase();
     }
 
     protected List<Resource> runQueryTest(Class<? extends Resource> resourceType, String parmName, String parmValue) throws Exception {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
@@ -13,7 +13,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.YearMonth;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -91,7 +90,7 @@ public class DateTimeHandler {
     // @formatter:on
 
     public static Timestamp generateTimestamp(Instant inst) {
-        return Timestamp.from(ZonedDateTime.ofInstant(inst, ZoneId.of("UTC")).toInstant());
+        return Timestamp.from(inst);
     }
 
     /**
@@ -253,11 +252,11 @@ public class DateTimeHandler {
             } else if (precision == 3) {
                 // HH:MM:SS - Third Colon
                 // 2019-12-11T00:00:00+05:00
-                zdt = zdt.truncatedTo(ChronoUnit.SECONDS).plus(1, ChronoUnit.SECONDS).minus(TICK, ChronoUnit.NANOS);
+                zdt = zdt.plus(1, ChronoUnit.SECONDS).minus(TICK, ChronoUnit.NANOS);
             } else if (precision == 4) {
                 // Nanoseconds
                 // 2019-12-11T00:00:00.000000+05:00
-                zdt = zdt.truncatedTo(ChronoUnit.MILLIS).plus(1, ChronoUnit.MILLIS).minus(TICK, ChronoUnit.NANOS);
+                logger.fine("Falling through as this is a nanoseconds value");
             }
 
             // ELSE -> HH:MM:SS.XXXXX - treat precise.

--- a/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
@@ -17,6 +17,7 @@ import java.time.temporal.TemporalAccessor;
 
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 
@@ -433,6 +434,13 @@ public class DateTimeHandlerTest {
         Instant upperBound = DateTimeHandler.generateUpperBound(null, value, v);
         assertEquals(lowerBound.toString(), "2019-10-11T11:00:00Z");
         assertEquals(upperBound.toString(), "2019-10-11T11:00:00.999999Z");
+    }
+
+    @Test
+    public void testToStringWithNullPrefixYearMonthDayHoursMinutesSeconds() throws FHIRSearchException {
+        DateTime dt = DateTime.of("2019-10-11T11:00:00Z");
+        assertEquals("2019-10-11T11:00:00Z", DateTime.PARSER_FORMATTER.format(dt.getValue()));
+        assertEquals("2019-10-11T11:00Z", dt.getValue().toString());
     }
 
     @Test


### PR DESCRIPTION
also added `shutdownDatabase` placeholder in AbstractPersistenceTest

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>