### PR TITLE
Fix healthcheck example

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -88,9 +88,10 @@ The Maven build creates the zip package under `fhir-install/target`. Alternative
 
 9.  After you start the server, you can verify that it's running properly by invoking the `$healthcheck` endpoint like this:
     ```
-    curl -k -u <username> https://<host>:<port>/fhir-server/api/v4/$endpoint
+    curl -k -u <username> 'https://<host>:<port>/fhir-server/api/v4/$healthcheck'
     ```
-    where `<username>` is one of the users configured in `server.xml` (default is `fhiruser`).
+    where `<username>` is one of the users configured in `server.xml` (default is `fhiruser`).  
+    Note: Use single quotes around the URL to prevent $healthcheck from being evaluated as an environment variable on unix-based operating systems.  
     The preceding command should produce output similar to the following:
     ```
     {


### PR DESCRIPTION
$endpoint should be $healthcheck; use single quotes around the URL