### PR TITLE
Add FHIRPatch benchmark and fix BenchmarkUtil

### DIFF
--- a/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRParserBenchmark.java
+++ b/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRParserBenchmark.java
@@ -77,7 +77,6 @@ public class FHIRParserBenchmark {
     }
     
     public static void main(String[] args) throws Exception {
-//        new FHIRBenchmarkRunner(FHIRParserBenchmark.class).runAll();
         new FHIRBenchmarkRunner(FHIRParserBenchmark.class).run();
     }
 }

--- a/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRPatchBenchmark.java
+++ b/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRPatchBenchmark.java
@@ -1,0 +1,85 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.benchmark;
+
+import java.io.StringReader;
+import java.time.Instant;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import com.ibm.fhir.benchmark.runner.FHIRBenchmarkRunner;
+import com.ibm.fhir.benchmark.util.BenchmarkUtil;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.patch.FHIRPatch;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.util.ModelSupport;
+import com.ibm.fhir.path.patch.FHIRPathPatch;
+
+public class FHIRPatchBenchmark {
+    private static final Extension FHIR_EXTENSION = Extension.builder()
+            .url("myTime")
+            .value(DateTime.now())
+            .build();
+    private static final JsonObject JSON_EXTENSION = Json.createObjectBuilder()
+            .add("url", "myTime")
+            .add("valueDateTime", Instant.now().toString())
+            .build();
+
+    @State(Scope.Benchmark)
+    public static class FHIRPathEvaluatorState {
+        Resource resource;
+        String fhirPath;
+
+        // JMH will inject the value into the annotated field before any Setup method is called.
+        @Param({"valuesets"})
+        public String exampleName;
+        
+        @Setup
+        public void setUp() throws Exception {
+            if (exampleName == null) {
+                System.err.println("exampleName is null; if you're in Eclipse then make sure annotation processing is on and you've ran 'mvn clean package'.");
+                System.exit(1);
+            }
+            System.out.println("Setting up for example " + exampleName);
+            String resourceText = BenchmarkUtil.getSpecExample(Format.JSON, exampleName);
+            resource = FHIRParser.parser(Format.JSON).parse(new StringReader(resourceText));
+            fhirPath = ModelSupport.getTypeName(resource.getClass());
+        }
+    }
+
+    @Benchmark
+    public Resource benchmarkFHIRPathPatch(FHIRPathEvaluatorState state) throws Exception {
+        FHIRPatch patch = FHIRPathPatch.builder()
+                .add(state.fhirPath, "extension", FHIR_EXTENSION)
+                .build();
+        return patch.apply(state.resource);
+    }
+
+    @Benchmark
+    public Resource benchmarkJSONPatch(FHIRPathEvaluatorState state) throws Exception {
+        FHIRPatch patch = FHIRPatch.patch(Json.createPatchBuilder()
+            .add("/extension", Json.createArrayBuilder().build())
+            .add("/extension/-", JSON_EXTENSION)
+            .build());
+        return patch.apply(state.resource);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new FHIRBenchmarkRunner(FHIRPatchBenchmark.class)
+                .run(BenchmarkUtil.getRandomSpecExampleName());
+    }
+}

--- a/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRPathEvaluatorBenchmark.java
+++ b/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/FHIRPathEvaluatorBenchmark.java
@@ -37,7 +37,7 @@ public class FHIRPathEvaluatorBenchmark {
     private static final String EXPRESSION = "Bundle.entry.resource.where(birthDate < @1950-01-01)";
 
     @State(Scope.Benchmark)
-    public static class FHIRPathEvaluatorState {        
+    public static class FHIRPathEvaluatorState {
         public static final String SPEC_EXAMPLE_NAME = System.getProperty(PROPERTY_EXAMPLE_NAME);
         public static final String JSON_SPEC_EXAMPLE = BenchmarkUtil.getSpecExample(Format.JSON, SPEC_EXAMPLE_NAME);
         public static final String EXPRESSION = System.getProperty(PROPERTY_EXPRESSION);

--- a/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/ObjectSizeEstimator.java
+++ b/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/ObjectSizeEstimator.java
@@ -22,7 +22,7 @@ import com.ibm.fhir.model.visitor.Visitable;
  * This only works when you configure the enclosing jar file as a java agent. For example:
  * 
  * <p>
- * {@code Java -javaagent:target/fhir-benchmarch-4.0.1-SNAPSHOT.jar ...}
+ * {@code Java -javaagent:target/fhir-benchmark-4.0.1-SNAPSHOT.jar ...}
  */
 public class ObjectSizeEstimator {
     private static ObjectSizeVisitor visitor = new ObjectSizeVisitor();

--- a/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/util/BenchmarkUtil.java
+++ b/fhir-benchmark/src/main/java/com/ibm/fhir/benchmark/util/BenchmarkUtil.java
@@ -31,7 +31,7 @@ public final class BenchmarkUtil {
      * @return the list of spec examples for which we have both an XML and JSON variant 
      */
     private static List<String> buildSpecExampleNames() {
-        try (Reader jsonReader = ExamplesUtil.resourceReader("json/spec.txt"); Reader xmlReader = ExamplesUtil.resourceReader("xml/spec.txt")) {
+        try (Reader jsonReader = ExamplesUtil.resourceReader("spec-json.txt"); Reader xmlReader = ExamplesUtil.resourceReader("spec-xml.txt")) {
             Set<String> jsonExampleNames = new BufferedReader(jsonReader)
                     .lines()
                     .filter(line -> line.startsWith("OK"))


### PR DESCRIPTION
Not a totally fair benchmark because we start with an in-memory resource, so the JSON patch has to generate, then patch, then parse.

```
Benchmark
(exampleName)   Mode  Cnt      Score   Error  Units
FHIRPatchBenchmark.benchmarkFHIRPathPatch
encounter-example-emerg  thrpt    2  11557.376          ops/s
FHIRPatchBenchmark.benchmarkJSONPatch
encounter-example-emerg  thrpt    2   1051.019          ops/s
```

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>