### PR TITLE
Add Lint for the Javadocs #545

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       # As the e2e tests are the fastest, opting to put javadoc:javadoc in fhir-parent
       # The profile avoids UML diagram creation
       run: |
-        find / -iname javadoc
+        export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
         mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
     - name: Server Integration Tests
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,8 @@ jobs:
     - name: Build samples
       run: mvn -B install --file fhir-examples/pom.xml --no-transfer-progress
     - name: Build parent without tests
-      run: mvn -B install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+      # As the e2e tests are the fastest, opting to put javadoc:javadoc in fhir-parent
+      run: mvn -B javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,12 @@ jobs:
       # As the e2e tests are the fastest, opting to put javadoc:javadoc in fhir-parent
       # The profile avoids UML diagram creation
       run: |
-        export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
+        JAVADOC_GOAL=""
+        if [ "${{ matrix.java }}" != "openjdk8" ]
+        then 
+          export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
+          JAVADOC_GOAL=" javadoc:javadoc "
+        fi
         mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
     - name: Server Integration Tests
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
       # The profile avoids UML diagram creation
       run: |
         export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
-        mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+        mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,9 +125,9 @@ jobs:
         if [ "${{ matrix.java }}" != "openjdk8" ]
         then 
           export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
-          JAVADOC_GOAL=" javadoc:javadoc "
+          JAVADOC_GOAL=" -Pvalidate-javadoc javadoc:javadoc "
         fi
-        mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
+        mvn -B ${JAVADOC_GOAL} install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,8 @@ jobs:
       run: mvn -B install --file fhir-examples/pom.xml --no-transfer-progress
     - name: Build parent without tests
       # As the e2e tests are the fastest, opting to put javadoc:javadoc in fhir-parent
-      run: mvn -B javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+      # The profile avoids UML diagram creation
+      run: mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,9 @@ jobs:
     - name: Build parent without tests
       # As the e2e tests are the fastest, opting to put javadoc:javadoc in fhir-parent
       # The profile avoids UML diagram creation
-      run: mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+      run: |
+        find / -iname javadoc
+        mvn -B -Pvalidate-javadoc javadoc:javadoc install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
           export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
           JAVADOC_GOAL=" -Pvalidate-javadoc javadoc:javadoc "
         fi
