### PR TITLE
_id and _lastUpdated search bindvariables are not added #577

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2020
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -133,20 +133,21 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         final String METHODNAME = "buildCountQuery";
         log.entering(CLASSNAME, METHODNAME);
 
-        List<Object> allBindVariables = new ArrayList<>();
-
         StringBuilder queryString = new StringBuilder();
         queryString.append(SELECT_COUNT_ROOT);
         queryString.append(LEFT_PAREN);
         queryString.append(QuerySegmentAggregator.SELECT_ROOT);
         buildFromClause(queryString, resourceType.getSimpleName());
 
-        // An important step here is to add _id and _lastUpdated
+        // An important step here is to add _id and _lastUpdated and then
+        // the regular bind variables. 
+        List<Object> allBindVariables = new ArrayList<>();
         allBindVariables.addAll(idsObjects);
         allBindVariables.addAll(lastUpdatedObjects);
+        this.addBindVariables(allBindVariables);
 
+        // Add the Where Clause
         buildWhereClause(queryString, null);
-
         queryString.append(COMBINED_RESULTS);
 
         SqlQueryData queryData = new SqlQueryData(queryString.toString(), allBindVariables);
@@ -172,9 +173,6 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         final String METHODNAME = "buildQuery";
         log.entering(CLASSNAME, METHODNAME);
 
-        List<Object> allBindVariables = new ArrayList<>();
-        this.addBindVariables(allBindVariables);
-
         StringBuilder queryString = new StringBuilder();
         queryString.append(InclusionQuerySegmentAggregator.SELECT_ROOT).append(LEFT_PAREN);
         queryString.append(InclusionQuerySegmentAggregator.SELECT_ROOT).append(LEFT_PAREN);
@@ -183,8 +181,11 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         buildFromClause(queryString, resourceType.getSimpleName());
 
         // An important step here is to add _id and _lastUpdated
+        // then add the regular bind variables.
+        List<Object> allBindVariables = new ArrayList<>();
         allBindVariables.addAll(idsObjects);
         allBindVariables.addAll(lastUpdatedObjects);
+        this.addBindVariables(allBindVariables);
 
         buildWhereClause(queryString, null);
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/InclusionQuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -134,14 +134,17 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         log.entering(CLASSNAME, METHODNAME);
 
         List<Object> allBindVariables = new ArrayList<>();
-        this.addBindVariables(allBindVariables);
 
         StringBuilder queryString = new StringBuilder();
         queryString.append(SELECT_COUNT_ROOT);
         queryString.append(LEFT_PAREN);
         queryString.append(QuerySegmentAggregator.SELECT_ROOT);
         buildFromClause(queryString, resourceType.getSimpleName());
-        allBindVariables.addAll(this.idsObjects);
+
+        // An important step here is to add _id and _lastUpdated
+        allBindVariables.addAll(idsObjects);
+        allBindVariables.addAll(lastUpdatedObjects);
+
         buildWhereClause(queryString, null);
 
         queryString.append(COMBINED_RESULTS);
@@ -171,14 +174,18 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
 
         List<Object> allBindVariables = new ArrayList<>();
         this.addBindVariables(allBindVariables);
-        allBindVariables.addAll(this.idsObjects);
 
         StringBuilder queryString = new StringBuilder();
         queryString.append(InclusionQuerySegmentAggregator.SELECT_ROOT).append(LEFT_PAREN);
         queryString.append(InclusionQuerySegmentAggregator.SELECT_ROOT).append(LEFT_PAREN);
         queryString.append(QuerySegmentAggregator.SELECT_ROOT);
+
         buildFromClause(queryString, resourceType.getSimpleName());
-        allBindVariables.addAll(this.idsObjects);
+
+        // An important step here is to add _id and _lastUpdated
+        allBindVariables.addAll(idsObjects);
+        allBindVariables.addAll(lastUpdatedObjects);
+
         buildWhereClause(queryString, null);
 
         // Add ordering
@@ -217,8 +224,10 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         subQueryString.append("P1.LOGICAL_RESOURCE_ID IN ");
         // (SELECT R.LOGICAL_RESOURCE_ID  
         subQueryString.append("(SELECT R.LOGICAL_RESOURCE_ID ");
