### PR TITLE
issue #615 - added support for the profile parameter in $validate

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -3672,7 +3672,7 @@ public class FHIRResource implements FHIRResourceHelpers {
                 .status(PublicationStatus.ACTIVE)
                 .date(DateTime.of(ZonedDateTime.now(ZoneOffset.UTC)))
                 .kind(CapabilityStatementKind.CAPABILITY)
-                .fhirVersion(FHIRVersion.VERSION_4_0_0)
+                .fhirVersion(FHIRVersion.VERSION_4_0_1)
                 .format(format).patchFormat(Code.of(FHIRMediaType.APPLICATION_JSON_PATCH))
                 .version(string(buildInfo.getBuildVersion()))
                 .name(string(FHIR_SERVER_NAME))


### PR DESCRIPTION
Added tests to FHIRValidateOperationTest for:
* a valid vital sign observation
* a valid respiration rate observation
* an invalid heartRate observation

Also fixed the ordering of expected vs actual for existing tests.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>