### PR TITLE
issue #528 - update Conformance.md and tweak datetime precision

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -127,7 +127,7 @@ If not specified on a query string, the default prefix is `eq`.
 The IBM FHIR Server adheres to the specification with two minor exceptions:
 * The server supports search query values with fractional seconds; any search query value given with fractional seconds is treated as precise value, whereas search query values without fractional seconds are handled as an implicit range (e.g. `2000-04-30T23:59:00` becomes the range `[2000-04-30T23:59:00, 2000-04-30T23:59:01)`).
 * Dates and DateTimes (and query parameter values for date search parameters) which are expressed without timezones are handled as UTC values.
-  * This differs slightly from the specification which indicates that "Where both search parameters and resource element date times do not have time zones, the servers local time zone should be assumed". However, because both the element values AND search query parameters are handled in the same way, this difference will only matter when timezones are specified on one side (resource element or search query parameter) but not the other. For example, a query like `Patient?birthdate=2019-01-01` would match a resource with a value of `2019-01-01`, but would *not* match a resource with a value of `2019-01-01T20:00:00-04:00`.
+  * This differs slightly from the specification which indicates that "Where both search parameters and resource element date times do not have time zones, the servers local time zone should be assumed". However, because both the element values AND search query parameters are handled in the same way, this difference matters only when timezones are specified on one side (resource element or search query parameter) but not the other. For example, a query like `Patient?birthdate=2019-01-01` would match a resource with a value of `2019-01-01`, but would *not* match a resource with a value of `2019-01-01T20:00:00-04:00`.
 
 All search parameter values are stored in the database in UTC time in order to improve data portability.
 
@@ -138,7 +138,7 @@ Query parameter values without fractional seconds will be handled as an implicit
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.999999Z
 
-Query parameter values with fractional seconds will be handled with exact match semantics (ignoring precision). For example, a search like `Patient?birthdate=2019-01-01T12:00:00.1Z` would include resources with the following effectiveDateTime values:
+Query parameter values with fractional seconds is handled with exact match semantics (ignoring precision). For example, a search like `Patient?birthdate=2019-01-01T12:00:00.1Z` would include resources with the following effectiveDateTime values:
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.100Z
 * 2019-01-01T12:00:00.100000Z

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -124,16 +124,21 @@ The `eb` and `ap` prefixes are not supported for searches which target values of
 If not specified on a query string, the default prefix is `eq`.
 
 ### Searching on Date
-The FHIR server adheres to the specification except in cases where a time is included in the search query value. When a time is specified, the implementation requires an hour, minute, second, and timezone value. Including these values is consistent with the way in which `instant` and `dateTime` data types are defined at https://www.hl7.org/fhir/R4/datatypes.html#primitive. However, the implementation differs from the description at https://www.hl7.org/fhir/R4/search.html#date, which allows clients to include hours and minutes, but to omit values for seconds and time zone.
+The IBM FHIR Server adheres to the specification with two minor exceptions:
+* The server supports search query values with fractional seconds; any search query value given with fractional seconds is treated as precise value, whereas search query values without fractional seconds are handled as an implicit range (e.g. `2000-04-30T23:59:00` becomes the range `[2000-04-30T23:59:00, 2000-04-30T23:59:01)`).
+* Dates and DateTimes (and query parameter values for date search parameters) which are expressed without timezones are handled as UTC values.
+  * This differs slightly from the specification which indicates that "Where both search parameters and resource element date times do not have time zones, the servers local time zone should be assumed". However, because both the element values AND search query parameters are handled in the same way, this difference will only matter when timezones are specified on one side (resource element or search query parameter) but not the other. For example, a query like `Patient?birthdate=2019-01-01` would match a resource with a value of `2019-01-01`, but would *not* match a resource with a value of `2019-01-01T20:00:00-04:00`.
 
-The IBM FHIR Server stores up to 6 fractional seconds (microsecond granularity) for Instant and DateTime values (when present) and allows clients to search with these as well.
+All search parameter values are stored in the database in UTC time in order to improve data portability.
+
+The IBM FHIR Server stores up to 6 fractional seconds (microsecond granularity) for Instant and DateTime values.
 
 Query parameter values without fractional seconds will be handled as an implicit range. For example, a search like `Patient?date=2019-01-01T12:00:00Z` would include resources with the following effectiveDateTime values:
 * 2019-01-01T12:00:00Z
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.999999Z
 
-Query parameter values with fractional seconds will be handled with exact match semantics (ignoring precision). For example, a search like `Patient?date=2019-01-01T12:00:00.100Z` would include resources with the following effectiveDateTime values:
+Query parameter values with fractional seconds will be handled with exact match semantics (ignoring precision). For example, a search like `Patient?birthdate=2019-01-01T12:00:00.1Z` would include resources with the following effectiveDateTime values:
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.100Z
 * 2019-01-01T12:00:00.100000Z

