### PR TITLE
issue #528 - use UTC in DateTimeHandlerTest and ParameterExtractionTest

### DIFF
--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
@@ -18,7 +18,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.List;
+import java.util.TimeZone;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.resource.SearchParameter;
@@ -98,6 +100,11 @@ public class ParameterExtractionTest {
     private static final SearchParameter uriSearchParam = searchParamBuilder.type(SearchParamType.URI).build();
     private static final SearchParameter stringSearchParam = searchParamBuilder.type(SearchParamType.STRING).build();
     private static final SearchParameter tokenSearchParam = searchParamBuilder.type(SearchParamType.TOKEN).build();
+    
+    @BeforeClass
+    public void setSystemTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
     
     @Test
     public void testBoolean() throws FHIRPersistenceProcessorException {

--- a/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
@@ -14,7 +14,9 @@ import static org.testng.Assert.assertTrue;
 import java.time.Instant;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.util.TimeZone;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.type.DateTime;
@@ -22,6 +24,11 @@ import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 
 public class DateTimeHandlerTest {
+
+    @BeforeClass
+    public void setSystemTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
 
     @Test
     public void testYearParser() throws FHIRSearchException {


### PR DESCRIPTION
Now the DateTimeHandler are dependent on the current timezone of the
java runtime.  On our CI environment, it must be UTC.  Now we'll set UTC
as the default timezone at the beginning of these tests so they can pass
like they used to.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>