### PR TITLE
issue #535 - Deduplicate the SearchParameter map

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.search.parameters;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.ibm.fhir.model.resource.SearchParameter;
+
+/**
+ * A object for storing multiple on a common list of SearchParameter 
+ */
+public class ParametersMap {
+    private final Map<String, SearchParameter> codeMap;
+    private final Map<String, SearchParameter> urlMap;
+
+    /**
+     * Construct a ParametersMap from a Bunlde of SearchParameter
+     */
+    public ParametersMap() {
+        // LinkedHashMaps to preserve insertion order
+        codeMap = new LinkedHashMap<>();
+        urlMap = new LinkedHashMap<>();
+    }
+
+    /**
+     * @implSpec package-private to prevent insertion from outside the package
+     */
+    void insert(String code, String url, SearchParameter parameter) {
+        codeMap.put(code, parameter);
+        urlMap.put(url, parameter);
+    }
+
+    /**
+     * @implSpec package-private to prevent insertion from outside the package
+     */
+    void insertAll(ParametersMap map) {
+        codeMap.putAll(map.codeMap);
+        urlMap.putAll(map.urlMap);
+    }
+
+    public SearchParameter lookupByCode(String searchParameterCode) {
+        return codeMap.get(searchParameterCode);
+    }
+
+    public SearchParameter lookupByUrl(String searchParameterUrl) {
+        return urlMap.get(searchParameterUrl);
+    }
+
+    public Collection<SearchParameter> values() {
+        return codeMap.values();
+    }
+
+    public boolean isEmpty() {
+        return codeMap.isEmpty();
+    }
+
+    public int size() {
+        return codeMap.size();
+    }
+}

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
@@ -6,36 +6,24 @@
 
 package com.ibm.fhir.search.parameters;
 