--- a/fhir-examples/src/main/resources/json/ibm/basic/BasicDate.json
+++ b/fhir-examples/src/main/resources/json/ibm/basic/BasicDate.json
@@ -14,7 +14,7 @@
     },
     {
       "url": "http://example.org/dateTime",
-      "valueDateTime": "2018-10-29T17:12:00-04:00"
+      "valueDateTime": "2019-12-31T20:00:00-04:00"
     },
     {
       "url": "http://example.org/time",

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -652,7 +652,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             java.time.Instant inst = DateTimeHandler.generateValue(date.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
-            inst = DateTimeHandler.generateUpperBound(date.getValue());
+            inst = DateTimeHandler.generateUpperBound(date);
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }
@@ -671,7 +671,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             java.time.Instant inst = DateTimeHandler.generateValue(dateTime.getValue());
             p.setValueDate(DateTimeHandler.generateTimestamp(inst));
             p.setValueDateStart(DateTimeHandler.generateTimestamp(inst));
-            inst = DateTimeHandler.generateUpperBound(dateTime.getValue());
+            inst = DateTimeHandler.generateUpperBound(dateTime);
             p.setValueDateEnd(DateTimeHandler.generateTimestamp(inst));
         }
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
     @AfterClass
     public void removeSavedResourcesAndResetTenant() throws Exception {
         if (savedResource != null && persistence.isDeleteSupported()) {
-            persistence.delete(getDefaultPersistenceContext(), Basic.class, savedResource.getId());
+//            persistence.delete(getDefaultPersistenceContext(), Basic.class, savedResource.getId());
             if (persistence.isTransactional()) {
                 persistence.getTransaction().commit();
             }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
     @AfterClass
     public void removeSavedResourcesAndResetTenant() throws Exception {
         if (savedResource != null && persistence.isDeleteSupported()) {
-//            persistence.delete(getDefaultPersistenceContext(), Basic.class, savedResource.getId());
+            persistence.delete(getDefaultPersistenceContext(), Basic.class, savedResource.getId());
             if (persistence.isTransactional()) {
                 persistence.getTransaction().commit();
             }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -20,111 +20,520 @@ import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.test.TestUtil;
 
 /**
- * <a href="https://hl7.org/fhir/search.html#date>FHIR Specification: Search
+ * <a href="https://hl7.org/fhir/search.html#date">FHIR Specification: Search
  * - Date</a> Tests
  */
 public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
-
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
     }
-
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("date");
     }
-
-    @Test
-    public void testSearchDate_date_UTC() throws Exception {
-        // "date" is 2018-10-29
-        // The following tests use 2018-10-28
-        assertSearchDoesntReturnSavedResource("date", "2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ne2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ge2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "sa2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("date", "ap2018-10-28T23:59:59.999999Z");
-    }
-
-    @Test
-    public void testSearchDate_date() throws Exception {
-        // "date" is 2018-10-29
-        assertSearchReturnsSavedResource("date", "2018-10-29");
-        assertSearchReturnsSavedResource("date", "lt2018-10-29");
-        assertSearchReturnsSavedResource("date", "gt2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
-
-        assertSearchReturnsSavedResource("date", "le2018-10-29");
-        assertSearchReturnsSavedResource("date", "ge2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29");
-        assertSearchReturnsSavedResource("date", "ap2018-10-29");
-
-        // Specificity, says the EQ range does not overlap. 
-        assertSearchDoesntReturnSavedResource("date", "2018-10-29T17:12:00-04:00");
-
-        // Not equals is the inverse of the previous. 
-        assertSearchReturnsSavedResource("date", "ne2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "lt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "gt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "le2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "ge2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("date", "ap2018-10-29T17:12:00-04:00");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-28");
-        assertSearchReturnsSavedResource("date", "ne2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28");
-        assertSearchReturnsSavedResource("date", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
-        assertSearchReturnsSavedResource("date", "ge2018-10-28");
-        assertSearchReturnsSavedResource("date", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28");
-        assertSearchReturnsSavedResource("date", "ap2018-10-28");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-30");
-        assertSearchReturnsSavedResource("date", "ne2018-10-30");
-        assertSearchReturnsSavedResource("date", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30");
-        assertSearchReturnsSavedResource("date", "le2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30");
-        assertSearchReturnsSavedResource("date", "eb2018-10-30");
-        assertSearchReturnsSavedResource("date", "ap2018-10-30");
-
-        assertSearchDoesntReturnSavedResource("date", "2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "ne2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "lt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "le2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("date", "ap2018-10-30T00:00:00.000001Z");
-
-        // The test is checking against ... valueDate": "2018-10-29"
-        // As this test is using an implied range with SECONDS, it's the proper behavior. 
-        assertSearchDoesntReturnSavedResource("date", "2018-10-29T21:12:00");
-    }
     
     @Test
-    public void testSearchDateExactPrecision() throws Exception {
+    public void testSearchDate_date_Day_noTZ() throws Exception {
         // "date" is 2018-10-29
-        assertSearchReturnsSavedResource("date", "2018-10-29T00:00:00.000000Z");
-    }
+        
+        // the day before
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28");
 
+        // the exact day
+        assertSearchReturnsSavedResource(     "date",   "2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "ne2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29");
+
+        // the day after
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_noTZ() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59");
+        
+        // the first second of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+//        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00");
+        // This one returns the resource because we consider this a range from 00:00:00 to 00:00:01 and the ranges overlap
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59");
+        // This one returns the resource because there are fractions of a second between 23:59:59 and 23:59:59.999999
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_EDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59-04:00");
+//        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59-04:00");
+        
+        // the first second of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00-04:00");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00-04:00");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59-04:00");
+//        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59-04:00");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00-04:00");
+    }
+    @Test
+    public void testSearchDate_date_Seconds_UTC() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last second before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59Z");
+        
+        // the first second of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00Z");
+        // This one returns the resource because we consider this a range from 00:00:00 to 00:00:01 and the ranges overlap
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00Z");
+        
+        // a second in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00Z");
+        
+        // the last second of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59Z");
+        // This one returns the resource because there are fractions of a second between 23:59:59 and 23:59:59.999999
+        assertSearchReturnsSavedResource("date", "gt2018-10-29T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59Z");
+        
+        // the first second after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00Z");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_noTZ() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999");
+        
+        // the first instant of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+//        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_EDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999-04:00");
+//        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999-04:00");
+        
+        // the first instant of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0-04:00");
+//        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0-04:00");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0-04:00");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999-04:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999-04:00");
+//        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999-04:00");
+//        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999-04:00");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0-04:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0-04:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0-04:00");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_IDT() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999+03:00");
+        
+        // the first instant of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0+03:00");
+//        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0+03:00");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0+03:00");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999+03:00");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999+03:00");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999+03:00");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0+03:00");
+//        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0+03:00");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0+03:00");
+//        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0+03:00");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0+03:00");
+    }
+    @Test
+    public void testSearchDate_date_Fractions_UTC() throws Exception {
+        // "date" is 2018-10-29
+        
+        // the last instant before 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-28T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "le2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999Z");
+        
+        // the first instant of the day
+        // This one shouldn't return the resource because the search range does not include the entire target range.
+//        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "lt2018-10-29T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0Z");
+        
+        // an instant in the middle of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "gt2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T17:12:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0Z");
+        
+        // the last instant of the day
+        // This one doesn't return the resource because the search range does not include the entire target range.
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999Z");
+        // This one is the exact inverse of the previous.
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-29T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-29T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-29T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-29T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ge2018-10-29T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999Z");
+        
+        // the first instant after 2018-10-29
+        assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "lt2018-10-30T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "gt2018-10-30T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "le2018-10-30T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "ge2018-10-30T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "eb2018-10-30T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "date", "ap2018-10-30T00:00:00.0Z");
+    }
     @Test
     public void testSearchDate_date_missing() throws Exception {
         assertSearchReturnsSavedResource("date:missing", "false");
         assertSearchDoesntReturnSavedResource("date:missing", "true");
-
         assertSearchReturnsSavedResource("missing-date:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-date:missing", "false");
     }
-
     @Test
     public void testSearchDate_date_chained() throws Exception {
         // Date is specific - 2018-10-29
@@ -133,7 +542,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnComposition("subject:Basic.date", "2018-10-29T17:12:00");
         assertSearchDoesntReturnComposition("subject:Basic.date", "2025-10-29");
     }
-
     @Test
     public void testSearchDate_date_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -142,7 +550,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-
     @Test
     public void testSearchDate_date_or() throws Exception {
         // Date is 2018-10-29
@@ -156,7 +563,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("date", "ge2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29,9999-01-01");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29,9999-01-01");
-
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,lt2018-10-28");
         assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-30");
         assertSearchReturnsSavedResource("date", "9999-01-01,lt2018-10-29");
@@ -166,110 +572,224 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
         assertSearchReturnsSavedResource("date", "9999-01-01,le2018-10-29");
         assertSearchReturnsSavedResource("date", "9999-01-01,ge2018-10-29");
-
         assertSearchReturnsSavedResource("date", "9999-01-01,sa2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,sa2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,eb2018-10-29");
     }
-
     @Test
     public void testSearchDate_date_or_NE() throws Exception {
         // "date" is 2018-10-29
         assertSearchReturnsSavedResource("date", "9999-10-29,ne2018-10-28");
         assertSearchDoesntReturnSavedResource("date", "9999-01-01,ne2018-10-29");
         assertSearchDoesntReturnSavedResource("date", "ne2018-10-29,ne2018-10-29");
-
     }
-
     @Test
     public void testSearchDate_date_or_AP() throws Exception {
         assertSearchReturnsSavedResource("date", "ap2018-10-29,9999-01-01");
         assertSearchReturnsSavedResource("date", "9999-01-01,ap2018-10-29");
     }
-
     @Test
-    public void testSearchDate_dateTime() throws Exception {
-        // "dateTime" is 2018-10-29T17:12:00-04:00
-        assertSearchReturnsSavedResource("dateTime", "2018-10-29");
-        assertSearchDoesntReturnSavedResource("dateTime", "ne2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-29");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-29");
-
-        assertSearchReturnsSavedResource("dateTime", "2018-10-29T17:12:00.000000-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-29T17:12:00-04:00");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-29T17:12:00-04:00");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "le2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-28");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-28");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "lt2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "gt2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "le2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ge2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "sa2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-28T23:59:59.999999Z");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "ge2018-10-30");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "eb2018-10-30");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-30");
-
-        assertSearchDoesntReturnSavedResource("dateTime", "2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "ne2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "lt2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "gt2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "le2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "ge2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("dateTime", "sa2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchReturnsSavedResource("dateTime", "ap2018-10-30T00:00:00.000001Z");
+    public void testSearchDate_dateTime_Day_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        
+        // the day before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-30");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-30");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-30");
+//        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-30");
+        
+        // the day of
+//        assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
+//        assertSearchDoesntReturnSavedResource("dateTime", "ne2019-12-31");
+//        assertSearchReturnsSavedResource(     "dateTime", "lt2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31");
+//        assertSearchReturnsSavedResource(     "dateTime", "le2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31");
+        
+        // the day after
+//        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01");
+//        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01");
+//        assertSearchDoesntReturnSavedResource("dateTime", "gt2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01");
+//        assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
+//        assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
+    @Test
+    public void testSearchDate_dateTime_Seconds_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
 
+        // the second before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59");
+        
+        // the exact second
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00");
+        
+        // the next second
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "gt2020-01-01T00:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01T00:00:01");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01T00:00:01");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:01");
+    }
+    @Test
+    public void testSearchDate_dateTime_Seconds_UTC() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
+        
+        // the second before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59Z");
+        
+        // the exact second
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00Z");
+        
+        // the next second
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "gt2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01T00:00:01Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01T00:00:01Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:01Z");
+    }
+    @Test
+    public void testSearchDate_dateTime_Fractions_noTZ() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+
+        // the instant before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59.999999");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59.999999");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59.999999");
+        
+        // the exact instant
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00.0");
+//        assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2020-01-01T00:00:00.0");
+        // This one returns the resource because 20:00:00-04:00 is saved as a range [00:00:00,00:00:01)
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.0");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.0");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.0");
+        
+        // the next instant
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.000001");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.000001");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.000001");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.000001");
+    }
+    @Test
+    public void testSearchDate_dateTime_Fractions_UTC() throws Exception {
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+
+        // the instant before
+        assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "le2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59.999999Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59.999999Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59.999999Z");
+        
+        // the exact instant
+        assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00.0Z");
+//        assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "lt2020-01-01T00:00:00.0Z");
+        // This one returns the resource because 20:00:00-04:00 is saved as a range [00:00:00,00:00:01)
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.0Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.0Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.0Z");
+        
+        // the next instant
+        assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "gt2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "le2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ge2020-01-01T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.000001Z");
+        assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.000001Z");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.000001Z");
+    }
     @Test
     public void testSearchDate_dateTime_chained() throws Exception {
-        // dateTime is 2018-10-29T17:12:00-04:00
-        // Add precision, otherwise a range .000000 
-        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29T17:12:00.000000-04:00");
-        assertSearchReturnsComposition("subject:Basic.dateTime", "2018-10-29");
-
+        // "dateTime" is 2019-12-31T20:00:00-04:00
+        
+        assertSearchReturnsComposition("subject:Basic.dateTime", "2019-12-31T20:00:00-04:00");
         assertSearchDoesntReturnSavedResource("subject:Basic.dateTime", "2025-10-29");
     }
