### PR TITLE
Add Positional Search (near) with :missing modifier #510

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -1164,14 +1164,14 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         final String METHODNAME = "buildLocationQuerySegment";
         log.entering(CLASSNAME, METHODNAME, parmName);
 
-        // Build this piece of the segment:
-        // (P1.PARAMETER_NAME_ID = x AND
         StringBuilder whereClauseSegment = new StringBuilder();
-        this.populateNameIdSubSegment(whereClauseSegment, parmName, PARAMETER_TABLE_ALIAS);
-
         List<Object> bindVariables = new ArrayList<>();
+
+        StringBuilder populateNameIdSubSegment = new StringBuilder();
+        this.populateNameIdSubSegment(populateNameIdSubSegment, parmName, PARAMETER_TABLE_ALIAS);
+
         LocationParmBehaviorUtil behaviorUtil = new LocationParmBehaviorUtil();
-        behaviorUtil.buildLocationSearchQuery(whereClauseSegment, bindVariables, boundingAreas);
+        behaviorUtil.buildLocationSearchQuery(populateNameIdSubSegment.toString(), whereClauseSegment, bindVariables, boundingAreas);
 
         SqlQueryData queryData = new SqlQueryData(whereClauseSegment.toString(), bindVariables);
         log.exiting(CLASSNAME, METHODNAME, whereClauseSegment.toString());

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/LocationParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/LocationParmBehaviorUtil.java
@@ -17,13 +17,16 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LTE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.OR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.PARAMETER_TABLE_ALIAS;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.SPACE;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 import com.ibm.fhir.search.location.bounding.Bounding;
 import com.ibm.fhir.search.location.bounding.BoundingBox;
+import com.ibm.fhir.search.location.bounding.BoundingMissing;
 import com.ibm.fhir.search.location.bounding.BoundingRadius;
+import com.ibm.fhir.search.location.bounding.BoundingType;
 
 /**
  * Location Behavior Util generates SQL and loads the variables into bind
@@ -42,21 +45,35 @@ public class LocationParmBehaviorUtil {
      * @param bindVariables
      * @param boundingAreas
      */
