### PR TITLE
Incorporate and Improve test coverage in the build/site #248

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
         BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
         BINTRAY_PASSWORD: ${{ secrets.BINTRAY_PASSWORD }}
+        CODECOV_RUNME: ${{ secrets.CODECOV_RUNME }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         CI: true
         JAVA_HOME: /opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
       run: |

--- a/build/release/README.md
+++ b/build/release/README.md
@@ -31,3 +31,24 @@ The archive contains the following:
 - and an aggregated view of code coverage - fhir-install/target/site/jacoco-aggregate/index.html
 
 The jacoco-aggregate shows the cross-project unit test code coverage, and NOT the integration tests. 
+
+### CodeCov.io
+The IBM project is at https://codecov.io/gh/IBM/FHIR  As of right now it does not have authorization for the details from IBM/FHIR. 
+
+In order to submit the files to codecov.io, a Personal Access token must be added on https://github.com/IBM/FHIR/settings/secrets as CODECOV_TOKEN .  The token in place right now is invalid. 
+
+Also add CODECOV_RUNME secret, and set anything as the value. If this secret is passed as a non-empty string, the codecov.io 
+runs.  To stop it running, remove the secret.
+
+To generate the jacoco.xml file locally, run the following: 
+```
+mvn -f fhir-examples clean install 
+PROFILES_ARR=(model-all-tests)
+PROFILES_ARR+=(validation-all-tests)
+PROFILES_ARR+=(search-all-tests)
+PROFILES_ARR+=(jdbc-all-tests)
+PROFILES_ARR+=(aggregate-report)
+PROFILES=$(IFS=, ; echo "${PROFILES_ARR[*]}")
+mvn -P${PROFILES} -f fhir-parent test jacoco:report
+mvn -Paggregate-report,${PROFILES} -f fhir-parent jacoco:report-aggregate
+```

--- a/build/release/code-coverage.sh
+++ b/build/release/code-coverage.sh
@@ -41,6 +41,15 @@ function code_coverage {
     check_and_fail $? "${FUNCNAME[0]} - stopped - ${PROJECT_PATH}"
 }
 
+# upload_to_codecov - uploads to codecov.io
+function upload_to_codecov { 
+    announce "${FUNCNAME[0]}"
+    TOKEN="$1"
+    cd fhir-install/target
+    curl -s https://codecov.io/bash -o codecov.sh -U "--http1.1"
+    bash codecov.sh -t "${TOKEN}" -f '!*.json'
+}
+
 ###############################################################################
 # check to see if mvn exists
 if which mvn | grep -i mvn
@@ -58,5 +67,11 @@ PROFILES_ARR+=(jdbc-all-tests)
 PROFILES_ARR+=(aggregate-report) # this one is required to aggregate all of the dependencies
 PROFILES=$(IFS=, ; echo "${PROFILES_ARR[*]}")
 code_coverage 'fhir-parent' "-P${PROFILES}"
+
+# Uploads to CodeCov
+if [ ! -z "${CODECOV_RUNME}" ]
+then 
+    upload_to_codecov "${CODECOV_TOKEN}"
+fi
 
 # EOF

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/ConfigurationServiceTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/ConfigurationServiceTest.java
@@ -1,11 +1,12 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.config.test;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -21,7 +22,7 @@ import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
 import com.ibm.fhir.config.mock.MockPropertyGroup;
 
 public class ConfigurationServiceTest {
-    
+
     @AfterMethod
     public void cleanUp() {
         System.setProperty(ConfigurationService.PROPERTY_GROUP_CLASSNAME, "");
@@ -31,25 +32,60 @@ public class ConfigurationServiceTest {
     public void testLoadConfiguration() throws Exception {
         PropertyGroup pg = ConfigurationService.loadConfiguration("fhirConfig.json");
         assertNotNull(pg);
-                
+
         // Validate retrieval of an array of strings.
-       
+
         Object[] includeResourceTypes = pg.getArrayProperty("fhirServer/notifications/common/includeResourceTypes");
         assertNotNull(includeResourceTypes);
         assertEquals(8, includeResourceTypes.length);
         assertEquals("QuestionnaireResponse", (String) includeResourceTypes[0]);
         assertEquals("CarePlan", (String) includeResourceTypes[1]);
-        
+
         // Validate the notifications properties.
         PropertyGroup notificationProps = pg.getPropertyGroup("fhirServer/notifications");
         List<PropertyEntry> props = notificationProps.getProperties();
         assertNotNull(props);
-        assertEquals(3, props.size());
+        assertEquals(5, props.size());
         assertNotNull(notificationProps.getPropertyGroup("common"));
         assertNotNull(notificationProps.getPropertyGroup("websocket"));
         assertNotNull(notificationProps.getPropertyGroup("kafka"));
+
+        Double d = notificationProps.getDoubleProperty("count-time-1", 1.0d);
+        assertNotNull(d);
+        assertEquals(11.0, d);
+
+        d = notificationProps.getDoubleProperty("count-time-3", 1.0d);
+        assertNotNull(d);
+        assertEquals(1.0, d);
+
+        d = notificationProps.getDoubleProperty("count-time-1");
+        assertNotNull(d);
+        assertEquals(11.0, d);
+
+        assertNotNull(notificationProps.toString());
+        assertFalse(notificationProps.toString().isEmpty());
     }
-    
+
+    @Test(expectedExceptions = { java.lang.IllegalArgumentException.class })
+    public void testLoadConfigurationIllegalArg() throws Exception {
+        PropertyGroup pg = ConfigurationService.loadConfiguration("fhirConfig.json");
+        assertNotNull(pg);
+
+        Object[] includeResourceTypes = pg.getArrayProperty("fhirServer/notifications/common/includeResourceTypes");
+        assertNotNull(includeResourceTypes);
+        assertEquals(8, includeResourceTypes.length);
+        assertEquals("QuestionnaireResponse", (String) includeResourceTypes[0]);
+        assertEquals("CarePlan", (String) includeResourceTypes[1]);
+
+        // Validate the notifications properties.
+        PropertyGroup notificationProps = pg.getPropertyGroup("fhirServer/notifications");
+        List<PropertyEntry> props = notificationProps.getProperties();
+        assertNotNull(props);
+        assertEquals(5, props.size());
+
+        notificationProps.getDoubleProperty("count-time-2", 1.0);
+    }
+
     @Test
     public void testMockPropertyGroup1() throws Exception {
         System.setProperty(ConfigurationService.PROPERTY_GROUP_CLASSNAME, MockPropertyGroup.class.getName());
@@ -57,13 +93,13 @@ public class ConfigurationServiceTest {
         assertNotNull(pg);
         assertTrue(pg instanceof MockPropertyGroup);
     }
-    
+
     @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testMockPropertyGroup2() throws Exception {
         System.setProperty(ConfigurationService.PROPERTY_GROUP_CLASSNAME, "BAD_CLASS_NAME");
         ConfigurationService.loadConfiguration("fhirConfig.json");
     }
-    
+
     @Test(expectedExceptions = { IllegalArgumentException.class })
     public void testMockPropertyGroup3() throws Exception {
         System.setProperty(ConfigurationService.PROPERTY_GROUP_CLASSNAME, TestMockPropertyGroup.class.getName());

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.config.test;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
@@ -24,34 +25,34 @@ import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 
 public class FHIRConfigHelperTest {
-    
-    String[] array1 = { "token1", "token2"};
+
+    String[] array1 = { "token1", "token2" };
     List<String> expectedList1 = Arrays.asList(array1);
 
-    String[] array2 = { "token3", "token4"};
+    String[] array2 = { "token3", "token4" };
     List<String> expectedList2 = Arrays.asList(array2);
-    
+
     // String used to write out json config file on the fly.
-    String tenant3ConfigTemplate = 
+    String tenant3ConfigTemplate =
             "{ \"fhirServer\": { \"property1\": \"__A__\", \"property2\": \"__B__\" }}";
-    
+
     @BeforeClass
     public void setup() {
         FHIRConfiguration.setConfigHome("target/test-classes");
     }
-    
+
     @BeforeMethod
     @AfterMethod
     public void clearThreadLocal() {
         FHIRRequestContext.remove();
     }
-    
+
     @Test
     public void testDefaultConfig1() throws Exception {
         String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
         assertNotNull(tenant);
         assertEquals("default", tenant);
-        
+
         List<String> l;
         String s;
         Boolean b;
@@ -60,221 +61,238 @@ public class FHIRConfigHelperTest {
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
         assertEquals("defaultValue1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
         assertEquals("defaultValue2", s);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
         assertEquals(expectedList1, l);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupB/boolProp1", null);
         assertNotNull(s);
         assertEquals("false", s);
-        
+
         i = FHIRConfigHelper.getIntProperty("collection/groupC/intProp1", null);
         assertNotNull(i);
         assertEquals(12345, i.intValue());
-        
+
         i = FHIRConfigHelper.getIntProperty("collection/groupC/intProp2", null);
         assertNotNull(i);
         assertEquals(12345, i.intValue());
-        
+
         d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp2", null);
         assertNotNull(d);
         assertEquals(12345.001, d.doubleValue());
     }
-    
+
     @Test
     public void testTenant1() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
-        
+
         String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
         assertNotNull(tenant);
         assertEquals("tenant1", tenant);
-        
+
         List<String> l;
         String s;
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
         assertEquals("tenant1Value1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
         assertEquals("defaultValue2", s);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.TRUE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
         assertEquals(expectedList2, l);
     }
-    
+
     @Test
     public void testTenant2() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext("tenant2"));
-        
+
         String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
         assertNotNull(tenant);
         assertEquals("tenant2", tenant);
-        
+
         List<String> l;
         String s;
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
         assertEquals("defaultValue1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
         assertEquals("tenant2Value2", s);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
         assertEquals(Boolean.TRUE, b);
-        
+
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
         assertEquals(0, l.size());
     }
-    
+
     @Test
     public void testTenant3() throws Exception {
         // Create initial version of tenant3's config file.
         String fname = "target/test-classes/config/tenant3/fhir-server-config.json";
         PrintWriter pw = new PrintWriter(fname);
-        String jsonString = tenant3ConfigTemplate.replaceAll("__A__", "property1Value1").replaceAll("__B__", "property2Value1");
-        
+        String jsonString =
+                tenant3ConfigTemplate.replaceAll("__A__", "property1Value1").replaceAll("__B__", "property2Value1");
+
         pw.println(jsonString);
         pw.close();
-        
+
         // Set our thread local to "tenant3"
         FHIRRequestContext.set(new FHIRRequestContext("tenant3"));
-        
+
         // Load tenant3's config and check the initial property values.
         String s = FHIRConfigHelper.getStringProperty("fhirServer/property1", null);
         assertNotNull(s);
         assertEquals("property1Value1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("fhirServer/property2", null);
         assertNotNull(s);
         assertEquals("property2Value1", s);
-        
+
         // Sleep for just a bit to make sure the updated config file has a newer timestamp.
         Thread.sleep(1000);
-        
+
         // Next, make changes to the config file on disk and re-check the values.
-        pw = new PrintWriter(fname);
-        jsonString = tenant3ConfigTemplate.replaceAll("__A__", "property1Value2").replaceAll("__B__", "property2Value2");
+        pw         = new PrintWriter(fname);
+        jsonString =
+                tenant3ConfigTemplate.replaceAll("__A__", "property1Value2").replaceAll("__B__", "property2Value2");
         pw.println(jsonString);
         pw.close();
-        
+
         s = FHIRConfigHelper.getStringProperty("fhirServer/property1", null);
         assertNotNull(s);
         assertEquals("property1Value2", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("fhirServer/property2", null);
         assertNotNull(s);
         assertEquals("property2Value2", s);
     }
-    
+
     @Test
     public void testTenant4() throws Exception {
         // "tenant4" does not have a fhir-server-config.json in place, so we SHOULD
         // end up retrieving the property values from the "default" tenant's config file.
         FHIRRequestContext.set(new FHIRRequestContext("tenant4"));
-        
+
         String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
         assertNotNull(tenant);
         assertEquals("default", tenant);
-        
+
         List<String> l;
         String s;
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
         assertEquals("defaultValue1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
         assertEquals("defaultValue2", s);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
         assertEquals(expectedList1, l);
+
+        Double d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp1", 1.0);
+        assertNotNull(d);
+        assertEquals(12345.001, d);
+
+        d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp2", 1.0);
+        assertNotNull(d);
+        assertEquals(12345.001, d);
+
+        d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp3", 1.0);
+        assertNotNull(d);
+        assertEquals(1.0, d);
+        
+        assertNotNull(FHIRConfiguration.getInstance().loadConfiguration().toString());
+        assertFalse(FHIRConfiguration.getInstance().loadConfiguration().toString().isEmpty());
     }
-    
+
     @Test
     public void testTenant5() throws Exception {
         // "tenant5" contains property groups from default, but includes only new properties
         // within those group.   Make sure we can retrieve those, plus the property values within
         // those groups that exist only in the default config.
         FHIRRequestContext.set(new FHIRRequestContext("tenant5"));
-        
+
         String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
         assertNotNull(tenant);
         assertEquals("tenant5", tenant);
-        
+
         List<String> l;
         String s;
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/newProp1", null);
         assertNotNull(s);
         assertEquals("newValue1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
         assertEquals("defaultValue1", s);
-        
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
         assertEquals("defaultValue2", s);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
         assertEquals(Boolean.FALSE, b);
-        
+
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/newBoolProp1", null);
         assertNotNull(b);
         assertEquals(Boolean.TRUE, b);
-        
+
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
         assertEquals(expectedList1, l);
     }
-    
+
     @Test
     public void testGetConfiguredTenants() {
         List<String> tenants = FHIRConfiguration.getInstance().getConfiguredTenants();
@@ -286,5 +304,4 @@ public class FHIRConfigHelperTest {
         assertTrue(tenants.contains("tenant3"));
         assertTrue(tenants.contains("tenant5"));
     }
-
 }

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/PropertyGroupTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/PropertyGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,55 +28,55 @@ public class PropertyGroupTest {
     private static final JsonBuilderFactory BUILDER_FACTORY = Json.createBuilderFactory(null);
     private JsonObject jsonObj1 = null;
     private JsonObject jsonObj2 = null;
-    
-    private boolean debug = false;
+
+    private boolean DEBUG = true;
 
     @BeforeClass
     public void setup() {
-
         // Build a JSON object for testing.
-        jsonObj1 = BUILDER_FACTORY.createObjectBuilder()
-                .add("level1", BUILDER_FACTORY.createObjectBuilder()
-                    .add("level2", BUILDER_FACTORY.createObjectBuilder()
-                        .add("level3", BUILDER_FACTORY.createObjectBuilder()
-                            .add("stringProp", "stringValue")
-                            .add("intProp", 123)
-                            .add("booleanProp", true))))
-                .build();
+        jsonObj1 =
+                BUILDER_FACTORY.createObjectBuilder()
+                        .add("level1", BUILDER_FACTORY.createObjectBuilder()
+                                .add("level2", BUILDER_FACTORY.createObjectBuilder()
+                                        .add("level3", BUILDER_FACTORY.createObjectBuilder()
+                                                .add("stringProp", "stringValue")
+                                                .add("intProp", 123)
+                                                .add("booleanProp", true)
+                                                .add("booleanProp-2", "true"))))
+                        .build();
 
         // Simulate a snippet of the fhir-server config.
-        jsonObj2 = BUILDER_FACTORY.createObjectBuilder()
-                .add("fhir-server", BUILDER_FACTORY.createObjectBuilder()
-                    .add("server-core", BUILDER_FACTORY.createObjectBuilder()
-                        .add("truststoreLocation", "XYZ")
-                        .add("truststorePassword", "change-password"))
-                    .add("notifications", BUILDER_FACTORY.createObjectBuilder()
-                        .add("common", BUILDER_FACTORY.createObjectBuilder()
-                            .add("includeResourceTypes", BUILDER_FACTORY.createArrayBuilder()
-                                .add("Patient")
-                                .add("Observation")))
-                        .add("kafka", BUILDER_FACTORY.createObjectBuilder()
-                            .add("enabled", true)
-                            .add("connectionProperties", BUILDER_FACTORY.createObjectBuilder()
-                                .add("groupId", "group1")
-                                .add("bootstrap.servers", "localhost:1234")
-                                .add("change-password", "change-password"))
-                            )
-                        )
-                    .add("object-array", BUILDER_FACTORY.createArrayBuilder()
-                        .add(BUILDER_FACTORY.createObjectBuilder()
-                            .add("url", "http://localhost")
-                            .add("type", "insecure"))
-                        .add(BUILDER_FACTORY.createObjectBuilder()
-                            .add("url", "https://localhost")
-                            .add("type", "secure")))
-                    .add("int-array", BUILDER_FACTORY.createArrayBuilder()
-                        .add(1)
-                        .add(2)
-                        .add(3)))
-                .build();
-        
-        if (debug) {
+        jsonObj2 =
+                BUILDER_FACTORY.createObjectBuilder()
+                        .add("fhir-server", BUILDER_FACTORY.createObjectBuilder()
+                                .add("server-core", BUILDER_FACTORY.createObjectBuilder()
+                                        .add("truststoreLocation", "XYZ")
+                                        .add("truststorePassword", "change-password"))
+                                .add("notifications", BUILDER_FACTORY.createObjectBuilder()
+                                        .add("common", BUILDER_FACTORY.createObjectBuilder()
+                                                .add("includeResourceTypes", BUILDER_FACTORY.createArrayBuilder()
+                                                        .add("Patient")
+                                                        .add("Observation")))
+                                        .add("kafka", BUILDER_FACTORY.createObjectBuilder()
+                                                .add("enabled", true)
+                                                .add("connectionProperties", BUILDER_FACTORY.createObjectBuilder()
+                                                        .add("groupId", "group1")
+                                                        .add("bootstrap.servers", "localhost:1234")
+                                                        .add("change-password", "change-password"))))
+                                .add("object-array", BUILDER_FACTORY.createArrayBuilder()
+                                        .add(BUILDER_FACTORY.createObjectBuilder()
+                                                .add("url", "http://localhost")
+                                                .add("type", "insecure"))
+                                        .add(BUILDER_FACTORY.createObjectBuilder()
+                                                .add("url", "https://localhost")
+                                                .add("type", "secure")))
+                                .add("int-array", BUILDER_FACTORY.createArrayBuilder()
+                                        .add(1)
+                                        .add(2)
+                                        .add(3)))
+                        .build();
+
+        if (DEBUG) {
             System.out.println("\njsonObj1 contents:\n" + jsonObj1.toString());
             System.out.println("\njsonObj2 contents:\n" + jsonObj2.toString());
         }
@@ -117,6 +117,10 @@ public class PropertyGroupTest {
         Boolean value = pg.getBooleanProperty("level1/level2/level3/booleanProp");
         assertNotNull(value);
         assertEquals(Boolean.TRUE, value);
+
+        value = pg.getBooleanProperty("level1/level2/level3/booleanProp-2");
+        assertNotNull(value);
+        assertEquals(Boolean.TRUE, value);
     }
 
     @Test
@@ -128,7 +132,7 @@ public class PropertyGroupTest {
         assertEquals("Patient", (String) array[0]);
         assertEquals("Observation", (String) array[1]);
     }
-    
+
     @Test
     public void testStringListProperty() throws Exception {
         PropertyGroup pg = new PropertyGroup(jsonObj2);
@@ -137,8 +141,8 @@ public class PropertyGroupTest {
         assertEquals(2, strings.size());
         assertEquals("Patient", strings.get(0));
         assertEquals("Observation", strings.get(1));
-        
-        pg = new PropertyGroup(jsonObj2);
+
+        pg      = new PropertyGroup(jsonObj2);
         strings = pg.getStringListProperty("fhir-server/int-array");
         assertNotNull(strings);
         assertEquals(3, strings.size());
@@ -159,7 +163,7 @@ public class PropertyGroupTest {
         if (!(array[1] instanceof PropertyGroup)) {
             fail("array element 1 not a PropertyGroup!");
         }
-        
+
         // Check the first element.
         PropertyGroup pg0 = (PropertyGroup) array[0];
         String url = pg0.getStringProperty("url");
@@ -168,7 +172,7 @@ public class PropertyGroupTest {
         String type = pg0.getStringProperty("type");
         assertNotNull(type);
         assertEquals("insecure", type);
-        
+
         // Check the second element.
         PropertyGroup pg1 = (PropertyGroup) array[1];
         url = pg1.getStringProperty("url");
@@ -202,53 +206,53 @@ public class PropertyGroupTest {
         PropertyGroup pg = new PropertyGroup(jsonObj2);
         pg.getArrayProperty("fhir-server/notifications/kafka");
     }
-    
+
     @Test
     public void testGetProperties1() throws Exception {
         PropertyGroup pg = new PropertyGroup(jsonObj2);
         PropertyGroup connectionProps = pg.getPropertyGroup("fhir-server/notifications/kafka/connectionProperties");
         assertNotNull(connectionProps);
-        
+
         List<PropertyEntry> properties = connectionProps.getProperties();
         assertNotNull(properties);
         assertEquals(3, properties.size());
-        
+
         PropertyEntry propEntry = properties.get(0);
         assertNotNull(propEntry);
         assertEquals("groupId", propEntry.getName());
         assertEquals("group1", (String) propEntry.getValue());
-        
+
         propEntry = properties.get(1);
         assertNotNull(propEntry);
         assertEquals("bootstrap.servers", propEntry.getName());
         assertEquals("localhost:1234", (String) propEntry.getValue());
-        
+
         propEntry = properties.get(2);
         assertNotNull(propEntry);
         assertEquals("change-password", propEntry.getName());
         assertEquals("change-password", (String) propEntry.getValue());
     }
-    
+
     @Test
     public void testGetProperties2() throws Exception {
         PropertyGroup rootPG = new PropertyGroup(jsonObj2);
         PropertyGroup fhirServerPG = rootPG.getPropertyGroup("fhir-server");
         assertNotNull(fhirServerPG);
-        
+
         List<PropertyEntry> properties = fhirServerPG.getProperties();
         assertNotNull(properties);
         assertEquals(4, properties.size());
-        
+
         PropertyEntry propEntry = properties.get(0);
         assertNotNull(propEntry);
         assertEquals("server-core", propEntry.getName());
         assertTrue(propEntry.getValue() instanceof PropertyGroup);
-        
+
         propEntry = properties.get(1);
         assertNotNull(propEntry);
         assertEquals("notifications", propEntry.getName());
         assertTrue(propEntry.getValue() instanceof PropertyGroup);
-        
+
         propEntry = properties.get(2);
         assertNotNull(propEntry);
         assertEquals("object-array", propEntry.getName());
@@ -257,7 +261,7 @@ public class PropertyGroupTest {
             assertNotNull(obj);
             assertTrue(obj instanceof PropertyGroup);
         }
-        
+
         propEntry = properties.get(3);
         assertNotNull(propEntry);
         assertEquals("int-array", propEntry.getName());
@@ -273,16 +277,16 @@ public class PropertyGroupTest {
         PropertyGroup rootPG = new PropertyGroup(jsonObj2);
         PropertyGroup pg = rootPG.getPropertyGroup("fhir-server/notifications/common");
         assertNotNull(pg);
-        
+
         List<PropertyEntry> properties = pg.getProperties();
         assertNotNull(properties);
         assertEquals(1, properties.size());
-        
+
         PropertyEntry propEntry = properties.get(0);
         assertNotNull(propEntry);
         assertEquals("includeResourceTypes", propEntry.getName());
         assertTrue(propEntry.getValue() instanceof List);
-        assertEquals(2, ((List<?>)propEntry.getValue()).size());
+        assertEquals(2, ((List<?>) propEntry.getValue()).size());
         for (Object obj : (List<?>) propEntry.getValue()) {
             assertNotNull(obj);
             assertTrue(obj instanceof String);

--- a/fhir-config/src/test/resources/fhirConfig.json
+++ b/fhir-config/src/test/resources/fhirConfig.json
@@ -14,6 +14,8 @@
             ]
         },
         "notifications":{
+            "count-time-1" : 11.0,
+            "count-time-2" : "12.0",
             "common":{
                 "includeResourceTypes":[
                     "QuestionnaireResponse",

--- a/fhir-examples/src/main/resources/ibm-json.txt
+++ b/fhir-examples/src/main/resources/ibm-json.txt
@@ -1426,3 +1426,5 @@ OK         json/ibm/minimal/ValueSet-6.json
 OK         json/ibm/minimal/ValueSet-7.json
 OK         json/ibm/minimal/VerificationResult-1.json
 OK         json/ibm/minimal/VisionPrescription-1.json
+VALIDATION json/ibm/coverage/parameters-contactdetail.json
+VALIDATION json/ibm/coverage/basic-type.json

--- a/fhir-examples/src/main/resources/ibm-xml.txt
+++ b/fhir-examples/src/main/resources/ibm-xml.txt
@@ -1426,3 +1426,5 @@ OK         xml/ibm/minimal/ValueSet-6.xml
 OK         xml/ibm/minimal/ValueSet-7.xml
 OK         xml/ibm/minimal/VerificationResult-1.xml
 OK         xml/ibm/minimal/VisionPrescription-1.xml
+VALIDATION xml/ibm/coverage/parameters-contactdetail.xml
+VALIDATION xml/ibm/coverage/basic-type.xml

--- a/fhir-examples/src/main/resources/json/ibm/coverage/basic-type.json
+++ b/fhir-examples/src/main/resources/json/ibm/coverage/basic-type.json
@@ -1,0 +1,55 @@
+{
+	"resourceType": "Basic",
+	"extension": [{
+		"url": "https://extension-base64",
+		"valueBase64Binary": "VEhJUyBJUyBBIEZBS0UgUEFZTE9BRA=="
+	},
+	{
+		"url": "https://extension-Boolean",
+		"valueBoolean": true
+	},
+	{
+		"url": "https://extension-Canonical",
+		"valueCanonical": "https://mycanonical"
+	},
+	{
+		"url": "https://extension-base64",
+		"valueBase64Binary": "VEhJUyBJUyBBIEZBS0UgUEFZTE9BRA=="
+	},
+	{
+		"url": "https://extension-ContactDetail",
+		"valueContactDetail": {
+			"name": "Patient P",
+			"telecom": [{
+				"value": "1-111-111-1111",
+				"use": "home"
+			}]
+		}
+	},
+	{
+		"url": "https://extension-Count",
+		"valueCount": {
+			"value": 10.0,
+			"comparator": ">=",
+			"unit": "kg"
+		}
+	},
+	{
+		"url": "https://extension-Distance",
+		"valueDistance": {
+			"value": 10.0,
+			"unit": "km"
+		}
+	},
+	{
+		"url": "https://extension-MoneyQuantity",
+		"valueQuantity": {
+			"value": 10.0,
+			"unit": "$"
+		}
+	}],
+	"code": {
+		"id": "1-2-3-4",
+		"text": "Demo"
+	}
+}

--- a/fhir-examples/src/main/resources/json/ibm/coverage/parameters-contactdetail.json
+++ b/fhir-examples/src/main/resources/json/ibm/coverage/parameters-contactdetail.json
@@ -1,0 +1,18 @@
+{
+	"resourceType": "Parameters",
+	"id": "5d475b8a-6abe-43d4-b587-ce7d63c2628a",
+	"parameter": [{
+		"name": "_demo",
+		"valueContributor": {
+			"type": "author",
+			"name": "contributor-name",
+			"contact": [{
+				"name": "Patient P",
+				"telecom": [{
+					"value": "1-111-111-1111",
+					"use": "home"
+				}]
+			}]
+		}
+	}]
+}

--- a/fhir-examples/src/main/resources/xml/ibm/coverage/basic-type.xml
+++ b/fhir-examples/src/main/resources/xml/ibm/coverage/basic-type.xml
@@ -1,0 +1,47 @@
+<Basic xmlns="http://hl7.org/fhir">
+    <extension url="https://extension-base64">
+        <valueBase64Binary
+            value="VEhJUyBJUyBBIEZBS0UgUEFZTE9BRA==" />
+    </extension>
+    <extension url="https://extension-Boolean">
+        <valueBoolean value="true" />
+    </extension>
+    <extension url="https://extension-Canonical">
+        <valueCanonical value="https://mycanonical" />
+    </extension>
+    <extension url="https://extension-base64">
+        <valueBase64Binary
+            value="VEhJUyBJUyBBIEZBS0UgUEFZTE9BRA==" />
+    </extension>
+    <extension url="https://extension-ContactDetail">
+        <valueContactDetail>
+            <name value="Patient P" />
+            <telecom>
+                <value value="1-111-111-1111" />
+                <use value="home" />
+            </telecom>
+        </valueContactDetail>
+    </extension>
+    <extension url="https://extension-Count">
+        <valueCount>
+            <value value="10.0" />
+            <comparator value="&gt;=" />
+            <unit value="kg" />
+        </valueCount>
+    </extension>
+    <extension url="https://extension-Distance">
+        <valueDistance>
+            <value value="10.0" />
+            <unit value="km" />
+        </valueDistance>
+    </extension>
+    <extension url="https://extension-MoneyQuantity">
+        <valueQuantity>
+            <value value="10.0" />
+            <unit value="$" />
+        </valueQuantity>
+    </extension>
+    <code id="1-2-3-4">
+        <text value="Demo" />
+    </code>
+</Basic>

--- a/fhir-examples/src/main/resources/xml/ibm/coverage/parameters-contactdetail.xml
+++ b/fhir-examples/src/main/resources/xml/ibm/coverage/parameters-contactdetail.xml
@@ -1,0 +1,17 @@
+<Parameters xmlns="http://hl7.org/fhir">
+    <id value="851051fe-004e-4e64-bf4e-46853c86e5b6" />
+    <parameter>
+        <name value="_demo" />
+        <valueContributor>
+            <type value="author" />
+            <name value="contributor-name" />
+            <contact>
+                <name value="Patient P" />
+                <telecom>
+                    <value value="1-111-111-1111" />
+                    <use value="home" />
+                </telecom>
+            </contact>
+        </valueContributor>
+    </parameter>
+</Parameters>

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -293,46 +293,6 @@ public class FHIRUtil {
     }
 
     /**
-     * use {@link ModelSupport#getTypeName(Class)}
-     */
-    @Deprecated
-    public static String getTypeName(Class<?> type) {
-        String typeName = type.getSimpleName();
-        if (Code.class.isAssignableFrom(type)) {
-            typeName = "code";
-        } else if (isPrimitiveType(type)) {
-            typeName = typeName.substring(0, 1).toLowerCase() + typeName.substring(1);
-        }
-        return typeName;
-    }
-
-    /**
-     * @deprecated use {@link ModelSupport#isPrimitiveType(Class)}
-     */
-    @Deprecated
-    public static boolean isPrimitiveType(Class<?> type) {
-        return Base64Binary.class.equals(type) ||
-            com.ibm.fhir.model.type.Boolean.class.equals(type) ||
-            com.ibm.fhir.model.type.String.class.isAssignableFrom(type) || 
-            Uri.class.isAssignableFrom(type) ||
-            DateTime.class.equals(type) || 
-            Date.class.equals(type) ||
-            Time.class.equals(type) || 
-            Instant.class.equals(type) || 
-            com.ibm.fhir.model.type.Integer.class.isAssignableFrom(type) || 
-            Decimal.class.equals(type) || 
-            Xhtml.class.equals(type);
-    }
-
-    /**
-     * @deprecated use {@link ModelSupport#isChoiceElementType(Class)}
-     */
-    @Deprecated
-    public static boolean isChoiceElementType(Class<?> type) {
-        return CHOICE_ELEMENT_TYPES.contains(type);
-    }
-
-    /**
      * Read JSON from InputStream {@code stream} and parse it into a FHIR resource. Non-mandatory elements which are not
      * in {@code elementsToInclude} will be filtered out.
      * 

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
@@ -125,7 +125,7 @@ public class ResourceCoverageTest {
             }
         }
     }
-    
+
     @Test
     public void testResourcesWithXml() throws Exception {
         List<String> SKIP = Arrays.asList("DomainResource", "Resource", "Builder");
@@ -137,42 +137,41 @@ public class ResourceCoverageTest {
 
                 Resource.Builder builder = resource.toBuilder();
                 Method[] methods = builder.getClass().getMethods();
-                for(Method method : methods) {
+                for (Method method : methods) {
                     if (method.getName().equals("extension") && method.toString().contains("java.util.Collection")) {
                         List<Extension> extensions = Arrays.asList(buildBooleanTrue());
                         builder = (Resource.Builder) method.invoke(builder, extensions);
                     }
-                    
-                    if (method.getName().equals("modifierExtension") && method.toString().contains("java.util.Collection")) {
+
+                    if (method.getName().equals("modifierExtension")
+                            && method.toString().contains("java.util.Collection")) {
                         List<Extension> extensions = Arrays.asList(buildBooleanTrue());
                         builder = (Resource.Builder) method.invoke(builder, extensions);
                     }
                 }
                 resource = builder.build();
-                
+
                 try (StringWriter writer = new StringWriter()) {
                     FHIRGenerator.generator(Format.JSON).generate(resource, writer);
                     String outJson = writer.toString();
                     assertNotNull(outJson);
                     assertFalse(outJson.isEmpty());
-                    
+
                     try (ByteArrayInputStream in = new ByteArrayInputStream(outJson.getBytes())) {
                         Resource resource2 = FHIRParser.parser(Format.JSON).parse(in).as(Resource.class);
                         assertNotNull(resource2);
-                        assertTrue(true);
                     }
                 }
-                
+
                 try (StringWriter writer = new StringWriter()) {
                     FHIRGenerator.generator(Format.XML).generate(resource, writer);
                     String outXML = writer.toString();
                     assertNotNull(outXML);
                     assertFalse(outXML.isEmpty());
-                    
+
                     try (ByteArrayInputStream in = new ByteArrayInputStream(outXML.getBytes())) {
                         Resource resource2 = FHIRParser.parser(Format.XML).parse(in).as(Resource.class);
                         assertNotNull(resource2);
-                        assertTrue(true);
                     }
                 }
             }
@@ -183,12 +182,10 @@ public class ResourceCoverageTest {
         for (Method method : methods) {
             if (method.getName().startsWith("get")) {
                 method.invoke(resource);
-                assertTrue(true);
             }
 
             if (method.getName().equals("hashCode")) {
                 method.invoke(resource);
-                assertTrue(true);
             }
 
             if (method.getName().equals("equals")) {
@@ -197,23 +194,21 @@ public class ResourceCoverageTest {
 
                 String x = "BAD";
                 method.invoke(resource, x);
-                assertTrue(true);
-                
+
                 if (resource instanceof Resource) {
-                    Resource r = (Resource) resource; 
-                    Resource r2 = r.toBuilder().build(); 
+                    Resource r = (Resource) resource;
+                    Resource r2 = r.toBuilder().build();
                     assertTrue(r.equals(r2));
                 }
             }
 
             if (method.getName().equals("hasChildren")) {
                 method.invoke(resource);
-                assertTrue(true);
             }
         }
     }
 
-    public void buildTestForUncoveredTypes() throws Exception {
+    public static void main(String[] args) throws Exception {
         List<Extension> extensions = new ArrayList<>();
         extensions.add(buildBase64Binary());
         extensions.add(buildBooleanTrue());
@@ -238,7 +233,6 @@ public class ResourceCoverageTest {
             try (ByteArrayInputStream in = new ByteArrayInputStream(out.getBytes())) {
                 Basic basicParsed = FHIRParser.parser(Format.XML).parse(in).as(Basic.class);
                 assertNotNull(basicParsed);
-                assertTrue(true);
             }
         }
 
@@ -253,7 +247,6 @@ public class ResourceCoverageTest {
             try (ByteArrayInputStream in = new ByteArrayInputStream(out.getBytes())) {
                 Basic basicParsed = FHIRParser.parser(Format.JSON).parse(in).as(Basic.class);
                 assertNotNull(basicParsed);
-                assertTrue(true);
             }
         }
     }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
@@ -1,0 +1,260 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.model.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.Basic;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Base64Binary;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.ContactDetail;
+import com.ibm.fhir.model.type.ContactPoint;
+import com.ibm.fhir.model.type.Count;
+import com.ibm.fhir.model.type.Decimal;
+import com.ibm.fhir.model.type.Distance;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.MoneyQuantity;
+import com.ibm.fhir.model.type.code.ContactPointUse;
+import com.ibm.fhir.model.type.code.QuantityComparator;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.model.type.code.ResourceType.ValueSet;
+
+/**
+ * This class exercises the getters in the resource package.
+ */
+public class ResourceCoverageTest {
+
+    public static byte[] PAYLOAD = "THIS IS A FAKE PAYLOAD".getBytes();
+
+    public static Extension buildBooleanTrue() {
+        return Extension.builder().url("https://extension-Boolean")
+                .value(com.ibm.fhir.model.type.Boolean.builder().value("TRUE").build()).build();
+    }
+
+    public static Extension buildBase64Binary() {
+        return Extension.builder().url("https://extension-base64")
+                .value(Base64Binary.builder().value(PAYLOAD).build()).build();
+    }
+
+    public static Extension buildId() {
+        return Extension.builder().url("https://extension-base64")
+                .value(Base64Binary.builder().value(PAYLOAD).build()).build();
+    }
+
+    public static Extension buildCanonical() {
+        return Extension.builder().url("https://extension-Canonical")
+                .value(com.ibm.fhir.model.type.Canonical.builder().value("https://mycanonical").build())
+                .build();
+    }
+
+    public static Extension buildContactDetail() {
+        return Extension.builder().url("https://extension-ContactDetail")
+                .value(ContactDetail.builder().name(string("Patient P"))
+                        .telecom(ContactPoint.builder().use(ContactPointUse.HOME)
+                                .value(string("1-111-111-1111")).build())
+                        .build())
+                .build();
+    }
+
+    private static Extension buildCount() {
+        Count count =
+                Count.builder().comparator(QuantityComparator.GREATER_OR_EQUALS).value(Decimal.of("10.0"))
+                        .unit(string("kg")).build();
+        return Extension.builder().url("https://extension-Count").value(count).build();
+    }
+
+    private static Extension buildDistance() {
+        Distance distance = Distance.builder().unit(string("km")).value(Decimal.of("10.0")).build();
+        return Extension.builder().url("https://extension-Distance")
+                .value(distance).build();
+    }
+
+    private static Extension buildMoneyQuantity() {
+        MoneyQuantity moneyQuantity = MoneyQuantity.builder().unit(string("$")).value(Decimal.of("10.0")).build();
+        return Extension.builder().url("https://extension-MoneyQuantity")
+                .value(moneyQuantity).build();
+    }
+
+    @Test
+    public void testResources() throws Exception {
+        List<String> SKIP = Arrays.asList("DomainResource", "Resource", "Builder");
+        ValueSet[] values = ResourceType.ValueSet.values();
+        for (ValueSet valueSet : values) {
+            if (!SKIP.contains(valueSet.value())) {
+                Resource resource =
+                        TestUtil.readExampleResource("json/ibm/complete-mock/" + valueSet.value() + "-1.json");
+                Method[] methods = resource.getClass().getMethods();
+                runMethods(resource, methods);
+                Class<?>[] clzs = resource.getClass().getClasses();
+                for (Class<?> clz : clzs) {
+
+                    if (!SKIP.contains(clz.getSimpleName())) {
+                        Method m = resource.getClass().getMethod("get" + clz.getSimpleName());
+                        Object o = m.invoke(resource);
+                        if (o.getClass().getSimpleName().contains("List")) {
+                            @SuppressWarnings("unchecked")
+                            List<Object> os = ((List<Object>) o);
+                            if (!os.isEmpty()) {
+                                runMethods(os.get(0), clz.getMethods());
+                            }
+                        } else if (!o.getClass().getSimpleName().contains("Class")) {
+                            runMethods(o, clz.getMethods());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    @Test
+    public void testResourcesWithXml() throws Exception {
+        List<String> SKIP = Arrays.asList("DomainResource", "Resource", "Builder");
+        ValueSet[] values = ResourceType.ValueSet.values();
+        for (ValueSet valueSet : values) {
+            if (!SKIP.contains(valueSet.value())) {
+                Resource resource =
+                        TestUtil.readExampleResource("xml/ibm/complete-mock/" + valueSet.value() + "-1.xml");
+
+                Resource.Builder builder = resource.toBuilder();
+                Method[] methods = builder.getClass().getMethods();
+                for(Method method : methods) {
+                    if (method.getName().equals("extension") && method.toString().contains("java.util.Collection")) {
+                        List<Extension> extensions = Arrays.asList(buildBooleanTrue());
+                        builder = (Resource.Builder) method.invoke(builder, extensions);
+                    }
+                    
+                    if (method.getName().equals("modifierExtension") && method.toString().contains("java.util.Collection")) {
+                        List<Extension> extensions = Arrays.asList(buildBooleanTrue());
+                        builder = (Resource.Builder) method.invoke(builder, extensions);
+                    }
+                }
+                resource = builder.build();
+                
+                try (StringWriter writer = new StringWriter()) {
+                    FHIRGenerator.generator(Format.JSON).generate(resource, writer);
+                    String outJson = writer.toString();
+                    assertNotNull(outJson);
+                    assertFalse(outJson.isEmpty());
+                    
+                    try (ByteArrayInputStream in = new ByteArrayInputStream(outJson.getBytes())) {
+                        Resource resource2 = FHIRParser.parser(Format.JSON).parse(in).as(Resource.class);
+                        assertNotNull(resource2);
+                        assertTrue(true);
+                    }
+                }
+                
+                try (StringWriter writer = new StringWriter()) {
+                    FHIRGenerator.generator(Format.XML).generate(resource, writer);
+                    String outXML = writer.toString();
+                    assertNotNull(outXML);
+                    assertFalse(outXML.isEmpty());
+                    
+                    try (ByteArrayInputStream in = new ByteArrayInputStream(outXML.getBytes())) {
+                        Resource resource2 = FHIRParser.parser(Format.XML).parse(in).as(Resource.class);
+                        assertNotNull(resource2);
+                        assertTrue(true);
+                    }
+                }
+            }
+        }
+    }
+
+    public void runMethods(Object resource, Method[] methods) throws Exception {
+        for (Method method : methods) {
+            if (method.getName().startsWith("get")) {
+                method.invoke(resource);
+                assertTrue(true);
+            }
+
+            if (method.getName().equals("hashCode")) {
+                method.invoke(resource);
+                assertTrue(true);
+            }
+
+            if (method.getName().equals("equals")) {
+                method.invoke(resource, resource);
+                assertTrue(true);
+
+                String x = "BAD";
+                method.invoke(resource, x);
+                assertTrue(true);
+                
+                if (resource instanceof Resource) {
+                    Resource r = (Resource) resource; 
+                    Resource r2 = r.toBuilder().build(); 
+                    assertTrue(r.equals(r2));
+                }
+            }
+
+            if (method.getName().equals("hasChildren")) {
+                method.invoke(resource);
+                assertTrue(true);
+            }
+        }
+    }
+
+    public void buildTestForUncoveredTypes() throws Exception {
+        List<Extension> extensions = new ArrayList<>();
+        extensions.add(buildBase64Binary());
+        extensions.add(buildBooleanTrue());
+        extensions.add(buildCanonical());
+        extensions.add(buildId());
+        extensions.add(buildContactDetail());
+        extensions.add(buildCount());
+        extensions.add(buildDistance());
+        extensions.add(buildMoneyQuantity());
+
+        CodeableConcept code = CodeableConcept.builder().id("1-2-3-4").text(string("Demo")).build();
+        Basic basic = Basic.builder().code(code).extension(extensions).build();
+
+        try (StringWriter writer = new StringWriter()) {
+            FHIRGenerator.generator(Format.XML).generate(basic, writer);
+
+            String out = writer.toString();
+            assertNotNull(out);
+            assertFalse(out.isEmpty());
+            System.out.println(out);
+
+            try (ByteArrayInputStream in = new ByteArrayInputStream(out.getBytes())) {
+                Basic basicParsed = FHIRParser.parser(Format.XML).parse(in).as(Basic.class);
+                assertNotNull(basicParsed);
+                assertTrue(true);
+            }
+        }
+
+        try (StringWriter writer = new StringWriter()) {
+            FHIRGenerator.generator(Format.JSON).generate(basic, writer);
+
+            String out = writer.toString();
+            assertNotNull(out);
+            assertFalse(out.isEmpty());
+            System.out.println(out);
+
+            try (ByteArrayInputStream in = new ByteArrayInputStream(out.getBytes())) {
+                Basic basicParsed = FHIRParser.parser(Format.JSON).parse(in).as(Basic.class);
+                assertNotNull(basicParsed);
+                assertTrue(true);
+            }
+        }
+    }
+}

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -17,7 +17,7 @@
         <surefire.plugin.version>3.0.0-M3</surefire.plugin.version>
         <!-- needed for generating jacoco aggregate report in fhir-coverage-reports -->
         <maven.surefire.report.plugin>${surefire.plugin.version}</maven.surefire.report.plugin>
-        <jacoco.plugin.version>0.8.2</jacoco.plugin.version>
+        <jacoco.plugin.version>0.8.5</jacoco.plugin.version>
         <argLine>-Dfile.encoding=UTF-8</argLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <my.maven.war.plugin>3.2.3</my.maven.war.plugin>


### PR DESCRIPTION
- Add Examples to increase Test Coverage
	- parameters-contactdetail.[json/xml]
	- basic-type.[json/xml]
- Add coverage for get method tests
- Update fhir-parent to use the latest jacoco plugin
- Increase code coverage of fhir-config
- Update fhir-model to remove unused FHIRUtil method
- Add a switch to turn on/off codecov.io

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>