-
     @Test
     public void testSearchDate_dateTime_missing() throws Exception {
         assertSearchReturnsSavedResource("dateTime:missing", "false");
         assertSearchDoesntReturnSavedResource("dateTime:missing", "true");
-
         assertSearchReturnsSavedResource("missing-dateTime:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-dateTime:missing", "false");
     }
-
     @Test
     public void testSearchDate_instant() throws Exception {
         // instant is 2018-10-29T17:12:44-04:00
@@ -279,32 +799,24 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44-00:00");
         assertSearchReturnsSavedResource("instant", "2018-10-29T21:12:44Z");
     }
-
     @Test
     public void testSearchDate_instant_precise() throws Exception {
         // Searching by second should include all instants within that second (regardless of sub-seconds)
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:02Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0001-01-01T01:01:01.1Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0001-01-01T01:01:01.12Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0002-02-02T02:02:02.12Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0002-02-02T02:02:02.123Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0003-03-03T03:03:03.123Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0003-03-03T03:03:03.1234Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0004-04-04T04:04:04.1234Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0004-04-04T04:04:04.12345Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchDoesntReturnSavedResource("instant-precise", "0005-05-05T05:05:05.123456Z");
-
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06Z");
         assertSearchReturnsSavedResource("instant-precise", "0006-06-06T06:06:06.123456Z");
     }