-    public void buildLocationSearchQuery(StringBuilder whereClauseSegment, List<Object> bindVariables,
-            List<Bounding> boundingAreas) {
-        // Clause: AND (
-        whereClauseSegment.append(AND)
-                .append(LEFT_PAREN);
+    public void buildLocationSearchQuery(String populateNameIdSubSegment, StringBuilder whereClauseSegment,
+            List<Object> bindVariables, List<Bounding> boundingAreas) {
+        int instance = 0;
 
         boolean first = true;
-        for (Bounding area : boundingAreas) {
-            // If this is not the first, we want to make this a co-joined set of conditions.
-            // ) OR (
-            if (!first) {
+        int processed = 0;
+        // Strips out the MISSING bounds. 
+        for (Bounding area : boundingAreas.stream()
+                .filter(area -> !BoundingType.MISSING.equals(area.getType())).collect(Collectors.toList())) {
+            if (instance == area.instance()) {
+                processed++;
+                if (instance > 0) {
+                    whereClauseSegment.append(RIGHT_PAREN)
+                            .append(AND)
+                            .append(LEFT_PAREN);
+                }
+
+                // Build this piece of the segment:
+                // (P1.PARAMETER_NAME_ID = x AND (
                 whereClauseSegment
-                        .append(RIGHT_PAREN)
-                        .append(OR)
-                        .append(LEFT_PAREN);
+                        .append(populateNameIdSubSegment).append(AND).append(SPACE);
+                instance++;
+                first = true;
+            }
+
+            if (!first) {
+                // If this is not the first, we want to make this a co-joined set of conditions.
+                // ) OR (
+                whereClauseSegment.append(OR);
             } else {
                 first = false;
             }
@@ -67,13 +84,26 @@ public class LocationParmBehaviorUtil {
                 buildQueryForBoundingRadius(whereClauseSegment, bindVariables,
                         (BoundingRadius) area);
                 break;
+            case MISSING:
+                buildQueryForBoundingMissing(populateNameIdSubSegment, whereClauseSegment, (BoundingMissing) area);
+                break;
             case BOX:
             default:
                 buildQueryForBoundingBox(whereClauseSegment, bindVariables, (BoundingBox) area);
                 break;
             }
         }
-        whereClauseSegment.append(RIGHT_PAREN);
+
+        if (processed > 0) {
+            for (int i = 0; i < processed; i++) {
+                whereClauseSegment.append(RIGHT_PAREN);
+            }
+        }
+    }
+
+    public void buildQueryForBoundingMissing(String populateNameIdSubSegment, StringBuilder whereClauseSegment,
+            BoundingMissing missingArea) {
+        // No Operation - the main logic is contained in the process Missing parameter
     }
 
     /**
@@ -88,7 +118,7 @@ public class LocationParmBehaviorUtil {
         // Now build the piece that compares the BoundingBox longitude and latitude values
         // to the persisted longitude and latitude parameters.
         whereClauseSegment
-                .append(JDBCConstants.SPACE)
+                .append(LEFT_PAREN)
                 // LAT <= ? --- LAT >= MIN_LAT
                 .append(PARAMETER_TABLE_ALIAS).append(DOT).append(LATITUDE_VALUE).append(GTE)
                 .append(BIND_VAR)
@@ -124,7 +154,7 @@ public class LocationParmBehaviorUtil {
             BoundingRadius boundingRadius) {
         // This section of code is based on code from http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates
         whereClauseSegment
-                .append(JDBCConstants.SPACE)
+                .append(LEFT_PAREN)
                 .append(PARAMETER_TABLE_ALIAS).append(DOT).append(LATITUDE_VALUE).append(LTE)
                 .append(BIND_VAR)
                 .append(AND)

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
@@ -16,6 +16,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.FileInputStream;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -112,7 +113,22 @@ public class JDBCSearchNearTest {
         if (searchParamCode != null && queryValue != null) {
             queryParms.put(searchParamCode, Collections.singletonList(queryValue));
         }
+        return runQueryTest(queryParms);
+    }
 
+    public MultiResourceResult<Resource> runQueryTestMultiples(String searchParamCode, String... queryValues)
+            throws Exception {
+        Map<String, List<String>> queryParms = new LinkedHashMap<String, List<String>>(queryValues.length);
+        for (String queryValue : queryValues) {
+            if (searchParamCode != null && queryValue != null) {
+                queryParms.put(searchParamCode, Collections.singletonList(queryValue));
+            }
+        }
+        System.out.println(queryParms);
+        return runQueryTest(queryParms);
+    }
+
+    public MultiResourceResult<Resource> runQueryTest(Map<String, List<String>> queryParms) throws Exception {
         FHIRSearchContext ctx = SearchUtil.parseQueryParameters(Location.class, queryParms, true);
         FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, ctx);
         MultiResourceResult<Resource> result = persistence.search(persistenceContext, Location.class);
@@ -210,6 +226,19 @@ public class JDBCSearchNearTest {
         String queryValue = "42.25475478|-83.6945691|0.0|km";
 
         MultiResourceResult<Resource> result = runQueryTest(searchParamCode, queryValue);
+        assertNotNull(result);
+        assertNotEquals(result.getResource().size(), 0);
+        assertNull(result.getOutcome());
+    }
+
+    @Test
+    public void testSearchPositionSearchExactMatchMultiples() throws Exception {
+        // Should match the loaded resource
+        String searchParamCode = "near";
+        String queryValue1 = "42.25475478|-83.6945691|0.0|km";
+        String queryValue2 = "42.25475478|-83.6945691|0.0|km";
+
+        MultiResourceResult<Resource> result = runQueryTestMultiples(searchParamCode, queryValue1, queryValue2);
         assertNotNull(result);
         assertNotEquals(result.getResource().size(), 0);
         assertNull(result.getOutcome());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -615,7 +615,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "ge2019-12-30");
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-30");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-30");
-//        assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-30");
+        // assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-30");
         
         // the day of
         assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
@@ -637,6 +637,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01");
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
         assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
+        // This test is very dynamic and is not reliable. 
         assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -638,7 +638,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
         assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
         // This test is very dynamic and is not reliable. 
-        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
+        // assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
     @Test
     public void testSearchDate_dateTime_Seconds_noTZ() throws Exception {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -638,7 +638,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
         assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
         // This test is very dynamic and is not reliable. 
-        // assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
+        assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
     @Test
     public void testSearchDate_dateTime_Seconds_noTZ() throws Exception {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
@@ -149,6 +149,7 @@ public class SearchConstants {
                     put(SearchConstants.Type.DATE, Arrays.asList(Modifier.MISSING));
                     put(SearchConstants.Type.QUANTITY, Arrays.asList(Modifier.MISSING));
                     put(SearchConstants.Type.COMPOSITE, Arrays.asList(Modifier.MISSING));
+                    put(SearchConstants.Type.SPECIAL, Arrays.asList(Modifier.MISSING));
                 }
             });
 

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/NearLocationHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/NearLocationHandler.java
@@ -15,11 +15,13 @@ import java.util.stream.Collectors;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.search.SearchConstants;
+import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.exception.SearchExceptionUtil;
 import com.ibm.fhir.search.location.bounding.Bounding;
 import com.ibm.fhir.search.location.bounding.BoundingBox;
+import com.ibm.fhir.search.location.bounding.BoundingMissing;
 import com.ibm.fhir.search.location.bounding.BoundingRadius;
 import com.ibm.fhir.search.location.uom.UOMManager;
 import com.ibm.fhir.search.parameters.QueryParameter;
@@ -166,53 +168,81 @@ public class NearLocationHandler {
         List<Bounding> boundingAreas = new ArrayList<>();
         // We are only interested in the near and near-distance parameters.
         // Extract the following data elements: latitude, longitude, distance, distance unit
+        int instance = 0;
         for (QueryParameter queryParm : queryParameters.stream().collect(Collectors.toList())) {
-            for (QueryParameterValue value : queryParm.getValues()) {
-                if (NEAR.equals(queryParm.getCode())) {
+            // Only process the NEAR values IFF it's actually 'near'
+            if (NEAR.equals(queryParm.getCode())) {
+                Modifier modifier = queryParm.getModifier();
+                if (modifier != null && Modifier.MISSING.equals(modifier)) {
+                    BoundingMissing missing = new BoundingMissing();
+                    missing.setInstance(instance);
 
-                    // Make sure that the prefixes are properly defined. 
-                    Prefix prefix = value.getPrefix();
-                    if (prefix != null && Prefix.EQ.compareTo(prefix) != 0) {
-                        throw new FHIRSearchException("Only prefixes allowed for near search are [default/empty, EQ].");
+                    Boolean miss = null;
+                    for (QueryParameterValue value : queryParm.getValues()) {
+                        if (miss != null && miss != Boolean.parseBoolean(value.getValueCode())) {
+                            // user has requested both missing and not missing values for this field which makes no sense
+                            logger.warning(
+                                    "Processing query with conflicting values for query param with 'missing' modifier");
+                        } else {
+                            miss = Boolean.parseBoolean(value.getValueCode());
+                        }
                     }
-
-                    double latitude;
-                    double longitude;
-                    double distance = DEFAULT_DISTANCE;
-                    String unit = DEFAULT_UNIT;
-
-                    try {
-                        // [latitude]|[longitude]|[distance]|[units]
-                        // -83.694810|42.256500|11.20|km
-                        String[] components =
-                                value.getValueString().split(SearchConstants.BACKSLASH_NEGATIVE_LOOKBEHIND + "\\|");
-
-                        // If less than 2, it's going to generate an NPE (caught in the outer exception). 
-                        latitude  = Double.parseDouble(components[0]);
-                        longitude = Double.parseDouble(components[1]);
-
-                        // Distance is included
-                        if (components.length >= 3) {
-                            distance = Double.parseDouble(components[2]);
+                    missing.setMissing(miss);
+                    boundingAreas.add(missing);
+                } else {
+                    for (QueryParameterValue value : queryParm.getValues()) {
+                        // Make sure that the prefixes are properly defined. 
+                        Prefix prefix = value.getPrefix();
+                        if (prefix != null && Prefix.EQ.compareTo(prefix) != 0) {
+                            throw new FHIRSearchException(
+                                    "Only prefixes allowed for near search are [default/empty, EQ].");
                         }
 
-                        // The user has set the units value. 
-                        if (components.length >= 3) {
-                            unit = components[3];
+                        double latitude;
+                        double longitude;
+                        double distance = DEFAULT_DISTANCE;
+                        String unit = DEFAULT_UNIT;
+
+                        try {
+                            // [latitude]|[longitude]|[distance]|[units]
+                            // -83.694810|42.256500|11.20|km
+                            String[] components =
+                                    value.getValueString().split(SearchConstants.BACKSLASH_NEGATIVE_LOOKBEHIND + "\\|");
+
+                            // If less than 2, it's going to generate an NPE (caught in the outer exception). 
+                            latitude  = Double.parseDouble(components[0]);
+                            longitude = Double.parseDouble(components[1]);
+
+                            // Distance is included
+                            if (components.length >= 3) {
+                                distance = Double.parseDouble(components[2]);
+                            }
+
+                            // The user has set the units value. 
+                            if (components.length >= 3) {
+                                unit = components[3];
+                            }
+                        } catch (NumberFormatException | NullPointerException e) {
+                            throw SearchExceptionUtil
+                                    .buildNewInvalidSearchException("Invalid parameters for the 'near' search");
                         }
-                    } catch (NumberFormatException | NullPointerException e) {
-                        throw SearchExceptionUtil
-                                .buildNewInvalidSearchException("Invalid parameters for the 'near' search");
-                    }
 
-                    // Switch between the types bounding radius and boxes. 
-                    if (boundingRadius) {
-                        boundingAreas.add(createBoundingRadius(latitude, longitude, distance, unit));
-                    } else {
-                        boundingAreas.add(createBoundingBox(latitude, longitude, distance, unit));
-                    }
+                        // Switch between the types bounding radius and boxes.
+                        Bounding bounding;
+                        if (boundingRadius) {
+                            bounding = createBoundingRadius(latitude, longitude, distance, unit);
+                        } else {
+                            bounding = createBoundingBox(latitude, longitude, distance, unit);
+                        }
 
+                        // Identifies which Query parameter
+                        bounding.setInstance(instance);
+                        boundingAreas.add(bounding);
+                    }
                 }
+
+                // Increment the 'near'
+                instance++;
             }
         }
         return boundingAreas;
@@ -260,7 +290,8 @@ public class NearLocationHandler {
     }
 
     /**
-     * overrides the bounding functionality. 
+     * overrides the bounding functionality.
+     * 
      * @param boundingRadius
      */
     public void setBounding(boolean boundingRadius) {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/NearLocationHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/NearLocationHandler.java
@@ -166,7 +166,7 @@ public class NearLocationHandler {
     public List<Bounding> generateLocationPositionsFromParameters(List<QueryParameter> queryParameters)
             throws FHIRSearchException {
         List<Bounding> boundingAreas = new ArrayList<>();
-        // We are only interested in the near and near-distance parameters.
+        // We are only interested in the near parameter.
         // Extract the following data elements: latitude, longitude, distance, distance unit
         int instance = 0;
         for (QueryParameter queryParm : queryParameters.stream().collect(Collectors.toList())) {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/Bounding.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/Bounding.java
@@ -12,22 +12,39 @@ import java.util.List;
  * Bounding defines an area that is searched with a location.
  * There are default constraints included in this implementation.
  */
-public interface Bounding {
+public abstract class Bounding {
+    private int instance = 0;
+
+    /**
+     * sets the instance number
+     */
+    public void setInstance(int instance) {
+        this.instance = instance;
+    }
+
+    /**
+     * @return the instance of the parameter
+     */
+    public int instance() { 
+        return instance;
+    }
 
     /**
      * validates the Longitude and Latitude is valid for the Bounding area.
      */
-    public void validate();
-    
+    public abstract void validate();
+
     /**
      * gets the coordinates in an ordered list
+     * 
      * @return
      */
-    public List<Double> getDataPoints();
-    
+    public abstract List<Double> getDataPoints();
+
     /**
-     * returns the bounding type - radius or box. 
+     * returns the bounding type - radius or box.
+     * 
      * @return
      */
-    public BoundingType getType();
+    public abstract BoundingType getType();
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingBox.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingBox.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2019
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,7 +20,7 @@ import com.ibm.fhir.search.location.util.LocationUtil;
  * Latitude: 90 to 0 to -90 <br>
  * Longitude: 180 to 0 -180 <br>
  */
-public class BoundingBox implements Bounding {
+public class BoundingBox extends Bounding {
     public Double minLatitude;
     public Double maxLatitude;
     public Double minLongitude;
@@ -123,6 +123,6 @@ public class BoundingBox implements Bounding {
     @Override
     public String toString() {
         return "BoundingBox [minLatitude=" + minLatitude + ", maxLatitude=" + maxLatitude + ", minLongitude="
-                + minLongitude + ", maxLongitude=" + maxLongitude + "]";
+                + minLongitude + ", maxLongitude=" + maxLongitude + ", instance=" + super.instance() +"]";
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingMissing.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingMissing.java
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.search.location.bounding;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class is used to indicate a Missing search.
+ */
+public class BoundingMissing extends Bounding {
+
+    private Boolean missing = Boolean.FALSE;
+
+    public BoundingMissing() {
+        // No Operation
+    }
+
+    public Boolean getMissing() {
+        return missing;
+    }
+
+    public void setMissing(Boolean missing) {
+        this.missing = missing;
+    }
+
+    public void validate() {
+        // No Operation
+    }
+
+    public BoundingType getType() {
+        return BoundingType.MISSING;
+    }
+
+    @Override
+    public List<Double> getDataPoints() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String toString() {
+        return "BoundingMissing [missing=" + missing + "]";
+    }
+}

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingRadius.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingRadius.java
@@ -16,7 +16,7 @@ import com.ibm.fhir.search.location.util.LocationUtil;
  * Latitude and Longtitude and the radius on the arc.
  * The radius on the arc must be in meters.
  */
-public class BoundingRadius implements Bounding {
+public class BoundingRadius extends Bounding {
 
     private Double latitude;
     private Double longitude;
@@ -98,6 +98,7 @@ public class BoundingRadius implements Bounding {
 
     @Override
     public String toString() {
-        return "BoundingRadius [latitude=" + latitude + ", longitude=" + longitude + "]";
+        return "BoundingRadius [latitude=" + latitude + ", longitude=" + longitude + ", instance=" + super.instance()
+                + "]";
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingType.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/location/bounding/BoundingType.java
@@ -11,5 +11,6 @@ package com.ibm.fhir.search.location.bounding;
  */
 public enum BoundingType {
     BOX, 
-    RADIUS
+    RADIUS,
+    MISSING
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/location/BoundingTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/location/BoundingTest.java
@@ -30,7 +30,7 @@ public class BoundingTest {
         assertEquals(bounding.getMaxLatitude(), 10.0);
         assertEquals(bounding.getMaxLongitude(), 20.0);
         assertEquals(bounding.toString(),
-                "BoundingBox [minLatitude=-10.0, maxLatitude=10.0, minLongitude=-10.0, maxLongitude=20.0]");
+                "BoundingBox [minLatitude=-10.0, maxLatitude=10.0, minLongitude=-10.0, maxLongitude=20.0, instance=0]");
         assertEquals(bounding.getDataPoints(), Arrays.asList(-10.0,  -10.0, 10.0, 20.0));
         assertEquals(bounding.getType(), BoundingType.BOX);
     }
@@ -122,7 +122,7 @@ public class BoundingTest {
         assertEquals(bounding.getLatitude(), 10.0);
         assertEquals(bounding.getLongitude(), 20.0);
         assertEquals(bounding.getRadius(), 4.0);
-        assertEquals(bounding.toString(), "BoundingRadius [latitude=10.0, longitude=20.0]");
+        assertEquals(bounding.toString(), "BoundingRadius [latitude=10.0, longitude=20.0, instance=0]");
         assertEquals(bounding.getDataPoints(), Arrays.asList(10.0, 20.0, 4.0));
         assertEquals(bounding.getType(), BoundingType.RADIUS);
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
@@ -14,6 +14,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.FHIRParameters;
@@ -25,26 +26,44 @@ import com.ibm.fhir.model.test.TestUtil;
 
 public class SearchNearTest extends FHIRServerTestBase {
     private String locationId;
+    private String locationAbsId;
 
     @Test(groups = { "server-search-near" })
     public void testCreateLocation() throws Exception {
         WebTarget target = getWebTarget();
 
         Location location = TestUtil.readExampleResource("json/spec/location-example.json");
-
+        Location locationAbs = TestUtil.readExampleResource("json/ibm/complete-absent/Location-1.json");
         Entity<Location> entity = Entity.entity(location, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Location").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
+        Entity<Location> entityAbs = Entity.entity(locationAbs, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response responseAbs = target.path("Location").request().post(entityAbs, Response.class);
+        assertResponse(responseAbs, Response.Status.CREATED.getStatusCode());
+
         locationId = getLocationLogicalId(response);
+        locationAbsId = getLocationLogicalId(response);
 
         // Next, call the 'read' API to retrieve the new Location and verify it.
         response   = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        
+        response   = target.path("Location/" + locationAbsId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+    }
+    
+    @AfterClass
+    public void testDeleteLocations() {
+        WebTarget target = getWebTarget();
+        Response response   = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
+        assertResponse(response, Response.Status.NO_CONTENT.getStatusCode());
+        response   = target.path("Location/" + locationAbsId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
+        assertResponse(response, Response.Status.NO_CONTENT.getStatusCode());
     }
 
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
-    public void testSearchAllUsingLocationNear() throws Exception {
+    public void testSearchUsingLocationNear() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("near", "42.256500|-83.694810|11.20|km");
         FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
@@ -55,7 +74,7 @@ public class SearchNearTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
-    public void testSearchAllUsingLocationNearExact() throws Exception {
+    public void testSearchUsingLocationNearExact() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("near", "42.25475478|-83.6945691|0.0|km");
         FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
@@ -64,9 +83,9 @@ public class SearchNearTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
-    
+
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
-    public void testSearchAllUsingLocationNearWithinRange() throws Exception {
+    public void testSearchUsingLocationNearWithinRange() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("near", "40.256500|-80.694810|500.0|km");
         FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
@@ -77,7 +96,7 @@ public class SearchNearTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
-    public void testSearchAllUsingLocationNearReturnNone() throws Exception {
+    public void testSearchUsingLocationNearReturnNone() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("near", "-83.694810|42.256500|11.20|km");
         FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
@@ -85,5 +104,39 @@ public class SearchNearTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
         assertEquals(bundle.getEntry().size(), 0);
+    }
+
+    @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
+    public void testSearchUsingLocationNearWithinRangeMultiple() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("near", "40.256500|-80.694810|500.0|km,40.256500|-80.694810|500.0|km");
+        parameters.searchParam("near", "42.256500|-83.694810|11.20|km");
+        FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
+        SearchAllTest.generateOutput(response.getResource(Bundle.class));
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+    
+    @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
+    public void testSearchUsingLocationWithMissing() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+    
+    @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
+    public void testSearchUsingLocationWithMissingFalse() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("near:missing", "false");
+        FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
     }
 }


### PR DESCRIPTION
- Add support for multiple instance of the _near parameter
- Improve AND coverage tests
- Add Bounding type for missing and corresponding support for it
- Enable Search's support of :missing
- Improve Test coverage for fhir-search-tests

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>