### PR TITLE
fixup issue #66 for bundle requests

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -4266,10 +4266,8 @@ public class FHIRResource implements FHIRResourceHelpers {
             if (resourceNamePathLocation != -1) {
                 baseUri = requestUri.substring(0, resourceNamePathLocation);
             } else {
-                String errMsg = "Error constructing the base URL of the server; "
-                        + "expected Resource type name was not found in the request uri '"
-                        + requestUri + "'";
-                log.log(Level.WARNING, errMsg);
+                // Assume the request was a batch/transaction and just use the requestUri as the base
+                baseUri = requestUri;
             }
         } else {
             if (baseUri.endsWith("/_history")) {


### PR DESCRIPTION
I didn't think we'd ever hit this case, but I found that we do for requests within a batch/transaction bundle.
Since those are always POSTed to the base uri, the simplest fix is to just use the requestUri as the baseUri in that case.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>