-
     @Test
     public void testSearchDate_dateTime_precise() throws Exception {
         assertSearchReturnsSavedResource("dateTime-precise", "0001-01-01T01:01:01.1Z");
@@ -314,26 +826,21 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("dateTime-precise", "0005-05-05T05:05:05.12345Z");
         assertSearchReturnsSavedResource("dateTime-precise", "0006-06-06T06:06:06.123456Z");
     }
-
     @Test
     public void testSearchDate_instant_chained() throws Exception {
         // Instant - 2018-10-29T17:12:44-04:00
         assertSearchReturnsComposition("subject:Basic.instant", "2018-10-29T17:12:44.000000-04:00");
     }
-
     @Test
     public void testSearchDate_instant_missing() throws Exception {
         assertSearchReturnsSavedResource("instant:missing", "false");
         assertSearchDoesntReturnSavedResource("instant:missing", "true");
-
         assertSearchReturnsSavedResource("missing-instant:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-instant:missing", "false");
     }
-
     ///////////////
     // Period tests
     ///////////////
-
     /*
      * <pre>
      * "url": "http://example.org/Period",
@@ -345,94 +852,102 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
      * 2018-10-29T21:18:00
      * </pre>
      */
-
     @Test
     public void testSearchDate_Period_EQ_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018");
         assertSearchDoesntReturnSavedResource("Period", "2017");
         assertSearchDoesntReturnSavedResource("Period", "2019");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10");
         assertSearchDoesntReturnSavedResource("Period", "2018-09");
         assertSearchDoesntReturnSavedResource("Period", "2018-11");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10-29T21");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T11");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T20");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Minutes() throws Exception {
