### PR TITLE
Add e2e tests for Windows #562

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
         java: [ 'openjdk11' ]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up OpenJDK
       uses: joschi/setup-jdk@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
       shell: powershell
       run: |
         & build/pre-integration-test.ps1
-        mvn -B test -DskipTests=false -f fhir-server-test/pom.xml -DskipWebSocketTest=true --no-transfer-progress
+        & 'mvn' '-B test -DskipTests=false -f fhir-server-test/pom.xml -DskipWebSocketTest=true --no-transfer-progress'
         & build/post-integration-test.ps1
     - name: Gather error logs
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,7 @@ jobs:
       shell: powershell
       run: |
         & build/pre-integration-test.ps1
-        $SIT=Split-Path $PSScriptRoot
-        & 'mvn' ' -B test -DskipTests=false -f ' $SIT '\fhir-server-test\pom.xml -DskipWebSocketTest=true --no-transfer-progress'
+        & mvn -B test -DskipTests=false -f .\fhir-server-test\pom.xml -DskipWebSocketTest=true --no-transfer-progress
         & build/post-integration-test.ps1
     - name: Gather error logs
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,10 +177,7 @@ jobs:
       shell: powershell
       run: |
         & build/pre-integration-test.ps1
-        & mvn -B test -DskipTests=false -f .\fhir-server-test\pom.xml -DskipWebSocketTest=true --no-transfer-progress
-    - name: shutdown the fhir-server 
-      shell: powershell
-      run: |
+        & build/tests.ps1
         & build/post-integration-test.ps1
     - name: Gather error logs
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,8 @@ jobs:
       shell: powershell
       run: |
         & build/pre-integration-test.ps1
-        & 'mvn' '-B test -DskipTests=false -f fhir-server-test/pom.xml -DskipWebSocketTest=true --no-transfer-progress'
+        $SIT=Split-Path $PSScriptRoot
+        & 'mvn' ' -B test -DskipTests=false -f ' $SIT '\fhir-server-test\pom.xml -DskipWebSocketTest=true --no-transfer-progress'
         & build/post-integration-test.ps1
     - name: Gather error logs
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,9 @@ jobs:
       run: |
         & build/pre-integration-test.ps1
         & mvn -B test -DskipTests=false -f .\fhir-server-test\pom.xml -DskipWebSocketTest=true --no-transfer-progress
+    - name: shutdown the fhir-server 
+      shell: powershell
+      run: |
         & build/post-integration-test.ps1
     - name: Gather error logs
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,3 +155,58 @@ jobs:
       with:
         name: integration-test-results-${{ matrix.java }}
         path: SIT/integration-test-results
+  e2e-tests-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        java: [ 'openjdk11' ]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up OpenJDK
+      uses: joschi/setup-jdk@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Build samples
+      shell: powershell
+      run: mvn -B install --file fhir-examples/pom.xml --no-transfer-progress
+    - name: Build parent without tests
+      shell: powershell
+      run: mvn -B install --file fhir-parent/pom.xml -DskipTests --no-transfer-progress
+    - name: Server Integration Tests
+      shell: powershell
+      run: |
+        & build/pre-integration-test.ps1
+        mvn -B test -DskipTests=false -f fhir-server-test/pom.xml -DskipWebSocketTest=true --no-transfer-progress
+        & build/post-integration-test.ps1
+    - name: Gather error logs
+      shell: powershell
+      if: failure()
+      run: |
+        Write-Host 'Clean up existing integration test results'
+        $it_results='SIT/integration-test-results'
+        If (Test-Path -Path $it_results) {
+          Remove-Item -path $it_results -Recurse -Force
+        }
+
+        Write-Host 'Create destinations for the files/folders'
+        $DST_SL='server-logs'
+        $DST_ST='fhir-server-test'
+        New-Item -Path $it_results -Name $DST_SL -ItemType 'directory' -Force
+        New-Item -Path $it_results -Name $DST_ST -ItemType 'directory' -Force
+
+        Write-Host 'Gathering post-test server logs'
+        $SRC_ST='SIT/wlp/usr/servers/fhir-server/logs'
+        $DST_SL_F=$it_results + '/' + $DST_SL
+        Copy-Item -Path $SRC_ST -Destination $DST_SL_F -Recurse -Force
+
+        Write-Host 'Gathering integration test output'
+        $SRC_ST='./fhir-server-test/target/surefire-reports'
+        $DST_ST_F=$it_results + '/' + $DST_ST
+        Copy-Item -Path $SRC_ST -Destination $DST_ST_F -Recurse -Force
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@master
+      with:
+        name: integration-test-results-windows-${{ matrix.java }}
+        path: SIT/integration-test-results

