### PR TITLE
issue #536 - introduce examples to the Swagger/OpenAPI

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
@@ -93,6 +93,10 @@ public abstract class Resource extends AbstractVisitable {
         return resourceType.isInstance(this);
     }
 
+    /**
+     * @throws ClassCastException
+     *     when this resources cannot be cast to the requested resourceType
+     */
     public <T extends Resource> T as(Class<T> resourceType) {
         return resourceType.cast(this);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
@@ -68,6 +68,10 @@ public abstract class Element extends AbstractVisitable {
         return elementType.isInstance(this);
     }
 
+    /**
+     * @throws ClassCastException
+     *     when this element cannot be cast to the requested elementType
+     */
     public <T extends Element> T as(Class<T> elementType) {
         return elementType.cast(this);
     }

--- a/fhir-swagger-generator/README.md
+++ b/fhir-swagger-generator/README.md
@@ -1,0 +1,40 @@
+# FHIR Swagger Generator
+
+This module provides classes for generating Swagger and/or OpenAPI definitions for the FHIR HTTP interface.
+
+It uses a combination of the HL7-provided specification artifacts and the generated java classes from `fhir-model`.
+
+## Usage
+
+Both the FHIRSwaggerGenerator and the FHIROpenApiGenerator are designed to generate one interface definition (swagger 2.0 or openapi 3.0) per resource type.
+The main driver for this approach is the assumption that most users of FHIR will be focused on a specific subset of the FHIR Resources. By default, the FHIRSwagger generates these files at `src/main/resources/swagger` whereas the OpenApiGenerator places them at `src/main/resources/openapi`. 
+
+Additionally, the FHIROpenApiGenerator will generate an "all-in-one" definition called all-openapi.json. This is the version of the OpenAPI definition that we ship with our server via the `fhir-openapi` project (e.g. see `fhir-openapi/src/main/webapp/META-INF/openapi.json`).
+
+To limit the number of resource types included in the output directories (and in the all-in-one mentioned above), you may pass a set of semicolon-delimited 
+filter strings as program arguments.
+
+For example, to generate definitions for `read, vread, and history` on the Patient API, `create, read, vread, history, and search` on the Contract API, and `read` on the RiskAssessment API (and no other output), you would invoke the generator with the following argument: 
+
+```
+Patient(read,vread,history);Contract(create,read,vread,history,search);RiskAssessment(read)
+```
+
+## Design decisions
+
+The FHIR API is [notoriously](https://chat.fhir.org/#narrow/stream/179166-implementers/topic/OpenAPI.20Support) [difficult](https://chat.fhir.org/#narrow/stream/179166-implementers/topic/OpenAPI) to represent in Swagger/OpenAPI. In fact, the value of such an API definition is questionable when the API itself is defined in a balloted HL7 / ISO standard that has such a rich collection of open source clients and servers which provide native support.
+
+Still, the broad adoption of Swagger/OpenAPI in the marketplace has driven a broad awareness and so many IT practitioners expect such an interface definition for all HTTP interfaces. We provide the generators in this module for these tools and practitioners and this has driven some of the key design decisions.
+
+Importantly, the Swagger/OpenAPI definitions generated in this project are NOT a full representation of the full HL7 FHIR HTTP interface, nor of the subset of that API supported by the IBM FHIR Server. For example, here are some of the simplifications made to the schema in order to improve approachability from both a tooling and end user standpoint:
+* FHIR supports extensions on primitive data types. However, the JSON serialization for that is a bit interesting, and these primitive extensions aren't used much in practice...so the generated swagger omits those.
+* FHIR supports "contained" resources, and so each resource type could technically contain any other resource type within it. However, to properly represent that structure, it would require that every endpoint definition include every single resource and datatype definition in the specification. Instead, we include just the elements for the resource(s) being generated.
+* FHIR choice elements with a type of `*` (like Extension.value[x]) can technically reference any FHIR data type, including rare/obscure ones like those defined at https://www.hl7.org/fhir/metadatatypes.html. For simplicity, we omit these from the swagger definition unless the Resource has an explicit field with this type.
+
+
+## Alternatives
+
+For those wishing to represent the full FHIR API in Swagger/OpenAPI (without the simplifications discussed above), we recommend using "external documentation" as described at https://swagger.io/specification/#externalDocumentationObject. Basically, instead of describing the FHIR schema in the subset of JsonSchema supported by OpenAPI, you just use OpenAPI to describe the interactions and reference the external specification as the documentation of the schema.
+
+
+FHIR® is the registered trademark of HL7 and is used with the permission of HL7.

--- a/fhir-swagger-generator/pom.xml
+++ b/fhir-swagger-generator/pom.xml
@@ -13,6 +13,12 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-examples</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -8,7 +8,9 @@ package com.ibm.fhir.openapi.generator;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -30,11 +32,13 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import javax.json.JsonReader;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
 
 import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.examples.ExamplesUtil;
 import com.ibm.fhir.model.annotation.Required;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
@@ -98,13 +102,16 @@ import com.ibm.fhir.swagger.generator.APIConnectAdapter;
  * Generate OpenAPI 3.0 from the HL7 FHIR R4 artifacts and IBM FHIR object model.
  * 
  * <p>
- * By default, this class will create a separate OpenAPI definition for each and every resource type;
- * each with all HTTP interactions enabled.
+ * By default, this class will generate:
+ * <ol>
+ * <li> an "all-in-one" OpenAPI definition for the entire api
+ * <li> a separate OpenAPI definition for each and every resource type; each with all HTTP interactions enabled
+ * </ol>
  * 
  * <p>
  * To limit the output to a given set of resources and/or interactions, pass a set of semicolon-delimited
  * filter strings of the form {@code ResourceType1(interaction1,interaction2)}.
- *  
+ * 
  * For example: 
  * <pre>
  * Patient(create,read,vread,history,search,update,delete);Contract(create,read,vread,history,search);RiskAssessment(read)
@@ -1069,7 +1076,20 @@ public class FHIROpenApiGenerator {
                 definition.add("required", requiredArray);
             }
 
+            if (Resource.class.isAssignableFrom(modelClass)) {
+                addExamples(modelClass, definition);
+            }
+
             definitions.add(getSimpleNameWithEnclosingNames(modelClass), definition);
+        }
+    }
+
+    public static void addExamples(Class<?> modelClass, JsonObjectBuilder definition) throws IOException {
+        if (!Modifier.isAbstract(modelClass.getModifiers())) {
+            // Change this from "complete-mock" to "minimal" to reduce the size of the generated definition
+            Reader example = ExamplesUtil.resourceReader("json/ibm/complete-mock/" + modelClass.getSimpleName() + "-1.json");
+            JsonReader jsonReader = Json.createReader(example);
+            definition.add("example", jsonReader.readObject());
         }
     }
 

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -156,7 +156,7 @@ public class FHIROpenApiGenerator {
         JsonObjectBuilder info = factory.createObjectBuilder();
         info.add("title", "Simplified FHIR API");
         info.add("description", "A simplified version of the HL7 FHIR API");
-        info.add("version", "4.0.0");
+        info.add("version", "4.0.1");
         swagger.add("info", info);
 
         JsonArrayBuilder servers = factory.createArrayBuilder();

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -855,6 +855,10 @@ public class FHIRSwaggerGenerator {
                 definition.add("required", requiredArray);
             }
 
+            if (Resource.class.isAssignableFrom(modelClass)) {
+                FHIROpenApiGenerator.addExamples(modelClass, definition);
+            }
+
             definitions.add(getSimpleNameWithEnclosingNames(modelClass), definition);
         }
     }

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeBuilder.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeBuilder.java
@@ -145,6 +145,14 @@ public class CodeBuilder {
         return this;
     }
     
