### PR TITLE
Put test derby db under target dir

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyMaster.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyMaster.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -78,12 +78,12 @@ public class DerbyMaster implements AutoCloseable {
     }
 
     /**
-     * Drop the contents of the database on disk. Must reside in the derby/ directory
+     * Drop the contents of the database on disk. Must contain 'derby/' in the path
      * as a simple check against accidentally wiping the wrong files
      * @param database
      */
     public static void dropDatabase(String database) {
-        if (!database.startsWith(DERBY_DIR)) {
+        if (!database.contains(DERBY_DIR)) {
             throw new IllegalArgumentException("Derby databases must start with: " + DERBY_DIR);
         }
 

--- a/fhir-persistence-jdbc/pom.xml
+++ b/fhir-persistence-jdbc/pom.xml
@@ -108,30 +108,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>derby</directory>
-                            <followSymlinks>false</followSymlinks>
-                            <useDefaultExcludes>true</useDefaultExcludes>
-                            <includes>
-                                <include>**/*</include>
-                            </includes>
-                        </fileset>
-                        <fileset>
-                            <directory>.</directory>
-                            <followSymlinks>false</followSymlinks>
-                            <useDefaultExcludes>true</useDefaultExcludes>
-                            <includes>
-                                <include>derby.log</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/FHIRDbDAOTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,8 +18,6 @@ import com.ibm.fhir.persistence.jdbc.dao.impl.FHIRDbDAOImpl;
 
 /**
  * This class tests the functions of the FHIR DB Data Access Object class.
- * @author markd
- *
  */
 public class FHIRDbDAOTest {
     /**
@@ -32,7 +30,7 @@ public class FHIRDbDAOTest {
         
         Properties props = new Properties();
         props.setProperty(FHIRDbDAO.PROPERTY_DB_DRIVER, "org.apache.derby.jdbc.EmbeddedDriver");
-        props.setProperty(FHIRDbDAO.PROPERTY_DB_URL, "jdbc:derby:target/fhirDB;create=true");
+        props.setProperty(FHIRDbDAO.PROPERTY_DB_URL, "jdbc:derby:target/derby/fhirDB;create=true");
         // Set the schemaName to the derby default so that it won't try using a non-existent FHIRDATA schema
         props.setProperty("schemaName", "APP");
         FHIRDbDAO dao = new FHIRDbDAOImpl(props);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -25,6 +25,7 @@ import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.test.common.AbstractPersistenceTest;
 import com.ibm.fhir.schema.derby.DerbyFhirDatabase;
 import com.ibm.fhir.validation.test.ValidationProcessor;
@@ -123,7 +124,7 @@ public class R4JDBCExamplesTest extends AbstractPersistenceTest {
     @Override
     public void bootstrapDatabase() throws Exception {
         // Create the derby database
-        this.database = new DerbyFhirDatabase();
+        this.database = new DerbyInitializer().bootstrapDb();
     }
 
     @AfterClass

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DerbyInitializer.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DerbyInitializer.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,22 +20,21 @@ import com.ibm.fhir.schema.derby.DerbyFhirDatabase;
 
 /**
  * This utility class initializes and bootstraps a FHIR Derby database for unit testing. 
- * If an existing database is found in the target path, it is reused. If not, a new database is defined and the appropriate DDL for
- * the FHIR schema is applied.
+ * If an existing database is found in the target path, it is reused. If not, a new database 
+ * is defined and the appropriate DDL for the FHIR schema is applied.
  * 
- * It's intended that this class be consumed by testng tests in the fhir-persistence-jdbc project.
- *
+ * It's intended that this class be consumed by TestNG tests in the fhir-persistence-jdbc project.
  */
 public class DerbyInitializer {
 
-    // All tests this same database, which we only have to bootstrap once
-    private static final String DB_NAME = "derby/fhirDB";
-    
+    // All tests use this same database, which we only have to bootstrap once
+    private static final String DB_NAME = "target/derby/fhirDB";
+
     // The translator to help us out with Derby urls/syntax/exceptions
     private static final IDatabaseTranslator DERBY_TRANSLATOR = new DerbyTranslator();
-    
+
     private Properties dbProps;
-    
+
     /**
      * Main method to facilitate standalone testing of this class.
      * @param args
@@ -57,7 +56,7 @@ public class DerbyInitializer {
         super();
         this.dbProps = new Properties();
     }
-    
+
     /**
      * Constructs a new DerbyInitializer using the passed database properties.
      */
@@ -68,26 +67,25 @@ public class DerbyInitializer {
 
     /**
      * Default bootstrap of the database. Does not drop/rebuild.
+     * 
+     * @return a DerbyFhirDatabase instance that represents the create database if one was created or null if it already exists 
      * @throws FHIRPersistenceDBConnectException
      * @throws SQLException
      */
-    public void bootstrapDb() throws FHIRPersistenceDBConnectException, SQLException {
-        bootstrapDb(false);
+    public DerbyFhirDatabase bootstrapDb() throws FHIRPersistenceDBConnectException, SQLException {
+        return bootstrapDb(false);
     }
-    
+
     /**
-     * Get the name of the schema holding all the FHIR resource tables
-     * @return
-     */
-    protected String getDataSchemaName() {
-        return dbProps.getProperty("schemaName", "FHIRDATA");
-    }
-    /**
-     * Establishes a connection to fhirDB. Creates the database if necessary complete with tables indexes.
+     * Tests for the existence of fhirDB and creates the database if necessary, complete with tables and indices.
+     * 
+     * @param reset
+     *            Whether to "reset" the database by deleting the existing one before attempting the create
+     * @return a DerbyFhirDatabase object if one was created or null if it already exists and {@code reset} is false
      * @throws FHIRPersistenceDBConnectException
-     * @throws SQLException 
+     * @throws SQLException
      */
-    public void bootstrapDb(boolean reset) throws FHIRPersistenceDBConnectException, SQLException {
+    public DerbyFhirDatabase bootstrapDb(boolean reset) throws FHIRPersistenceDBConnectException, SQLException {
         if (reset) {
             // wipes the disk content of the database. Hopefully there aren't any
             // open connections at this point
@@ -97,35 +95,39 @@ public class DerbyInitializer {
         // Inject the DB_NAME into the dbProps
         DerbyPropertyAdapter adapter = new DerbyPropertyAdapter(dbProps);
         adapter.setDatabase(DB_NAME);
-        
+
         // Only bootstrap the database if it is new
         boolean exists;
         try (Connection connection = getConnection()) {
             exists = true;
-        }
-        catch (SQLException x) {
+        } catch (SQLException x) {
             exists = false;
         }
- 
+
         if (exists) {
             System.out.println("Existing database: skipping bootstrap");
+            return null;
         }
         else {
             System.out.println("Bootstrapping database");
-            new DerbyFhirDatabase();
+            return new DerbyFhirDatabase(DB_NAME);
         }
     }
 
     /**
-     * Get a connection to an established database
-     * Autocommit is disabled (of course)
-     * @return
-     * @throws SQLException
+     * Get the name of the schema holding all the FHIR resource tables.
+     */
+    protected String getDataSchemaName() {
+        return dbProps.getProperty("schemaName", "FHIRDATA");
+    }
+
+    /**
+     * Get a connection to an established database.
+     * Autocommit is disabled (of course).
      */
     public Connection getConnection() throws SQLException {
         Connection connection = DriverManager.getConnection(DERBY_TRANSLATOR.getUrl(dbProps));
         connection.setAutoCommit(false);
         return connection;
     }
-    
 }

--- a/fhir-persistence-jdbc/src/test/resources/test.jdbc.properties
+++ b/fhir-persistence-jdbc/src/test/resources/test.jdbc.properties
@@ -4,7 +4,7 @@
 
 #Derby properties
 dbDriverName = org.apache.derby.jdbc.EmbeddedDriver
-dbUrl = jdbc:derby:derby/fhirDB
+dbUrl = jdbc:derby:target/derby/fhirDB
 
 #Db2 properties
 #dbDriverName = com.ibm.db2.jcc.DB2Driver

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/derby/DerbyFhirDatabase.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/derby/DerbyFhirDatabase.java
@@ -29,9 +29,19 @@ public class DerbyFhirDatabase implements AutoCloseable, IConnectionProvider {
     // The wrapper for managing a derby in-memory instance
     final DerbyMaster derby;
 
+    /**
+     * The default constructor will initialize the database at "derby/fhirDB".
+     */
     public DerbyFhirDatabase() throws SQLException {
-        logger.info("Creating Derby database for FHIR: " + DATABASE_NAME);
-        derby = new DerbyMaster(DATABASE_NAME);
+        this(DATABASE_NAME);
+    }
+
+    /**
+     * Construct a Derby database at the specified path and deploy the IBM FHIR Server schema.
+     */
+    public DerbyFhirDatabase(String dbPath) throws SQLException {
+        logger.info("Creating Derby database for FHIR: " + dbPath);
+        derby = new DerbyMaster(dbPath);
 
         // Lambdas are quite tasty for this sort of thing
         derby.runWithAdapter(adapter -> CreateVersionHistory.createTableIfNeeded(ADMIN_SCHEMA_NAME, adapter));

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbyFhirDatabaseTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbyFhirDatabaseTest.java
@@ -14,10 +14,11 @@ import com.ibm.fhir.schema.derby.DerbyFhirDatabase;
  * Unit test for the DerbyFhirDatabase utility
  */
 public class DerbyFhirDatabaseTest {
+    private static final String DB_NAME = "target/derby/fhirDB";
 
     @Test
     public void testFhirSchema() throws Exception {
-        try (DerbyFhirDatabase db = new DerbyFhirDatabase()) {
+        try (DerbyFhirDatabase db = new DerbyFhirDatabase(DB_NAME)) {
             System.out.println("FHIR database create successfully.");
         }
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -113,7 +113,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
      */
     protected void assertSearchReturnsSavedResource(String searchParamName, String queryValue) throws Exception {
         assertTrue("Expected resource was not returned from the search",
-            searchReturnsResource(searchParamName, queryValue, savedResource));
+                searchReturnsResource(searchParamName, queryValue, savedResource));
     }
 
     /**
@@ -122,7 +122,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
      */
     protected void assertSearchDoesntReturnSavedResource(String searchParamName, String queryValue) throws Exception {
         assertFalse("Unexpected resource was returned from the search",
-            searchReturnsResource(searchParamName, queryValue, savedResource));
+                searchReturnsResource(searchParamName, queryValue, savedResource));
     }
 
     /**


### PR DESCRIPTION
I found that eclipse kept "validating" the derby files in their present location, so I moved them under the target dir.