-        // The Search Value of the implied range DOES NOT contain the start/end fully. 
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
+        // The Search Value of the implied range DOES NOT contain the start/end fully.
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13");
     }
-
     @Test
     public void testSearchDate_Period_EQ_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         // The Search Value of the implied range DOES NOT contain the start/end fully.
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T21:13:00.000123");
     }
-
     @Test
     public void testSearchDate_Period_EQ_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "2018-10-29T17-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17-05:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:12:44-04:00");
-
         assertSearchReturnsSavedResource("Period", "eq2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "eq2018-10-29T17-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17-05:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eq2018-10-29T17:12:44-04:00");
-
         assertSearchDoesntReturnSavedResource("Period", "2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28T23:59:59.999999Z");
-
     }
-
     @Test
     public void testSearchDate_Period_LT_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "lt2017");
         assertSearchReturnsSavedResource("Period", "lt2018");
         assertSearchReturnsSavedResource("Period", "lt2019");
         assertSearchReturnsSavedResource("Period", "lt2020");
     }
-
     @Test
     public void testSearchDate_Period_LT_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "lt2018-09");
         assertSearchReturnsSavedResource("Period", "lt2018-10");
         assertSearchReturnsSavedResource("Period", "lt2018-11");
     }
-
     @Test
     public void testSearchDate_Period_LT_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28");
     }
-
     @Test
     public void testSearchDate_Period_LT_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21");
@@ -440,25 +955,28 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "lt2017-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T20");
     }
-
     @Test
     public void testSearchDate_Period_LT_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T21:00:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:18:01");
     }
-
     @Test
     public void testSearchDate_Period_LT_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T21:13:00.000123");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "lt2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_LT_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T15-05:00");
@@ -468,32 +986,36 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "lt2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-29T17:11:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_LE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2017");
         assertSearchReturnsSavedResource("Period", "le2018");
         assertSearchReturnsSavedResource("Period", "le2019");
         assertSearchReturnsSavedResource("Period", "le2020");
     }
-
     @Test
     public void testSearchDate_Period_LE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2018-09");
         assertSearchReturnsSavedResource("Period", "le2018-10");
         assertSearchReturnsSavedResource("Period", "le2018-11");
     }
-
     @Test
     public void testSearchDate_Period_LE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-27");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28");
         assertSearchReturnsSavedResource("Period", "le2018-10-29");
         assertSearchReturnsSavedResource("Period", "le2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_LE_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "le2017-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T17");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T20");
@@ -502,16 +1024,18 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "le2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T23");
     }
-
     @Test
     public void testSearchDate_Period_LE_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T21:00:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:18:01");
     }
