### PR TITLE
issue #726 reuse input stream of data source between chunks

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
@@ -37,6 +37,7 @@ import com.ibm.cloud.objectstorage.services.s3.model.S3Object;
 import com.ibm.cloud.objectstorage.services.s3.model.S3ObjectInputStream;
 import com.ibm.cloud.objectstorage.services.s3.model.UploadPartRequest;
 import com.ibm.cloud.objectstorage.services.s3.model.UploadPartResult;
+import com.ibm.fhir.bulkimport.ImportTransientUserData;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.resource.Resource;
@@ -155,41 +156,89 @@ public class BulkDataUtils {
     }
 
     public static int readFhirResourceFromObjectStore(AmazonS3 cosClient, String bucketName, String itemName,
-           int numOfLinesToSkip, List<Resource> fhirResources) {
-        int exported;
-        S3Object item = cosClient.getObject(new GetObjectRequest(bucketName, itemName));
-        try (S3ObjectInputStream s3InStream = item.getObjectContent();
-             BufferedReader resReader = new BufferedReader(new InputStreamReader(s3InStream))) {
-            exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
-            // Notify s3 client to abort and prevent the server from keeping on sending data.
-            s3InStream.abort();
-        } catch (Exception ioe) {
-            logger.warning("readFhirResourceFromObjectStore: " + "Error proccesing file " + itemName + " - " + ioe.getMessage());
-            exported = 0;
+           int numOfLinesToSkip, List<Resource> fhirResources, boolean isReuseInput, ImportTransientUserData transientUserData) {
+        int exported = 0;
+        if (isReuseInput) {
+            if (transientUserData.getBufferReader() == null) {
+                S3Object item = cosClient.getObject(new GetObjectRequest(bucketName, itemName));
+                S3ObjectInputStream s3InStream = item.getObjectContent();
+                transientUserData.setInputStream(s3InStream);
+                BufferedReader resReader = new BufferedReader(new InputStreamReader(s3InStream));
+                transientUserData.setBufferReader(resReader);
+            }
+            try {
+                exported = getFhirResourceFromBufferReader(transientUserData.getBufferReader(), 0, fhirResources);
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromObjectStore: " + "Error proccesing file " + itemName + " - " + ioe.getMessage());
+                exported = 0;
+            }
+
+        } else {
+            S3Object item = cosClient.getObject(new GetObjectRequest(bucketName, itemName));
+            try (S3ObjectInputStream s3InStream = item.getObjectContent();
+                 BufferedReader resReader = new BufferedReader(new InputStreamReader(s3InStream))) {
+                exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
+                // Notify s3 client to abort and prevent the server from keeping on sending data.
+                s3InStream.abort();
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromObjectStore: " + "Error proccesing file " + itemName + " - " + ioe.getMessage());
+                exported = 0;
+            }
+        }
+
+        return exported;
+    }
+
+
+    public static int readFhirResourceFromLocalFile(String filePath, int numOfLinesToSkip, List<Resource> fhirResources,
+            boolean isReuseInput, ImportTransientUserData transientUserData) {
+        int exported = 0;
+        if (isReuseInput) {
+            try {
+                if (transientUserData.getBufferReader() == null) {
+                    BufferedReader resReader = Files.newBufferedReader(Paths.get(filePath));
+                    transientUserData.setBufferReader(resReader);
+                }
+                exported = getFhirResourceFromBufferReader(transientUserData.getBufferReader(), 0, fhirResources);
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromLocalFile: " + "Error proccesing file " + filePath + " - " + ioe.getMessage());
+                exported = 0;
+            }
+        } else {
+            try (BufferedReader resReader = Files.newBufferedReader(Paths.get(filePath))) {
+                exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromLocalFile: " + "Error proccesing file " + filePath + " - " + ioe.getMessage());
+                exported = 0;
+            }
         }
         return exported;
     }
 
 
-    public static int readFhirResourceFromLocalFile(String filePath, int numOfLinesToSkip, List<Resource> fhirResources) {
-        int exported;
-        try (BufferedReader resReader = Files.newBufferedReader(Paths.get(filePath))) {
-            exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
-        } catch (Exception ioe) {
-            logger.warning("readFhirResourceFromLocalFile: " + "Error proccesing file " + filePath + " - " + ioe.getMessage());
-            exported = 0;
-        }
-        return exported;
-    }
-
-
-    public static int readFhirResourceFromHttps(String dataUrl, int numOfLinesToSkip, List<Resource> fhirResources) {
-        int exported;
-        try (BufferedReader resReader = new BufferedReader(new InputStreamReader(new URL(dataUrl).openConnection().getInputStream()))) {
-            exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
-        } catch (Exception ioe) {
-            logger.warning("readFhirResourceFromHttps: " + "Error proccesing file " + dataUrl + " - " + ioe.getMessage());
-            exported = 0;
+    public static int readFhirResourceFromHttps(String dataUrl, int numOfLinesToSkip, List<Resource> fhirResources,
+            boolean isReuseInput, ImportTransientUserData transientUserData) {
+        int exported = 0;
+        if (isReuseInput) {
+            try {
+                if (transientUserData.getBufferReader() == null) {
+                    InputStream inputStream = new URL(dataUrl).openConnection().getInputStream();
+                    transientUserData.setInputStream(inputStream);
+                    BufferedReader resReader = new BufferedReader(new InputStreamReader(inputStream));
+                    transientUserData.setBufferReader(resReader);
+                }
+                exported = getFhirResourceFromBufferReader(transientUserData.getBufferReader(), 0, fhirResources);
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromHttps: " + "Error proccesing file " + dataUrl + " - " + ioe.getMessage());
+                exported = 0;
+            }
+        } else {
+            try (BufferedReader resReader = new BufferedReader(new InputStreamReader(new URL(dataUrl).openConnection().getInputStream()))) {
+                exported = getFhirResourceFromBufferReader(resReader, numOfLinesToSkip, fhirResources);
+            } catch (Exception ioe) {
+                logger.warning("readFhirResourceFromHttps: " + "Error proccesing file " + dataUrl + " - " + ioe.getMessage());
+                exported = 0;
+            }
         }
         return exported;
     }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -51,4 +51,6 @@ public class Constants {
 
     // Control if push OperationOutcomes to COS/S3.
     public static final boolean IMPORT_IS_COLLECT_OPERATIONOUTCOMES = false;
+    // Control if reuse the input stream of the data source across the chunks.
+    public static final boolean IMPORT_IS_REUSE_INPUTSTREAM = false;
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -52,5 +52,5 @@ public class Constants {
     // Control if push OperationOutcomes to COS/S3.
     public static final boolean IMPORT_IS_COLLECT_OPERATIONOUTCOMES = false;
     // Control if reuse the input stream of the data source across the chunks.
-    public static final boolean IMPORT_IS_REUSE_INPUTSTREAM = false;
+    public static final boolean IMPORT_IS_REUSE_INPUTSTREAM = true;
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -117,10 +117,12 @@ public class ChunkReader extends AbstractItemReader {
 
         switch (BulkImportDataSourceStorageType.from(dataSourceStorageType)) {
         case HTTPS:
-            imported = BulkDataUtils.readFhirResourceFromHttps(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources);
+            imported = BulkDataUtils.readFhirResourceFromHttps(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources,
+                    Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
             break;
         case FILE:
-            imported = BulkDataUtils.readFhirResourceFromLocalFile(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources);
+            imported = BulkDataUtils.readFhirResourceFromLocalFile(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources,
+                    Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
             break;
         case AWSS3:
         case IBMCOS:
@@ -132,7 +134,8 @@ public class ChunkReader extends AbstractItemReader {
             } else {
                 logger.finer("readItem: Got CosClient successfully!");
             }
-            imported = BulkDataUtils.readFhirResourceFromObjectStore(cosClient, cosBucketName, importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources);
+            imported = BulkDataUtils.readFhirResourceFromObjectStore(cosClient, cosBucketName, importPartitionWorkitem,
+                    numOfLinesToSkip, loadedFhirResources, Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
             break;
         default:
             break;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.bulkimport;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
@@ -108,7 +109,9 @@ public class ChunkReader extends AbstractItemReader {
             return null;
         }
         List<Resource> loadedFhirResources = new ArrayList<Resource>();
-        logger.fine("readItem: get work item:" + importPartitionWorkitem + " resource type: " + importPartitionResourceType);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("readItem: get work item:" + importPartitionWorkitem + " resource type: " + importPartitionResourceType);
+        }
 
         ImportTransientUserData chunkData = (ImportTransientUserData) stepCtx.getTransientUserData();
         if (chunkData == null) {
@@ -145,7 +148,9 @@ public class ChunkReader extends AbstractItemReader {
         default:
             break;
         }
-        logger.fine("readItem: loaded " + imported + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("readItem: loaded " + imported + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
+        }
         chunkData.setNumOfToBeImported(imported);
         if (imported == 0) {
             return null;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
 import javax.batch.api.chunk.AbstractItemReader;
+import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
@@ -102,8 +103,12 @@ public class ChunkReader extends AbstractItemReader {
 
     @Override
     public Object readItem() throws Exception {
+        // If the job is being stopped or in other status except for "started", then stop the read.
+        if (!stepCtx.getBatchStatus().equals(BatchStatus.STARTED)) {
+            return null;
+        }
         List<Resource> loadedFhirResources = new ArrayList<Resource>();
-        logger.info("readItem: get work item:" + importPartitionWorkitem + " resource type: " + importPartitionResourceType);
+        logger.fine("readItem: get work item:" + importPartitionWorkitem + " resource type: " + importPartitionResourceType);
 
         ImportTransientUserData chunkData = (ImportTransientUserData) stepCtx.getTransientUserData();
         if (chunkData == null) {
@@ -140,7 +145,7 @@ public class ChunkReader extends AbstractItemReader {
         default:
             break;
         }
-        logger.info("readItem: loaded " + imported + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
+        logger.fine("readItem: loaded " + imported + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
         chunkData.setNumOfToBeImported(imported);
         if (imported == 0) {
             return null;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
@@ -162,7 +162,7 @@ public class ChunkWriter extends AbstractItemWriter {
         chunkData.setNumOfProcessedResources(chunkData.getNumOfProcessedResources() + processedNum);
         chunkData.setNumOfImportedResources(chunkData.getNumOfImportedResources() + succeededNum);
         chunkData.setNumOfImportFailures(chunkData.getNumOfImportFailures() + failedNum);
-        logger.info("writeItems: processed " + processedNum + " " + importPartitionResourceType + " from " +  chunkData.getImportPartitionWorkitem());
+        logger.fine("writeItems: processed " + processedNum + " " + importPartitionResourceType + " from " +  chunkData.getImportPartitionWorkitem());
 
         if (Constants.IMPORT_IS_COLLECT_OPERATIONOUTCOMES) {
             pushImportOperationOutcomes2COS(chunkData);
@@ -192,7 +192,7 @@ public class ChunkWriter extends AbstractItemWriter {
                     cosOperationOutcomesBucketName, chunkData.getUniqueID4ImportOperationOutcomes(),
                     chunkData.getUploadId4OperationOutcomes(), new ByteArrayInputStream(chunkData.getBufferStream4Import().toByteArray()),
                     chunkData.getBufferStream4Import().size(), chunkData.getPartNum4OperationOutcomes()));
-            logger.info("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4Import().size()
+            logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4Import().size()
                     + " bytes were successfully appended to COS object - " + chunkData.getUniqueID4ImportOperationOutcomes());
             chunkData.setPartNum4OperationOutcomes(chunkData.getPartNum4OperationOutcomes() + 1);
             chunkData.getBufferStream4Import().reset();
@@ -209,7 +209,7 @@ public class ChunkWriter extends AbstractItemWriter {
                     cosOperationOutcomesBucketName, chunkData.getUniqueID4ImportFailureOperationOutcomes(),
                     chunkData.getUploadId4FailureOperationOutcomes(), new ByteArrayInputStream(chunkData.getBufferStream4ImportError().toByteArray()),
                     chunkData.getBufferStream4ImportError().size(), chunkData.getPartNum4FailureOperationOutcomes()));
-            logger.info("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4ImportError().size()
+            logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4ImportError().size()
                     + " bytes were successfully appended to COS object - " + chunkData.getUniqueID4ImportFailureOperationOutcomes());
             chunkData.setPartNum4FailureOperationOutcomes(chunkData.getPartNum4FailureOperationOutcomes() + 1);
             chunkData.getBufferStream4ImportError().reset();

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.bulkimport;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
@@ -162,7 +163,9 @@ public class ChunkWriter extends AbstractItemWriter {
         chunkData.setNumOfProcessedResources(chunkData.getNumOfProcessedResources() + processedNum);
         chunkData.setNumOfImportedResources(chunkData.getNumOfImportedResources() + succeededNum);
         chunkData.setNumOfImportFailures(chunkData.getNumOfImportFailures() + failedNum);
-        logger.fine("writeItems: processed " + processedNum + " " + importPartitionResourceType + " from " +  chunkData.getImportPartitionWorkitem());
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("writeItems: processed " + processedNum + " " + importPartitionResourceType + " from " +  chunkData.getImportPartitionWorkitem());
+        }
 
         if (Constants.IMPORT_IS_COLLECT_OPERATIONOUTCOMES) {
             pushImportOperationOutcomes2COS(chunkData);
@@ -192,8 +195,10 @@ public class ChunkWriter extends AbstractItemWriter {
                     cosOperationOutcomesBucketName, chunkData.getUniqueID4ImportOperationOutcomes(),
                     chunkData.getUploadId4OperationOutcomes(), new ByteArrayInputStream(chunkData.getBufferStream4Import().toByteArray()),
                     chunkData.getBufferStream4Import().size(), chunkData.getPartNum4OperationOutcomes()));
-            logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4Import().size()
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4Import().size()
                     + " bytes were successfully appended to COS object - " + chunkData.getUniqueID4ImportOperationOutcomes());
+            }
             chunkData.setPartNum4OperationOutcomes(chunkData.getPartNum4OperationOutcomes() + 1);
             chunkData.getBufferStream4Import().reset();
         }
@@ -209,8 +214,10 @@ public class ChunkWriter extends AbstractItemWriter {
                     cosOperationOutcomesBucketName, chunkData.getUniqueID4ImportFailureOperationOutcomes(),
                     chunkData.getUploadId4FailureOperationOutcomes(), new ByteArrayInputStream(chunkData.getBufferStream4ImportError().toByteArray()),
                     chunkData.getBufferStream4ImportError().size(), chunkData.getPartNum4FailureOperationOutcomes()));
-            logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4ImportError().size()
+            if (logger.isLoggable(Level.FINE)) {
+                logger.fine("pushImportOperationOutcomes2COS: " + chunkData.getBufferStream4ImportError().size()
                     + " bytes were successfully appended to COS object - " + chunkData.getUniqueID4ImportFailureOperationOutcomes());
+            }
             chunkData.setPartNum4FailureOperationOutcomes(chunkData.getPartNum4FailureOperationOutcomes() + 1);
             chunkData.getBufferStream4ImportError().reset();
         }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
@@ -31,6 +31,11 @@ public class ImportJobListener implements JobListener {
         // Used for generating performance measurement per each resource type.
         HashMap<String, ImportCheckPointData> importedResourceTypeSummaries = new HashMap<>();
 
+        // If the job is stopped before any partition is finished, then nothing to show.
+        if (partitionSummaries == null) {
+            return;
+        }
+
         for (ImportCheckPointData partitionSummary : partitionSummaries) {
             ImportCheckPointData partitionSummaryInMap = importedResourceTypeSummaries.get(partitionSummary.getImportPartitionResourceType());
             if (partitionSummaryInMap == null) {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.bulkimport;
 
 import java.io.ByteArrayInputStream;
 import java.io.Serializable;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
@@ -113,8 +114,10 @@ public class ImportPartitionCollector implements PartitionCollector {
                             cosOperationOutcomesBucketName, partitionSummaryData.getUniqueID4ImportOperationOutcomes(),
                             partitionSummaryData.getUploadId4OperationOutcomes(), new ByteArrayInputStream(partitionSummaryData.getBufferStream4Import().toByteArray()),
                             partitionSummaryData.getBufferStream4Import().size(), partitionSummaryData.getPartNum4OperationOutcomes()));
-                    logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4Import().size()
+                    if (logger.isLoggable(Level.FINE)) {
+                        logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4Import().size()
                             + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueID4ImportOperationOutcomes());
+                    }
                     partitionSummaryData.setPartNum4OperationOutcomes(partitionSummaryData.getPartNum4OperationOutcomes() + 1);
                     partitionSummaryData.getBufferStream4Import().reset();
                 }
@@ -135,8 +138,10 @@ public class ImportPartitionCollector implements PartitionCollector {
                             cosOperationOutcomesBucketName, partitionSummaryData.getUniqueID4ImportFailureOperationOutcomes(),
                             partitionSummaryData.getUploadId4FailureOperationOutcomes(), new ByteArrayInputStream(partitionSummaryData.getBufferStream4ImportError().toByteArray()),
                             partitionSummaryData.getBufferStream4ImportError().size(), partitionSummaryData.getPartNum4FailureOperationOutcomes()));
-                    logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4ImportError().size()
+                    if (logger.isLoggable(Level.FINE)) {
+                        logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4ImportError().size()
                             + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueID4ImportFailureOperationOutcomes());
+                    }
                     partitionSummaryData.setPartNum4FailureOperationOutcomes(partitionSummaryData.getPartNum4FailureOperationOutcomes() + 1);
                     partitionSummaryData.getBufferStream4ImportError().reset();
                 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
@@ -12,10 +12,12 @@ import java.util.logging.Logger;
 
 import javax.batch.api.BatchProperty;
 import javax.batch.api.partition.PartitionCollector;
+import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
 
 import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
+import com.ibm.cloud.objectstorage.services.s3.model.S3ObjectInputStream;
 import com.ibm.fhir.bulkcommon.BulkDataUtils;
 import com.ibm.fhir.bulkcommon.Constants;
 
@@ -72,6 +74,23 @@ public class ImportPartitionCollector implements PartitionCollector {
     @Override
     public Serializable collectPartitionData() throws Exception{
         ImportTransientUserData partitionSummaryData  = (ImportTransientUserData)stepCtx.getTransientUserData();
+        BatchStatus batchStatus = stepCtx.getBatchStatus();
+
+        // If the job is being stopped or in other status except for "started", then do cleanup for the partition.
+        if (!batchStatus.equals(BatchStatus.STARTED)) {
+            if (partitionSummaryData.getInputStream() != null) {
+                if (partitionSummaryData.getInputStream() instanceof S3ObjectInputStream) {
+                    ((S3ObjectInputStream)partitionSummaryData.getInputStream()).abort();
+                }
+                partitionSummaryData.getInputStream().close();
+            }
+
+            if (partitionSummaryData.getBufferReader() != null) {
+                partitionSummaryData.getBufferReader().close();
+            }
+            return null;
+        }
+
         // This function is called at partition chunk check points and also at the end of partition processing.
         // So, check the NumOfToBeImported to make sure collect the statistic data for the partition only at the end,
         // also upload the remaining OperationComes to COS/S3 if any and finish the multiple-parts uploads.
@@ -94,7 +113,7 @@ public class ImportPartitionCollector implements PartitionCollector {
                             cosOperationOutcomesBucketName, partitionSummaryData.getUniqueID4ImportOperationOutcomes(),
                             partitionSummaryData.getUploadId4OperationOutcomes(), new ByteArrayInputStream(partitionSummaryData.getBufferStream4Import().toByteArray()),
                             partitionSummaryData.getBufferStream4Import().size(), partitionSummaryData.getPartNum4OperationOutcomes()));
-                    logger.info("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4Import().size()
+                    logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4Import().size()
                             + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueID4ImportOperationOutcomes());
                     partitionSummaryData.setPartNum4OperationOutcomes(partitionSummaryData.getPartNum4OperationOutcomes() + 1);
                     partitionSummaryData.getBufferStream4Import().reset();
@@ -116,7 +135,7 @@ public class ImportPartitionCollector implements PartitionCollector {
                             cosOperationOutcomesBucketName, partitionSummaryData.getUniqueID4ImportFailureOperationOutcomes(),
                             partitionSummaryData.getUploadId4FailureOperationOutcomes(), new ByteArrayInputStream(partitionSummaryData.getBufferStream4ImportError().toByteArray()),
                             partitionSummaryData.getBufferStream4ImportError().size(), partitionSummaryData.getPartNum4FailureOperationOutcomes()));
-                    logger.info("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4ImportError().size()
+                    logger.fine("pushImportOperationOutcomes2COS: " + partitionSummaryData.getBufferStream4ImportError().size()
                             + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueID4ImportFailureOperationOutcomes());
                     partitionSummaryData.setPartNum4FailureOperationOutcomes(partitionSummaryData.getPartNum4FailureOperationOutcomes() + 1);
                     partitionSummaryData.getBufferStream4ImportError().reset();

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
@@ -127,6 +127,15 @@ public class ImportPartitionCollector implements PartitionCollector {
                             partitionSummaryData.getUploadId4FailureOperationOutcomes(), partitionSummaryData.getDataPacks4FailureOperationOutcomes());
                 }
             }
+
+            if (partitionSummaryData.getBufferReader() != null) {
+                partitionSummaryData.getBufferReader().close();
+            }
+
+            if (partitionSummaryData.getInputStream() != null) {
+                partitionSummaryData.getInputStream().close();
+            }
+
             return ImportCheckPointData.fromImportTransientUserData(partitionSummaryData);
         } else {
             return null;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
@@ -178,7 +178,7 @@ public class ImportPartitionMapper implements PartitionMapper {
              logger.finer("getFhirDataSources4ObjectStore: Succeed get BucketName!");
          }
          cosBucketName = cosBucketName.toLowerCase();
-         if (!cosClient.doesBucketExist(cosBucketName)) {
+         if (!cosClient.doesBucketExistV2(cosBucketName)) {
              logger.warning("getFhirDataSources4ObjectStore: Bucket '" + cosBucketName + "' not found!");
              BulkDataUtils.listBuckets(cosClient);
              return fhirDataSources;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportTransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportTransientUserData.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 
-public class ImportTransientUserData extends ImportCheckPointData{
-    private static final long serialVersionUID = 1L;
+public class ImportTransientUserData extends ImportCheckPointData {
+    private static final long serialVersionUID = -2642411992044844735L;
     // Used for import OperationOutcomes, Bulk data import API defines optional links to the OperationOutcomes for each import data source,
     // Data in this buffer stream will be uploaded to storage like IBM COS and allow user to download via the link mentioned above.
     private ByteArrayOutputStream bufferStream4ImportError = new ByteArrayOutputStream();

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportTransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportTransientUserData.java
@@ -6,7 +6,9 @@
 
 package com.ibm.fhir.bulkimport;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.util.List;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
@@ -17,6 +19,9 @@ public class ImportTransientUserData extends ImportCheckPointData{
     // Data in this buffer stream will be uploaded to storage like IBM COS and allow user to download via the link mentioned above.
     private ByteArrayOutputStream bufferStream4ImportError = new ByteArrayOutputStream();
     private ByteArrayOutputStream bufferStream4Import = new ByteArrayOutputStream();
+
+    private InputStream inputStream = null;
+    private BufferedReader bufferReader = null;
 
     public ImportTransientUserData(String importPartitionWorkitem, int numOfProcessedResources,
             String importPartitionResourceType, int numOfImportedResource, int numOfImportFailures,
@@ -48,6 +53,22 @@ public class ImportTransientUserData extends ImportCheckPointData{
                 importCheckPointData.getUniqueID4ImportFailureOperationOutcomes(), importCheckPointData.getUniqueID4ImportOperationOutcomes(),
                 importCheckPointData.getUploadId4OperationOutcomes(), importCheckPointData.getDataPacks4OperationOutcomes(), importCheckPointData.getPartNum4OperationOutcomes(),
                 importCheckPointData.getUploadId4FailureOperationOutcomes(), importCheckPointData.getDataPacks4FailureOperationOutcomes(), importCheckPointData.getPartNum4FailureOperationOutcomes());
+    }
+
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    public void setInputStream(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public BufferedReader getBufferReader() {
+        return bufferReader;
+    }
+
+    public void setBufferReader(BufferedReader bufferReader) {
+        this.bufferReader = bufferReader;
     }
 
 }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
-import com.ibm.fhir.model.config.FHIRModelConfig;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.parser.FHIRParser;
@@ -44,10 +43,6 @@ import com.ibm.fhir.model.type.code.ResourceType.ValueSet;
  * This class exercises the getters in the resource package.
  */
 public class ResourceCoverageTest {
-
-    public ResourceCoverageTest() {
-        FHIRModelConfig.setCheckReferenceTypes(false);
-    }
 
     public static byte[] PAYLOAD = "THIS IS A FAKE PAYLOAD".getBytes();
 

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/ResourceCoverageTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.config.FHIRModelConfig;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.parser.FHIRParser;
@@ -43,6 +44,10 @@ import com.ibm.fhir.model.type.code.ResourceType.ValueSet;
  * This class exercises the getters in the resource package.
  */
 public class ResourceCoverageTest {
+
+    public ResourceCoverageTest() {
+        FHIRModelConfig.setCheckReferenceTypes(false);
+    }
 
     public static byte[] PAYLOAD = "THIS IS A FAKE PAYLOAD".getBytes();
 


### PR DESCRIPTION
Signed-off-by: Albert Wang <xuwang@us.ibm.com>

currently, we enable the reuse by default, and we can turn it off if need in the future.

**Test results(using the same 34M ndjson test file):**
**From local file**
**(1) without reuse**
---- Fhir resources imported in 365.517seconds ----
ResourceType 	 Imported 	 Failed
AllergyIntolerance	54238	0
 ---- Total: 54238 ImportRate: 148.38707912354283 ----
 **(2) with reuse**
 ---- Fhir resources imported in 358.754seconds ----
ResourceType 	 Imported 	 Failed
AllergyIntolerance	54238	0
 ---- Total: 54238 ImportRate: 151.1843770383048 ----
 
 **From COS:**
**(1) without reuse**
---- Fhir resources imported in 517.111seconds ----
ResourceType 	 Imported 	 Failed
AllergyIntolerance	54238	0
 ---- Total: 54238 ImportRate: 104.8865717418504 ----

**(2) with reuse**
---- Fhir resources imported in 367.606seconds ----
ResourceType 	 Imported 	 Failed
AllergyIntolerance	54238	0
 ---- Total: 54238 ImportRate: 147.54383769579385 ----
 
 