### PR TITLE
update _db2_default config

### DIFF
--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -87,10 +87,10 @@
                     "connectionProperties": {
                         "serverName": "localhost",
                         "portNumber": 50001,
-                        "user": "db2inst1",
+                        "user": "FHIRSERVER",
                         "password": "change-password",
                         "databaseName": "FHIRDB",
-                        "currentSchema": "FHIR1",
+                        "currentSchema": "FHIRDATA",
                         "driverType": 4,
                         "sslConnection": true,
                         "sslTrustStoreLocation": "resources/security/fhirTruststore.jks",


### PR DESCRIPTION
to match the username and schema name used at fhir-persistence-schema

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>