### PR TITLE
Issue #662 - add logic to handle empty context for 'conformsTo' function

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.path.function;
 
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_FALSE;
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_TRUE;
+import static com.ibm.fhir.path.util.FHIRPathUtil.empty;
 import static com.ibm.fhir.path.util.FHIRPathUtil.evaluatesToBoolean;
 import static com.ibm.fhir.path.util.FHIRPathUtil.getSingleton;
 import static com.ibm.fhir.path.util.FHIRPathUtil.getStringValue;
@@ -50,6 +51,10 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
     
     @Override
     public Collection<FHIRPathNode> apply(EvaluationContext evaluationContext, Collection<FHIRPathNode> context, List<Collection<FHIRPathNode>> arguments) {
+        if (context.isEmpty()) {
+            return empty();
+        }
+        
         if (!hasResourceNode(context) && !hasElementNode(context)) {
             throw new IllegalArgumentException("The 'conformsTo' function can only be invoked on a Resource or Element node");
         }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ConformsToTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ConformsToTest.java
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.validation.test;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.validation.FHIRValidator;
+
+public class ConformsToTest {
+    @Test
+    public void testConformsToWithEmptyContext() throws Exception {
+        try (InputStream in = ConformsToTest.class.getClassLoader().getResourceAsStream("JSON/us-core-patient.json")) {
+            Patient patient = FHIRParser.parser(Format.JSON).parse(in);
+            List<Issue> issues = FHIRValidator.validator().validate(patient);
+            assertEquals(issues.size(), 1);
+        }
+    }
+}

--- a/fhir-validation/src/test/resources/JSON/us-core-patient.json
+++ b/fhir-validation/src/test/resources/JSON/us-core-patient.json
@@ -1,0 +1,41 @@
+{
+    "resourceType": "Patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">empty</div>"
+    },
+    "meta": {
+        "profile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+        ]
+    },
+    "identifier": [
+        {
+            "type": {
+                "coding": [
+                    {
+                        "system": "http://hl7.org/fhir/v2/0203",
+                        "version": "2.5",
+                        "code": "MR",
+                        "display": "Medical record number"
+                    }
+                ]
+            },
+            "system": "http://example.com/medical-record-number",
+            "value": "1",
+            "assigner": {
+                "display": "EXAMPLE"
+            }
+        },
+        {
+            "system": "http://example.com/patient-identifier",
+            "value": "1-2-3-4",
+            "assigner": {
+                "display": "EXAMPLE"
+            }
+        }
+    ],
+    "gender": "male",
+    "birthDate": "2000-01-01",
+    "deceasedBoolean": true
+}


### PR DESCRIPTION
Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>