+
         // Add FROM clause for "root" resource type
         buildFromClause(subQueryString, resourceType.getSimpleName());
+
         // Add WHERE clause for "root" resource type
         buildWhereClause(subQueryString, null);
 
@@ -232,13 +241,14 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
         //The subquery should return a list of strings in the FHIR Reference String value format 
         //(e.g. {@code "Patient/<resource_id>"})
         SqlQueryData subQueryData = new SqlQueryData(subQueryString.toString(), bindVariables);
+
         boolean isFirstItem = true;
         for (String strValue : this.resourceDao.searchStringValues(subQueryData)) {
             if (!isFirstItem) {
                 queryString.append(COMMA);
             }
             if (strValue != null) {
-                queryString.append(QUOTE).append(strValue).append(QUOTE);
+                queryString.append(QUOTE).append(SqlParameterEncoder.encode(strValue)).append(QUOTE);
                 isFirstItem = false;
             }
         }
@@ -320,9 +330,14 @@ public class InclusionQuerySegmentAggregator extends QuerySegmentAggregator {
             // (SELECT 'Patient/' || LR.LOGICAL_ID
             queryString.append("(SELECT '").append(includeParm.getSearchParameterTargetType())
                     .append("/' || LR.LOGICAL_ID ");
+
             // Add FROM clause for "root" resource type
             buildFromClause(queryString, resourceType.getSimpleName());
+
+            // An important step here is to add _id and _lastUpdated
             bindVariables.addAll(this.idsObjects);
+            bindVariables.addAll(this.lastUpdatedObjects);
+
             // Add WHERE clause for "root" resource type
             buildWhereClause(queryString, null);
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2020
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -328,8 +328,7 @@ public class QuerySegmentAggregator {
          * ( SELECT * FROM BASIC_LOGICAL_RESOURCES ILR WHERE ILR.LOGICAL_ID IN ( ? ? ))
          * </pre>
          */
-        
-        // TODO: Optimize
+
         if (!queryParamIds.isEmpty()) {
             // ID, then special handling. 
             fromClause.append("( SELECT LOGICAL_ID, LOGICAL_RESOURCE_ID, CURRENT_RESOURCE_ID FROM ");

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/SortedQuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/SortedQuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2020
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/SortedQuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/SortedQuerySegmentAggregator.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -128,6 +128,10 @@ public class SortedQuerySegmentAggregator extends QuerySegmentAggregator {
 
             // Build FROM clause
             buildFromClause(sqlSortQuery, resourceType.getSimpleName());
+
+            // An important step here is to add _id and _lastUpdated
+            allBindVariables.addAll(idsObjects);
+            allBindVariables.addAll(lastUpdatedObjects);
 
             // Build LEFT OUTER JOIN clause
             sqlSortQuery.append(this.buildSortJoinClause());

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,6 @@ import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchDateTest;
 
 public class JDBCSearchDateTest extends AbstractSearchDateTest {
-
     private Properties testProps;
 
     public JDBCSearchDateTest() throws Exception {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2017,2020
+ * (C) Copyright IBM Corp. 2018,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.persistence.jdbc.test;
+package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
@@ -12,12 +12,13 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
-import com.ibm.fhir.persistence.test.common.AbstractIncludeRevincludeTest;
+import com.ibm.fhir.persistence.search.test.AbstractSearchIdAndLastUpdatedTest;
 
-public class JDBCIncludeRevincludeTest extends AbstractIncludeRevincludeTest {
+public class JDBCSearchIdLastUpdatedTest extends AbstractSearchIdAndLastUpdatedTest {
+
     private Properties testProps;
 
-    public JDBCIncludeRevincludeTest() throws Exception {
+    public JDBCSearchIdLastUpdatedTest() throws Exception {
         this.testProps = TestUtil.readTestProperties("test.jdbc.properties");
     }
 
@@ -27,7 +28,7 @@ public class JDBCIncludeRevincludeTest extends AbstractIncludeRevincludeTest {
         String dbDriverName = this.testProps.getProperty("dbDriverName");
         if (dbDriverName != null && dbDriverName.contains("derby")) {
             derbyInit = new DerbyInitializer(this.testProps);
-            derbyInit.bootstrapDb(false);
+            derbyInit.bootstrapDb();
         }
     }
 

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2020
+ * (C) Copyright IBM Corp. 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,7 +15,6 @@ import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchIdAndLastUpdatedTest;
 
 public class JDBCSearchIdLastUpdatedTest extends AbstractSearchIdAndLastUpdatedTest {
-
     private Properties testProps;
 
     public JDBCSearchIdLastUpdatedTest() throws Exception {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchIdLastUpdatedTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2020
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/JDBCIncludeRevincludeTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/JDBCIncludeRevincludeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2020
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -14,7 +14,6 @@ import static org.testng.Assert.fail;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -36,7 +35,7 @@ import com.ibm.fhir.model.test.TestUtil;
  * - _id and _lastUpdated</a> Tests
  */
 public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearchTest {
-    private Boolean DEBUG = Boolean.TRUE;
+    private Boolean DEBUG = Boolean.FALSE;
 
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
@@ -48,7 +47,6 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
         // this might deserve its own method, but just use setTenant for now 
         // since its called before creating any resources
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-4:00"));
-        System.out.println(ZoneId.systemDefault());
     }
 
     @Test
@@ -147,7 +145,6 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
         } catch (FHIRGeneratorException e) {
             fail("unable to generate the fhir resource to JSON", e);
         } catch (IOException e1) {
-            e1.printStackTrace();
             fail("unable to generate the fhir resource to JSON (io problem) ", e1);
         }
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -135,6 +135,29 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
         assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
     }
 
+    @Test
+    public void testSearchWholeSystemUsingIdAndLastUpdatedResourceWithSortGreaterThanEquals() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList("ge" + dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        // Sort id and then lastUpdated
+        queryParms.put("_sort", Collections.singletonList("_id,-_lastUpdated"));
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Basic.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
     /*
      * generates the output into a resource.
      */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2020
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -1,0 +1,154 @@
+/*
+ * (C) Copyright IBM Corp. 2018,2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.search.test;
+
+import static com.ibm.fhir.model.test.TestUtil.isResourceInResponse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
+import com.ibm.fhir.model.resource.Basic;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.test.TestUtil;
+
+/**
+ * <a href="https://hl7.org/fhir/search.html#date">FHIR Specification: Search
+ * - _id and _lastUpdated</a> Tests
+ */
+public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearchTest {
+    private Boolean DEBUG = Boolean.TRUE;
+
+    protected Basic getBasicResource() throws Exception {
+        return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
+    }
+
+    protected void setTenant() throws Exception {
+        FHIRRequestContext.get().setTenantId("default");
+
+        // this might deserve its own method, but just use setTenant for now 
+        // since its called before creating any resources
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT-4:00"));
+        System.out.println(ZoneId.systemDefault());
+    }
+
+    @Test
+    public void testSearchWholeSystemUsingIdAndLastUpdated() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchWholeSystemUsingIdAndLastUpdatedWithSort() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        // Sort id and then lastUpdated
+        queryParms.put("_sort", Collections.singletonList("_id,-_lastUpdated"));
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchWholeSystemUsingIdAndLastUpdatedResource() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Basic.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchWholeSystemUsingIdAndLastUpdatedResourceWithSort() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        // Sort id and then lastUpdated
+        queryParms.put("_sort", Collections.singletonList("_id,-_lastUpdated"));
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Basic.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    /*
+     * generates the output into a resource.
+     */
+    public static void generateOutput(Resource resource) {
+        try (StringWriter writer = new StringWriter();) {
+            FHIRGenerator.generator(Format.JSON, true).generate(resource, System.out);
+            System.out.println(writer.toString());
+        } catch (FHIRGeneratorException e) {
+            fail("unable to generate the fhir resource to JSON", e);
+        } catch (IOException e1) {
+            e1.printStackTrace();
+            fail("unable to generate the fhir resource to JSON (io problem) ", e1);
+        }
+    }
+}

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -104,6 +104,29 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
         List<String> savedLastUpdated = Collections.singletonList(dateTime);
         queryParms.put("_id", savedId);
         queryParms.put("_lastUpdated", savedLastUpdated);
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchAllUsingIdAndLastUpdatedWithSort() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+
+        // Sort id and then lastUpdated
+        queryParms.put("_sort", Collections.singletonList("_id,-_lastUpdated"));
 
         if (DEBUG) {
             generateOutput(savedResource);

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2020
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameterValue.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameterValue.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -159,9 +159,7 @@ public class QueryParameterValue {
         outputBuilder(returnString, valueSystem);
         outputBuilder(returnString, valueCode);
         outputBuilder(returnString, valueString);
-        outputBuilder(returnString, valueDate);
         outputBuilder(returnString, valueDateLowerBound);
-        outputBuilder(returnString, valueDateUpperBound);
 
         if (component != null && !component.isEmpty()) {
             String componentDelim = "";

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,10 +33,11 @@ import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
+import com.ibm.fhir.model.resource.Bundle.Link;
 import com.ibm.fhir.model.resource.Condition;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.OperationOutcome;
-import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
@@ -65,15 +66,16 @@ public class SearchAllTest extends FHIRServerTestBase {
         Coding tag = Coding.builder().system(uri("http://ibm.com/fhir/tag")).code(code("tag")).build();
         Coding tag2 = Coding.builder().system(uri("http://ibm.com/fhir/tag")).code(code("tag2")).build();
 
-        patient = patient.toBuilder()
-                .meta(Meta.builder()
-                        .security(security)
-                        .tag(tag)
-                        .tag(tag)
-                        .tag(tag2)
-                        .profile(Canonical.of("http://ibm.com/fhir/profile/Profile"))
-                        .build())
-                .build();
+        patient =
+                patient.toBuilder()
+                        .meta(Meta.builder()
+                                .security(security)
+                                .tag(tag)
+                                .tag(tag)
+                                .tag(tag2)
+                                .profile(Canonical.of("http://ibm.com/fhir/profile/Profile"))
+                                .build())
+                        .build();
 
         if (DEBUG_SEARCH) {
             generateOutput(patient);
@@ -87,16 +89,15 @@ public class SearchAllTest extends FHIRServerTestBase {
         patientId = getLocationLogicalId(response);
 
         // Next, call the 'read' API to retrieve the new patient and verify it.
-        response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        response  = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         patient4DuplicationTest = response.readEntity(Patient.class);
         TestUtil.assertResourceEquals(patient, patient4DuplicationTest);
 
         lastUpdated = patient4DuplicationTest.getMeta().getLastUpdated();
     }
-    
-    
-    @Test(groups = { "server-search-all" }, dependsOnMethods = {"testCreatePatient" })
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreatePatient" })
     public void testCreateObservation() throws Exception {
         WebTarget target = getWebTarget();
 
@@ -107,7 +108,7 @@ public class SearchAllTest extends FHIRServerTestBase {
                 Entity.entity(observation, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response =
                 target.path("Observation").request()
-                .post(entity, Response.class);
+                        .post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
     }
 
@@ -126,7 +127,7 @@ public class SearchAllTest extends FHIRServerTestBase {
     public void testSearchAllUsingLastUpdated() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_lastUpdated", lastUpdated.getValue().toString());
-        FHIRResponse response = client.searchAll(parameters,false);
+        FHIRResponse response = client.searchAll(parameters, false);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
@@ -163,10 +164,9 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
 
         assertNotNull(bundle);
-        if(DEBUG_SEARCH) {
+        if (DEBUG_SEARCH) {
             generateOutput(bundle);
         }
-        
 
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -201,9 +201,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         }
 
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatient" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatient" })
     public void testSearchAllUsing2TagsAndNoExistingTag() throws Exception {
         int firstRunNumber;
         FHIRParameters parameters = new FHIRParameters();
@@ -235,18 +236,18 @@ public class SearchAllTest extends FHIRServerTestBase {
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is 
             // no duplicated resource in the search results, Just need to do the verification for the second run.
-            HashSet<String> resourceIdSet = new HashSet<String>();  
-            for (Entry entry: bundle.getEntry()) {
+            HashSet<String> resourceIdSet = new HashSet<String>();
+            for (Entry entry : bundle.getEntry()) {
                 resourceIdSet.add(entry.getResource().getClass().getSimpleName()
                         + ":" + entry.getResource().getId());
             }
             assertTrue(bundle.getEntry().size() == resourceIdSet.size());
         }
     }
-    
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatient" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatient" })
     public void testSearchAllUsing2Tags() throws Exception {
         int firstRunNumber;
         FHIRParameters parameters = new FHIRParameters();
@@ -277,17 +278,18 @@ public class SearchAllTest extends FHIRServerTestBase {
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is 
             // no duplicated resource in the search results, Just need to do the verification for the second run.
-            HashSet<String> resourceIdSet = new HashSet<String>();  
-            for (Entry entry: bundle.getEntry()) {
+            HashSet<String> resourceIdSet = new HashSet<String>();
+            for (Entry entry : bundle.getEntry()) {
                 resourceIdSet.add(entry.getResource().getClass().getSimpleName()
                         + ":" + entry.getResource().getId());
             }
             assertTrue(bundle.getEntry().size() == resourceIdSet.size());
         }
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatient" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatient" })
     public void testSearchAllUsing2FullTags() throws Exception {
         int firstRunNumber;
         FHIRParameters parameters = new FHIRParameters();
@@ -318,8 +320,8 @@ public class SearchAllTest extends FHIRServerTestBase {
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is 
             // no duplicated resource in the search results, Just need to do the verification for the second run.
-            HashSet<String> resourceIdSet = new HashSet<String>();  
-            for (Entry entry: bundle.getEntry()) {
+            HashSet<String> resourceIdSet = new HashSet<String>();
+            for (Entry entry : bundle.getEntry()) {
                 resourceIdSet.add(entry.getResource().getClass().getSimpleName()
                         + ":" + entry.getResource().getId());
             }
@@ -327,8 +329,9 @@ public class SearchAllTest extends FHIRServerTestBase {
         }
     }
 
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatient" })
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatient" })
     public void testSearchAllUsingOneTag() throws Exception {
         int firstRunNumber;
         FHIRParameters parameters = new FHIRParameters();
@@ -359,15 +362,15 @@ public class SearchAllTest extends FHIRServerTestBase {
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is 
             // no duplicated resource in the search results, Just need to do the verification for the second run.
-            HashSet<String> resourceIdSet = new HashSet<String>();  
-            for (Entry entry: bundle.getEntry()) {
+            HashSet<String> resourceIdSet = new HashSet<String>();
+            for (Entry entry : bundle.getEntry()) {
                 resourceIdSet.add(entry.getResource().getClass().getSimpleName()
                         + ":" + entry.getResource().getId());
             }
             assertTrue(bundle.getEntry().size() == resourceIdSet.size());
         }
     }
-    
+
     @Test(groups = { "server-search-all" })
     public void testCreatePatientAndObservationWithUniqueTag() throws Exception {
         Coding uniqueTag = Coding.builder().system(uri("http://ibm.com/fhir/tag")).code(code(strUniqueTag)).build();
@@ -377,37 +380,39 @@ public class SearchAllTest extends FHIRServerTestBase {
         Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
         Coding security = Coding.builder().system(uri("http://ibm.com/fhir/security")).code(code("security")).build();
 
-        patient = patient.toBuilder()
-                .meta(Meta.builder()
-                        .security(security)
-                        .tag(uniqueTag)
-                        .profile(Canonical.of("http://ibm.com/fhir/profile/Profile"))
-                        .build())
-                .build();
+        patient =
+                patient.toBuilder()
+                        .meta(Meta.builder()
+                                .security(security)
+                                .tag(uniqueTag)
+                                .profile(Canonical.of("http://ibm.com/fhir/profile/Profile"))
+                                .build())
+                        .build();
 
         Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Patient").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
-        
+
         // Get the patient's logical id value.
         patientId2 = getLocationLogicalId(response);
-        
+
         // Create a new observation with the unique tag for the above patient.
         Observation observation =
                 TestUtil.buildPatientObservation(patientId2, "Observation1.json");
-        observation = observation.toBuilder()
-                .meta(Meta.builder()
-                        .tag(uniqueTag)
-                        .build())
-                .build();
+        observation =
+                observation.toBuilder()
+                        .meta(Meta.builder()
+                                .tag(uniqueTag)
+                                .build())
+                        .build();
 
         Entity<Observation> entity2 =
                 Entity.entity(observation, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response2 =
                 target.path("Observation").request()
-                .post(entity2, Response.class);
+                        .post(entity2, Response.class);
         assertResponse(response2, Response.Status.CREATED.getStatusCode());
-        
+
         // Create a Condition with subject points to the created patient.
         Condition condition = buildCondition(patientId2, "Condition.json");
         Entity<Condition> obs = Entity.entity(condition, FHIRMediaType.APPLICATION_FHIR_JSON);
@@ -415,9 +420,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2UsingUniqueTag() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_tag", strUniqueTag);
@@ -427,9 +433,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 2);
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2UsingUniqueTag_OneType() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_tag", strUniqueTag);
@@ -440,9 +447,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 1);
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2UsingUniqueTag_TwoTypes() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_tag", strUniqueTag);
@@ -454,9 +462,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 2);
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2_TwoTypes_ChainedParameter() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("subject:Patient._tag", strUniqueTag);
@@ -466,14 +475,15 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
-        assert(bundle.getEntry().size() == 2);
+        assert (bundle.getEntry().size() == 2);
         // verify self link in the response bundle
         assertTrue(bundle.getLink().size() == 1);
         assertTrue(bundle.getLink().get(0).getUrl().getValue().contains("subject:Patient._tag"));
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2_TwoTypes_InvalidChainedParameter() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("subject:Practitioner.name", "John");
@@ -483,9 +493,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertExceptionOperationOutcome(response.getResponse().readEntity(OperationOutcome.class),
                 "Modifier resource type [Practitioner] is not allowed for search parameter [subject] of resource type [Observation]");
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2UsingUniqueTag_TwoTypes_Summary() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_tag", strUniqueTag);
@@ -498,10 +509,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 2);
     }
-    
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2UsingUniqueTag_TwoTypes_elements() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("_tag", strUniqueTag);
@@ -514,9 +525,10 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 2);
     }
-    
-    @Test(groups = { "server-search-all"}, dependsOnMethods = {
-    "testCreatePatientAndObservationWithUniqueTag" })
+
+    @Test(
+            groups = { "server-search-all" }, dependsOnMethods = {
+                    "testCreatePatientAndObservationWithUniqueTag" })
     public void testSearchAll2_TwoTypes_InvalidInclude() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
         parameters.searchParam("subject:Practitioner.name", "John");
@@ -527,5 +539,58 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertExceptionOperationOutcome(response.getResponse().readEntity(OperationOutcome.class),
                 "system search not supported with _include or _revinclude");
     }
-    
+
+    @Test(groups = { "server-search-all" })
+    public void testSearchAllUrlReflexsivityUsingLastUpdated() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_lastUpdated", "ge2000");
+        FHIRResponse response = client.searchAll(parameters, false);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+        List<Link> links = bundle.getLink();
+
+        /*
+         * Runs through the links and checks for self and rel. 
+         * It subsequently connects to the self to verify it's 200. 
+         */
+        boolean validSelf = false;
+        boolean validRel = false;
+        for (Link link : links) {
+            String type = link.getRelation().getValue();
+            String uri = link.getUrl().getValue();
+            if ("self".equals(type)) {
+                verifyReflexsiveUrl(uri);
+                validSelf = true;
+            } else if ("next".equals(type)) {
+                verifyReflexsiveUrl(uri);
+                validRel = true;
+            }
+        }
+
+        assertTrue(validSelf);
+        assertTrue(validRel);
+    }
+
+    /*
+     * queries based on the URI the endpoint with the query parameter and value. 
+     */
+    private void verifyReflexsiveUrl(String uri) throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        WebTarget target = client.getWebTarget();
+        String queryParameterStrings = uri.replaceAll(target.getUri().toString() + "_search\\?","");
+        String[] queryParams = queryParameterStrings.split("&");
+        for(String queryParam : queryParams) {
+            String name = queryParam.split("=")[0];
+            String value = queryParam.split("=")[1];
+            parameters.searchParam(name,value);
+        }
+        
+        FHIRResponse response = client.searchAll(parameters, false);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
 }


### PR DESCRIPTION
- Add Bind Variables to Inclusion and Sorted Query Segment Aggregators
- Verify with tests
	- Whole System Search with SORT and without SORT
	- Resource Specific Search with SORT and without SORT

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>