### PR TITLE
site and readme documentation tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           export JAVA_HOME=/opt/hostedtoolcache/AdoptOpenJDK/1.0.0-releases-${{ matrix.java }}-hotspot-normal-latest/x64/
           JAVADOC_GOAL=" -Pvalidate-javadoc javadoc:javadoc "
         fi
-        mvn -B ${JAVADOC_GOAL} install --file fhir-parent -DskipTests -P integration --no-transfer-progress
+        mvn -B ${JAVADOC_GOAL} install --file fhir-parent -DskipTests -P integration --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
     - name: Server Integration Tests
       env:
         # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
@@ -137,7 +137,7 @@ jobs:
         export WORKSPACE=${GITHUB_WORKSPACE}
         build/pre-integration-test.sh
         env
-        mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress
+        mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
         build/post-integration-test.sh
     - name: Gather error logs
       if: failure()

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ To use the artifacts from a Maven project:
 |fhir-benchmark|Java Microbenchmark Harness (JMH) tests for measuring read/write/validation performance for the IBM FHIR Server and the HL7 FHIR Java Reference Implementation|false|
 
 ### Contributing to the IBM FHIR Server
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+The IBM FHIR Server is under active development. To help develop the server, clone or download the project and build it using Maven.
+See [Setting up for development](https://github.com/IBM/FHIR/wiki/Setting-up-for-development) for more information.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contributing your changes back to the project.
 
 ### License
 The IBM FHIR Server is licensed under the Apache 2.0 license. Full license text is

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -50,8 +50,8 @@ View information about recent changes that were made to this document. For more 
 ## 2.1 Installing a new server
 0.  Prereqs: The IBM FHIR Server requires Java 8 or higher and has been tested with OpenJDK 8, OpenJDK 11, and the IBM SDK, Java Technology Edition, Version 8. To install Java on your system, we recommend downloading and installing OpenJDK 8 from https://adoptopenjdk.net/.
 
-1.  To install the FHIR server, build or download the `fhir-install` zip installer (e.g. `fhir-server-distribution.zip` or `fhir-install-4.0.0-rc1-20191014-1610`).
-The Maven build creates the zip package under `fhir-install/target`. Alternatively, releases will be made available from the [Releases tab](https://github.com/ibm/fhir/releases).
+1.  To install the FHIR server, download or build the `fhir-install` zip installer (e.g. `fhir-server-distribution.zip`).
+Releases are available from the [Releases tab](https://github.com/ibm/fhir/releases). Alternatively, the Maven build creates the zip package under `fhir-install/target`.
 
 2.  Unzip the `.zip` package into a clean directory (referred to as `fhir-installer` here):
     ```

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -13,9 +13,6 @@ For a detailed description of conformance, please see [Conformance](/Conformance
 ## Running the IBM FHIR Server
 Information on installing, configuring, and running the IBM FHIR Server is available in the User Guide at [FHIRServerUsersGuide](/guides/FHIRServerUsersGuide).
 
-The IBM FHIR Server is currently under development. To run and develop with the server, you must clone or download the project and build it.
-See [Setting up for development](https://github.com/IBM/FHIR/wiki/Setting-up-for-development) for more info.
-
 ## Building on top of the IBM FHIR Server
 IBM FHIR Server artifacts are available in BinTray with a group ID of `com.ibm.fhir`.
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
@@ -42,7 +42,7 @@ import com.ibm.fhir.model.type.code.NarrativeStatus;
 
 public class FHIRPatchTest extends FHIRServerTestBase {    
     @Test(groups = { "fhir-patch" })
-    public void testPatchAddOperation() throws Exception {
+    public void testJSONPatchAddOperation() throws Exception {
         WebTarget target = getWebTarget();
         
         // Build a new Patient and then call the 'create' API.
@@ -85,7 +85,7 @@ public class FHIRPatchTest extends FHIRServerTestBase {
     }
     
     @Test(groups = { "fhir-patch" })
-    public void testPatchRemoveOperation() throws Exception {
+    public void testJSONPatchRemoveOperation() throws Exception {
         WebTarget target = getWebTarget();
         
         // Build a new Patient and then call the 'create' API.
@@ -124,7 +124,7 @@ public class FHIRPatchTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "fhir-patch" })
-    public void testPatchReplaceOperation() throws Exception {
+    public void testJSONPatchReplaceOperation() throws Exception {
         WebTarget target = getWebTarget();
         
         // Build a new Patient and then call the 'create' API.
@@ -163,7 +163,7 @@ public class FHIRPatchTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "fhir-patch" })
-    public void testPatchCopyOperation() throws Exception {
+    public void testJSONPatchCopyOperation() throws Exception {
         WebTarget target = getWebTarget();
         
         // Build a new Patient and then call the 'create' API.
@@ -206,7 +206,7 @@ public class FHIRPatchTest extends FHIRServerTestBase {
     }
     
     @Test(groups = { "fhir-patch" })
-    public void testPatchMoveOperation() throws Exception {
+    public void testJSONPatchMoveOperation() throws Exception {
         WebTarget target = getWebTarget();
         
         // Build a new Patient and then call the 'create' API.


### PR DESCRIPTION
* remove reference to the rc-1 zip installer from the user guide
* remove statement about how you "must" set up for development to use the server (from the site's index page)
* add a link to "setting up for development" from the README

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>