-
     @Test
     public void testSearchDate_Period_LE_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T21:13:00.000123");
@@ -519,9 +1043,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_LE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "le2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "le2018-10-29T15-05:00");
@@ -530,32 +1055,35 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:12:44-04:00");
         assertSearchReturnsSavedResource("Period", "le2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_GE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge1901");
         assertSearchReturnsSavedResource("Period", "ge2018");
         assertSearchDoesntReturnSavedResource("Period", "ge2019");
         assertSearchDoesntReturnSavedResource("Period", "ge2020");
     }
-
     @Test
     public void testSearchDate_Period_GE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge2018-09");
         assertSearchReturnsSavedResource("Period", "ge2018-10");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-11");
-
     }
-
     @Test
     public void testSearchDate_Period_GE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge2018-10-28");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_GE_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ge2019-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21");
@@ -563,17 +1091,18 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ge2017-10-29T22");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T20");
     }
-
     @Test
     public void testSearchDate_Period_GE_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T21:19");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:17");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:18");
-        assertSearchReturnsSavedResource("Period", "ge2017-10-29T21:12:00");
     }
-
     @Test
     public void testSearchDate_Period_GE_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:12:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21:13:00.000123");
@@ -581,9 +1110,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ge2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_GE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ge2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T21-00:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17-04:00");
@@ -594,47 +1124,53 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ge2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_GT_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2017");
         assertSearchReturnsSavedResource("Period", "gt2018");
         assertSearchDoesntReturnSavedResource("Period", "gt2019");
         assertSearchDoesntReturnSavedResource("Period", "gt2020");
     }
-
     @Test
     public void testSearchDate_Period_GT_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-09");
         assertSearchReturnsSavedResource("Period", "gt2018-10");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-11");
     }
-
     @Test
     public void testSearchDate_Period_GT_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-28");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_GT_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T20");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T17");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "gt2017-10-29T22");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21");
     }
-
     @Test
     public void testSearchDate_Period_GT_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:13");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T21:18");
     }
-
     @Test
     public void testSearchDate_Period_GT_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:11:00");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T21:12:00");
@@ -643,9 +1179,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_GT_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T20-00:00");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T18-04:00");
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T15-05:00");
@@ -655,47 +1192,53 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "gt2018-10-29T17:12:00-03:00");
         assertSearchDoesntReturnSavedResource("Period", "gt2018-10-29T17:18:00-05:00");
     }
-
     @Test
     public void testSearchDate_Period_SA_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2017");
         assertSearchDoesntReturnSavedResource("Period", "sa2018");
         assertSearchDoesntReturnSavedResource("Period", "sa2019");
         assertSearchDoesntReturnSavedResource("Period", "sa2020");
     }
-
     @Test
     public void testSearchDate_Period_SA_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-09");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-11");
     }
-
     @Test
     public void testSearchDate_Period_SA_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_SA_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T17");
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T20");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30T20");
     }
-
     @Test
     public void testSearchDate_Period_SA_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:11");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19");
     }
-
     @Test
     public void testSearchDate_Period_SA_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T21:00:00");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "sa2018-10-28T20:59:59.999999Z");
@@ -704,11 +1247,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T21:13:00.000123");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-30T00:00:00.000001Z");
-
     }
-
     @Test
     public void testSearchDate_Period_SA_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T18-02:00");
         assertSearchReturnsSavedResource("Period", "sa2018-10-29T15-05:00");
@@ -717,29 +1260,33 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "sa2018-10-29T17:12:44-04:00");
     }
-
     @Test
     public void testSearchDate_Period_EB_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018");
         assertSearchReturnsSavedResource("Period", "eb2019");
         assertSearchReturnsSavedResource("Period", "eb2020");
     }
-
     @Test
     public void testSearchDate_Period_EB_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10");
         assertSearchReturnsSavedResource("Period", "eb2018-11");
     }
-
     @Test
     public void testSearchDate_Period_EB_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29");
         assertSearchReturnsSavedResource("Period", "eb2018-10-30");
     }
-
     @Test
     public void testSearchDate_Period_EB_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21");
@@ -747,75 +1294,79 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "eb2017-10-29T22");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T20");
     }
-
     @Test
     public void testSearchDate_Period_EB_Minutes() throws Exception {
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:00:00");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:18:01");
     }
-
     @Test
     public void testSearchDate_Period_EB_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T21:19:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T21:13:00.000123");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28T23:59:59.999999Z");
-
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period", "eb2018-10-30T00:00:00.000001Z");
-
     }
-
     @Test
     public void testSearchDate_Period_EB_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T15-05:00");
         assertSearchReturnsSavedResource("Period", "eb2018-10-29T17:18:01-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:18:00-04:00");
-
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:12:44-04:00");
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_NE_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018");
         assertSearchReturnsSavedResource("Period", "ne2019");
         assertSearchReturnsSavedResource("Period", "ne2020");
     }
