### PR TITLE
Update liberty version

### DIFF
--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/kafka/Environment.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/kafka/Environment.java
@@ -38,7 +38,7 @@ public class Environment {
         logger.entering(CLASSNAME, METHODNAME);
 
         String kubEventStreamBinding = System.getenv(KUB_EVENTSTREAMS_BINDING);
-        logger.info(KUB_EVENTSTREAMS_BINDING + ": \n" + kubEventStreamBinding);
+        logger.fine(KUB_EVENTSTREAMS_BINDING + ": \n" + kubEventStreamBinding);
         return parseEventStreamsCredentials(kubEventStreamBinding);
     }
 

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -1,10 +1,10 @@
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2016,2019
+# (C) Copyright IBM Corp. 2016, 2020
 # 
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-FROM websphere-liberty:microProfile2 as base
+FROM websphere-liberty:kernel as base
 
 ENV LICENSE accept
 
@@ -23,7 +23,7 @@ RUN unzip -qq /fhir-installer/fhir-server-distribution.zip -d /fhir-installer/ &
     /opt/ibm/wlp/bin/installUtility install fhir-server --acceptLicense
 
 
-FROM websphere-liberty:microProfile2
+FROM websphere-liberty:kernel
 COPY --chown=1001:0 --from=base /opt/ibm/wlp/ /opt/ibm/wlp
 
 MAINTAINER John T.E. Timm <johntimm@us.ibm.com>

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -7,7 +7,7 @@
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-set LIBERTY_VERSION=19.0.0.8
+set LIBERTY_VERSION=19.0.0.12
 
 echo Executing %0 to deploy the fhir-server web application...
 

--- a/fhir-install/src/main/resources/scripts/install.sh
+++ b/fhir-install/src/main/resources/scripts/install.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 
-export LIBERTY_VERSION="19.0.0.8"
+export LIBERTY_VERSION="19.0.0.12"
 
 echo "
 Executing $0 to deploy the fhir-server web application...

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -10,7 +10,7 @@
     <name>IBM FHIR Server</name>
 
     <properties>
-        <liberty.version>19.0.0.8</liberty.version>
+        <liberty.version>19.0.0.12</liberty.version>
         <derby.version>10.14.2.0</derby.version>
         <db2.version>11.5.0.0</db2.version>
         <cxf.version>3.3.3</cxf.version>


### PR DESCRIPTION
Updated the packaged openliberty version from 19.0.0.8 to 19.0.0.12.

Also, I found that the websphere-liberty:microProfile2 tag isn't being
kept up-to-date, only websphere-liberty:kernel and
websphere-liberty:full, so I switched our Dockerfile to use
`websphere-liberty:kernel`

Finally, I reduced the log level of fhir-audit kafka/eventstreams
binding info...this message is logging our event streams credentials and
so I don't want it being logged by default.


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>