--- a/build/post-integration-test.ps1
+++ b/build/post-integration-test.ps1
@@ -1,0 +1,47 @@
+###############################################################################
+# (C) Copyright IBM Corp. 2020
+# 
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+Write-Host 'Performing integration test post-processing...'
+
+# The default path to the workspace
+# we have to account for the build directory
+$DIR_WORKSPACE= Split-Path $PSScriptRoot -Parent
+
+# Remove the entire SIT file tree if it exists
+[string]$SIT=$DIR_WORKSPACE + '\SIT'
+[string]$SIT = Resolve-Path $SIT
+
+# Stop the fhir server.
+Write-Host 'Stopping the fhir-server'
+$PROC=$SIT + '\wlp\bin\server'
+& $PROC stop fhir-server 
+Write-Host 'The fhir-server is stopped'
+
+Write-Host 'Clean up existing integration test results'
+$it_results='SIT/integration-test-results'
+If (Test-Path -Path $it_results) {
+  Remove-Item -path $it_results -Recurse -Force
+}
+
+Write-Host 'Create destinations for the files/folders'
+$DST_SL='server-logs'
+$DST_ST='fhir-server-test'
+New-Item -Path $it_results -Name $DST_SL -ItemType 'directory' -Force
+New-Item -Path $it_results -Name $DST_ST -ItemType 'directory' -Force
+
+Write-Host 'Gathering post-test server logs'
+$SRC_ST='SIT/wlp/usr/servers/fhir-server/logs'
+$DST_SL_F=$it_results + '/' + $DST_SL
+Copy-Item -Path $SRC_ST -Destination $DST_SL_F -Recurse -Force
+
+Write-Host 'Gathering integration test output'
+$SRC_ST='./fhir-server-test/target/surefire-reports'
+$DST_ST_F=$it_results + '/' + $DST_ST
+Copy-Item -Path $SRC_ST -Destination $DST_ST_F -Recurse -Force
+
+exit 0
+
+# End of Script