-
     @Test
     public void testSearchDate_Period_NE_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10");
         assertSearchReturnsSavedResource("Period", "ne2018-11");
     }
-
     @Test
     public void testSearchDate_Period_NE_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29");
         assertSearchReturnsSavedResource("Period", "ne2018-10-30");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28");
     }
-
     @Test
     public void testSearchDate_Period_NE_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T20");
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29T21");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T22");
     }
-
     @Test
     public void testSearchDate_Period_NE_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:12");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:12");
     }
-
     @Test
     public void testSearchDate_Period_NE_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:18:01");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T21:13:00");
@@ -823,9 +1374,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_NE_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T22-00:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T18-04:00");
         assertSearchDoesntReturnSavedResource("Period", "ne2018-10-29T16-05:00");
@@ -835,50 +1387,56 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ne2018-10-29T17:18:00-04:00");
     }
-
     @Test
     public void testSearchDate_Period_AP_Year() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018");
         assertSearchDoesntReturnSavedResource("Period", "ap2100");
         assertSearchDoesntReturnSavedResource("Period", "ap2000");
         assertSearchDoesntReturnSavedResource("Period", "ap2025");
     }
-
     @Test
     public void testSearchDate_Period_AP_Month() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10");
         assertSearchReturnsSavedResource("Period", "ap2018-11");
         assertSearchDoesntReturnSavedResource("Period", "ap2018-01");
     }
-
     @Test
     public void testSearchDate_Period_AP_Day() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "ap2018-01-01");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29");
         assertSearchReturnsSavedResource("Period", "ap2018-10-30");
         assertSearchDoesntReturnSavedResource("Period", "ap2019-01-01");
     }
-
     @Test
     public void testSearchDate_Period_AP_Hours() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T22");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T20");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T22");
     }
-
     @Test
     public void testSearchDate_Period_AP_Minutes() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:19");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:00:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:18:01");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21:00:00");
     }
-
     @Test
     public void testSearchDate_Period_AP_Seconds() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:19:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T21:13:00");
         assertSearchDoesntReturnSavedResource("Period", "ap2017-10-29T21:13:00.000123");
@@ -886,18 +1444,17 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ap2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28T23:59:59.999999Z");
     }
-
     @Test
     public void testSearchDate_Period_AP_ZonedDateTime() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29T17:12:44-04:00");
     }
-
     @Test
     public void testSearchDate_Period_NoStart() throws Exception {
         // "Period-noStart" has end=2018-10-29T17:18:00-04:00
-
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29");
@@ -912,21 +1469,18 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29");
-
         // search on the dateTime at the end of the Period-noStart
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29T17:18:00+04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-29T17:18:01-04:00");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "gt2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T17:18:00-04:00");
         assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28");
@@ -938,7 +1492,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28T23:59:59.999999Z");
@@ -950,7 +1503,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30");
@@ -960,7 +1512,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30");
-
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30T00:00:00.000001Z");
@@ -971,12 +1522,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001Z");
     }
-
     @Test
     public void testSearchDate_Period_NoEnd() throws Exception {
         // "Period-noEnd" has start=2018-10-29T17:12:00-04:00
-        // No End -  A missing upper boundary is "greater than" any actual date. 
-
+        // No End -  A missing upper boundary is "greater than" any actual date.
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-29");
@@ -989,7 +1538,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29");
-
         // search on the dateTime at the start of the Period-noEnd
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29T17:12:00-04:00");
@@ -1003,7 +1551,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29T17:12:00-04:00");
-
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1013,7 +1560,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28");
-
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28T23:59:59.999999Z");
@@ -1023,7 +1569,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28T23:59:59.999999Z");
-
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1038,7 +1583,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30");
-
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-30T00:00:00.000001Z");
@@ -1053,23 +1597,25 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T00:00:00.000000Z");
     }
-
     @Test
     public void testSearchDate_Period_chained() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsComposition("subject:Basic.Period", "2018-10-29");
     }
-
     @Test
     public void testSearchDate_Period_missing() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchReturnsSavedResource("Period:missing", "false");
         assertSearchDoesntReturnSavedResource("Period:missing", "true");
-
         assertSearchReturnsSavedResource("missing-Period:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Period:missing", "false");
     }
-
     @Test
     public void testSearchDate_Period_or() throws Exception {
+//      "start": "2018-10-29T17:12:00-04:00",
+//      "end": "2018-10-29T17:18:00-04:00"
         assertSearchDoesntReturnSavedResource("Period", "2018-10-28,9999-01-01");
         assertSearchReturnsSavedResource("Period", "ne2018-10-28,9999-01-01");
         assertSearchDoesntReturnSavedResource("Period", "lt2018-10-28,9999-01-01");
@@ -1080,7 +1626,6 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28,9999-01-01");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28,9999-01-01");
         assertSearchDoesntReturnSavedResource("Period", "ap2010-10-28,9999-01-01");