-        mvn -B ${JAVADOC_GOAL} install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
+        mvn -B ${JAVADOC_GOAL} install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -1,0 +1,76 @@
+name: Javadocs Build for Site
+
+on:
+  push:
+    tags: 
+        - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 'openjdk8']
+      fail-fast: false
+    steps:
+    - name: Gets the version
+      id: get_version
+      run: echo ::set-env name=TAG_VERSION::${GITHUB_REF/refs\/tags\//}
+    - name: Grab the Master Branch
+      uses: actions/checkout@v2
+      with:
+            working-directory: fhir
+            ref: refs/heads/master
+            fetch-depth: 1
+            path: fhir
+    - uses: actions/checkout@v1
+    - name: Set up OpenJDK
+      uses: joschi/setup-jdk@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Build samples
+      run: |
+            mvn -Pdeploy-version-release clean -f fhir-examples/pom.xml
+            mvn -B install --file fhir-examples/pom.xml --no-transfer-progress
+    - name: Build parent without tests
+      run: |
+            export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
+            mvn -Pdeploy-version-release clean -f fhir-parent/pom.xml -N
+            mvn -B site --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+            cp -R fhir-parent/target/site/apidocs apidocs/
+    - name: Grab the GH Pages Branch
+      uses: actions/checkout@v1
+      with:
+            working-directory: gh-pages
+            ref: refs/heads/gh-pages
+            fetch-depth: 1
+            path: docs
+            token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Commit and Add GH Pages
+      env:
+            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
+            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            CI: true
+      run: |
+            rm -rf ./javadocs/latest/
+            cp -Rf ../apidocs/* ./javadocs/
+            mv javadocs/apidocs javadocs/latest 
+            cp -Rf javadocs/javadocs javadocs/${TAG_VERSION}
+            date > build.txt
+            echo "javadocs" >> build.txt
+            git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git config --global user.name "Github Actions Bot - GH-Pages"
+            git add .
+            git commit -m "Automated gh-pages deployment of javadocs: $(date -u)"
+    - name: Push changes to GH Pages
+      env:
+            GITHUB_TOKEN: ${{ secrets.DOCS_SITE_TOKEN }}
+            GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+            GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+            CI: true
+      run: |
+            echo "Push Changes"
+            git branch
+            remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+            git push "${remote_repo}" HEAD:gh-pages

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -230,7 +230,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <!--  required for the Tyrus client to work on Java 11 -->
+                <!-- required for the Tyrus client to work on Java 11 -->
                 <groupId>javax.xml.ws</groupId>
                 <artifactId>jaxws-api</artifactId>
                 <version>2.3.0</version>
@@ -498,23 +498,47 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.0.1</version>
                     <configuration>
-                        <!-- no matter the JDK running the javadoc, it's important this be at 
-                        the minimum level we support, which is 8. -->
+                        <!-- speed up the build -->
+                        <isOffline>true</isOffline>
+                        <!-- no matter the JDK running the javadoc, it's 
+                            important this be at the minimum level we support, which is 8. -->
                         <source>8</source>
-                        <verbose>true</verbose>
+                        <!-- we don't need package -->
+                        <show>package</show>
+                        <!-- verbose if you are debugging -->
+                        <verbose>false</verbose>
+                        <dependencySourceIncludes>com.ibm.fhir:*</dependencySourceIncludes>
+                        <minmemory>2g</minmemory>
+                        <maxmemory>2g</maxmemory>
+                        <!-- doclint is none, otherwise build breaks -->
                         <doclint>none</doclint>
                         <additionalparam>-Xdoclint:none</additionalparam>
-                        <minmemory>512m</minmemory>
-                        <maxmemory>1g</maxmemory>
+                        <detectLinks>true</detectLinks>
+                        <docletArtifact>
+                            <groupId>nl.talsmasoftware</groupId>
+                            <artifactId>umldoclet</artifactId>
+                            <version>2.0.7</version>
+                        </docletArtifact>
+                        <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
+                        <additionalparam>
+                            -umlSkipStandardDoclet true
+                            -umlLogLevel INFO
+                            -umlImageFormat svg
+                        </additionalparam>
+                        <!-- control display -->
+                        <author>false</author>
+                        <windowtitle>IBM FHIR Server</windowtitle>
+                        <doctitle>${project.name} ${project.version}</doctitle>
                         <additionalOptions>
-                            <!-- makes the frames visible, disabled and going away eventually -->
+                            <!-- makes the frames visible, disabled and going 
+                                away eventually -->
                             <additionalOption>--frames</additionalOption>
                             <!-- Fixes the undefined redirect in search -->
                             <additionalOption>--no-module-directories</additionalOption>
@@ -528,16 +552,6 @@
                         <nodeprecated>true</nodeprecated>
                         <nodeprecatedlist>true</nodeprecatedlist>
                     </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>javadoc-no-fork</goal>
-                                <goal>test-javadoc-no-fork</goal>
-                            </goals>
-                            <phase>site</phase>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -690,8 +704,8 @@
         </profile>
         <profile>
             <id>deploy-version-rc</id>
-            <!-- This profile enables automation to change version and DEPLOY rc to bintray: 
-                mvn clean -Drc=1 -Pdeploy-version-rc -f fhir-tools/pom.xml -->
+            <!-- This profile enables automation to change version and DEPLOY 
+                rc to bintray: mvn clean -Drc=1 -Pdeploy-version-rc -f fhir-tools/pom.xml -->
             <properties>
                 <!-- the version to be set -->
                 <rc>1</rc>
@@ -809,7 +823,8 @@
         </profile>
         <profile>
             <id>validate-javadoc</id>
-            <!-- validate is an optimized javadoc:javadoc goal for processing only -->
+            <!-- validate is an optimized javadoc:javadoc goal for processing 
+                only -->
             <build>
                 <plugins>
                     <plugin>
@@ -821,8 +836,8 @@
                             <verbose>true</verbose>
                             <doclint>none</doclint>
                             <additionalparam>-Xdoclint:none</additionalparam>
-                            <minmemory>512m</minmemory>
-                            <maxmemory>1g</maxmemory>
+                            <minmemory>2g</minmemory>
+                            <maxmemory>2g</maxmemory>
                             <nohelp>true</nohelp>
                             <nodeprecated>true</nodeprecated>
                             <nodeprecatedlist>true</nodeprecatedlist>
@@ -832,67 +847,8 @@
                                 <id>attach-javadocs</id>
                                 <goals>
                                     <goal>javadoc-no-fork</goal>
-                                    <goal>test-javadoc-no-fork</goal>
                                 </goals>
                                 <phase>install</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>build-javadoc</id>
-            <!-- validate is an optimized javadoc:javadoc goal for processing only -->
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <inherited>false</inherited>
-                        <configuration>
-                            <!-- no matter the JDK running the javadoc, it's important this be at 
-                            the minimum level we support, which is 8. -->
-                            <source>8</source>
-                            <verbose>true</verbose>
-                            <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none</additionalparam>
-                            <minmemory>512m</minmemory>
-                            <maxmemory>1g</maxmemory>
-                            <additionalOptions>
-                                <!-- makes the frames visible, disabled and going away eventually -->
-                                <additionalOption>--frames</additionalOption>
-                                <!-- Fixes the undefined redirect in search -->
-                                <additionalOption>--no-module-directories</additionalOption>
-                            </additionalOptions>
-                            <header><![CDATA[<a href="/FHIR" class="bx--header__name" target="_parent"><span>IBM</span>&nbsp;FHIR®&nbsp;Server</a>]]></header>
-                            <bottom><![CDATA[Copyright 2019. <a href="http://www.ibm.com">IBM Corporation<a><br></br>FHIR&reg; is the registered trademark of HL7 and is used with the permission of HL7.]]></bottom>
-                            <author>false</author>
-                            <stylesheetfile>${project.build.directory}/../../fhir-parent/src/javadocs/stylesheet.css</stylesheetfile>
-                            <docletArtifact>
-                                <groupId>nl.talsmasoftware</groupId>
-                                <artifactId>umldoclet</artifactId>
-                                <version>2.0.5</version>
-                            </docletArtifact>
-                            <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
-                            <additionalparam>
-                                -umlSkipStandardDoclet true
-                                -umlLogLevel DEBUG
-                                -umlImageFormat png
-                            </additionalparam>
-                            <!-- skips the three entries -->
-                            <nohelp>true</nohelp>
-                            <nodeprecated>true</nodeprecated>
-                            <nodeprecatedlist>true</nodeprecatedlist>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>javadoc-no-fork</goal>
-                                    <goal>test-javadoc-no-fork</goal>
-                                </goals>
-                                <phase>site</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -906,40 +862,76 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <inherited>true</inherited>
                 <reportSets>
                     <reportSet>
+                        <id>aggregate</id>
+                        <inherited>false</inherited>
                         <reports>
                             <report>aggregate</report>
                         </reports>
                     </reportSet>
+                    <reportSet>
+                        <id>default</id>
+                        <inherited>false</inherited>
+                        <reports>
+                            <report>javadoc</report>
+                        </reports>
+                    </reportSet>
                 </reportSets>
                 <configuration>
-                    <dependencySourceIncludes>com.ibm.fhir:*</dependencySourceIncludes>
+                    <!-- speed up the build -->
+                    <isOffline>true</isOffline>
+                    <!-- no matter the JDK running the javadoc, it's important 
+                        this be at the minimum level we support, which is 8. -->
                     <source>8</source>
-                    <minmemory>512m</minmemory> 
-                    <maxmemory>1g</maxmemory>
+                    <!-- we don't need package -->
+                    <show>package</show>
+                    <!-- verbose if you are debugging -->
+                    <verbose>false</verbose>
+                    <dependencySourceIncludes>com.ibm.fhir:*</dependencySourceIncludes>
+                    <minmemory>2g</minmemory>
+                    <maxmemory>2g</maxmemory>
+                    <!-- doclint is none, otherwise build breaks -->
                     <doclint>none</doclint>
                     <additionalparam>-Xdoclint:none</additionalparam>
-                    <author>false</author>
                     <detectLinks>true</detectLinks>
                     <docletArtifact>
                         <groupId>nl.talsmasoftware</groupId>
                         <artifactId>umldoclet</artifactId>
-                        <version>2.0.5</version>
+                        <version>2.0.7</version>
                     </docletArtifact>
                     <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
                     <additionalparam>
                         -umlSkipStandardDoclet true
-                        -umlLogLevel DEBUG
-                        -umlImageFormat png
+                        -umlLogLevel INFO
+                        -umlImageFormat svg
                     </additionalparam>
+                    <!-- control display -->
+                    <author>false</author>
+                    <windowtitle>IBM FHIR Server</windowtitle>
+                    <doctitle>${project.name} ${project.version}</doctitle>
+                    <additionalOptions>
+                        <!-- makes the frames visible, disabled and going 
+                            away eventually -->
+                        <additionalOption>--frames</additionalOption>
+                        <!-- Fixes the undefined redirect in search -->
+                        <additionalOption>--no-module-directories</additionalOption>
+                    </additionalOptions>
+                    <header><![CDATA[<a href="/FHIR" class="bx--header__name" target="_parent"><span>IBM</span>&nbsp;FHIR®&nbsp;Server</a>]]></header>
+                    <bottom><![CDATA[Copyright 2019. <a href="http://www.ibm.com">IBM Corporation<a><br></br>FHIR&reg; is the registered trademark of HL7 and is used with the permission of HL7.]]></bottom>
+                    <author>false</author>
+                    <stylesheetfile>${project.build.directory}/../../fhir-parent/src/javadocs/stylesheet.css</stylesheetfile>
+                    <!-- skips the three entries -->
+                    <nohelp>true</nohelp>
+                    <nodeprecated>true</nodeprecated>
+                    <nodeprecatedlist>true</nodeprecatedlist>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <configuration>
+                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -951,5 +943,4 @@
             </plugin>
         </plugins>
     </reporting>
-
 </project>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -523,17 +523,6 @@
                         <bottom><![CDATA[Copyright 2019. <a href="http://www.ibm.com">IBM Corporation<a><br></br>FHIR&reg; is the registered trademark of HL7 and is used with the permission of HL7.]]></bottom>
                         <author>false</author>
                         <stylesheetfile>${project.build.directory}/../../fhir-parent/src/javadocs/stylesheet.css</stylesheetfile>
-                        <docletArtifact>
-                            <groupId>nl.talsmasoftware</groupId>
-                            <artifactId>umldoclet</artifactId>
-                            <version>2.0.5</version>
-                        </docletArtifact>
-                        <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
-                        <additionalparam>
-                            -umlSkipStandardDoclet true
-                            -umlLogLevel DEBUG
-                            -umlImageFormat png
-                        </additionalparam>
                         <!-- skips the three entries -->
                         <nohelp>true</nohelp>
                         <nodeprecated>true</nodeprecated>
@@ -846,6 +835,64 @@
                                     <goal>test-javadoc-no-fork</goal>
                                 </goals>
                                 <phase>install</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>build-javadoc</id>
+            <!-- validate is an optimized javadoc:javadoc goal for processing only -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <!-- no matter the JDK running the javadoc, it's important this be at 
+                            the minimum level we support, which is 8. -->
+                            <source>8</source>
+                            <verbose>true</verbose>
+                            <doclint>none</doclint>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <minmemory>512m</minmemory>
+                            <maxmemory>1g</maxmemory>
+                            <additionalOptions>
+                                <!-- makes the frames visible, disabled and going away eventually -->
+                                <additionalOption>--frames</additionalOption>
+                                <!-- Fixes the undefined redirect in search -->
+                                <additionalOption>--no-module-directories</additionalOption>
+                            </additionalOptions>
+                            <header><![CDATA[<a href="/FHIR" class="bx--header__name" target="_parent"><span>IBM</span>&nbsp;FHIR®&nbsp;Server</a>]]></header>
+                            <bottom><![CDATA[Copyright 2019. <a href="http://www.ibm.com">IBM Corporation<a><br></br>FHIR&reg; is the registered trademark of HL7 and is used with the permission of HL7.]]></bottom>
+                            <author>false</author>
+                            <stylesheetfile>${project.build.directory}/../../fhir-parent/src/javadocs/stylesheet.css</stylesheetfile>
+                            <docletArtifact>
+                                <groupId>nl.talsmasoftware</groupId>
+                                <artifactId>umldoclet</artifactId>
+                                <version>2.0.5</version>
+                            </docletArtifact>
+                            <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
+                            <additionalparam>
+                                -umlSkipStandardDoclet true
+                                -umlLogLevel DEBUG
+                                -umlImageFormat png
+                            </additionalparam>
+                            <!-- skips the three entries -->
+                            <nohelp>true</nohelp>
+                            <nodeprecated>true</nodeprecated>
+                            <nodeprecatedlist>true</nodeprecatedlist>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                    <goal>test-javadoc-no-fork</goal>
+                                </goals>
+                                <phase>site</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -818,6 +818,40 @@
                 </repository>
             </distributionManagement>
         </profile>
+        <profile>
+            <id>validate-javadoc</id>
+            <!-- validate is an optimized javadoc:javadoc goal for processing only -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <source>8</source>
+                            <verbose>true</verbose>
+                            <doclint>none</doclint>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <minmemory>512m</minmemory>
+                            <maxmemory>1g</maxmemory>
+                            <nohelp>true</nohelp>
+                            <nodeprecated>true</nodeprecated>
+                            <nodeprecatedlist>true</nodeprecatedlist>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                    <goal>test-javadoc-no-fork</goal>
+                                </goals>
+                                <phase>install</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <reporting>


### PR DESCRIPTION
``` sh
       JAVADOC_GOAL=""
        if [ "${{ matrix.java }}" != "openjdk8" ]
        then 
          export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
          JAVADOC_GOAL=" -Pvalidate-javadoc javadoc:javadoc "
        fi
        mvn -B ${JAVADOC_GOAL} install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress -X
```

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>