+    public CodeBuilder javadocThrows(String exception, String description) {
+        indent().append(" * @throws").append(" ").append(exception).newLine();
+        for (String line : wrap(escape(normalizeSpace(description)))) {
+            indent().append(" *     ").append(line).newLine();
+        }
+        return this;
+    }
+    
     public CodeBuilder javadocSee(String reference) {
         return indent()
                 .append(" * @see")

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -1739,6 +1739,9 @@ public class CodeGenerator {
                 ._return("resourceType.isInstance(this)")
             .end().newLine();
             
+            cb.javadocStart()
+                .javadocThrows("ClassCastException", "when this resources cannot be cast to the requested resourceType")
+                .javadocEnd();
             cb.method(mods("public"), "<T extends Resource> T", "as", params("Class<T> resourceType"))
                 ._return("resourceType.cast(this)")
             .end().newLine();
@@ -1748,6 +1751,9 @@ public class CodeGenerator {
                 ._return("elementType.isInstance(this)")
             .end().newLine();
             
+            cb.javadocStart()
+                .javadocThrows("ClassCastException", "when this element cannot be cast to the requested elementType")
+                .javadocEnd();
             cb.method(mods("public"), "<T extends Element> T", "as", params("Class<T> elementType"))
                 ._return("elementType.cast(this)")
             .end().newLine();


### PR DESCRIPTION
By default, we'll now use the first `complete-mock` example for each
applicable resourceType.

In addition, I flipped this to "minimal" and used that to generate a new
version of the "all-in-one" in our `fhir-openapi` project.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>