### PR TITLE
Refactoring and addition of FHIRUtil.createStandaloneBundle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
     - name: Server Integration Tests
       shell: powershell
       run: |
+        $ErrorActionPreference = "Stop"
         & build/pre-integration-test.ps1
         & build/tests.ps1
         & build/post-integration-test.ps1

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/CollectingVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/CollectingVisitor.java
@@ -16,10 +16,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.visitor.DefaultVisitor;
+import com.ibm.fhir.model.visitor.Visitable;
 
+/**
+ * Visits a Resource or Element and collects all of its descendants of a given type into a single list
+ * 
+ * @param <T> The type of object to collect
+ * @implNote The order of the list will be consistent with a depth-first traversal of the visited object
+ */
 public class CollectingVisitor<T> extends DefaultVisitor {
     protected final List<T> result = new ArrayList<>();
     protected final Class<T> type;
@@ -40,13 +45,9 @@ public class CollectingVisitor<T> extends DefaultVisitor {
     }
 
     @Override
-    public void visitStart(java.lang.String elementName, int elementIndex, Element element) {
-        collect(element);
-    }
-
-    @Override
-    public void visitStart(java.lang.String elementName, int elementIndex, Resource resource) {
-        collect(resource);
+    public boolean visit(java.lang.String elementName, int elementIndex, Visitable visitable) {
+        collect(visitable);
+        return true;
     }
 
     @Override

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -12,11 +12,7 @@ import static com.ibm.fhir.model.FHIRModel.getToStringPrettyPrinting;
 import static com.ibm.fhir.model.type.String.string;
 import static java.util.Objects.nonNull;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.Reader;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -24,12 +20,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -47,66 +41,21 @@ import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.FHIRModel;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
-import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
-import com.ibm.fhir.model.parser.FHIRJsonParser;
-import com.ibm.fhir.model.parser.FHIRParser;
-import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.DomainResource;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.type.Address;
-import com.ibm.fhir.model.type.Age;
-import com.ibm.fhir.model.type.Annotation;
-import com.ibm.fhir.model.type.Attachment;
-import com.ibm.fhir.model.type.Base64Binary;
-import com.ibm.fhir.model.type.Canonical;
-import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
-import com.ibm.fhir.model.type.ContactDetail;
-import com.ibm.fhir.model.type.ContactPoint;
-import com.ibm.fhir.model.type.Contributor;
-import com.ibm.fhir.model.type.Count;
-import com.ibm.fhir.model.type.DataRequirement;
-import com.ibm.fhir.model.type.Date;
-import com.ibm.fhir.model.type.DateTime;
-import com.ibm.fhir.model.type.Decimal;
-import com.ibm.fhir.model.type.Distance;
-import com.ibm.fhir.model.type.Dosage;
-import com.ibm.fhir.model.type.Duration;
-import com.ibm.fhir.model.type.Expression;
 import com.ibm.fhir.model.type.Extension;
-import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Id;
-import com.ibm.fhir.model.type.Identifier;
-import com.ibm.fhir.model.type.Instant;
-import com.ibm.fhir.model.type.Markdown;
 import com.ibm.fhir.model.type.Meta;
-import com.ibm.fhir.model.type.Money;
-import com.ibm.fhir.model.type.MoneyQuantity;
-import com.ibm.fhir.model.type.Oid;
-import com.ibm.fhir.model.type.ParameterDefinition;
-import com.ibm.fhir.model.type.Period;
-import com.ibm.fhir.model.type.PositiveInt;
-import com.ibm.fhir.model.type.Quantity;
-import com.ibm.fhir.model.type.Range;
-import com.ibm.fhir.model.type.Ratio;
 import com.ibm.fhir.model.type.Reference;
-import com.ibm.fhir.model.type.RelatedArtifact;
-import com.ibm.fhir.model.type.SampledData;
-import com.ibm.fhir.model.type.Signature;
-import com.ibm.fhir.model.type.SimpleQuantity;
-import com.ibm.fhir.model.type.Time;
-import com.ibm.fhir.model.type.Timing;
-import com.ibm.fhir.model.type.TriggerDefinition;
-import com.ibm.fhir.model.type.UnsignedInt;
 import com.ibm.fhir.model.type.Uri;
-import com.ibm.fhir.model.type.Url;
-import com.ibm.fhir.model.type.UsageContext;
 import com.ibm.fhir.model.type.Uuid;
-import com.ibm.fhir.model.type.Xhtml;
+import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.ResourceType;
@@ -119,60 +68,6 @@ public class FHIRUtil {
     private static final JsonBuilderFactory BUILDER_FACTORY = Json.createBuilderFactory(null);
     public static final Pattern REFERENCE_PATTERN = buildReferencePattern();
     private static final Logger log = Logger.getLogger(FHIRUtil.class.getName());
-    private static final Map<String, Class<?>> RESOURCE_TYPE_MAP = buildResourceTypeMap();
-    private static final Set<Class<?>> CHOICE_ELEMENT_TYPES = new HashSet<>(Arrays.asList(
-        Base64Binary.class,
-        com.ibm.fhir.model.type.Boolean.class,
-        Canonical.class,
-        Code.class,
-        Date.class,
-        DateTime.class,
-        Decimal.class,
-        Id.class,
-        Instant.class,
-        com.ibm.fhir.model.type.Integer.class,
-        Markdown.class,
-        Oid.class,
-        PositiveInt.class,
-        com.ibm.fhir.model.type.String.class,
-        Time.class,
-        UnsignedInt.class,
-        Uri.class,
-        Url.class,
-        Uuid.class,
-        Address.class,
-        Age.class,
-        Annotation.class,
-        Attachment.class,
-        CodeableConcept.class,
-        Coding.class,
-        ContactPoint.class,
-        Count.class,
-        Distance.class,
-        Duration.class,
-        HumanName.class,
-        Identifier.class,
-        Money.class,
-        MoneyQuantity.class, // profiled type
-        Period.class,
-        Quantity.class,
-        Range.class,
-        Ratio.class,
-        Reference.class,
-        SampledData.class,
-        SimpleQuantity.class, // profiled type
-        Signature.class,
-        Timing.class,
-        ContactDetail.class,
-        Contributor.class,
-        DataRequirement.class,
-        Expression.class,
-        ParameterDefinition.class,
-        RelatedArtifact.class,
-        TriggerDefinition.class,
-        UsageContext.class,
-        Dosage.class));
-    private static final Map<String, String> CONCRETE_TYPE_NAME_MAP = buildConcreteTypeNameMap();
     private static final OperationOutcome ALL_OK = OperationOutcome.builder()
         .issue(Issue.builder()
         .severity(IssueSeverity.INFORMATION)
@@ -218,39 +113,6 @@ public class FHIRUtil {
         }
     }
 
-    @Deprecated
-    private static Map<String, String> buildConcreteTypeNameMap() {
-        Map<String, String> concreteTypeNameMap = new HashMap<>();
-        concreteTypeNameMap.put("SimpleQuantity", "Quantity");
-        concreteTypeNameMap.put("MoneyQuantity", "Quantity");
-        return concreteTypeNameMap;
-    }
-
-    /**
-     * Get the name of the concrete type associated with a data type
-     * 
-     * @param typeName
-     *            the type name
-     * @return the name of the concrete type (if one exists) (e.g. Quantity for SimpleQuantity) otherwise, return input
-     *         parameter
-     * @deprecated use {@link ModelSupport#getConcreteType(Class)}
-     */
-    @Deprecated
-    public static String getConcreteTypeName(String typeName) {
-        if (isProfiledType(typeName)) {
-            return CONCRETE_TYPE_NAME_MAP.get(typeName);
-        }
-        return typeName;
-    }
-
-    /**
-     * @deprecated use {@link ModelSupport#isProfiledType(Class)}
-     */
-    @Deprecated
-    public static boolean isProfiledType(String typeName) {
-        return CONCRETE_TYPE_NAME_MAP.containsKey(typeName);
-    }
-
     private static Pattern buildReferencePattern() {
         StringBuilder sb = new StringBuilder();
         sb.append("((http|https)://([A-Za-z0-9\\\\\\/\\.\\:\\%\\$\\-])*)?(");
@@ -259,143 +121,6 @@ public class FHIRUtil {
             .collect(Collectors.joining("|")));
         sb.append(")\\/[A-Za-z0-9\\-\\.]{1,64}(\\/_history\\/[A-Za-z0-9\\-\\.]{1,64})?");
         return Pattern.compile(sb.toString());
-    }
-
-    /**
-     * @deprecated use {@link ModelSupport#isResourceType(String)}
-     */
-    @Deprecated
-    public static boolean isStandardResourceType(String name) {
-        return RESOURCE_TYPE_MAP.containsKey(name);
-    }
-
-    /**
-     * @deprecated use {@link ModelSupport#getResourceType(String)}
-     */
-    @Deprecated
-    public static Class<?> getResourceType(String name) {
-        return RESOURCE_TYPE_MAP.get(name);
-    }
-
-    @Deprecated
-    private static Map<String, Class<?>> buildResourceTypeMap() {
-        Map<String, Class<?>> resourceTypeMap = new LinkedHashMap<>();
-        for (ResourceType.ValueSet value : ResourceType.ValueSet.values()) {
-            String resourceTypeName = value.value();
-            try {
-                Class<?> resourceTypeClass = Class.forName("com.ibm.fhir.model.resource." + resourceTypeName);
-                resourceTypeMap.put(resourceTypeName, resourceTypeClass);
-            } catch (Exception e) {
-                throw new Error(e);
-            }
-        }
-        return resourceTypeMap;
-    }
-
-    /**
-     * Read JSON from InputStream {@code stream} and parse it into a FHIR resource. Non-mandatory elements which are not
-     * in {@code elementsToInclude} will be filtered out.
-     * 
-     * @param resourceType
-     * @param in
-     * @param elementsToInclude
-     *            a list of element names to include in the returned resource; null to skip filtering
-     * @return a fhir-model resource containing mandatory elements and the elements requested (if they are present in
-     *         the JSON)
-     * @deprecated use {@link FHIRParser} directly
-     */
-    @Deprecated
-    public static <T extends Resource> T readAndFilterJson(Class<T> resourceType, InputStream in, List<String> elementsToInclude) throws FHIRParserException {
-        return FHIRParser.parser(Format.JSON).as(FHIRJsonParser.class).parseAndFilter(in, elementsToInclude);
-    }
-
-    /**
-     * Read a FHIR resource from {@code reader} in the requested {@code format}.
-     * 
-     * @deprecated use {@link FHIRParser} directly
-     */
-    @Deprecated
-    public static <T extends Resource> T read(Class<T> resourceType, Format format, Reader reader) throws FHIRParserException {
-        return FHIRParser.parser(format).parse(reader);
-    }
-
-    /**
-     * Read a FHIR resource from {@code in} in the requested {@code format}.
-     * 
-     * @deprecated use {@link FHIRParser} directly
-     */
-    @Deprecated
-    public static <T extends Resource> T read(Class<T> resourceType, Format format, InputStream in) throws FHIRParserException {
-        return FHIRParser.parser(format).parse(in);
-    }
-
-    /**
-     * Read JSON from {@link java.io.Reader#read()} and parse it into a FHIR resource. Non-mandatory elements which are not in
-     * elementsToInclude will be filtered out.
-     * 
-     * @param resourceType
-     * @param reader
-     * @param elementsToInclude
-     *            a list of element names to include in the returned resource; null to skip filtering
-     * @return a fhir-model resource containing mandatory elements and the elements requested (if they are present in
-     *         the JSON)
-     * @deprecated use {@link FHIRParser} directly
-     */
-    @Deprecated
-    public static <T extends Resource> T readAndFilterJson(Class<T> resourceType, Reader reader, List<String> elementsToInclude) throws FHIRParserException {
-        return FHIRParser.parser(Format.JSON).as(FHIRJsonParser.class).parseAndFilter(reader, elementsToInclude);
-    }
-
-    /**
-     * @deprecated use {@link FHIRParser} directly
-     */
-    @Deprecated
-    public static <T extends Resource> T toResource(Class<T> resourceType, JsonObject jsonObject) throws FHIRParserException {
-        return FHIRParser.parser(Format.JSON).as(FHIRJsonParser.class).parse(jsonObject);
-    }
-
-    /**
-     * Write a resource in XML or JSON to a given output stream, without pretty-printing. This method will close the
-     * output stream after writing to it, so passing System.out / System.err is discouraged.
-     * 
-     * @deprecated use {@link FHIRGenerator} directly
-     */
-    @Deprecated
-    public static <T extends Resource> void write(T resource, Format format, OutputStream stream) throws FHIRGeneratorException {
-        write(resource, format, stream, false);
-    }
-
-    /**
-     * Write a resource in XML or JSON to a given output stream, with an option to pretty-print the output. This method
-     * will close the output stream after writing to it, so passing System.out / System.err is discouraged.
-     * 
-     * @deprecated use {@link FHIRGenerator} directly
-     */
-    @Deprecated
-    public static <T extends Resource> void write(T resource, Format format, OutputStream stream, boolean formatted) throws FHIRGeneratorException {
-        FHIRGenerator.generator(format, formatted).generate(resource, stream);
-    }
-
-    /**
-     * Write a resource in XML or JSON using the passed writer, without pretty-printing. This method will close the
-     * writer after writing to it.
-     * 
-     * @deprecated use {@link FHIRGenerator} directly
-     */
-    @Deprecated
-    public static <T extends Resource> void write(T resource, Format format, Writer writer) throws FHIRGeneratorException {
-        write(resource, format, writer, false);
-    }
-
-    /**
-     * Write a resource in XML or JSON using the passed writer, with an option to pretty-print the output. This method
-     * will close the writer after writing to it.
-     * 
-     * @deprecated use {@link FHIRGenerator} directly
-     */
-    @Deprecated
-    public static <T extends Resource> void write(T resource, Format format, Writer writer, boolean prettyPrinting) throws FHIRGeneratorException {
-        FHIRGenerator.generator(format, prettyPrinting).generate(resource, writer);
     }
 
     // copy an immutable JsonObject into a mutable JsonObjectBuilder
@@ -764,15 +489,21 @@ public class FHIRUtil {
      * @param resource
      *            the resource
      * @return the name of the resource type associated with the resource
+     * @deprecated use {@link ModelSupport.getTypeName(Class<?>)}
      */
+    @Deprecated
     public static String getResourceTypeName(Resource resource) {
         return resource.getClass().getSimpleName();
     }
 
+    /**
+     * @return a list of all resource type names, including abstract supertypes
+     * @implNote this list does not include "logical" resources like {code MetadataResource}
+     */
     public static List<String> getResourceTypeNames() {
-        List<String> typeNameList = new ArrayList<String>();
-        typeNameList.addAll(RESOURCE_TYPE_MAP.keySet());
-        return typeNameList;
+        return Arrays.stream(ResourceType.ValueSet.values())
+                .map(ResourceType.ValueSet::value)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -789,5 +520,39 @@ public class FHIRUtil {
         default:
             return true;
         }
+    }
+    
+    /**
+     * Create a self-contained bundle from the passed map of resources, replacing Resource.id values and 
+     * references with a generated UUID.
+     * 
+     * @param bundleType
+     *            The type of bundle to create
+     * @param resources
+     *            A mapping from String identifiers to Resources. For resources with no logical id, the key can be any
+     *            string
+     * @return a Bundle with the passed resources with ids and references replaced by UUIDs
+     */
+    public static Bundle createStandaloneBundle(BundleType bundleType, Map<String,Resource> resources) {
+        Map<String,String> localRefMap = new HashMap<>();
+
+        List<Entry> entries = new ArrayList<>();
+        for (String key : resources.keySet()) {
+            Uuid uuid = Uuid.of("urn:uuid:" + UUID.randomUUID());
+            localRefMap.put(key, uuid.getValue());
+            entries.add(Entry.builder()
+                .fullUrl(uuid)
+                .resource(resources.get(key))
+                .build());
+        }
+
+        Bundle bundle = Bundle.builder()
+            .type(bundleType)
+            .entry(entries)
+            .build();
+        
+        ReferenceMappingVisitor<Bundle> referenceMappingVisitor = new ReferenceMappingVisitor<>(localRefMap);
+        bundle.accept(referenceMappingVisitor);
+        return referenceMappingVisitor.getResult();
     }
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
@@ -602,6 +602,8 @@ public final class ModelSupport {
 
     /**
      * @return the name of the FHIR data type which corresponds to the passed type
+     * @implNote primitive types will start with a lowercase letter,
+     *           complex types and resources with an uppercaseletter
      */
     public static String getTypeName(Class<?> type) {
         String typeName = type.getSimpleName();
@@ -615,6 +617,8 @@ public final class ModelSupport {
 
     /**
      * @return the set of FHIR data type names for the passed modelClass and its supertypes
+     * @implNote primitive types will start with a lowercase letter,
+     *           complex types and resources with an uppercaseletter
      */
     public static Set<String> getTypeNames(Class<?> modelClass) {
         Set<String> typeNames = new HashSet<>();

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ReferenceMappingVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ReferenceMappingVisitor.java
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.server.util;
+package com.ibm.fhir.model.util;
 
 import static com.ibm.fhir.model.type.String.string;
 
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.type.Reference;
@@ -17,49 +18,40 @@ import com.ibm.fhir.model.visitor.Visitable;
 
 /**
  * Copy the value of each element within a Resource/Element to a new element
- * with the same values, replacing local Reference values with a new value
+ * with the same values, replacing {@code Reference.reference} values with a new value
  * 
- * @author AlbertWang
  * @param <T> The type to copy. Only visitables of this type should be visited.
  */
 public class ReferenceMappingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private static final Logger log = java.util.logging.Logger.getLogger(ReferenceMappingVisitor.class.getName());
     private Map<String, String> localRefMap;
-    String errorMsg = null;
 
     /**
-     * @param localRefMap
+     * @param localRefMap a mapping from the current Reference values to the desired ones
      */
     public ReferenceMappingVisitor(Map<String, String> localRefMap) {
         super();
         this.localRefMap = localRefMap;
-
     }
 
     @Override
     public boolean visit(String elementName, int elementIndex, Reference reference) {
         if (reference != null && reference.getReference() != null && reference.getReference().hasValue()) {
-            String value = reference.getReference().getValue();
-            // Use more generic urn: to handle all cases including the legacy integration tests
-            if (value.startsWith("urn:")) {
-                String externalRef = localRefMap.get(value);
-                if (externalRef == null) {
-                    errorMsg += "Local reference '" + value + "' is undefined in the request bundle. ";
-                } else {
-                    ((Reference.Builder) getBuilder()).reference(string(externalRef));
-                    markDirty();
-                    log.finer("Convert local ref '" + value + "' to external ref '" + externalRef + "'.");
+            String refValue = reference.getReference().getValue();
+            String newRefValue = localRefMap.get(refValue);
+            if (newRefValue != null) {
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Replacing '" + refValue + "' with new value '" + newRefValue + "'");
+                }
+                ((Reference.Builder) getBuilder()).reference(string(newRefValue));
+                markDirty();
+            } else {
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Reference '" + refValue + "' is not replaced "
+                            + "because it was not found in the local reference map");
                 }
             }
         }
         return false;
     }
-
-    /**
-     * @return the errorMsg
-     */
-    public String getErrorMsg() {
-        return errorMsg;
-    }
-
 }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/util/test/ReferenceMappingVistorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/util/test/ReferenceMappingVistorTest.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.server.test;
+package com.ibm.fhir.model.util.test;
 
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.AssertJUnit.assertNotSame;
@@ -32,7 +32,7 @@ import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.String;
-import com.ibm.fhir.server.util.ReferenceMappingVisitor;
+import com.ibm.fhir.model.util.ReferenceMappingVisitor;
 
 public class ReferenceMappingVistorTest {
     public boolean DEBUG = false;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/Base64BinaryTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/Base64BinaryTest.java
@@ -112,7 +112,7 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
         if (DEBUG) {
-            FHIRUtil.write(docRef, Format.JSON, System.out);
+            FHIRGenerator.generator(Format.JSON).generate(docRef, System.out);
         }
 
         // Retrieve the DocumentReference
@@ -122,7 +122,7 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         DocumentReference responseDocRef = response.readEntity(DocumentReference.class);
 
         if (DEBUG) {
-            FHIRUtil.write(responseDocRef, Format.JSON, System.out);
+            FHIRGenerator.generator(Format.JSON).generate(responseDocRef, System.out);
         }
 
         // Compare original and retrieved values.


### PR DESCRIPTION
1. Moved ReferenceMappingVisitor from fhir-server to fhir-model and
refactored it to allow any mapping (not just UUID -> logical id)

2. Introduced FHIRUtil.createStandaloneBundle for adding resources to a
bundle and replacing internal references with bundle-local UUID values

3. Removed deprecated FHIRUtil methods and added deprecated flag to
FHIRUtil.getResourceTypeName(Resource resource)

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>