-
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,2018-10-28");
         assertSearchReturnsSavedResource("Period", "9999-01-01,ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,lt2018-10-28");
@@ -1091,13 +1636,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,ap2010-10-28");
     }
-
-    // We decided that Periods with no start or end should not even be indexed 
+    // We decided that Periods with no start or end should not even be indexed
     //    @Test
     //    public void testSearchDate_Period_NoStartOrEnd() throws Exception {
     //        assertSearchReturnsSavedResource("Period-noStartOrEnd", "2018-10-29T17:12:44-04:00");
     //    }
-
     // Timing search is not working properly.
     //    @Test
     //    public void testSearchDate_Timing_EventsOnly() throws Exception {
@@ -1115,53 +1658,47 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     //    public void testSearchDate_Timing_BoundPeriod() throws Exception {
     //        testSearchDateReturnsResourceWithExtension("Timing-boundPeriod", "2018-10-29T17:18:00-04:00", "http://example.org/TimingBoundsPeriod");
     //    }
-
     /*
      * Currently, documented in our conformance statement. We do not support
      * modifiers on chained parameters.
      * https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
      */
-
     //    @Test
     //    public void testSearchDate_instant_chained_missing() throws Exception {
     //        assertSearchReturnsSavedResource("subject:Basic.instant:missing", "false");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.instant:missing", "true");
-    //        
+    //
     //        assertSearchReturnsSavedResource("subject:Basic.missing-instant:missing", "true");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-instant:missing", "false");
     //    }
-
     //  @Test
     //  public void testSearchDate_Period_chained_missing() throws Exception {
     //      assertSearchReturnsComposition("subject:Basic.Period:missing", "false");
     //      assertSearchDoesntReturnComposition("subject:Basic.Period:missing", "true");
-    //      
+    //
     //      assertSearchReturnsComposition("subject:Basic.missing-Period:missing", "true");
     //      assertSearchDoesntReturnComposition("subject:Basic.missing-Period:missing", "false");
     //  }
-
     /*
      * Currently, documented in our conformance statement. We do not support
      * modifiers on chained parameters.
      * https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
      */
-
     //    @Test
     //    public void testSearchDate_date_chained_missing() throws Exception {
     //        assertSearchReturnsComposition("subject:Basic.date:missing", "false");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.date:missing", "true");
-    //        
+    //
     //        assertSearchReturnsComposition("subject:Basic.missing-date:missing", "true");
     //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-date:missing", "false");
     //    }
-
     //    @Test
     //    public void testSearchDate_dateTime_chained_missing() throws Exception {
     //        assertSearchReturnsComposition("subject:Basic.dateTime:missing", "false");
     //        assertSearchDoesntReturnComposition("subject:Basic.dateTime:missing", "true");
-    //        
+    //
     //        assertSearchReturnsComposition("subject:Basic.missing-dateTime:missing", "true");
     //        assertSearchDoesntReturnComposition("subject:Basic.missing-dateTime:missing", "false");
     //    }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.LogManager;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeClass;

--- a/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
@@ -17,6 +17,7 @@ import java.time.temporal.TemporalAccessor;
 
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 
@@ -433,6 +434,13 @@ public class DateTimeHandlerTest {
         Instant upperBound = DateTimeHandler.generateUpperBound(null, value, v);
         assertEquals(lowerBound.toString(), "2019-10-11T11:00:00Z");
         assertEquals(upperBound.toString(), "2019-10-11T11:00:00.999999Z");
+    }
+
+    @Test
+    public void testToStringWithNullPrefixYearMonthDayHoursMinutesSeconds() throws FHIRSearchException {
+        DateTime dt = DateTime.of("2019-10-11T11:00:00Z");
+        assertEquals("2019-10-11T11:00:00Z", DateTime.PARSER_FORMATTER.format(dt.getValue()));
+        assertEquals("2019-10-11T11:00Z", dt.getValue().toString());
     }
 
     @Test


### PR DESCRIPTION
1. added a bunch more date and datetime tests to AbstractSearchDateTest
(and reorganized some ones that were there)

2. found and fixed one problematic case:

We were capturing the precision wrong for Datetime values which include
0 seconds.  Our algorithm relied on TemporalAccessor.toString but this
method actually excludes the seconds when they are 0. This was causing
us to store values like `2019-12-31T20:00:00Z` as the range
`[2019-12-31T20:00:00Z, 2019-12-31T20:00:59.999999Z)` instead of
`[2019-12-31T20:00:00Z, 2019-12-31T20:00:00.999999Z)`. I addressed it by
using the DateTime or Date PARSER_FORMATTER (depending on its type).

3. updated BasicDate.json to test with a more "interesting"
dateTime...one that strattles the edge of a year, month, and day.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>