### PR TITLE
issue #528 - use server timezone to interpret dates

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -85,8 +85,8 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 |Reference                 |`:[type]`,`:missing`            |exact match search|
 |URI                       |`:below`,`:above`,`:missing`    |exact match search|
 |Token                     |`:missing`                      |exact match search|
-|Number                    |`:missing`                      |exact match search|
-|Date                      |`:missing`                      |exact match search|
+|Number                    |`:missing`                      |implicit range search (see http://hl7.org/fhir/R4/search.html#number)|
+|Date                      |`:missing`                      |implicit range search (see https://www.hl7.org/fhir/search.html#date)|
 |Quantity                  |`:missing`                      |implicit range search (see http://hl7.org/fhir/R4/search.html#quantity)|
 |Composite                 |`:missing`                      |processes each parameter component according to its type|
 |Special (near)            | none                           |searches a bounding area according to the value of the `fhirServer/search/useBoundingRadius` property|
@@ -124,21 +124,22 @@ The `eb` and `ap` prefixes are not supported for searches which target values of
 If not specified on a query string, the default prefix is `eq`.
 
 ### Searching on Date
-The IBM FHIR Server adheres to the specification with two minor exceptions:
-* The server supports search query values with fractional seconds; any search query value given with fractional seconds is treated as precise value, whereas search query values without fractional seconds are handled as an implicit range (e.g. `2000-04-30T23:59:00` becomes the range `[2000-04-30T23:59:00, 2000-04-30T23:59:01)`).
-* Dates and DateTimes (and query parameter values for date search parameters) which are expressed without timezones are handled as UTC values.
-  * This differs slightly from the specification which indicates that "Where both search parameters and resource element date times do not have time zones, the servers local time zone should be assumed". However, because both the element values AND search query parameters are handled in the same way, this difference will only matter when timezones are specified on one side (resource element or search query parameter) but not the other. For example, a query like `Patient?birthdate=2019-01-01` would match a resource with a value of `2019-01-01`, but would *not* match a resource with a value of `2019-01-01T20:00:00-04:00`.
+The IBM FHIR Server implements date search as according to the specification.
 
-All search parameter values are stored in the database in UTC time in order to improve data portability.
+The IBM FHIR Server supports up to 6 fractional seconds (microsecond granularity) for Instant and DateTime values and all extracted parameter values are stored in the database in UTC in order to improve data portability.
 
-The IBM FHIR Server stores up to 6 fractional seconds (microsecond granularity) for Instant and DateTime values.
+Dates and DateTimes which are expressed without timezones are assumed to be in the local timezone of the application server at the time of parameter extraction.
+Similarly, query parameter date values with no timezone are assumed to be in the local time of the server at the time the search is invoked.
+To ensure consistency of search results, clients are recommended to include the timezone on all search query values that include a time.
 
-Query parameter values without fractional seconds will be handled as an implicit range. For example, a search like `Patient?date=2019-01-01T12:00:00Z` would include resources with the following effectiveDateTime values:
+Finally, the server extends the specified capabilities with support for "exact match" semantics on fractional seconds.
+
+Query parameter values without fractional seconds will be handled as an implicit range. For example, a search like `Observatoin?date=2019-01-01T12:00:00Z` would return resources with the following effectiveDateTime values:
 * 2019-01-01T12:00:00Z
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.999999Z
 
-Query parameter values with fractional seconds will be handled with exact match semantics (ignoring precision). For example, a search like `Patient?birthdate=2019-01-01T12:00:00.1Z` would include resources with the following effectiveDateTime values:
+Query parameter values with fractional seconds will be handled with exact match semantics (ignoring precision). For example, a search like `Observation?date=2019-01-01T12:00:00.1Z` would return resources with the following effectiveDateTime values:
 * 2019-01-01T12:00:00.1Z
 * 2019-01-01T12:00:00.100Z
 * 2019-01-01T12:00:00.100000Z

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -11,7 +11,6 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_END;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DATE_START;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EQ;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.GTE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
@@ -172,25 +171,17 @@ public class DateParmBehaviorUtil {
      */
     public void buildEqualsRangeClause(StringBuilder whereClauseSegment, List<Timestamp> bindVariables,
             String tableAlias, Instant lowerBound, Instant upperBound) {
-        bindVariables.add(generateTimestamp(lowerBound));
+        // @formatter:off
+        whereClauseSegment
+                .append(LEFT_PAREN)
+                    .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
+                .append(AND)
+                    .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
+                .append(RIGHT_PAREN);
+        // @formatter:on
 
-        if (!lowerBound.equals(upperBound)) {
-            // @formatter:off
-            whereClauseSegment
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
-                    .append(AND)
-                        .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
-                    .append(RIGHT_PAREN);
-            // @formatter:on
-            bindVariables.add(generateTimestamp(upperBound));
-        } else {
-            // Exact match of an instant. 
-            whereClauseSegment
-                    .append(LEFT_PAREN)
-                        .append(tableAlias).append(DOT).append(DATE_START).append(EQ).append(BIND_VAR)
-                    .append(RIGHT_PAREN);
-        }
+        bindVariables.add(generateTimestamp(lowerBound));
+        bindVariables.add(generateTimestamp(upperBound));
     }
 
     /**

--- a/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
@@ -13,7 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.YearMonth;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -21,6 +21,7 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
+import java.time.zone.ZoneRules;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.type.Date;
@@ -141,29 +142,30 @@ public class DateTimeHandler {
      */
     public static Instant generateValue(TemporalAccessor value) {
         Instant response;
+        ZoneRules defaultOffsetRules = ZoneId.systemDefault().getRules();
         if (value instanceof java.time.Year) {
             // YEAR - 1
             Year year = (Year) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
-            response = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
         } else if (value instanceof YearMonth) {
             // Month - 1
             // Grab the values for Year/Month Value
             YearMonth ym = (YearMonth) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
-            response = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
         } else if (value instanceof LocalDate) {
             // LocalDate - YYYY-MM-DD
             LocalDate ld = (LocalDate) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ld.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
             local    = local.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
-            response = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
         } else if (value instanceof LocalDateTime) {
             // LocalDate - YYYY-MM-DD HH
             LocalDateTime local = (LocalDateTime) value;
-            response = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime zdt = (ZonedDateTime) value;
             response = zdt.toInstant();
@@ -206,14 +208,14 @@ public class DateTimeHandler {
      */
     public static Instant generateUpperBound(Prefix prefix, TemporalAccessor value, String originalString) {
         Instant response = null;
-
+        ZoneRules defaultOffsetRules = ZoneId.systemDefault().getRules();
         if (value instanceof java.time.Year) {
             // YEAR + 1
             Year year = (Year) value;
             year = year.plus(1, ChronoUnit.YEARS);
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
             response =
-                    ZonedDateTime.of(local, ZoneOffset.UTC).toInstant().minus(TICK,
+                    ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant().minus(TICK,
                             ChronoUnit.NANOS);
         } else if (value instanceof YearMonth) {
             // Grab the values for Year/Month Value
@@ -222,7 +224,7 @@ public class DateTimeHandler {
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
             response =
-                    ZonedDateTime.of(local, ZoneOffset.UTC).toInstant().minus(TICK,
+                    ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant().minus(TICK,
                             ChronoUnit.NANOS);
         } else if (value instanceof LocalDate) {
             // LocalDate - YYYY-MM-DD
@@ -232,7 +234,7 @@ public class DateTimeHandler {
             local    = local.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
             local    = local.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
             response =
-                    ZonedDateTime.of(local, ZoneOffset.UTC).toInstant().minus(TICK,
+                    ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant().minus(TICK,
                             ChronoUnit.NANOS);
         } else if (value instanceof LocalDateTime) {
             // LocalDate - YYYY-MM-DD
@@ -251,7 +253,7 @@ public class DateTimeHandler {
 
             // ELSE -> HH:MM:SS.XXXXX
             // The point is treated as exact.
-            response = ZonedDateTime.of(local, ZoneOffset.UTC).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
 
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime zdt = (ZonedDateTime) value;


### PR DESCRIPTION
This PR builds on #529 and can be taken in whole or in part.

The spec says "Where both search parameters and resource element date
times do not have time zones, the servers local time zone should be
assumed" and so I wanted to see what that would look like.

Its not very clear what is "correct" if only one of those two excludes
time zones. It doesn't matter much on the parameter extraction side
because all datetimes with times in them are required to have a
timezone, but I think I like the idea of handling searches w/o timezone
info via local time, because usually if someone puts a date or datetime
without a timezone they are expecting local time and not UTC time.

In the process, I also found a discrepency between our EQ and NE
behavior. To rectify this, I removed the "exactly equals DATE_START"
omptimization because I think its not always right...for example if the
indexed value was actually a Period then we shold consider an exact
point to be equal to that Period (even if the start matches).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>