-import static com.ibm.fhir.model.type.String.string;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
-import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.type.code.ResourceType;
-import com.ibm.fhir.path.FHIRPathNode;
-import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
-import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.search.SearchConstants;
 
 /**
@@ -43,11 +31,7 @@ import com.ibm.fhir.search.SearchConstants;
  * which overwrites the behaviors of the buildInSearchParameters.
  * 
  * <br>
- * Loads the class in the classloader to initialize static members. Call this before using the class in order to avoid a
- * slight performance hit on first use.
- * 
- * @author pbastide
- * @author markd
+ * Call {@link #init()} before using the class in order to avoid a slight performance hit on first use.
  */
 public final class ParametersUtil {
 
@@ -70,6 +54,7 @@ public final class ParametersUtil {
 
     // Logging:
     public static final String LOG_PARAMETERS = "Parameter is loaded -> %s";
+    public static final String MISSING_EXPRESSION_WARNING = "Skipping parameter '%s' with missing expression";
     public static final String LOG_HEADER = "BASE:RESOURCE_NAME:SearchParameter";
     public static final String LOG_SIZE = "Size: %s";
     private static final String LOG_OUTPUT = "%s|%s|%s";
@@ -79,185 +64,95 @@ public final class ParametersUtil {
     private static final String COMMA = ",";
     private static final String EQUALS = "=";
 
-    // Unsupported Operations in FHIR Path
-    public static final String OPERATION_RESOLVE = "resolve()";
-    public static final String OPERATION_CONTAINS = ".contains";
-    private static final List<String> UNSUPPORTED_OPERATIONS = Arrays.asList(OPERATION_CONTAINS);
+    private static final Map<String, ParametersMap> builtInSearchParameters = loadBuiltIns();
 
-    private static final String REPLACE_RESOLVE = "(\\.where\\([\\s]{0,}resolve\\(\\)[\\s]{0,}[is]{0,2}[\\s]{0,}[\\w]{0,}\\))";
-
-    private static final String CONTAINS_EXPR = "\\.contains\\.";
-    private static final String CONTAINS_EXPR_REPLACE = ".`contains`.";
-    private static final String CONTAINS_END_EXPR = ".contains";
-    private static final String CONTAINS_END_EXPR_REPLACE = ".`contains`";
-
-    private static final Map<String, Map<String, SearchParameter>> builtInSearchParameters = loadBuiltIn();
-
-    private static final String INVALID_EXPRESSION = "/NONE/";
+    private static final String MISSING_EXPRESSION = "/NONE/";
 
     private ParametersUtil() {
         // No Operation
     }
 
     /**
-     * Loads the class in the classloader to initialize static members. Call this before using the class in order to
-     * avoid a slight performance hit on first use.
+     * Loads the class in the classloader to initialize static members.
+     * Call this before using the class in order to avoid a slight performance hit on first use.
      */
     public static void init() {
         // No Operation
     }
 
-    /*
-     * wraps the error thrown, catches it, and enables a user to operate.
-     * @return
+    /**
+     * Loads the built-in search parameters and constructs . 
+     * 
+     * @return a map of ParametersMaps, keyed by resourceType
+     * @throws FHIRParserException 
      */
-    private static Map<String, Map<String, SearchParameter>> loadBuiltIn() {
-        Map<String, Map<String, SearchParameter>> result = null;
+    private static Map<String, ParametersMap> loadBuiltIns() {
+        Map<String, ParametersMap> map;
+
         try {
-            result = populateSearchParameterMapFromResource(FHIR_DEFAULT_SEARCH_PARAMETERS_FILE);
-        } catch (IOException e) {
-            // This Exception is HIGHLY improbable.
-            log.warning(BUILTIN_ERROR_EXCEPTION);
+            InputStream builtInFile = ParametersUtil.class.getClassLoader().getResourceAsStream(FHIR_DEFAULT_SEARCH_PARAMETERS_FILE);
+            Bundle bundle = FHIRParser.parser(Format.JSON).parse(builtInFile);
+
+            map = buildSearchParametersMapFromBundle(bundle);
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "Unexpected error while loading built-in search parameters", e);
+            map = Collections.emptyMap();
         }
-        return result;
+
+        return map;
     }
 
     /**
-     * This is a convenience function that simply returns the built-in (spec-defined) SearchParameters as a map keyed by
-     * resource type.
+     * Builds a Map of ParameterMaps from the passed Bundle.
+     * 
+     * @param bundle a Bundle of type Collection with entries of type SearchParameter
+     * @return a Map of ParameterMaps, keyed by resourceType
+     * @throws ClassCastException if the Bundle contains entries of any type other than SearchParameter
      */
-    public static Map<String, Map<String, SearchParameter>> getBuiltInSearchParameterMap() {
-        return builtInSearchParameters;
-    }
-
-    /**
-     * Returns a Map containing the SearchParameters loaded from the specified classpath resource.
-     *
-     * @param resourceName
-     *            the name of a resource available on the current classpath from which the SearchParameters are to be
-     *            loaded
-     * @return the Map containing the SearchParameters
-     * @throws IOException
-     */
-    public static Map<String, Map<String, SearchParameter>> populateSearchParameterMapFromResource(String resourceName) throws IOException {
-        // Capture Exception here and wrap and log out an issue with Search
-        try (InputStream stream = ParametersUtil.class.getClassLoader().getResourceAsStream(resourceName)) {
-            if (stream == null) {
-                throw new FileNotFoundException(String.format(ERROR_EXCEPTION, resourceName));
+    public static Map<String, ParametersMap> buildSearchParametersMapFromBundle(Bundle bundle) {
+        Map<String, ParametersMap> typeToParamMap = new HashMap<>();
+        
+        for (Bundle.Entry entry : bundle.getEntry()) {
+            SearchParameter parameter = entry.getResource().as(SearchParameter.class);
+            
+            // Conditional Logging intentionally avoids forming of the String.
+            if (log.isLoggable(Level.FINE)) {
+                log.fine(String.format(LOG_PARAMETERS, parameter.getCode().getValue()));
             }
-            return populateSearchParameterMapFromStream(stream);
-        }
-    }
 
-    /**
-     * Returns a Map containing the SearchParameters loaded from the specified File object.
-     *
-     * @param file
-     *            a File object which represents the file from which the SearchParameters are to be loaded
-     * @return the Map containing the SearchParameters
-     * 
-     * @throws IOException
-     */
-    public static Map<String, Map<String, SearchParameter>> populateSearchParameterMapFromFile(File file) throws IOException {
-        try (FileInputStream stream = new FileInputStream(file)) {
-            return populateSearchParameterMapFromStream(stream);
-        }
-    }
-
-    /**
-     * populates the search parameter map and defaults to json
-     * 
-     * @param stream
-     * @return
-     */
-    public static Map<String, Map<String, SearchParameter>> populateSearchParameterMapFromStream(InputStream stream) {
-        return populateSearchParameterMapFromStreamByFormat(stream, Format.JSON);
-    }
-
-    /**
-     * populates the search parameter map and is XML
-     * 
-     * @param stream
-     * @return
-     */
-    public static Map<String, Map<String, SearchParameter>> populateSearchParameterMapFromStreamXML(InputStream stream) {
-        return populateSearchParameterMapFromStreamByFormat(stream, Format.XML);
-    }
-
-    /*
-     * Loads SearchParameters using the specified InputStream and returns a Map containing them.
-     * @param stream the InputStream from which to load the SearchParameters
-     * @param Format
-     * @return
-     */
-    private static Map<String, Map<String, SearchParameter>> populateSearchParameterMapFromStreamByFormat(InputStream stream, Format format) {
-        // Format is never null, as this method is private and hidden.
-        // In order to maintain this contract, and avoid the check, keep private.
-
-        Map<String, Map<String, SearchParameter>> searchParameterMap = new HashMap<>();
-
-        // The code block is isolating the effects of exceptions by capturing the exceptions here
-        // and returning an empty searchParameterMap, and continuing operation.
-        // The failure is logged out.
-        try {
-            // The code is agnostic to format.
-            Bundle bundle = FHIRParser.parser(format).parse(stream);
-
-            FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
-            EvaluationContext evaluationContext = new EvaluationContext(bundle);
-            Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, FHIR_PATH_BUNDLE_ENTRY);
-
-            List<SearchParameter> paramList = result.stream()
-                    .map(node -> node.asResourceNode().resource().as(SearchParameter.class))
-                    .collect(Collectors.toList());
-            for (SearchParameter parameter : paramList) {
-
-                // Conditional Logging intentionally avoids forming of the String.
+            if (parameter.getExpression() == null || !parameter.getExpression().hasValue()) {
                 if (log.isLoggable(Level.FINE)) {
-                    log.fine(String.format(LOG_PARAMETERS, parameter.getCode().getValue()));
+                    log.fine(String.format(MISSING_EXPRESSION, parameter.getCode().getValue()));
                 }
-
-                // Cleanse Unsupported Expressions
-                parameter = removeUnsupportedExpressions(parameter);
-
-                // Don't allow if Parameter is null
-                if (parameter != null) {
-
-                    /*
-                     * In R4, SearchParameter changes from a single Base resource to an array.
-                     * As Base is an array, there are going be potential collisions in the map.
-                     */
-                    List<ResourceType> types = parameter.getBase();
-                    for (ResourceType type : types) {
-                        String base = type.getValue();
-
-                        // Logic seems poor, refactor.
-                        Map<String, SearchParameter> map = searchParameterMap.get(base);
-                        if (map == null) {
-                            // Changed to LinkedHashMap for performance reasons.
-                            map = new LinkedHashMap<>();
-                            searchParameterMap.put(base, map);
-                        }
-
-                        // check and warn if the parameter name and code do not agree.
-                        String code = parameter.getCode().getValue();
-                        String name = parameter.getName().getValue();
-                        checkAndWarnForIssueWithCodeAndName(code, name);
-                        map.put(code, parameter);
-                        
-                        // also add the parameter under its canonical uri
-                        map.put(parameter.getUrl().getValue(), parameter);
-                    }
-                }
-
+                continue;
             }
-        } catch (FHIRException fe) {
-            // This exception is highly unlikely, but still possible.
-            log.warning(String.format(ERROR_EXCEPTION, FROM_STEAM));
-        }
 
-        // Must be unmodifiable, lest there be side effects.
-        return Collections.unmodifiableMap(assignInheritedToAll(searchParameterMap));
+            /*
+             * In R4, SearchParameter changes from a single Base resource to an array.
+             * As Base is an array, there are going be potential collisions in the map.
+             */
+            List<ResourceType> types = parameter.getBase();
+            for (ResourceType type : types) {
+                String base = type.getValue();
+
+                ParametersMap map = typeToParamMap.get(base);
+                if (map == null) {
+                    map = new ParametersMap();
+                    typeToParamMap.put(base, map);
+                }
+
+                // check and warn if the parameter name and code do not agree.
+                String code = parameter.getCode().getValue();
+                String name = parameter.getName().getValue();
+                checkAndWarnForIssueWithCodeAndName(code, name);
+
+                // add the map entry with keys for both the code and the url
+                map.insert(code, parameter.getUrl().getValue(), parameter);
+            }
+        }
+        
+        // Return an unmodifiable copy, lest there be side effects.
+        return Collections.unmodifiableMap(assignInheritedToAll(typeToParamMap));
     }
 
     /**
@@ -266,7 +161,7 @@ public final class ParametersUtil {
      * @param code
      * @param name
      */
-    public static void checkAndWarnForIssueWithCodeAndName(String code, String name) {
+    static void checkAndWarnForIssueWithCodeAndName(String code, String name) {
         // Name A natural language name identifying the search parameter. This name should be usable as an identifier
         // for the module by machine processing applications such as code generation.
         // @see https://www.hl7.org/fhir/searchparameter-definitions.html#SearchParameter.name
@@ -275,103 +170,18 @@ public final class ParametersUtil {
         // @see https://www.hl7.org/fhir/searchparameter-definitions.html#SearchParameter.code
 
         if (code != null && name != null && code.compareTo(name) != 0 && log.isLoggable(Level.WARNING)) {
-
             // Note, this is conditionally output, while the code assist complains it is not.
             log.warning(String.format(NO_MATCH_ON_NAME_CODE, code, name));
-
         }
-
     }
 
     /**
-     * removes unsupported expressions from Search.
-     * 
-     * @param parameter
-     * @return
+     * @return a map of maps
+     *         The outer map is keyed by resource type.
+     *         The inner map is keyed by both SearchParameter.code and SearchParameter.url
      */
-    public static SearchParameter removeUnsupportedExpressions(SearchParameter parameter) {
-        SearchParameter revisedParameter;
-
-        // Only add the ones that have expressions.
-        if (parameter == null) {
-            revisedParameter = null;
-        } else if (parameter.getBase().contains(ResourceType.DOMAIN_RESOURCE)) {
-            // Domain Resources are a special case where the expression is unknown.
-            // We want this to pass through no matter what.
-            revisedParameter = parameter;
-        } else if (parameter.getExpression() == null) {
-            revisedParameter = null;
-        } else {
-
-            // Issue 206: FHIRPath -> resolve() is an unsupported value.
-            // process over the entire expression string
-            // and execute for every string for the unsupported types.
-            // Right now, unsupported is <code>resolve()</code>
-
-            boolean expressionChanged = false;
-            String expressions = parameter.getExpression().getValue();
-            for (String operation : UNSUPPORTED_OPERATIONS) {
-
-                if (expressions.contains(operation)) {
-                    expressionChanged = true;
-                    expressions = processResolve(expressions);
-                    expressions = processContains(expressions);
-                }
-
-            }
-
-            if (expressions.trim().isEmpty()) {
-                // We've removed all expressions as they are unsupported.
-                revisedParameter = null;
-            } else if (expressionChanged) {
-                // If revised, send back
-                revisedParameter = parameter.toBuilder().expression(string(expressions)).build();
-            } else {
-                // Don't revise, send it back.
-                revisedParameter = parameter;
-            }
-
-        }
-
-        return revisedParameter;
-    }
-
-    /**
-     * processes, and conditionally updates the resultingExpressions as a side effect. This side effect approach is
-     * designed to limit the cognitive complexity, and was not the first choice of inline comparisions.
-     * 
-     * @param expressions
-     */
-    public static String processResolve(String expressions) {
-        String result = expressions;
-        if (UNSUPPORTED_OPERATIONS.contains(OPERATION_RESOLVE) && expressions.contains(OPERATION_RESOLVE)) {
-            result = expressions.replaceAll(REPLACE_RESOLVE, SearchConstants.EMPTY_QUERY_STRING).trim();
-        }
-        return result;
-    }
-
-    /**
-     * processes the issues with `ValueSet.expansion.contains.code` when the value is unescaped.
-     * 
-     * @param expression
-     */
-    public static String processContains(String expression) {
-        String result = expression;
-        if (UNSUPPORTED_OPERATIONS.contains(OPERATION_CONTAINS)) {
-
-            result = expression.replaceAll(CONTAINS_EXPR, CONTAINS_EXPR_REPLACE);
-
-            if (result.endsWith(CONTAINS_END_EXPR)) {
-                result = result.replace(CONTAINS_END_EXPR, CONTAINS_END_EXPR_REPLACE);
-            }
-
-            // Logging out details
-            if (log.isLoggable(Level.FINER)) {
-                log.finer("Not good... Expression is invalid [" + expression + "] [" + result + "]");
-            }
-
-        }
-        return result;
+    public static Map<String, ParametersMap> getBuiltInSearchParametersMap() {
+        return builtInSearchParameters;
     }
 
     /*
@@ -379,46 +189,30 @@ public final class ParametersUtil {
      * @param searchParameterMap
      * @return
      */
-    private static Map<String, Map<String, SearchParameter>> assignInheritedToAll(Map<String, Map<String, SearchParameter>> searchParameterMap) {
+    private static Map<String, ParametersMap> assignInheritedToAll(Map<String, ParametersMap> searchParameterMap) {
 
         // Hierarchy of Resources drives the search parameters assigned in the map.
         // Resource > DomainResource > Instance (e.g. Claim or CarePlan).
         // As such all Resources receive, some receive DomainResource, and individual instances remain untouched.
 
-        Map<String, SearchParameter> resourceMap = searchParameterMap.get(SearchConstants.RESOURCE_RESOURCE);
-        Map<String, SearchParameter> domainResourceMap = searchParameterMap.get(SearchConstants.DOMAIN_RESOURCE_RESOURCE);
+        ParametersMap resourceMap = searchParameterMap.get(SearchConstants.RESOURCE_RESOURCE);
+        ParametersMap domainResourceMap = searchParameterMap.get(SearchConstants.DOMAIN_RESOURCE_RESOURCE);
 
-        // Checks the edge case where there are no RESOURCE found
-        for (Entry<String, Map<String, SearchParameter>> entry : searchParameterMap.entrySet()) {
-
-            if (resourceMap != null && entry.getKey().compareTo(SearchConstants.RESOURCE_RESOURCE) != 0) {
-                // Great, now we want to take the resourceMap and add to this tree.
-                entry.getValue().putAll(resourceMap);
+        for (Entry<String, ParametersMap> entry : searchParameterMap.entrySet()) {
+            // Checks the edge case where there are no RESOURCE found
+            if (resourceMap != null && !SearchConstants.RESOURCE_RESOURCE.equals(entry.getKey())) {
+                // Take the resourceMap and add to this tree.
+                entry.getValue().insertAll(resourceMap);
             }
 
             // Checks the edge case where there are no DOMAIN RESOURCE found
             // We're now dealing with DomainResource
             if (domainResourceMap != null && !RESOURCE_ONLY.contains(entry.getKey())) {
-                entry.getValue().putAll(domainResourceMap);
+                entry.getValue().insertAll(domainResourceMap);
             }
-
         }
 
         return searchParameterMap;
-    }
-
-    /**
-     * gets the resource or an empty list
-     * 
-     * @param resourceType
-     * @return
-     */
-    public static Map<String, SearchParameter> getBuiltInSearchParameterMapByResourceType(String resourceType) {
-        Map<String, SearchParameter> result = getBuiltInSearchParameterMap().get(resourceType);
-        if (result == null) {
-            result = Collections.emptyMap();
-        }
-        return Collections.unmodifiableMap(result);
     }
 
     /**
@@ -435,19 +229,19 @@ public final class ParametersUtil {
      * @param out
      * @param searchParamsMap
      */
-    private static void print(PrintStream out, Map<String, Map<String, SearchParameter>> searchParamsMap) {
+    private static void print(PrintStream out, Map<String, ParametersMap> searchParamsMap) {
         Set<String> keys = searchParamsMap.keySet();
         out.println(SearchConstants.LOG_BOUNDARY);
         out.println(LOG_HEADER);
         out.println(String.format(LOG_SIZE, keys.size()));
         for (String base : keys) {
-            Map<String, SearchParameter> tmp = searchParamsMap.get(base);
-            for (Entry<String, SearchParameter> entry : tmp.entrySet()) {
-                String expressions = INVALID_EXPRESSION;
-                if (entry.getValue().getExpression() != null) {
-                    expressions = entry.getValue().getExpression().getValue();
+            ParametersMap tmp = searchParamsMap.get(base);
+            for(SearchParameter param : tmp.values()) {
+                String expression = MISSING_EXPRESSION;
+                if (param.getExpression() != null) {
+                    expression = param.getExpression().getValue();
                 }
-                out.println(String.format(LOG_OUTPUT, base, entry.getKey(), expressions));
+                out.println(String.format(LOG_OUTPUT, base, param.getCode().getValue(), expression));
             }
             out.println(SearchConstants.LOG_BOUNDARY);
         }
@@ -461,8 +255,6 @@ public final class ParametersUtil {
      * @param out
      */
     public static void printSearchParameter(SearchParameter parameter, PrintStream out) {
-
-        // Issue 202: Changed to code
         String code = parameter.getCode().getValue();
         List<ResourceType> types = parameter.getBase();
 
@@ -477,5 +269,4 @@ public final class ParametersUtil {
         builder.append(RIGHT);
         out.println(builder.toString());
     }
-
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/cache/TenantSpecificSearchParameterCache.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/cache/TenantSpecificSearchParameterCache.java
@@ -7,6 +7,8 @@
 package com.ibm.fhir.search.parameters.cache;
 
 import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -14,7 +16,10 @@ import java.util.logging.Logger;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.core.TenantSpecificFileBasedCache;
 import com.ibm.fhir.exception.FHIROperationException;
-import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.search.parameters.ParametersMap;
 import com.ibm.fhir.search.parameters.ParametersUtil;
 
 /**
@@ -25,7 +30,7 @@ import com.ibm.fhir.search.parameters.ParametersUtil;
  * should change one line in this class, and be instantiated in the SearchUtil, and embedded in the call to Parameters.
  * Alternatively, one could, upon not finding the JSON file, load the XML file.
  */
-public class TenantSpecificSearchParameterCache extends TenantSpecificFileBasedCache<Map<String, Map<String, SearchParameter>>> {
+public class TenantSpecificSearchParameterCache extends TenantSpecificFileBasedCache<Map<String, ParametersMap>> {
 
     private static final String CLASSNAME = TenantSpecificSearchParameterCache.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
@@ -56,13 +61,15 @@ public class TenantSpecificSearchParameterCache extends TenantSpecificFileBasedC
      * @see com.ibm.fhir.core.TenantSpecificFileBasedCache#createCachedObject(java.lang.String)
      */
     @Override
-    public Map<String, Map<String, SearchParameter>> createCachedObject(File f) throws Exception {
+    public Map<String, ParametersMap> createCachedObject(File f) throws Exception {
         try {
             // Added logging to help diagnose issues while loading the files.
             if (log.isLoggable(Level.FINE)) {
                 log.fine(String.format(LOG_FILE_LOAD, f.toURI()));
             }
-            return ParametersUtil.populateSearchParameterMapFromFile(f);
+            Reader reader = new FileReader(f);
+            Bundle bundle = FHIRParser.parser(Format.JSON).parse(reader);
+            return ParametersUtil.buildSearchParametersMapFromBundle(bundle);
         } catch (Throwable t) {
             // In R4, there are two files used with postfix JSON.
             // Default is to use JSON in R4

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -421,23 +421,12 @@ public class SearchUtil {
     public static SearchParameter getSearchParameter(String resourceType, String code) throws Exception {
         String tenantId = FHIRRequestContext.get().getTenantId();
 
-        SearchParameter result = null;
-
         // First try to find the search parameter within the specified tenant's map.
-        Map<String, ParametersMap> spMaps = getTenantOrDefaultSPMap(tenantId);
-        if (spMaps != null && !spMaps.isEmpty()) {
-            ParametersMap parametersMap = spMaps.get(resourceType);
-            if (parametersMap != null && !parametersMap.isEmpty()) {
-                result = parametersMap.lookupByCode(code);
-            }
-        }
+        SearchParameter result = getSearchParameterByCodeIfPresent(getTenantOrDefaultSPMap(tenantId), resourceType, code);
 
         // If we didn't find it within the tenant's map, then look within the built-in map.
         if (result == null) {
-            ParametersMap parametersMap = ParametersUtil.getBuiltInSearchParametersMap().get(resourceType);
-            if (parametersMap != null && !parametersMap.isEmpty()) {
-                result = parametersMap.lookupByCode(code);
-            }
+            result = getSearchParameterByCodeIfPresent(ParametersUtil.getBuiltInSearchParametersMap(), resourceType, code);
 
             // If we found it within the built-in search parameters, apply our filtering rules.
             if (result != null) {
@@ -450,6 +439,25 @@ public class SearchUtil {
                 result = (filteredResult.isEmpty() ? null : filteredResult.iterator().next());
             }
         }
+        return result;
+    }
+    
+    /**
+     * @param spMaps
+     * @param resourceType
+     * @param uri
+     * @return the SearchParameter for type {@code resourceType} with code {@code code} or null if it doesn't exist 
+     */
+    private static SearchParameter getSearchParameterByCodeIfPresent(Map<String, ParametersMap> spMaps, String resourceType, String code) {
+        SearchParameter result = null;
+        
+        if (spMaps != null && !spMaps.isEmpty()) {
+            ParametersMap parametersMap = spMaps.get(resourceType);
+            if (parametersMap != null && !parametersMap.isEmpty()) {
+                result = parametersMap.lookupByCode(code);
+            }
+        }
+        
         return result;
     }
 
@@ -465,23 +473,13 @@ public class SearchUtil {
      */
     public static SearchParameter getSearchParameter(String resourceType, Canonical uri) throws Exception {
         String tenantId = FHIRRequestContext.get().getTenantId();
-        SearchParameter result = null;
         
         // First try to find the search parameter within the specified tenant's map.
-        Map<String, ParametersMap> spMaps = getTenantOrDefaultSPMap(tenantId);
-        if (spMaps != null && !spMaps.isEmpty()) {
-            ParametersMap parametersMap = spMaps.get(resourceType);
-            if (parametersMap != null && !parametersMap.isEmpty()) {
-                result = parametersMap.lookupByUrl(uri.getValue());
-            }
-        }
+        SearchParameter result = getSearchParameterByUrlIfPresent(getTenantOrDefaultSPMap(tenantId), resourceType, uri);
 
         // If we didn't find it within the tenant's map, then look within the built-in map.
         if (result == null) {
-            ParametersMap parametersMap = ParametersUtil.getBuiltInSearchParametersMap().get(resourceType);
-            if (parametersMap != null && !parametersMap.isEmpty()) {
-                result = parametersMap.lookupByUrl(uri.getValue());
-            }
+            result = getSearchParameterByUrlIfPresent(ParametersUtil.getBuiltInSearchParametersMap(), resourceType, uri);
 
             // If we found it within the built-in search parameters, apply our filtering rules.
             if (result != null) {
@@ -493,6 +491,25 @@ public class SearchUtil {
                 result = (filteredResult.isEmpty() ? null : filteredResult.iterator().next());
             }
         }
+        return result;
+    }
+
+    /**
+     * @param spMaps
+     * @param resourceType
+     * @param uri
+     * @return the SearchParameter for type {@code resourceType} with url {@code uri} or null if it doesn't exist 
+     */
+    private static SearchParameter getSearchParameterByUrlIfPresent(Map<String, ParametersMap> spMaps, String resourceType, Canonical uri) {
+        SearchParameter result = null;
+        
+        if (spMaps != null && !spMaps.isEmpty()) {
+            ParametersMap parametersMap = spMaps.get(resourceType);
+            if (parametersMap != null && !parametersMap.isEmpty()) {
+                result = parametersMap.lookupByUrl(uri.getValue());
+            }
+        }
+        
         return result;
     }
 

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -53,7 +53,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Medication");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters2", result);
-        assertEquals(23 * 2, result.size());
+        assertEquals(21, result.size());
     }
 
     @Test
@@ -63,7 +63,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters1", result);
-        assertEquals(52 * 2, result.size());
+        assertEquals(50, result.size());
     }
 
     @Test
@@ -76,12 +76,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Patient", result);
-        assertEquals(43 * 2, result.size());
+        assertEquals(41, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Observation", result);
-        assertEquals(52 * 2, result.size());
+        assertEquals(50, result.size());
     }
 
     @Test
@@ -95,11 +95,11 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters4/Observation", result);
-        assertEquals(9 * 2, result.size());
+        assertEquals(8, result.size());
         SearchParameter sp = result.get(0);
         assertNotNull(sp);
         assertEquals("code", sp.getCode().getValue());
-        sp = result.get(2); // skip index=1 because its the same SP as index=0 but with a different key
+        sp = result.get(1);
         assertNotNull(sp);
         assertEquals("_id", sp.getCode().getValue());
     }
@@ -112,7 +112,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters5/Device", result);
-        assertEquals(9 * 2, result.size());
+        assertEquals(8, result.size());
         List<String> names = getSearchParameterNames(result);
         assertTrue(names.contains("patient"));
         assertTrue(names.contains("organization"));
@@ -126,7 +126,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters6/Patient", result);
-        assertEquals(11 * 2, result.size());
+        assertEquals(10, result.size());
         List<String> names = getSearchParameterNames(result);
         assertTrue(names.contains("active"));
         assertTrue(names.contains("address"));
@@ -138,7 +138,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("MedicationAdministration");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters6/MedicationAdministration", result);
-        assertEquals(27 * 2, result.size());
+        assertEquals(25, result.size());
     }
 
     @Test
@@ -149,12 +149,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Patient", result);
-        assertEquals(43 * 2, result.size());
+        assertEquals(41, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Device", result);
-        assertEquals(26 * 2, result.size());
+        assertEquals(24, result.size());
     }
 
     @Test
@@ -167,7 +167,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters2", result);
-        assertEquals(30 * 2, result.size());
+        assertEquals(29, result.size());
     }
 
     @Test
@@ -355,7 +355,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertEquals(36 * 2, result.size());
+        assertEquals(35, result.size());
 
         // Sleep a bit to allow file mod times to register.
         Thread.sleep(1000);
@@ -373,7 +373,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertNotEquals(34 * 2, result.size());
+        assertNotEquals(33, result.size());
 
         // Sleep a bit to allow file mod times to register.
         Thread.sleep(1000);
@@ -388,7 +388,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertEquals(36 * 2, result.size());
+        assertEquals(35, result.size());
     }
 
     /**

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
@@ -52,7 +52,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
             ParametersUtil.print(System.out);
         }
 
-        assertEquals(45 * 2, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -65,12 +65,12 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters2/Patient", result);
-        assertEquals(36 * 2, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters2/Observation", result);
-        assertEquals(45 * 2, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -90,19 +90,19 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
             System.out.println("As Follows: ");
             System.out.println(result.stream().map(in -> in.getCode().getValue()).collect(Collectors.toList()));
         }
-        assertEquals(2 * 2, result.size());
+        assertEquals(2, result.size());
         SearchParameter sp = result.get(0);
         assertNotNull(sp);
         assertEquals("code", sp.getCode().getValue());
 
-        sp = result.get(2); // skip index=1 because its the same as index=0 but with a canonical key
+        sp = result.get(1);
         assertNotNull(sp);
         assertEquals("value-range", sp.getCode().getValue());
 
         result = SearchUtil.getSearchParameters("Immunization");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters3/Immunization", result);
-        assertEquals(23 * 2, result.size());
+        assertEquals(22, result.size());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters4/Device", result);
-        assertEquals(2 * 2, result.size());
+        assertEquals(2, result.size());
         List<String> codes = getSearchParameterNames(result);
         assertTrue(codes.contains("patient"));
         assertTrue(codes.contains("organization"));
@@ -127,7 +127,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters5/Patient", result);
-        assertEquals(4 * 2, result.size());
+        assertEquals(4, result.size());
         List<String> codes = getSearchParameterNames(result);
         assertTrue(codes.contains("active"));
         assertTrue(codes.contains("address"));
@@ -139,7 +139,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         result = SearchUtil.getSearchParameters("MedicationAdministration");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters5/MedicationAdministration", result);
-        assertEquals(20 * 2, result.size());
+        assertEquals(19, result.size());
     }
 
     @Test
@@ -150,11 +150,11 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters6/Patient", result);
-        assertEquals(36 * 2, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters6/Device", result);
-        assertEquals(19 * 2, result.size());
+        assertEquals(18, result.size());
     }
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -10,15 +10,17 @@ import static com.ibm.fhir.model.type.String.string;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.io.Reader;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -26,6 +28,10 @@ import java.util.function.Consumer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.parser.exception.FHIRParserException;
+import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Markdown;
@@ -45,41 +51,42 @@ import com.ibm.fhir.search.test.BaseSearchTest;
 public class ParametersUtilTest extends BaseSearchTest {
 
     @Test
-    public void testGetBuildInSearchParameterMap() throws IOException {
+    public void testGetBuiltInSearchParameterMap() throws IOException {
         // Tests JSON
-        Map<String, Map<String, SearchParameter>> params = ParametersUtil.getBuiltInSearchParameterMap();
+        Map<String, ParametersMap> params = ParametersUtil.getBuiltInSearchParametersMap();
         assertNotNull(params);
         // Intentionally the data is caputred in the bytearray output stream.
         try (ByteArrayOutputStream outBA = new ByteArrayOutputStream(); PrintStream out = new PrintStream(outBA, true);) {
             ParametersUtil.print(out);
             Assert.assertNotNull(outBA);
         }
-        // 134 + DomainResource
-        assertEquals(params.size(), 135);
+        assertEquals(params.size(), 134);
     }
 
     @Test()
-    public void testPopulateSearchParameterMapFromStreamXML() throws IOException {
+    public void testPopulateSearchParameterMapFromStreamXML() throws IOException, FHIRParserException {
         // Tests XML (once we support reading XML)
         try (InputStream stream = ParametersUtil.class.getClassLoader().getResourceAsStream("search-parameters.xml")) {
-            Map<String, Map<String, SearchParameter>> params = ParametersUtil.populateSearchParameterMapFromStreamXML(stream);
+            Bundle bundle = FHIRParser.parser(Format.XML).parse(stream);
+            Map<String, ParametersMap> params = ParametersUtil.buildSearchParametersMapFromBundle(bundle);
             assertNotNull(params);
             if (DEBUG) {
                 ParametersUtil.print(System.out);
             }
-            // 134 + DomainResource
-            assertEquals(params.size(), 135);
+            assertEquals(params.size(), 134);
         }
 
     }
 
     @Test(expectedExceptions = {})
-    public void testPopulateSearchParameterMapFromFile() throws IOException {
+    public void testPopulateSearchParameterMapFromFile() throws IOException, FHIRParserException {
         File customSearchParams = new File("src/test/resources/config/tenant1/extension-search-parameters.json");
         if (DEBUG) {
             System.out.println(customSearchParams.getAbsolutePath());
         }
-        Map<String, Map<String, SearchParameter>> params = ParametersUtil.populateSearchParameterMapFromFile(customSearchParams);
+        Reader reader = new FileReader(customSearchParams);
+        Bundle bundle = FHIRParser.parser(Format.JSON).parse(reader);
+        Map<String, ParametersMap> params = ParametersUtil.buildSearchParametersMapFromBundle(bundle);
         if (DEBUG) {
             System.out.println(params.keySet());
         }
@@ -98,6 +105,9 @@ public class ParametersUtilTest extends BaseSearchTest {
             ParametersUtil.print(out);
             assertNotNull(outBA);
             assertNotNull(outBA.toByteArray());
+            if (DEBUG) {
+                System.out.println(outBA);
+            }
         } catch (Exception e) {
             fail();
         }
@@ -105,106 +115,35 @@ public class ParametersUtilTest extends BaseSearchTest {
     }
 
     @Test(expectedExceptions = {})
-    public void testGetBuiltInSearchParameterMapByResourceTypeInvalid() {
+    public void testGetBuiltInSearchParameterMapByResourceType() {
         // getBuiltInSearchParameterMapByResourceType
-        Map<String, SearchParameter> result = ParametersUtil.getBuiltInSearchParameterMapByResourceType("Junk");
+        Map<String, ParametersMap> result = ParametersUtil.getBuiltInSearchParametersMap();
         assertNotNull(result);
-        assertTrue(result.isEmpty());
-    }
-
-    @Test(expectedExceptions = {})
-    public void testGetBuiltInSearchParameterMapByResourceTypeValid() {
-        // getBuiltInSearchParameterMapByResourceType
-        Map<String, SearchParameter> result = ParametersUtil.getBuiltInSearchParameterMapByResourceType("Observation");
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-    }
-
-    @Test(expectedExceptions = { FileNotFoundException.class })
-    public void testPopulateSearchParameterMapFromResourceNull() throws IOException {
-        String invalidResourceName = "INVALID_RESOURCE";
-        ParametersUtil.populateSearchParameterMapFromResource(invalidResourceName);
+        assertNull(result.get("Junk"));
+        assertFalse(result.get("Observation").isEmpty());
     }
 
     @Test
     public void testResourceDefaults() throws IOException {
-        Map<String, SearchParameter> params1 = ParametersUtil.getBuiltInSearchParameterMapByResourceType("Observation");
-        Map<String, SearchParameter> params2 = ParametersUtil.getBuiltInSearchParameterMapByResourceType("Resource");
+        Map<String, ParametersMap> result = ParametersUtil.getBuiltInSearchParametersMap();
+        ParametersMap params1 = result.get("Observation");
+        ParametersMap params2 = result.get("Resource");
 
         // Check that each returned "Resource" is included in the first set returned.
         assertNotNull(params1);
         assertNotNull(params2);
-        assertEquals(params2.size(), 7 * 2);
-        params2.keySet().stream().forEach(new Consumer<String>() {
+        assertEquals(params2.size(), 6);
+        params2.values().stream().forEach(new Consumer<SearchParameter>() {
 
             @Override
-            public void accept(String resourceParam) {
+            public void accept(SearchParameter resourceParam) {
                 if (DEBUG) {
-                    System.out.println("Checking Resource Param -> " + resourceParam);
+                    System.out.println("Checking Resource Param -> " + resourceParam.getId());
                 }
-                assertTrue(params1.containsKey(resourceParam));
+                assertTrue(params1.values().contains(resourceParam));
             }
 
         });
-    }
-
-    /*
-     * Generate Search parameter
-     */
-    private SearchParameter generateSearchParameter(String expressions) {
-        SearchParameter.Builder builder = SearchParameter.builder();
-        builder.url(com.ibm.fhir.model.type.Uri.uri("test"));
-        builder.name(string("test"));
-        builder.status(PublicationStatus.ACTIVE);
-        builder.description(Markdown.builder().id("test").value("test").build());
-        builder.code(Code.builder().id("test").value("test").build());
-        builder.base(ResourceType.ACCOUNT);
-        builder.type(SearchParamType.COMPOSITE);
-        builder.expression(string(expressions));
-        return builder.build();
-    }
-
-    @Test
-    public void testRemoveUnsupportedExpressionsParameterResolves() {
-
-        String expressions = "resolve() ";
-        assertNotNull(ParametersUtil.removeUnsupportedExpressions(generateSearchParameter(expressions)));
-
-        expressions = "resolve() | resolve() | resolve()";
-        assertNotNull(ParametersUtil.removeUnsupportedExpressions(generateSearchParameter(expressions)));
-
-        expressions = "resolve() | resolve() | resolve ()";
-        assertNotNull(ParametersUtil.removeUnsupportedExpressions(generateSearchParameter(expressions)));
-
-        // issue 206: Resolve is no longer removed
-        // The checks are flipped and left for posterity as they should be true.
-        expressions = ".where(resolve())";
-        assertNotNull(ParametersUtil.removeUnsupportedExpressions(generateSearchParameter(expressions)));
-
-        expressions = "CarePlan.subject.where(resolve() is Patient) ";
-        assertEquals(ParametersUtil.processResolve(expressions), expressions);
-
-        expressions =
-                "AllergyIntolerance.patient | CarePlan.subject.where(resolve() is Patient) | CareTeam.subject.where(resolve() is Patient) | ClinicalImpression.subject.where(resolve() is Patient) | Composition.subject.where(resolve() is Patient) | Condition.subject.where(resolve() is Patient) | Consent.patient | DetectedIssue.patient | DeviceRequest.subject.where(resolve() is Patient) | DeviceUseStatement.subject | DiagnosticReport.subject.where(resolve() is Patient) | DocumentManifest.subject.where(resolve() is Patient) | DocumentReference.subject.where(resolve() is Patient) | Encounter.subject.where(resolve() is Patient) | EpisodeOfCare.patient | FamilyMemberHistory.patient | Flag.subject.where(resolve() is Patient) | Goal.subject.where(resolve() is Patient) | ImagingStudy.subject.where(resolve() is Patient) | Immunization.patient | List.subject.where(resolve() is Patient) | MedicationAdministration.subject.where(resolve() is Patient) | MedicationDispense.subject.where(resolve() is Patient) | MedicationRequest.subject.where(resolve() is Patient) | MedicationStatement.subject.where(resolve() is Patient) | NutritionOrder.patient | Observation.subject.where(resolve() is Patient) | Procedure.subject.where(resolve() is Patient) | RiskAssessment.subject.where(resolve() is Patient) | ServiceRequest.subject.where(resolve() is Patient) | SupplyDelivery.patient | VisionPrescription.patient";
-        assertEquals(ParametersUtil.processResolve(expressions), expressions);
-
-        expressions =
-                "AllergyIntolerance.patient | CarePlan.subject.where(resolve() is Patient) | CareTeam.subject.where(resolve() is Patient) | ClinicalImpression.subject.where(resolve() is Patient) | Composition.subject.where(resolve() is Patient) | Condition.subject.where(resolve() is Patient) | Consent.patient | DetectedIssue.patient | DeviceRequest.subject.where(resolve() is Patient) | DeviceUseStatement.subject | DiagnosticReport.subject.where(resolve() is Patient) | DocumentManifest.subject.where(resolve() is Patient) | DocumentReference.subject.where(resolve() is Patient) | Encounter.subject.where(resolve() is Patient) | EpisodeOfCare.patient | FamilyMemberHistory.patient | Flag.subject.where(resolve() is Patient) | Goal.subject.where(resolve() is Patient) | ImagingStudy.subject.where(resolve() is Patient) | Immunization.patient | List.subject.where(resolve() is Patient) | MedicationAdministration.subject.where(resolve() is Patient) | MedicationDispense.subject.where(resolve() is Patient) | MedicationRequest.subject.where(resolve() is Patient) | MedicationStatement.subject.where(resolve() is Patient) | NutritionOrder.patient | Observation.subject.where(resolve() is Patient) | Procedure.subject.where(resolve() is Patient) | RiskAssessment.subject.where(resolve() is Patient) | ServiceRequest.subject.where(resolve() is Patient) | SupplyDelivery.patient | VisionPrescription.patient";
-        String output = ParametersUtil.removeUnsupportedExpressions(generateSearchParameter(expressions)).getExpression().getValue();
-        assertNotNull(output);
-        if (DEBUG) {
-            System.out.println(output);
-        }
-        assertTrue(output.contains("resolve()"));
-
-    }
-
-    @Test
-    public void testProcessResolve() {
-        // issue 206: Resolve is no longer removed
-        String expressions = "Procedure.subject.where(resolve() is Patient)";
-        assertEquals(ParametersUtil.processResolve(expressions), expressions);
-
     }
 
     @Test
@@ -221,7 +160,6 @@ public class ParametersUtilTest extends BaseSearchTest {
                 System.out.println(outBA.toString("UTF-8"));
             }
         }
-
     }
 
     @Test
@@ -245,24 +183,4 @@ public class ParametersUtilTest extends BaseSearchTest {
 
         assertTrue(true);
     }
-    
-    @Test
-    public void testProcessContains() {
-        String expression = "ValueSet.expansion.contains.code";
-        String result = ParametersUtil.processContains(expression);
-        assertEquals(result, "ValueSet.expansion.`contains`.code");
-        
-        expression = "ValueSet.expansion.contains";
-        result = ParametersUtil.processContains(expression);
-        assertEquals(result, "ValueSet.expansion.`contains`");
-        
-        expression = "ValueSet.expansion.contains()";
-        result = ParametersUtil.processContains(expression);
-        assertEquals(result, "ValueSet.expansion.contains()");
-        
-        expression = "ValueSet.expansion.contains().code";
-        result = ParametersUtil.processContains(expression);
-        assertEquals(result, "ValueSet.expansion.contains().code");
-    }
-
 }


### PR DESCRIPTION
Previously, the parameter maps built by ParametersUtil had each
SearchParameter listed twice...once by "code" and once by "url".

This pull request introduces a new ParametersMap object that
encapsulates two separate maps and presents it as a single object.

Also removed the notion of "UNSUPPORTED_EXPRESSION" since 
4.0.1 artifacts now have valid FHIRPath and our FHIRPath engine
now supports `resolve()`.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>