### PR TITLE
Refactored FHIRPathPatch into builder pattern

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathNode.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathNode.java
@@ -11,8 +11,24 @@ import java.util.stream.Stream;
 
 import com.ibm.fhir.path.visitor.FHIRPathNodeVisitor;
 
+/**
+ * Data in FHIRPath is represented as a tree of labeled nodes, where each node may optionally carry a 
+ * primitive value and have child nodes.
+ * Nodes need not have a unique label, and leaf nodes must carry a primitive value.
+ */
 public interface FHIRPathNode extends Comparable<FHIRPathNode> {
+    /**
+     * The name of the FHIRPathNode
+     * 
+     * @implNote If this FHIRPathNode exists within a FHIRPath tree, this will match the element name.
+     *           Otherwise, null.
+     */
     String name();
+    /**
+     * A generated path to the node
+     * @implNote If this FHIRPathNode exists within a FHIRPath tree, this represents the location of the
+     *           node in the tree. Otherwise, null.
+     */
     String path();
     FHIRPathType type();
     boolean hasValue();

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -98,6 +98,13 @@ public class FHIRPathEvaluator {
         return evaluate(new EvaluationContext(), expr, empty());
     }
     
+    /**
+     * @param resourceOrElement
+     * @param expr
+     * @return a potentially-empty non-null collection of FHIRPathNodes
+     * @throws FHIRPathException
+     * @throws NullPointerException if any of the passed arguments are null
+     */
     public Collection<FHIRPathNode> evaluate(Visitable resourceOrElement, String expr) throws FHIRPathException {
         Objects.requireNonNull("resourceOrElement cannot be null");
 
@@ -127,6 +134,14 @@ public class FHIRPathEvaluator {
         return evaluate(evaluationContext, expr, singleton(node));
     }
     
+    /**
+     * @param evaluationContext
+     * @param expr
+     * @param initialContext
+     * @return a potentially-empty non-null collection of FHIRPathNodes
+     * @throws FHIRPathException
+     * @throws NullPointerException if any of the passed arguments are null
+     */
     public Collection<FHIRPathNode> evaluate(EvaluationContext evaluationContext, String expr, Collection<FHIRPathNode> initialContext) throws FHIRPathException {
         Objects.requireNonNull(evaluationContext);
         Objects.requireNonNull(initialContext);
@@ -144,7 +159,7 @@ public class FHIRPathEvaluator {
     
     private static ExpressionContext compile(String expr) {
         FHIRPathLexer lexer = new FHIRPathLexer(CharStreams.fromString(expr));
-        CommonTokenStream tokens = new CommonTokenStream(lexer);        
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
         FHIRPathParser parser = new FHIRPathParser(tokens);
         return parser.expression();
     }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
@@ -111,7 +111,7 @@ public class FHIRPathPatch implements FHIRPatch {
         Builder builder = FHIRPathPatch.builder();
         
         for (Parameter param : params.getParameter()) {
-            if (!"operation".equals(param.getName().getValue())) {
+            if (!FHIRPathPatchOperation.OPERATION.equals(param.getName().getValue())) {
                 throw new IllegalArgumentException("Each FHIRPath patch operation must have a name of 'operation'");
             }
             addOperation(builder, param);

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
@@ -60,28 +60,51 @@ public class FHIRPathPatch implements FHIRPatch {
             // hidden constructor
         }
     
+        /**
+         * Add an add operation to the FHIRPathPatch
+         */
         public Builder add(String path, String elementName, Element element) {
             operations.add(new FHIRPathPatchAdd(path, elementName, element));
             return this;
         }
         
+        /**
+         * Add a delete operation to the FHIRPathPatch
+         */
         public Builder delete(String path) {
             operations.add(new FHIRPathPatchDelete(path));
             return this;
         }
         
+        /**
+         * Add an insert operation to the FHIRPathPatch
+         */
         public Builder insert(String path, Element element, Integer index) {
             operations.add(new FHIRPathPatchInsert(path, element, index));
             return this;
         }
         
+        /**
+         * Add a move operation to the FHIRPathPatch
+         */
         public Builder move(String path, Integer source, Integer destination) {
             operations.add(new FHIRPathPatchMove(path, source, destination));
             return this;
         }
         
+        /**
+         * Add an add operation to the FHIRPathPatch
+         */
         public Builder replace(String path, Element element) {
             operations.add(new FHIRPathPatchReplace(path, element));
+            return this;
+        }
+        
+        /**
+         * Add all patch operations from the passed FHIRPathPatch
+         */
+        public Builder from(FHIRPathPatch patch) {
+            operations.addAll(patch.operations);
             return this;
         }
         
@@ -93,11 +116,6 @@ public class FHIRPathPatch implements FHIRPatch {
          */
         public FHIRPathPatch build() {
             return new FHIRPathPatch(this);
-        }
-
-        protected Builder from(FHIRPathPatch patch) {
-            operations.addAll(patch.operations);
-            return this;
         }
     }
     

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatch.java
@@ -122,6 +122,7 @@ public class FHIRPathPatch implements FHIRPatch {
     
     /**
      * Parse the passed Parameter and add it to the builder
+     * 
      * @throws IllegalArgumentException if the Parameter object does not represent a valid FHIRPath Patch operation
      */
     private static FHIRPathPatchOperation addOperation(Builder builder, Parameter operation) {

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchAdd.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchAdd.java
@@ -6,15 +6,19 @@
 
 package com.ibm.fhir.path.patch;
 
+import static com.ibm.fhir.model.type.String.string;
+
 import java.util.Objects;
 
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
-public class FHIRPathPatchAdd extends FHIRPathPatchOperation {
+class FHIRPathPatchAdd extends FHIRPathPatchOperation {
     String fhirPath;
     String name;
     Element value;
@@ -32,5 +36,28 @@ public class FHIRPathPatchAdd extends FHIRPathPatchOperation {
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }
+    }
+
+    @Override
+    public Parameter toParameter() {
+        return Parameter.builder()
+                .name(string(OPERATION))
+                .part(Parameter.builder()
+                    .name(string(TYPE))
+                    .value(Code.of(FHIRPathPatchType.ADD.value()))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(PATH))
+                    .value(string(fhirPath))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(NAME))
+                    .value(string(name))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(VALUE))
+                    .value(value)
+                    .build())
+                .build();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchDelete.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchDelete.java
@@ -6,12 +6,16 @@
 
 package com.ibm.fhir.path.patch;
 
+import static com.ibm.fhir.model.type.String.string;
+
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
-public class FHIRPathPatchDelete extends FHIRPathPatchOperation {
+class FHIRPathPatchDelete extends FHIRPathPatchOperation {
     String fhirPath;
     String elementName;
 
@@ -27,5 +31,20 @@ public class FHIRPathPatchDelete extends FHIRPathPatchOperation {
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }
+    }
+
+    @Override
+    public Parameter toParameter() {
+        return Parameter.builder()
+                .name(string(OPERATION))
+                .part(Parameter.builder()
+                    .name(string(TYPE))
+                    .value(Code.of(FHIRPathPatchType.DELETE.value()))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(PATH))
+                    .value(string(fhirPath))
+                    .build())
+                .build();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchDelete.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchDelete.java
@@ -8,6 +8,8 @@ package com.ibm.fhir.path.patch;
 
 import static com.ibm.fhir.model.type.String.string;
 
+import java.util.Objects;
+
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
 import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.type.Code;
@@ -17,17 +19,15 @@ import com.ibm.fhir.path.util.FHIRPathUtil;
 
 class FHIRPathPatchDelete extends FHIRPathPatchOperation {
     String fhirPath;
-    String elementName;
 
     public FHIRPathPatchDelete(String fhirPath) {
-        this.fhirPath = fhirPath;
-        this.elementName = getElementName(fhirPath);
+        this.fhirPath = Objects.requireNonNull(fhirPath);
     }
 
     @Override
     public <T extends Resource> T apply(T resource) throws FHIRPatchException {
         try {
-            return FHIRPathUtil.delete(resource, fhirPath, elementName);
+            return FHIRPathUtil.delete(resource, fhirPath);
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchInsert.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchInsert.java
@@ -6,15 +6,19 @@
 
 package com.ibm.fhir.path.patch;
 
+import static com.ibm.fhir.model.type.String.string;
+
 import java.util.Objects;
 
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
-public class FHIRPathPatchInsert extends FHIRPathPatchOperation {
+class FHIRPathPatchInsert extends FHIRPathPatchOperation {
     String fhirPath;
     Element value;
     int index;
@@ -34,5 +38,28 @@ public class FHIRPathPatchInsert extends FHIRPathPatchOperation {
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }
+    }
+
+    @Override
+    public Parameter toParameter() {
+        return Parameter.builder()
+                .name(string(OPERATION))
+                .part(Parameter.builder()
+                    .name(string(TYPE))
+                    .value(Code.of(FHIRPathPatchType.ADD.value()))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(PATH))
+                    .value(string(fhirPath))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(VALUE))
+                    .value(value)
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(INDEX))
+                    .value(com.ibm.fhir.model.type.Integer.of(index))
+                    .build())
+                .build();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchInsert.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchInsert.java
@@ -22,19 +22,17 @@ class FHIRPathPatchInsert extends FHIRPathPatchOperation {
     String fhirPath;
     Element value;
     int index;
-    String elementName;
 
     public FHIRPathPatchInsert(String fhirPath, Element value, Integer index) {
         this.fhirPath = Objects.requireNonNull(fhirPath);
         this.value = Objects.requireNonNull(value);
         this.index = Objects.requireNonNull(index);
-        this.elementName = getElementName(fhirPath);
     }
 
     @Override
     public <T extends Resource> T apply(T resource) throws FHIRPatchException {
         try {
-            return FHIRPathUtil.insert(resource, fhirPath, elementName, index, value);
+            return FHIRPathUtil.insert(resource, fhirPath, index, value);
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchMove.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchMove.java
@@ -21,19 +21,17 @@ class FHIRPathPatchMove extends FHIRPathPatchOperation {
     String fhirPath;
     int source;
     int destination;
-    String elementName;
 
     public FHIRPathPatchMove(String fhirPath, Integer source, Integer destination) {
         this.fhirPath = Objects.requireNonNull(fhirPath);
         this.source = Objects.requireNonNull(source);
         this.destination = Objects.requireNonNull(destination);
-        this.elementName = getElementName(fhirPath);
     }
 
     @Override
     public <T extends Resource> T apply(T resource) throws FHIRPatchException {
         try {
-            return FHIRPathUtil.move(resource, fhirPath, elementName, source, destination);
+            return FHIRPathUtil.move(resource, fhirPath, source, destination);
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchMove.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchMove.java
@@ -6,14 +6,18 @@
 
 package com.ibm.fhir.path.patch;
 
+import static com.ibm.fhir.model.type.String.string;
+
 import java.util.Objects;
 
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
-public class FHIRPathPatchMove extends FHIRPathPatchOperation {
+class FHIRPathPatchMove extends FHIRPathPatchOperation {
     String fhirPath;
     int source;
     int destination;
@@ -33,5 +37,28 @@ public class FHIRPathPatchMove extends FHIRPathPatchOperation {
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }
+    }
+
+    @Override
+    public Parameter toParameter() {
+        return Parameter.builder()
+                .name(string(OPERATION))
+                .part(Parameter.builder()
+                    .name(string(TYPE))
+                    .value(Code.of(FHIRPathPatchType.ADD.value()))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(PATH))
+                    .value(string(fhirPath))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(SOURCE))
+                    .value(com.ibm.fhir.model.type.Integer.of(source))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(DESTINATION))
+                    .value(com.ibm.fhir.model.type.Integer.of(destination))
+                    .build())
+                .build();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchOperation.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchOperation.java
@@ -8,10 +8,10 @@ package com.ibm.fhir.path.patch;
 
 import com.ibm.fhir.model.patch.FHIRPatch;
 import com.ibm.fhir.model.resource.Parameters.Parameter;
-import com.ibm.fhir.model.type.Code;
-import com.ibm.fhir.model.type.Element;
 
-public abstract class FHIRPathPatchOperation implements FHIRPatch {
+abstract class FHIRPathPatchOperation implements FHIRPatch {
+    public static final String OPERATION = "operation";
+    
     public static final String TYPE = "type";
     public static final String PATH = "path";
     public static final String NAME = "name";
@@ -19,88 +19,7 @@ public abstract class FHIRPathPatchOperation implements FHIRPatch {
     public static final String INDEX = "index";
     public static final String SOURCE = "source";
     public static final String DESTINATION = "destination";
-
-    /**
-     * Parse the passed Parameter into the appropriate FHIRPathPatchOperation
-     * @throws IllegalArgumentException if the Parameter object does not represent a valid FHIRPath Patch operation
-     */
-    public static FHIRPathPatchOperation parse(Parameter operation) {
-        boolean foundType = false, foundPath = false, foundName = false, foundValue = false, foundIndex = false, foundSource = false, foundDestination = false;
-        FHIRPathPatchType type = null;
-        String fhirPath = null;
-        String name = null;
-        Element value = null;
-        Integer index = null;
-        Integer source = null;
-        Integer destination = null;
-
-        for (Parameter part : operation.getPart()) {
-            String partName = part.getName().getValue();
-            switch (partName) {
-            case TYPE:
-                Code valueCode = validatePartAndGetValue(foundType, part, Code.class);
-                type = FHIRPathPatchType.from(valueCode.getValue());
-                foundType = true;
-                break;
-            case PATH:
-                fhirPath = validatePartAndGetValue(foundPath, part, com.ibm.fhir.model.type.String.class).getValue();
-                foundPath = true;
-                break;
-            case NAME:
-                name = validatePartAndGetValue(foundName, part, com.ibm.fhir.model.type.String.class).getValue();
-                foundName = true;
-                break;
-            case VALUE:
-                if (part.getValue() == null) {
-                    throw new UnsupportedOperationException("Nested value patches are not yet supported");
-                }
-                value = validatePartAndGetValue(foundValue, part, Element.class);
-                foundValue = true;
-                break;
-            case INDEX:
-                index = validatePartAndGetValue(foundIndex, part, com.ibm.fhir.model.type.Integer.class).getValue();
-                foundIndex = true;
-                break;
-            case SOURCE:
-                source = validatePartAndGetValue(foundSource, part, com.ibm.fhir.model.type.Integer.class).getValue();
-                foundSource = true;
-                break;
-            case DESTINATION:
-                destination = validatePartAndGetValue(foundDestination, part, com.ibm.fhir.model.type.Integer.class).getValue();
-                foundDestination = true;
-                break;
-            default:
-                throw new IllegalArgumentException("Found invalid part with name '" + partName + "'");
-            }
-        }
-        if (type == null) {
-            throw new IllegalArgumentException("Missing required part with name 'type'");
-        }
-        try {
-            switch (type) {
-            case ADD:       return new FHIRPathPatchAdd(fhirPath, name, value);
-            case DELETE:    return new FHIRPathPatchDelete(fhirPath);
-            case INSERT:    return new FHIRPathPatchInsert(fhirPath, value, index);
-            case MOVE:      return new FHIRPathPatchMove(fhirPath, source, destination);
-            case REPLACE:   return new FHIRPathPatchReplace(fhirPath, value);
-            default:
-                throw new IllegalArgumentException("Invalid FHIRPath patch operation type: " + type.name());
-            }
-        } catch (NullPointerException e) {
-            throw new IllegalArgumentException("Invalid parameters for patch operation " + type.name(), e);
-        }
-    }
-
-    private static <T extends Element> T validatePartAndGetValue(boolean alreadyFound, Parameter part, Class<T> valueType) {
-        if (alreadyFound) {
-            throw new IllegalArgumentException("Part with name='" + part.getName() + "' cannot be repeated");
-        }
-        if (!part.getValue().is(valueType)) {
-            throw new IllegalArgumentException("Part with name='" + part.getName() + "' must be of type " + valueType.getSimpleName());
-        }
-        return part.getValue().as(valueType);
-    }
-
+    
     /**
      * Infer the element name from a given fhirPath
      * 
@@ -116,4 +35,9 @@ public abstract class FHIRPathPatchOperation implements FHIRPatch {
         }
         return lastSegment;
     }
+
+    /**
+     * Convert the FHIRPathPatchOperation to a Parameters.Parameter element
+     */
+    public abstract Parameter toParameter();
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchOperation.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchOperation.java
@@ -11,7 +11,7 @@ import com.ibm.fhir.model.resource.Parameters.Parameter;
 
 abstract class FHIRPathPatchOperation implements FHIRPatch {
     public static final String OPERATION = "operation";
-    
+
     public static final String TYPE = "type";
     public static final String PATH = "path";
     public static final String NAME = "name";
@@ -19,22 +19,6 @@ abstract class FHIRPathPatchOperation implements FHIRPatch {
     public static final String INDEX = "index";
     public static final String SOURCE = "source";
     public static final String DESTINATION = "destination";
-    
-    /**
-     * Infer the element name from a given fhirPath
-     * 
-     * @param fhirPath
-     *            A "simple" fhirpath expression with no functions or operations
-     * @return the elementName of the element that the given path would select
-     */
-    protected String getElementName(String fhirPath) {
-        String[] segments = fhirPath.split("\\.");
-        String lastSegment = segments[segments.length - 1];
-        if (lastSegment.contains("[")) {
-            return lastSegment.substring(0, lastSegment.indexOf("["));
-        }
-        return lastSegment;
-    }
 
     /**
      * Convert the FHIRPathPatchOperation to a Parameters.Parameter element

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchReplace.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchReplace.java
@@ -6,15 +6,19 @@
 
 package com.ibm.fhir.path.patch;
 
+import static com.ibm.fhir.model.type.String.string;
+
 import java.util.Objects;
 
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
-public class FHIRPathPatchReplace extends FHIRPathPatchOperation {
+class FHIRPathPatchReplace extends FHIRPathPatchOperation {
     String fhirPath;
     Element value;
     String elementName;
@@ -32,5 +36,24 @@ public class FHIRPathPatchReplace extends FHIRPathPatchOperation {
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }
+    }
+
+    @Override
+    public Parameter toParameter() {
+        return Parameter.builder()
+                .name(string(OPERATION))
+                .part(Parameter.builder()
+                    .name(string(TYPE))
+                    .value(Code.of(FHIRPathPatchType.ADD.value()))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(PATH))
+                    .value(string(fhirPath))
+                    .build())
+                .part(Parameter.builder()
+                    .name(string(VALUE))
+                    .value(value)
+                    .build())
+                .build();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchReplace.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/patch/FHIRPathPatchReplace.java
@@ -21,18 +21,16 @@ import com.ibm.fhir.path.util.FHIRPathUtil;
 class FHIRPathPatchReplace extends FHIRPathPatchOperation {
     String fhirPath;
     Element value;
-    String elementName;
 
     public FHIRPathPatchReplace(String fhirPath, Element value) {
         this.fhirPath = Objects.requireNonNull(fhirPath);
         this.value = Objects.requireNonNull(value);
-        this.elementName = getElementName(fhirPath);
     }
 
     @Override
     public <T extends Resource> T apply(T resource) throws FHIRPatchException {
         try {
-            return FHIRPathUtil.replace(resource, fhirPath, elementName, value);
+            return FHIRPathUtil.replace(resource, fhirPath, value);
         } catch (FHIRPathException e) {
             throw new FHIRPatchException("Error executing fhirPath", fhirPath);
         }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.path.util;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
 
 import com.ibm.fhir.model.resource.Resource;
@@ -15,7 +16,7 @@ import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
-public class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
+class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private Stack<Visitable> visitStack;
     
     private Visitable parent;
@@ -29,9 +30,9 @@ public class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      */
     public AddingVisitor(Visitable parent, String elementName, Visitable value) {
         this.visitStack = new Stack<Visitable>();
-        this.parent = parent;
-        this.elementNameToAdd = elementName;
-        this.value = value instanceof Code ?
+        this.parent = Objects.requireNonNull(parent);
+        this.elementNameToAdd = Objects.requireNonNull(elementName);
+        this.value = Objects.requireNonNull(value) instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)value) : value;
     }
     

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
@@ -61,7 +61,7 @@ class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
                 value.accept(this.elementNameToAdd, this);
             } else if (resource == value) {
                 markDirty();
-            } else if (elementName.equals(this.elementNameToAdd)) {
+            } else if (visitStack.peek() == parent && elementName.equals(this.elementNameToAdd)) {
                 // XXX: assuming that we have the right parent is potentially dangerous
                 throw new IllegalStateException("Add cannot replace an existing value");
             }
@@ -76,7 +76,7 @@ class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
                 value.accept(this.elementNameToAdd, this);
             } else if (element == value) {
                 markDirty();
-            } else if (elementName.equals(this.elementNameToAdd)) {
+            } else if (visitStack.peek() == parent && elementName.equals(this.elementNameToAdd)) {
                 // XXX: assuming that we have the right parent is potentially dangerous
                 throw new IllegalStateException("Add cannot replace an existing value");
             }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
@@ -7,7 +7,6 @@ package com.ibm.fhir.path.util;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Stack;
 
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Code;
@@ -17,70 +16,62 @@ import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
 class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
-    private Stack<Visitable> visitStack;
-    
-    private Visitable parent;
+    private String path;
     private String elementNameToAdd;
+    private boolean isRepeatingElement;
     private Visitable value;
 
     /**
-     * @param parent
-     * @param elementName
-     * @param value
+     * @param parent the resource or element to add to
+     * @param parentPath a "simple" FHIRPath path to the parent of the element being added
+     * @param elementName the name of the element to add
+     * @param value the element to add
      */
-    public AddingVisitor(Visitable parent, String elementName, Visitable value) {
-        this.visitStack = new Stack<Visitable>();
-        this.parent = Objects.requireNonNull(parent);
+    public AddingVisitor(Visitable parent, String parentPath, String elementName, Visitable value) {
+        this.path = Objects.requireNonNull(parentPath);
         this.elementNameToAdd = Objects.requireNonNull(elementName);
+        this.isRepeatingElement = ModelSupport.isRepeatingElement(parent.getClass(), elementName);
         this.value = Objects.requireNonNull(value) instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)value) : value;
     }
     
     @Override
-    protected void doVisitStart(String elementName, int elementIndex, Resource resource) {
-        visitStack.push(resource);
-    }
-    
-    @Override
-    protected void doVisitStart(String elementName, int elementIndex, Element element) {
-        visitStack.push(element);
-    }
-    
-    @Override
     protected void doVisitListEnd(String elementName, List<? extends Visitable> visitables, Class<?> type) {
-        if (visitStack.peek() == parent && type.isAssignableFrom(value.getClass()) && elementName.equals(this.elementNameToAdd)) {
+        if (getPath().equals(path) &&
+                type.isAssignableFrom(value.getClass()) &&
+                elementName.equals(this.elementNameToAdd)) {
             getList().add(value);
             markListDirty();
         }
     }
     
     @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Resource resource) {
-        if (!ModelSupport.isRepeatingElement(parent.getClass(), this.elementNameToAdd)) {
-            if (resource == parent) {
-                value.accept(this.elementNameToAdd, this);
-            } else if (resource == value) {
+    public boolean visit(String elementName, int index, Visitable value) {
+        if (!isRepeatingElement) {
+            if (this.value == value) {
                 markDirty();
-            } else if (visitStack.peek() == parent && elementName.equals(this.elementNameToAdd)) {
-                // XXX: assuming that we have the right parent is potentially dangerous
-                throw new IllegalStateException("Add cannot replace an existing value");
+            } else if (getPath().equals(path + "." + elementNameToAdd)) {
+                throw new IllegalStateException("Add cannot replace an existing value at " + getPath());
             }
         }
-        visitStack.pop();
+        return true;
+    }
+    
+    @Override
+    protected void doVisitEnd(String elementName, int elementIndex, Resource resource) {
+        if (!isRepeatingElement) {
+            if (getPath().equals(path)) {
+                value.accept(this.elementNameToAdd, this);
+            }
+        }
     }
     
     @Override
     protected void doVisitEnd(String elementName, int elementIndex, Element element) {
-        if (!ModelSupport.isRepeatingElement(parent.getClass(), this.elementNameToAdd)) {
-            if (element == parent) {
+        if (!isRepeatingElement) {
+            if (getPath().equals(path)) {
                 value.accept(this.elementNameToAdd, this);
-            } else if (element == value) {
-                markDirty();
-            } else if (visitStack.peek() == parent && elementName.equals(this.elementNameToAdd)) {
-                // XXX: assuming that we have the right parent is potentially dangerous
-                throw new IllegalStateException("Add cannot replace an existing value");
             }
         }
-        visitStack.pop();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
@@ -5,74 +5,25 @@
  */
 package com.ibm.fhir.path.util;
 
-import java.util.List;
 import java.util.Objects;
-import java.util.Stack;
 
-import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.type.Element;
-import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
 class DeletingVisitor<T extends Visitable> extends CopyingVisitor<T> {
-    private Stack<Visitable> visitStack;
-    
-    private Visitable parent;
-    private String elementNameToDelete;
-    private Visitable toDelete;
+    private String pathToDelete;
 
-    /**
-     * @param parent
-     * @param elementName
-     * @param toDelete
-     */
-    public DeletingVisitor(Visitable parent, String elementName, Visitable toDelete) {
-        this.visitStack = new Stack<Visitable>();
-        this.parent = Objects.requireNonNull(parent);
-        this.elementNameToDelete = Objects.requireNonNull(elementName);
-        this.toDelete = Objects.requireNonNull(toDelete);
+    public DeletingVisitor(String pathToDelete) {
+        this.pathToDelete = Objects.requireNonNull(pathToDelete);
     }
-    
+
     @Override
-    protected void doVisitStart(String elementName, int elementIndex, Resource resource) {
-        visitStack.push(resource);
-    }
-    
-    @Override
-    protected void doVisitStart(String elementName, int elementIndex, Element element) {
-        visitStack.push(element);
-    }
-    
-    @Override
-    protected void doVisitListEnd(String elementName, List<? extends Visitable> visitables, Class<?> type) {
-        if (visitStack.peek() == parent && type.isAssignableFrom(toDelete.getClass()) && elementName.equals(this.elementNameToDelete)) {
-            for (int i = 0; i < visitables.size(); i++) {
-                if (visitables.get(i) == toDelete) {
-                    getList().remove(i);
-                    markListDirty();
-                }
-            }
+    public boolean visit(String elementName, int index, Visitable value) {
+        if (pathToDelete.equals(getPath())) {
+            delete();
+            markDirty();
+            return false;
         }
-    }
-    
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Resource resource) {
-        if (!ModelSupport.isRepeatingElement(parent.getClass(), this.elementNameToDelete)) {
-            if (elementName.equals(this.elementNameToDelete) && resource == toDelete) {
-                delete();
-            }
-        }
-        visitStack.pop();
-    }
-    
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Element element) {
-        if (!ModelSupport.isRepeatingElement(parent.getClass(), this.elementNameToDelete)) {
-            if (elementName.equals(this.elementNameToDelete) && element == toDelete) {
-                delete();
-            }
-        }
-        visitStack.pop();
+        return true;
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.path.util;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
 
 import com.ibm.fhir.model.resource.Resource;
@@ -14,7 +15,7 @@ import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
-public class DeletingVisitor<T extends Visitable> extends CopyingVisitor<T> {
+class DeletingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private Stack<Visitable> visitStack;
     
     private Visitable parent;
@@ -28,9 +29,9 @@ public class DeletingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      */
     public DeletingVisitor(Visitable parent, String elementName, Visitable toDelete) {
         this.visitStack = new Stack<Visitable>();
-        this.parent = parent;
-        this.elementNameToDelete = elementName;
-        this.toDelete = toDelete;
+        this.parent = Objects.requireNonNull(parent);
+        this.elementNameToDelete = Objects.requireNonNull(elementName);
+        this.toDelete = Objects.requireNonNull(toDelete);
     }
     
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/InsertingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/InsertingVisitor.java
@@ -7,18 +7,13 @@ package com.ibm.fhir.path.util;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Stack;
 
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Code;
-import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
 class InsertingVisitor<T extends Visitable> extends CopyingVisitor<T> {
-    private Stack<Visitable> visitStack;
-    
-    private Visitable parent;
+    private String parentPath;
     private String elementNameToInsert;
     private int index;
     private Visitable value;
@@ -29,9 +24,8 @@ class InsertingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @param index
      * @param value
      */
-    public InsertingVisitor(Visitable parent, String elementName, int index, Visitable value) {
-        this.visitStack = new Stack<Visitable>();
-        this.parent = Objects.requireNonNull(parent);
+    public InsertingVisitor(Visitable parent, String parentPath, String elementName, int index, Visitable value) {
+        this.parentPath = Objects.requireNonNull(parentPath);
         this.elementNameToInsert = Objects.requireNonNull(elementName);
         this.index = index;
         this.value = Objects.requireNonNull(value) instanceof Code ?
@@ -39,30 +33,10 @@ class InsertingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     }
 
     @Override
-    protected void doVisitStart(String elementName, int elementIndex, Resource resource) {
-        visitStack.push(resource);
-    }
-
-    @Override
-    protected void doVisitStart(String elementName, int elementIndex, Element element) {
-        visitStack.push(element);
-    }
-
-    @Override
     protected void doVisitListEnd(String elementName, List<? extends Visitable> visitables, Class<?> type) {
-        if (visitStack.peek() == parent && type.isAssignableFrom(value.getClass()) && elementName.equals(this.elementNameToInsert)) {
+        if (getPath().equals(parentPath) && elementName.equals(this.elementNameToInsert)) {
             getList().add(index, value);
             markListDirty();
         }
-    }
-
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Resource resource) {
-        visitStack.pop();
-    }
-
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Element element) {
-        visitStack.pop();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.path.util;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
 
 import com.ibm.fhir.model.resource.Resource;
@@ -13,7 +14,7 @@ import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
-public class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
+class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private Stack<Visitable> visitStack;
     
     private Visitable parent;
@@ -29,8 +30,8 @@ public class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      */
     public MovingVisitor(Visitable parent, String elementName, int sourceIndex, int targetIndex) {
         this.visitStack = new Stack<Visitable>();
-        this.parent = parent;
-        this.elementName = elementName;
+        this.parent = Objects.requireNonNull(parent);
+        this.elementName = Objects.requireNonNull(elementName);
         this.sourceIndex = sourceIndex;
         this.targetIndex = targetIndex;
     }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
@@ -7,17 +7,12 @@ package com.ibm.fhir.path.util;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Stack;
 
-import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
 class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
-    private Stack<Visitable> visitStack;
-    
-    private Visitable parent;
+    private String parentPath;
     private String elementName;
     private int sourceIndex;
     private int targetIndex;
@@ -28,40 +23,19 @@ class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @param index
      * @param value
      */
-    public MovingVisitor(Visitable parent, String elementName, int sourceIndex, int targetIndex) {
-        this.visitStack = new Stack<Visitable>();
-        this.parent = Objects.requireNonNull(parent);
+    public MovingVisitor(String parentPath, String elementName, int sourceIndex, int targetIndex) {
+        this.parentPath = Objects.requireNonNull(parentPath);
         this.elementName = Objects.requireNonNull(elementName);
         this.sourceIndex = sourceIndex;
         this.targetIndex = targetIndex;
     }
 
     @Override
-    protected void doVisitStart(String elementName, int elementIndex, Resource resource) {
-        visitStack.push(resource);
-    }
-
-    @Override
-    protected void doVisitStart(String elementName, int elementIndex, Element element) {
-        visitStack.push(element);
-    }
-
-    @Override
     protected void doVisitListEnd(String elementName, List<? extends Visitable> visitables, Class<?> type) {
-        if (visitStack.peek() == parent && elementName.equals(this.elementName)) {
+        if (getPath().equals(parentPath) && elementName.equals(this.elementName)) {
             Visitable visitable = getList().remove(sourceIndex);
             getList().add(targetIndex, visitable);
             markListDirty();
         }
-    }
-    
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Resource resource) {
-        visitStack.pop();
-    }
-    
-    @Override
-    protected void doVisitEnd(String elementName, int elementIndex, Element element) {
-        visitStack.pop();
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/ReplacingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/ReplacingVisitor.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.path.util;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Stack;
 
 import com.ibm.fhir.model.resource.Resource;
@@ -15,7 +16,7 @@ import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.visitor.CopyingVisitor;
 import com.ibm.fhir.model.visitor.Visitable;
 
-public class ReplacingVisitor<T extends Visitable> extends CopyingVisitor<T> {
+class ReplacingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private Stack<Visitable> visitStack;
 
     private Visitable parent;
@@ -30,10 +31,10 @@ public class ReplacingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      */
     public ReplacingVisitor(Visitable parent, String elementName, Visitable oldValue, Visitable newValue) {
         this.visitStack = new Stack<Visitable>();
-        this.parent = parent;
-        this.elementNameToReplace = elementName;
-        this.oldValue = oldValue;
-        this.newValue = newValue instanceof Code ?
+        this.parent = Objects.requireNonNull(parent);
+        this.elementNameToReplace = Objects.requireNonNull(elementName);
+        this.oldValue = Objects.requireNonNull(oldValue);
+        this.newValue = Objects.requireNonNull(newValue) instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)newValue) : newValue;
     }
 

--- a/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
@@ -1,0 +1,154 @@
+/*
+ * (C) Copyright IBM Corp. 2019, 2020
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.path.patch.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.patch.exception.FHIRPatchException;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.HumanName;
+import com.ibm.fhir.model.type.Identifier;
+import com.ibm.fhir.model.type.Time;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.path.patch.FHIRPathPatch;
+
+public class FHIRPathPatchBuilderTest {
+    @Test
+    private void patchBuilderTest() throws Exception {
+        Patient patient = Patient.builder().id("test").build();
+        
+        Patient patchedPatient = addViaPatch(patient);
+        patient = addViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+        
+        patchedPatient = deleteViaPatch(patient);
+        patient = deleteViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+        
+        patchedPatient = insertViaPatch(patient);
+        patient = insertViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+        
+        patchedPatient = moveViaPatch(patient);
+        patient = moveViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+        
+        patchedPatient = replaceViaPatch(patient);
+        patient = replaceViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+    }
+
+    private Patient addViaBuilder(Patient patient) {
+        return patient.toBuilder()
+                .identifier(Identifier.builder()
+                    .system(Uri.of("mySystem"))
+                    .value(string("it-me"))
+                    .build())
+                .name(HumanName.builder()
+                               .given(string("First"))
+                               .family(string("Last"))
+                               .extension(Extension.builder()
+                                   .url("myExtension")
+                                   .extension(Extension.builder()
+                                       .url("lunchTime")
+                                       .value(Time.of("12:00:00"))
+                                       .build())
+                                   .build())
+                               .build(),
+                      HumanName.builder().family(string("Last")).build())
+                .active(com.ibm.fhir.model.type.Boolean.TRUE)
+                .build();
+    }
+
+    private Patient addViaPatch(Patient patient) throws FHIRPatchException {
+        return FHIRPathPatch.builder()
+                .add("Patient", "identifier", Identifier.builder().system(Uri.of("mySystem")).build())
+                .add("Patient.identifier", "value", string("it-me"))
+                .add("Patient", "name", HumanName.builder().family(string("Last")).build())
+                .add("Patient", "name", HumanName.builder().family(string("Last")).build())
+                .add("Patient.name[0]", "given", string("First"))
+                .add("Patient.name[0]", "extension", Extension.builder().url("myExtension").build())
+                .add("Patient.name[0].extension", "extension", Extension.builder().url("lunchTime").build())
+                .add("Patient.name[0].extension.extension", "value", Time.of("12:00:00"))
+                .add("Patient.identifier", "value", string("it-me"))
+                .add("Patient", "active", com.ibm.fhir.model.type.Boolean.TRUE)
+                .build()
+                .apply(patient);
+    }
+    
+    private Patient deleteViaBuilder(Patient patient) {
+        return patient.toBuilder()
+                .identifier(Collections.emptySet())
+                .active(null)
+                .build();
+    }
+
+    private Patient deleteViaPatch(Patient patient) throws FHIRPatchException {
+        return FHIRPathPatch.builder()
+                .delete("Patient.active")
+                .delete("Patient.identifier")
+                .build()
+                .apply(patient);
+    }
+
+    private Patient insertViaBuilder(Patient patient) {
+        List<HumanName> names = new ArrayList<>(patient.getName());
+        names.add(2, HumanName.builder().family(string("Inserted")).build());
+        
+        List<Extension> name1extensions = new ArrayList<>(names.get(0).getExtension());
+        name1extensions.add(0, Extension.builder().url("inserted").value(string("value")).build());
+        names.set(0, names.get(0).toBuilder().extension(name1extensions).build());
+        
+        return patient.toBuilder()
+                .name(names)
+                .build();
+    }
+
+    private Patient insertViaPatch(Patient patient) throws FHIRPatchException {
+        return FHIRPathPatch.builder()
+                .insert("Patient.name", HumanName.builder().family(string("Inserted")).build(), 2)
+                .insert("Patient.name[0].extension", 
+                        Extension.builder().url("inserted").value(string("value")).build(), 0)
+                .build()
+                .apply(patient);
+    }
+
+    private Patient moveViaBuilder(Patient patient) {
+        List<HumanName> names = new ArrayList<>(patient.getName());
+        HumanName toMove = names.remove(0);
+        names.add(2, toMove);
+        return patient.toBuilder().name(names).build();
+    }
+
+    private Patient moveViaPatch(Patient patient) throws FHIRPatchException {
+        return FHIRPathPatch.builder()
+                .move("Patient.name", 0, 2)
+                .build()
+                .apply(patient);
+    }
+
+    private Patient replaceViaBuilder(Patient patient) {
+        List<HumanName> names = new ArrayList<>(patient.getName());
+        names.set(0, patient.getName().get(0).toBuilder().family(string("UpdatedLast")).build());
+        return patient.toBuilder().name(names).build();
+    }
+
+    private Patient replaceViaPatch(Patient patient) throws FHIRPatchException {
+        return FHIRPathPatch.builder()
+                .replace("Patient.name[0].family", string("UpdatedLast"))
+                .build()
+                .apply(patient);
+    }
+}

--- a/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
@@ -82,7 +82,6 @@ public class FHIRPathPatchBuilderTest {
                 .add("Patient.name[0]", "extension", Extension.builder().url("myExtension").build())
                 .add("Patient.name[0].extension", "extension", Extension.builder().url("lunchTime").build())
                 .add("Patient.name[0].extension.extension", "value", Time.of("12:00:00"))
-                .add("Patient.identifier", "value", string("it-me"))
                 .add("Patient", "active", com.ibm.fhir.model.type.Boolean.TRUE)
                 .build()
                 .apply(patient);

--- a/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathPatchBuilderTest.java
@@ -26,27 +26,50 @@ import com.ibm.fhir.path.patch.FHIRPathPatch;
 
 public class FHIRPathPatchBuilderTest {
     @Test
-    private void patchBuilderTest() throws Exception {
+    private void patchBuilderTestIncremental() throws Exception {
         Patient patient = Patient.builder().id("test").build();
         
-        Patient patchedPatient = addViaPatch(patient);
+        Patient patchedPatient = buildAdd().apply(patient);
         patient = addViaBuilder(patient);
         assertEquals(patchedPatient, patient);
         
-        patchedPatient = deleteViaPatch(patient);
+        patchedPatient = buildDelete().apply(patient);
         patient = deleteViaBuilder(patient);
         assertEquals(patchedPatient, patient);
         
-        patchedPatient = insertViaPatch(patient);
+        patchedPatient = buildInsert().apply(patient);
         patient = insertViaBuilder(patient);
         assertEquals(patchedPatient, patient);
         
-        patchedPatient = moveViaPatch(patient);
+        patchedPatient = buildMove().apply(patient);
         patient = moveViaBuilder(patient);
         assertEquals(patchedPatient, patient);
         
-        patchedPatient = replaceViaPatch(patient);
+        patchedPatient = buildReplace().apply(patient);
         patient = replaceViaBuilder(patient);
+        assertEquals(patchedPatient, patient);
+    }
+    
+    @Test
+    private void patchBuilderTestAll() throws Exception {
+        Patient patient = Patient.builder().id("test").build();
+        
+        FHIRPathPatch allPatch = FHIRPathPatch.builder()
+            .from(buildAdd())
+            .from(buildDelete())
+            .from(buildInsert())
+            .from(buildMove())
+            .from(buildReplace())
+            .build();
+        
+        Patient patchedPatient = allPatch.apply(patient);
+        
+        patient = addViaBuilder(patient);
+        patient = deleteViaBuilder(patient);
+        patient = insertViaBuilder(patient);
+        patient = moveViaBuilder(patient);
+        patient = replaceViaBuilder(patient);
+        
         assertEquals(patchedPatient, patient);
     }
 
@@ -72,7 +95,7 @@ public class FHIRPathPatchBuilderTest {
                 .build();
     }
 
-    private Patient addViaPatch(Patient patient) throws FHIRPatchException {
+    private FHIRPathPatch buildAdd() throws FHIRPatchException {
         return FHIRPathPatch.builder()
                 .add("Patient", "identifier", Identifier.builder().system(Uri.of("mySystem")).build())
                 .add("Patient.identifier", "value", string("it-me"))
@@ -83,8 +106,7 @@ public class FHIRPathPatchBuilderTest {
                 .add("Patient.name[0].extension", "extension", Extension.builder().url("lunchTime").build())
                 .add("Patient.name[0].extension.extension", "value", Time.of("12:00:00"))
                 .add("Patient", "active", com.ibm.fhir.model.type.Boolean.TRUE)
-                .build()
-                .apply(patient);
+                .build();
     }
     
     private Patient deleteViaBuilder(Patient patient) {
@@ -94,12 +116,11 @@ public class FHIRPathPatchBuilderTest {
                 .build();
     }
 
-    private Patient deleteViaPatch(Patient patient) throws FHIRPatchException {
+    private FHIRPathPatch buildDelete() throws FHIRPatchException {
         return FHIRPathPatch.builder()
                 .delete("Patient.active")
                 .delete("Patient.identifier")
-                .build()
-                .apply(patient);
+                .build();
     }
 
     private Patient insertViaBuilder(Patient patient) {
@@ -115,13 +136,12 @@ public class FHIRPathPatchBuilderTest {
                 .build();
     }
 
-    private Patient insertViaPatch(Patient patient) throws FHIRPatchException {
+    private FHIRPathPatch buildInsert() throws FHIRPatchException {
         return FHIRPathPatch.builder()
                 .insert("Patient.name", HumanName.builder().family(string("Inserted")).build(), 2)
                 .insert("Patient.name[0].extension", 
                         Extension.builder().url("inserted").value(string("value")).build(), 0)
-                .build()
-                .apply(patient);
+                .build();
     }
 
     private Patient moveViaBuilder(Patient patient) {
@@ -131,11 +151,10 @@ public class FHIRPathPatchBuilderTest {
         return patient.toBuilder().name(names).build();
     }
 
-    private Patient moveViaPatch(Patient patient) throws FHIRPatchException {
+    private FHIRPathPatch buildMove() throws FHIRPatchException {
         return FHIRPathPatch.builder()
                 .move("Patient.name", 0, 2)
-                .build()
-                .apply(patient);
+                .build();
     }
 
     private Patient replaceViaBuilder(Patient patient) {
@@ -144,10 +163,9 @@ public class FHIRPathPatchBuilderTest {
         return patient.toBuilder().name(names).build();
     }
 
-    private Patient replaceViaPatch(Patient patient) throws FHIRPatchException {
+    private FHIRPathPatch buildReplace() throws FHIRPatchException {
         return FHIRPathPatch.builder()
                 .replace("Patient.name[0].family", string("UpdatedLast"))
-                .build()
-                .apply(patient);
+                .build();
     }
 }

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathUtilTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathUtilTest.java
@@ -44,6 +44,41 @@ public class FHIRPathUtilTest {
         assertEquals(fhirpathPatient, builderPatient);
     }
 
+    @Test
+    void testAddDuplicate() throws Exception {
+        HumanName name1 = HumanName.builder()
+                .given(string("John"))
+                .family(string("Smith"))
+                .build();
+
+        HumanName name2 = HumanName.builder()
+                .given(string("John"))
+                .family(string("Smith"))
+                .suffix(Collections.singleton(string("II")))
+                .build();
+        Patient builderPatient = Patient.builder()
+                .id("test")
+                .name(name1, name2)
+                .build();
+
+        Patient fhirpathPatient = Patient.builder()
+                .id("test")
+                // note that the same exact object is added twice
+                .name(name1, name1)
+                .build();
+        fhirpathPatient = FHIRPathUtil.add(fhirpathPatient, "Patient.name[1]", "suffix", string("II"));
+        assertEquals(fhirpathPatient, builderPatient);
+
+
+        fhirpathPatient = Patient.builder().id("test").build();
+        // note that the same exact object is added twice
+        fhirpathPatient = FHIRPathUtil.add(fhirpathPatient, "Patient", "name", name1);
+        fhirpathPatient = FHIRPathUtil.add(fhirpathPatient, "Patient", "name", name1);
+        fhirpathPatient = FHIRPathUtil.add(fhirpathPatient, "Patient.name[1]", "suffix", string("II"));
+
+        assertEquals(fhirpathPatient, builderPatient);
+    }
+
     @Test(expectedExceptions = FHIRPatchException.class)
     void testAddExisting() throws Exception {
         Patient fhirpathPatient = Patient.builder().deceased(Boolean.FALSE).build();

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathUtilTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/FHIRPathUtilTest.java
@@ -66,8 +66,8 @@ public class FHIRPathUtilTest {
                 .build();
 
         Patient fhirpathPatient = Patient.builder().id("test").build();
-        fhirpathPatient = FHIRPathUtil.insert(fhirpathPatient, "Patient.name", "name", 0, name2);
-        fhirpathPatient = FHIRPathUtil.insert(fhirpathPatient, "Patient.name", "name", 0, name1);
+        fhirpathPatient = FHIRPathUtil.add(fhirpathPatient, "Patient", "name", name2);
+        fhirpathPatient = FHIRPathUtil.insert(fhirpathPatient, "Patient.name", 0, name1);
 
         assertEquals(fhirpathPatient, builderPatient);
     }
@@ -89,8 +89,8 @@ public class FHIRPathUtilTest {
                 .name(Collections.emptySet())
                 .build();
 
-        Patient fhirpathPatient = FHIRPathUtil.delete(patient, "Patient.deceased", "deceased");
-        fhirpathPatient = FHIRPathUtil.delete(fhirpathPatient, "Patient.name[0]", "name");
+        Patient fhirpathPatient = FHIRPathUtil.delete(patient, "Patient.deceased");
+        fhirpathPatient = FHIRPathUtil.delete(fhirpathPatient, "Patient.name[0]");
 
         assertEquals(fhirpathPatient, builderPatient);
     }
@@ -113,8 +113,8 @@ public class FHIRPathUtilTest {
                         .build()))
                 .build();
 
-        Patient fhirpathPatient = FHIRPathUtil.replace(patient, "Patient.deceased", "deceased", Boolean.FALSE);
-        fhirpathPatient = FHIRPathUtil.replace(fhirpathPatient, "Patient.name[0].given[0]", "given", string("Jane"));
+        Patient fhirpathPatient = FHIRPathUtil.replace(patient, "Patient.deceased", Boolean.FALSE);
+        fhirpathPatient = FHIRPathUtil.replace(fhirpathPatient, "Patient.name[0].given[0]", string("Jane"));
 
         assertEquals(fhirpathPatient, builderPatient);
     }
@@ -136,7 +136,7 @@ public class FHIRPathUtilTest {
         Patient fhirpathPatient = Patient.builder()
                 .name(name2, name1)
                 .build();
-        fhirpathPatient = FHIRPathUtil.move(fhirpathPatient, "Patient.name", "name", 1, 0);
+        fhirpathPatient = FHIRPathUtil.move(fhirpathPatient, "Patient.name", 1, 0);
 
         assertEquals(fhirpathPatient, builderPatient);
     }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -459,7 +459,7 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIRPatch patch;
             try {
-                patch = new FHIRPathPatch(parameters);
+                patch = FHIRPathPatch.from(parameters);
             } catch(IllegalArgumentException e) {
                 throw buildRestException(e.getMessage(), Status.BAD_REQUEST, IssueType.INVALID);
             }
@@ -574,7 +574,12 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
-            FHIRPatch patch = new FHIRPathPatch(parameters);
+            FHIRPatch patch;
+            try {
+                patch = FHIRPathPatch.from(parameters);
+            } catch(IllegalArgumentException e) {
+                throw buildRestException(e.getMessage(), Status.BAD_REQUEST, IssueType.INVALID);
+            }
 
             String searchQueryString = httpServletRequest.getQueryString();
             if (searchQueryString == null || searchQueryString.isEmpty()) {


### PR DESCRIPTION
Also:
1. added `toParameters()` to set up use from the client
2. removed hacky logic for retrieving the element name from a path
    It turns out that our FHIRPathNode object already exposes the element
    name from a selected node.
    This works for all cases other than inserting an element at position 0
    of an empty list, and its not clear from the spec whether that should be
    supported or not. Now we throw UnsupportedOperationException in that
    case.
3. reduced the visibility of all the patch visitors, added null
    checks, and improved documentation of both the visitors and select
    methods in the FHIRPath model.
4. fixed major issue caused by use of parent identity in the fhirpathpatch visitors

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>