--- a/build/pre-integration-test.ps1
+++ b/build/pre-integration-test.ps1
@@ -1,0 +1,179 @@
+###############################################################################
+# (C) Copyright IBM Corp. 2020
+# 
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+<# 
+ This script will install the fhir server on the local machine and then
+ start it up so that we can run server integration tests
+ . - top level directory of the GitHub Actions workspace
+ .\SIT - holds everything related to server integration tests
+ .\SIT\fhir-server-dist - installer contents (after unzipping)
+ .\SIT\wlp - fhir server installation 
+#>
+
+# Initial wait time after the "server start" command returns
+$SERVER_WAITTIME=30
+
+# Sleep interval after each "metadata" invocation
+$SLEEP_INTERVAL=10
+
+# Max number of "metadata" tries to detect server is running
+$MAX_TRIES=10
+
+# The default path to the workspace
+# we have to account for the build directory
+# Reference https://stackoverflow.com/a/34089841/1873438
+Write-Host 'Preparing environment for fhir-server integration tests'
+$DIR_WORKSPACE= Split-Path $PSScriptRoot -Parent
+
+# Remove the entire SIT file tree If it exists
+[string]$SIT=$DIR_WORKSPACE + '\SIT'
+If ( Test-Path -Path $SIT ) {
+    Write-Host 'Removing -> ' $SIT
+    Remove-Item -Path $SIT -Recurse -Force
+}
+
+# Create the directory
+New-Item -Path $DIR_WORKSPACE -Name 'SIT' -ItemType 'directory'
+[string]$SIT = Resolve-Path $SIT
+
+# Install a fresh copy of the fhir server
+Write-Host 'Unzipping fhir-server installer...'
+[string]$ZIP_FILE=$DIR_WORKSPACE + '\fhir-install\target\fhir-server-distribution.zip'
+Expand-Archive -LiteralPath $ZIP_FILE -DestinationPath $SIT
+
+# Setup and install the FHIR Server
+Write-Host 'Installing fhir server in Integration Tests'
+Write-Host ' - Directory - ' $SIT
+& $SIT\fhir-server-dist\install.bat $SIT
+
+# If the Config Exists, let's wipe it outfind 
+Write-Host 'Copying configuration to install location'
+$RM_ITEM=[string]$SIT + '\wlp\usr\servers\fhir-server\config'
+If ( Test-Path $RM_ITEM ) {
+    Write-Host 'Removing -> ' $RM_ITEM
+    Remove-Item -path $RM_ITEM -Recurse -Force
+}
+
+$SERVER_ROOT=[string]$SIT + '\wlp\usr\servers\fhir-server\'
+New-Item -Path $SERVER_ROOT -Name 'config' -ItemType 'directory'
+
+# Copy over the Files for default, tenant1, tenant2
+$DR_ITEM=[string]$DIR_WORKSPACE + '\fhir-server\liberty-config\config\*'
+$DR_ITEM_DST=[string]$DIR_WORKSPACE + '\SIT\wlp\usr\servers\fhir-server\config\'
+Copy-Item $DR_ITEM -Destination $DR_ITEM_DST -Recurse
+
+$DR_ITEM1=[string]$DIR_WORKSPACE + '\fhir-server\liberty-config-tenants\config\*'
+Copy-Item $DR_ITEM1 -Destination $DR_ITEM_DST -Recurse
+
+Write-Host 'Copying test artifacts to install location'
+$CP_ITEM=[string]$DIR_WORKSPACE + '\fhir-operation\target\fhir-operation-*-tests.jar'
+$USERLIB_DST=[string]$DIR_WORKSPACE + '\SIT\wlp\usr\servers\fhir-server\userlib'
+$USERLIB_DIR=[string]$DIR_WORKSPACE + '\SIT\wlp\usr\servers\fhir-server'
+
+If (!(Test-Path -Path $USERLIB_DIR) ) {
+    New-Item -Path $USERLIB_DIR -Name 'userlib' -ItemType 'directory'
+}
+Copy-Item $CP_ITEM -Destination $USERLIB_DST
+
+# Start up the fhir server
+$DATE_PS=[System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId((Get-Date), 'Greenwich Standard Time').ToString('t')
+Write-Host '>>> Current time: ' $DATE_PS
+
+Write-Host 'Starting fhir server'
+$PROC=$SIT + '\wlp\bin\server'
+& $PROC start fhir-server 
+
+# Get the Updated Start Time
+$DATE_PS=[System.TimeZoneInfo]::ConvertTimeBySystemTimeZoneId((Get-Date), 'Greenwich Standard Time').ToString('t')
+Write-Host '>>> Current time: ' $DATE_PS
+
+# Sleep for a bit to let the server startup
+Write-Host 'Sleeping ' $SERVER_WAITTIME ' to let the server start'
+Start-Sleep -s $SERVER_WAITTIME
+
+# Ignore Self Signed Certificates and use TLS
+# Reference https://stackoverflow.com/a/46254549/1873438
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+Add-Type -TypeDefinition @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+"@
+$AllProtocols = [System.Net.SecurityProtocolType]'Ssl3,Tls,Tls11,Tls12'
+[System.Net.ServicePointManager]::SecurityProtocol = $AllProtocols
+[System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+
+# Next, we'll invoke the metadata API to detect when the
+# server is ready to accept requests.
+Write-Host 'Waiting for fhir-server to complete initialization'
+$metadata_url='https://localhost:9443/fhir-server/api/v4/metadata'
+$tries=1
+$STATUS=0
+
+while ( ($STATUS -ne 200) -and ($tries -le $MAX_TRIES) ) {
+    Write-Host 'Executing[' $tries ']: server check'
+
+    # Execute the connection to the HTTP Endpoint 
+    $UserPassword = 'fhiruser:change-password'
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($UserPassword)
+    $base64 = [System.Convert]::ToBase64String($bytes)
+    $req = Invoke-WebRequest -Method Get -Uri $metadata_url -Headers @{"Authorization" = "Basic $base64"; "Content-Type" = "application/json"} -UseBasicParsing    
+
+    # Check the Status Code that comes back
+    $STATUS = $req.StatusCode
+    Write-Host 'Status code: ' $status
+
+    # Wait If the Status is NE 200
+    If ( $STATUS -ne 200 ) {
+       Write-Host 'Sleeping for ' $SLEEP_INTERVAL ' secs'
+       Start-Sleep -s $SLEEP_INTERVAL
+    }
+    $tries++
+}
+
+# Gather server logs in case there was a problem starting up the server
+Write-Host 'Collecting pre-test server logs'
+$pre_it_logs=[string]$SIT + '\pre-it-logs\'
+$zip_file= [string]$DIR_WORKSPACE + '\pre-it-logs.zip'
+
+If (Test-Path -Path $pre_it_logs) {
+    Remove-Item -path $pre_it_log -recurse -force
+    Remove-Item -path $zip_file -force
+}
+
+New-Item -Path $SIT -Name 'pre-it-logs' -ItemType 'directory'
+
+$LOG_DIR=[string]$SIT + '\wlp\usr\servers\fhir-server\logs'
+Copy-Item -Path $LOG_DIR -destination $pre_it_logs -Recurse
+
+# Create the Zip File 
+$compress = @{
+LiteralPath= $pre_it_logs
+CompressionLevel = 'Fastest'
+DestinationPath = $zip_file
+}
+Compress-Archive @compress -Force
+
+# If we weren't able to detect the fhir server ready within the allotted timeframe,
+# then exit now...
+If ( $STATUS -ne 200 ) {
+    [string]$ERROR_MSG = 'Could not establish a connection to the fhir-server within ' + $tries + 'REST API invocations'
+    Write-Error $ERROR_MSG
+    exit 1
+} 
+
+Write-Host 'The fhir-server is apparently running'
+
+exit 0
+
+# End of Script 

--- a/build/tests.ps1
+++ b/build/tests.ps1
@@ -1,0 +1,19 @@
+###############################################################################
+# (C) Copyright IBM Corp. 2020
+# 
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+
+Write-Host 'Performing Tests'
+& mvn -B test -DskipTests=false -f .\fhir-server-test\pom.xml -DskipWebSocketTest=true --log-file out.log --no-transfer-progress
+
+If ( (Get-Content out.log -Tail 10 | Select-String -pattern "BUILD SUCCESS").Length > 0) {
+    Write-Host 'Performing Tests - Success'
+    exit 0
+} else { 
+    Write-Host 'Performing Tests - Fail'
+    cat out.log
+    exit -1
+}
+
+# End of Script

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,7 +16,6 @@ import java.util.logging.Logger;
  * This class serves up a singleton instance of ConfigurationService containing the FHIR Server's configuration.
  */
 public class FHIRConfiguration {
-    
     private static final Logger log = Logger.getLogger(FHIRConfiguration.class.getName());
 
     public static final String CONFIG_LOCATION = "config";
@@ -104,8 +103,8 @@ public class FHIRConfiguration {
         if (s == null) {
             s = "";
         }
-        if (!s.isEmpty() && !s.endsWith("/")) {
-            s += "/";
+        if (!s.isEmpty() && !s.endsWith(File.separator)) {
+            s += File.separator;
         }
         
         configHome = s;

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -4,20 +4,18 @@ Builds and manages the multi-tenant FHIR R4 RDBMS schema (Db2). Includes Derby s
 
 # To Execute the fhir-persistence-schema 
 
-1 - Execute the jar corresponding command, where VERSION is the version of the fhir-persistence-schema shaded jar that you are using, and SCHEMA_COMMAND is the documented schema command you are using.
+1 - Execute the jar corresponding command, where SCHEMA_COMMAND is the documented schema command you are using.
 
 *Linux/Mac*  
 
 ```
-VERSION=4.0.0-SNAPSHOT
-java -jar ./fhir-persistence-schema-${VERSION}.jar SCHEMA_COMMAND
+java -jar ./fhir-persistence-schema.jar SCHEMA_COMMAND
 ```
 
 *Windows*
 
 ```
-set VERSION=4.0.0-SNAPSHOT
-java -jar ./fhir-persistence-schema-%VERSION%.jar SCHEMA_COMMAND
+java -jar ./fhir-persistence-schema.jar SCHEMA_COMMAND
 ```
 
 Note: the jar file is stored locally in `fhir-persistence-schema/target` or in the Artifactory repository for this project.
@@ -153,15 +151,13 @@ To manually apply the DDL to a Db2 instance:
 *Linux/Mac*  
 
 ```
-VERSION=4.0.0-SNAPSHOT
-java -cp ./fhir-persistence-schema-${VERSION}.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
+java -cp ./fhir-persistence-schema.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
 ```
 
 *Windows*
 
 ```
-set VERSION=4.0.0-SNAPSHOT
-java -cp ./fhir-persistence-schema-%VERSION%.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
+java -cp ./fhir-persistence-schema.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
 ```
 
 Note: the jar file is stored locally in `fhir-persistence-schema/target` or in the Artifactory repository for this project.

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -4,18 +4,20 @@ Builds and manages the multi-tenant FHIR R4 RDBMS schema (Db2). Includes Derby s
 
 # To Execute the fhir-persistence-schema 
 
-1 - Execute the jar corresponding command, where SCHEMA_COMMAND is the documented schema command you are using.
+1 - Execute the jar corresponding command, where VERSION is the version of the fhir-persistence-schema shaded jar that you are using, and SCHEMA_COMMAND is the documented schema command you are using.
 
 *Linux/Mac*  
 
 ```
-java -jar ./fhir-persistence-schema.jar SCHEMA_COMMAND
+VERSION=4.0.0-SNAPSHOT
+java -jar ./fhir-persistence-schema-${VERSION}.jar SCHEMA_COMMAND
 ```
 
 *Windows*
 
 ```
-java -jar ./fhir-persistence-schema.jar SCHEMA_COMMAND
+set VERSION=4.0.0-SNAPSHOT
+java -jar ./fhir-persistence-schema-%VERSION%.jar SCHEMA_COMMAND
 ```
 
 Note: the jar file is stored locally in `fhir-persistence-schema/target` or in the Artifactory repository for this project.
@@ -151,13 +153,15 @@ To manually apply the DDL to a Db2 instance:
 *Linux/Mac*  
 
 ```
-java -cp ./fhir-persistence-schema.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
+VERSION=4.0.0-SNAPSHOT
+java -cp ./fhir-persistence-schema-${VERSION}.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
 ```
 
 *Windows*
 
 ```
-java -cp ./fhir-persistence-schema.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
+set VERSION=4.0.0-SNAPSHOT
+java -cp ./fhir-persistence-schema-%VERSION%.jar com.ibm.fhir.schema.app.SchemaPrinter --to-file
 ```
 
 Note: the jar file is stored locally in `fhir-persistence-schema/target` or in the Artifactory repository for this project.

--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -3,7 +3,7 @@
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
-    <display-name>IBM FHIR® Server</display-name>
+    <display-name>IBM FHIR&reg; Server</display-name>
     <servlet>
         <servlet-name>FHIRRestServlet</servlet-name>
         <servlet-class>com.ibm.websphere.jaxrs.server.IBMRestServlet</servlet-class>

--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -3,7 +3,7 @@
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
-    <display-name>IBM FHIR&reg; Server</display-name>
+    <display-name>IBM FHIR Server</display-name>
     <servlet>
         <servlet-name>FHIRRestServlet</servlet-name>
         <servlet-class>com.ibm.websphere.jaxrs.server.IBMRestServlet</servlet-class>


### PR DESCRIPTION
- Remove invalid character and replace with valid encoded character
- Change to use File.separator instead of hard coded "/"
- Add pre/post integration scripts
- Add job to build.yml

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>