### PR TITLE
REST layer refactoring/cleanup

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -162,7 +162,11 @@ Throughout this document, we use a path notation to refer to property names. For
 ## 3.3 Tenant-specific configuration properties
 The FHIR server supports certain multi-tenant features. One such feature is the ability to set certain configuration properties on a per-tenant basis.
 
-In general, the configuration properties for a particular tenant are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/fhir-server-config.json` file, where `<tenant-id>` refers to the tenant's “short name” or tenant id.The global configuration is considered to be associated with a tenant named `default`, so those properties are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/fhir-server-config.json` file. Similarly, tenant-specific search parameters are found at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/extension-search-parameters.json` whereas the global/default extension search parameters are at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/extension-search-parameters.json`.
+In general, the configuration properties for a particular tenant are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/fhir-server-config.json` file, where `<tenant-id>` refers to the tenant's “short name” or tenant id.
+
+The global configuration is considered to be associated with a tenant named `default`, so those properties are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/fhir-server-config.json` file.
+
+Similarly, tenant-specific search parameters are found at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/extension-search-parameters.json`, whereas the global/default extension search parameters are at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/extension-search-parameters.json`.
 
 Search parameters are handled like a single configuration properly; providing a tenant-specific file will override the global/default extension search parameters as defined at [FHIRSearchConfiguration](https://ibm.github.io/FHIR/guides/FHIRSearchConfiguration).
 
@@ -1393,12 +1397,21 @@ This section contains reference information about each of the configuration prop
 
 
 ### 5.1.3 Property attributes
+Depending on the context of their use, config properties can be:
+* tenant-specific or global
+* dynamic or static
+
+The following table tracks which properties can be set on a tenant-specific basis
+and which properties are loaded dynamically.
+If you change a properties that has an `N` in the `Dynamic?` column, it means you
+must restart the server for that change to take effect.
+
 | Property Name                 | Tenant-specific? | Dynamic? |
 |-------------------------------|------------------|----------|
 |`fhirServer/core/defaultPrettyPrint`|Y|Y|
 |`fhirServer/core/tenantIdHeaderName`|N|N|
 |`fhirServer/core/dataSourceIdHeaderName`|N|N|
-|`fhirServer/core/originalRequestUriHeaderName`|Y|Y|
+|`fhirServer/core/originalRequestUriHeaderName`|N|N|
 |`fhirServer/core/defaultHandling`|Y|Y|
 |`fhirServer/core/allowClientHandlingPref`|Y|Y|
 |`fhirServer/core/checkReferenceTypes`|N|N|

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/group/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/group/ChunkReader.java
@@ -145,7 +145,7 @@ public class ChunkReader extends AbstractItemReader {
 
                 queryParameters.put("_sort", Arrays.asList(new String[] { Constants.FHIR_SEARCH_LASTUPDATED }));
                 searchContext = SearchUtil.parseQueryParameters("Patient", patientId,
-                        ModelSupport.getResourceType(resourceTypes.get(indexOfCurrentResourceType)), queryParameters, null, true);
+                        ModelSupport.getResourceType(resourceTypes.get(indexOfCurrentResourceType)), queryParameters, true);
                 do {
                     searchContext.setPageSize(pageSize);
                     searchContext.setPageNumber(compartmentPageNum);

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/patient/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/patient/ChunkReader.java
@@ -137,7 +137,7 @@ public class ChunkReader extends AbstractItemReader {
 
                 queryParameters.put("_sort", Arrays.asList(new String[] { Constants.FHIR_SEARCH_LASTUPDATED }));
                 searchContext = SearchUtil.parseQueryParameters("Patient", patient.getId(),
-                        ModelSupport.getResourceType(resourceTypes.get(indexOfCurrentResourceType)), queryParameters, null, true);
+                        ModelSupport.getResourceType(resourceTypes.get(indexOfCurrentResourceType)), queryParameters, true);
                 do {
                     searchContext.setPageSize(pageSize);
                     searchContext.setPageNumber(compartmentPageNum);

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
@@ -32,6 +32,7 @@ public class FHIRRequestContext {
     private String tenantKey;
     private String dataStoreId;
     private String requestUniqueId;
+    private String originalRequestUri;
     
     // Default to the "strict" handling which means the server will reject unrecognized search parameters and elements
     private HTTPHandlingPreference handlingPreference = HTTPHandlingPreference.STRICT;
@@ -184,5 +185,19 @@ public class FHIRRequestContext {
      */
     public void setReturnPreference(HTTPReturnPreference returnPreference) {
         this.returnPreference = returnPreference;
+    }
+
+    /**
+     * @return the originalRequestUri
+     */
+    public String getOriginalRequestUri() {
+        return originalRequestUri;
+    }
+
+    /**
+     * @param originalRequestUri the originalRequestUri to set
+     */
+    public void setOriginalRequestUri(String originalRequestUri) {
+        this.originalRequestUri = originalRequestUri;
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1001,8 +1001,7 @@ public class SearchUtil {
     public static FHIRSearchContext parseQueryParameters(String compartmentName, String compartmentLogicalId,
             Class<?> resourceType,
             Map<String, List<String>> queryParameters, String queryString) throws Exception {
-        return parseQueryParameters(compartmentName, compartmentLogicalId, resourceType, queryParameters, queryString,
-                true);
+        return parseQueryParameters(compartmentName, compartmentLogicalId, resourceType, queryParameters, true);
     }
 
     /**
@@ -1012,8 +1011,7 @@ public class SearchUtil {
      * @throws Exception
      */
     public static FHIRSearchContext parseQueryParameters(String compartmentName, String compartmentLogicalId,
-            Class<?> resourceType,
-            Map<String, List<String>> queryParameters, String queryString, boolean lenient) throws Exception {
+            Class<?> resourceType, Map<String, List<String>> queryParameters, boolean lenient) throws Exception {
         List<QueryParameter> parameters = new ArrayList<>();
         QueryParameter parameter;
         QueryParameterValue value;

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/CompartmentParseQueryParmsTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/CompartmentParseQueryParmsTest.java
@@ -218,7 +218,7 @@ public class CompartmentParseQueryParmsTest extends BaseSearchTest {
         assertFalse(selfUri.contains(queryString), selfUri + " contain unexpectedExceptions query parameter 'fakeParameter'");
 
         try {
-            SearchUtil.parseQueryParameters(compartmentName, compartmentLogicalId, resourceType, queryParameters, null, false);
+            SearchUtil.parseQueryParameters(compartmentName, compartmentLogicalId, resourceType, queryParameters, false);
             fail("expectedExceptions parseQueryParameters to throw due to strict mode but it didn't.");
         } catch (Exception e) {
             assertTrue(e instanceof FHIRSearchException);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,25 +7,27 @@
 package com.ibm.fhir.server.filter.rest;
 
 import java.io.IOException;
+import java.net.URI;
 import java.security.Principal;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
 
 import org.owasp.encoder.Encode;
 
 import com.ibm.fhir.config.FHIRConfigHelper;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.core.HTTPHandlingPreference;
 import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.exception.FHIRException;
@@ -39,14 +41,15 @@ import com.ibm.fhir.model.util.FHIRUtil;
 /**
  * This class is a servlet filter which is registered with the REST API's servlet. The main purpose of the class is to
  * log entry/exit information and elapsed time for each REST API request processed by the server.
- * 
- * @author padams
  */
-public class FHIRRestServletFilter implements Filter {
+public class FHIRRestServletFilter extends HttpFilter {
+    private static final long serialVersionUID = 1L;
+
     private static final Logger log = Logger.getLogger(FHIRRestServletFilter.class.getName());
 
     private static String tenantIdHeaderName = null;
     private static String datastoreIdHeaderName = null;
+    private static String originalRequestUriHeaderName = null;
     private static final String preferHeaderName = "Prefer";
     private static final String preferHandlingHeaderSectionName = "handling";
     private static final String preferReturnHeaderSectionName = "return";
@@ -54,39 +57,38 @@ public class FHIRRestServletFilter implements Filter {
     private static String defaultTenantId = null;
     private static final HTTPReturnPreference defaultHttpReturnPref = HTTPReturnPreference.MINIMAL;
 
-    /*
-     * (non-Javadoc)
-     * @see javax.servlet.Filter#doFilter(javax.servlet.ServletRequest, javax.servlet.ServletResponse,
-     * javax.servlet.FilterChain) This method will intercept incoming HTTP requests and log entry/exit messages.
-     */
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         if (log.isLoggable(Level.FINE)) {
             log.entering(this.getClass().getName(), "doFilter");
         }
 
         long initialTime = System.currentTimeMillis();
-        
+
         String tenantId = defaultTenantId;
         String dsId = FHIRConfiguration.DEFAULT_DATASTORE_ID;
-        
+        String requestUrl = getRequestURL(request);
+        String originalRequestUri = getRequestURL(request);
+
         // Wrap the incoming servlet request with our own implementation.
-        if (request instanceof HttpServletRequest) {
-            FHIRHttpServletRequestWrapper requestWrapper = new FHIRHttpServletRequestWrapper((HttpServletRequest) request);
-            request = requestWrapper;
-            if (log.isLoggable(Level.FINEST)) {
-                log.finest("Wrapped HttpServletRequest object...");
-            }
-            
-            String t = ((HttpServletRequest) request).getHeader(tenantIdHeaderName);
-            if (t != null) {
-                tenantId = t;
-            }
-            
-            t = ((HttpServletRequest) request).getHeader(datastoreIdHeaderName);
-            if (t != null) {
-                dsId = t;
-            }
+        request = new FHIRHttpServletRequestWrapper(request);
+        if (log.isLoggable(Level.FINEST)) {
+            log.finest("Wrapped HttpServletRequest object...");
+        }
+
+        String t = request.getHeader(tenantIdHeaderName);
+        if (t != null) {
+            tenantId = t;
+        }
+
+        t = request.getHeader(datastoreIdHeaderName);
+        if (t != null) {
+            dsId = t;
+        }
+
+        t = getOriginalRequestURI(request);
+        if (t != null) {
+            originalRequestUri = t;
         }
 
         // Log a "request received" message.
@@ -100,56 +102,33 @@ public class FHIRRestServletFilter implements Filter {
         requestDescription.append("] method:[");
         requestDescription.append(getRequestMethod(request));
         requestDescription.append("] uri:[");
-        requestDescription.append(getRequestURL(request));
-        final String encodedRequestDescription = Encode.forHtml(requestDescription.toString());
-
+        requestDescription.append(requestUrl);
+        if (!requestUrl.equals(originalRequestUri)) {
+            requestDescription.append("] originalUri:[");
+            requestDescription.append(originalRequestUri);
+        }
+        requestDescription.append("]");
+        String encodedRequestDescription = Encode.forHtml(requestDescription.toString());
         log.info("Received request: " + encodedRequestDescription);
-        
+
         try {
             // Create a new FHIRRequestContext and set it on the current thread.
             FHIRRequestContext context = new FHIRRequestContext(tenantId, dsId);
             FHIRRequestContext.set(context);
-            
+
+            context.setOriginalRequestUri(originalRequestUri);
+
             // Set the handling preference.
-            HTTPHandlingPreference handlingPref = HTTPHandlingPreference.from(FHIRConfigHelper.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_HANDLING, "strict"));
-            boolean allowClientHandlingPref = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_ALLOW_CLIENT_HANDLING_PREF, true);
-            if (allowClientHandlingPref) {
-                String handlingPrefString = ((HttpServletRequest) request).getHeader(preferHeaderName + ":" + preferHandlingHeaderSectionName);
-                if (handlingPrefString != null && !handlingPrefString.isEmpty()) {
-                    try {
-                        handlingPref = HTTPHandlingPreference.from(handlingPrefString);
-                    } catch (IllegalArgumentException e) {
-                        String message = "Invalid HTTP handling preference passed in header 'Prefer': '" + handlingPrefString + "'";
-                        if (handlingPref == HTTPHandlingPreference.STRICT) {
-                            throw new FHIRException(message + "; use 'strict' or 'lenient'.");
-                        } else {
-                            log.fine(message + "; using " + handlingPref.value() + ".");
-                        }
-                    }
-                }
-            }
-            FHIRRequestContext.get().setHandlingPreference(handlingPref);
+            HTTPHandlingPreference handlingPref = computeHandlingPref(request);
+            context.setHandlingPreference(handlingPref);
 
             // Set the return preference.
-            HTTPReturnPreference returnPref = defaultHttpReturnPref;
-            String returnPrefString = ((HttpServletRequest) request).getHeader(preferHeaderName + ":" + preferReturnHeaderSectionName);
-            if (returnPrefString != null && !returnPrefString.isEmpty()) {
-                try {
-                    returnPref = HTTPReturnPreference.from(returnPrefString);
-                } catch (IllegalArgumentException e) {
-                    String message = "Invalid HTTP return preference passed in header 'Prefer': '" + returnPrefString + "'";
-                    if (handlingPref == HTTPHandlingPreference.STRICT) {
-                        throw new FHIRException(message + "; use 'minimal', 'representation' or 'OperationOutcome'.");
-                    } else {
-                        log.fine(message + "; using " + returnPref.value() + ".");
-                    }
-                }
-            }
-            FHIRRequestContext.get().setReturnPreference(returnPref);
+            HTTPReturnPreference returnPref = computeReturnPref(request, handlingPref);
+            context.setReturnPreference(returnPref);
 
             // Pass the request through to the next filter in the chain.
             chain.doFilter(request, response);
-        } catch (FHIRException e) {
+        } catch (Exception e) {
             log.log(Level.INFO, "Error while setting request context or processing request", e);
             
             OperationOutcome outcome = FHIRUtil.buildOperationOutcome(e, IssueType.INVALID, IssueSeverity.FATAL, false);
@@ -206,6 +185,45 @@ public class FHIRRestServletFilter implements Filter {
         }
     }
 
+    private HTTPHandlingPreference computeHandlingPref(ServletRequest request) throws FHIRException {
+        HTTPHandlingPreference handlingPref = HTTPHandlingPreference.from(FHIRConfigHelper.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_HANDLING, "strict"));
+        boolean allowClientHandlingPref = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_ALLOW_CLIENT_HANDLING_PREF, true);
+        if (allowClientHandlingPref) {
+            String handlingPrefString = ((HttpServletRequest) request).getHeader(preferHeaderName + ":" + preferHandlingHeaderSectionName);
+            if (handlingPrefString != null && !handlingPrefString.isEmpty()) {
+                try {
+                    handlingPref = HTTPHandlingPreference.from(handlingPrefString);
+                } catch (IllegalArgumentException e) {
+                    String message = "Invalid HTTP handling preference passed in header 'Prefer': '" + handlingPrefString + "'";
+                    if (handlingPref == HTTPHandlingPreference.STRICT) {
+                        throw new FHIRException(message + "; use 'strict' or 'lenient'.");
+                    } else {
+                        log.fine(message + "; using " + handlingPref.value() + ".");
+                    }
+                }
+            }
+        }
+        return handlingPref;
+    }
+
+    private HTTPReturnPreference computeReturnPref(ServletRequest request, HTTPHandlingPreference handlingPref) throws FHIRException {
+        HTTPReturnPreference returnPref = defaultHttpReturnPref;
+        String returnPrefString = ((HttpServletRequest) request).getHeader(preferHeaderName + ":" + preferReturnHeaderSectionName);
+        if (returnPrefString != null && !returnPrefString.isEmpty()) {
+            try {
+                returnPref = HTTPReturnPreference.from(returnPrefString);
+            } catch (IllegalArgumentException e) {
+                String message = "Invalid HTTP return preference passed in header 'Prefer': '" + returnPrefString + "'";
+                if (handlingPref == HTTPHandlingPreference.STRICT) {
+                    throw new FHIRException(message + "; use 'minimal', 'representation' or 'OperationOutcome'.");
+                } else {
+                    log.fine(message + "; using " + returnPref.value() + ".");
+                }
+            }
+        }
+        return returnPref;
+    }
+
     private Format chooseResponseFormat(String acceptableContentTypes) {
         if (acceptableContentTypes.contains(com.ibm.fhir.core.FHIRMediaType.APPLICATION_FHIR_JSON) ||
                 acceptableContentTypes.contains(MediaType.APPLICATION_JSON)) {
@@ -248,53 +266,80 @@ public class FHIRRestServletFilter implements Filter {
     /**
      * Returns the full request URL (i.e. http://host:port/a/path?queryString) associated with the specified request.
      */
-    private String getRequestURL(ServletRequest request) {
-        String url = null;
-
-        if (request instanceof HttpServletRequest) {
-            HttpServletRequest httpRequest = (HttpServletRequest) request;
-            StringBuffer sb = httpRequest.getRequestURL();
-            String queryString = httpRequest.getQueryString();
-            if (queryString != null && !queryString.isEmpty()) {
-                sb.append("?");
-                sb.append(queryString);
-            }
-            url = sb.toString();
+    private String getRequestURL(HttpServletRequest request) {
+        StringBuffer sb = request.getRequestURL();
+        String queryString = request.getQueryString();
+        if (queryString != null && !queryString.isEmpty()) {
+            sb.append("?");
+            sb.append(queryString);
         }
-        return (url != null ? url : "<unknown>");
+        return sb.toString();
     }
 
-    /*
-     * (non-Javadoc)
-     * @see javax.servlet.Filter#destroy()
+    /**
+     * Get the original request URL from either the HttpServletRequest or a configured Header (in case of re-writing proxies).
+     *
+     * @param request
+     * @return String The complete request URI
      */
+    private String getOriginalRequestURI(HttpServletRequest request) {
+        String requestUri = null;
+        
+        // First, check the configured header for the original request URI (in case any proxies have overwritten the user-facing URL)
+        if (originalRequestUriHeaderName != null) {
+            requestUri = request.getHeader(originalRequestUriHeaderName);
+            if (requestUri != null && !requestUri.isEmpty()) {
+                // Try to parse it as a URI to ensure its valid
+                try {
+                    URI originalRequestUri = new URI(requestUri);
+                    // If its not absolute, then construct an absolute URI (or else JAX-RS will append the path to the current baseUri)
+                    if (!originalRequestUri.isAbsolute()) {
+                        requestUri = UriBuilder.fromUri(getRequestURL(request))
+                            .replacePath(originalRequestUri.getPath()).build().toString();
+                    }
+                } catch (Exception e) {
+                    log.log(Level.WARNING, "Error while computing the original request URI", e);
+                    requestUri = null;
+                }
+            }
+        }
+
+        // If there was no configured header or the header wasn't present, construct it from the HttpServletRequest
+        if (requestUri == null || requestUri.isEmpty()) {
+            StringBuilder requestUriBuilder = new StringBuilder(request.getRequestURL());
+            String queryString = request.getQueryString();
+            if (queryString != null && !queryString.isEmpty()) {
+                requestUriBuilder.append("?").append(queryString);
+            }
+            requestUri = requestUriBuilder.toString();
+        }
+        return requestUri;
+    }
+
     @Override
     public void destroy() {
         // Nothing to do here...
     }
 
-    /*
-     * (non-Javadoc)
-     * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)
-     */
     @Override
-    public void init(FilterConfig config) throws ServletException {
+    public void init(FilterConfig filterConfig) throws ServletException {
         try {
-            tenantIdHeaderName = 
-                    FHIRConfiguration.getInstance().loadConfiguration()
-                    .getStringProperty(FHIRConfiguration.PROPERTY_TENANT_ID_HEADER_NAME, FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME);
-
+            PropertyGroup config = FHIRConfiguration.getInstance().loadConfiguration();
+            
+            tenantIdHeaderName = config.getStringProperty(FHIRConfiguration.PROPERTY_TENANT_ID_HEADER_NAME,
+                    FHIRConfiguration.DEFAULT_TENANT_ID_HEADER_NAME);
             log.info("Configured tenant-id header name is: " +  tenantIdHeaderName);
 
-            datastoreIdHeaderName = 
-                    FHIRConfiguration.getInstance().loadConfiguration()
-                    .getStringProperty(FHIRConfiguration.PROPERTY_DATASTORE_ID_HEADER_NAME, FHIRConfiguration.DEFAULT_DATASTORE_ID_HEADER_NAME);
-
+            datastoreIdHeaderName = config.getStringProperty(FHIRConfiguration.PROPERTY_DATASTORE_ID_HEADER_NAME,
+                    FHIRConfiguration.DEFAULT_DATASTORE_ID_HEADER_NAME);
             log.info("Configured datastore-id header name is: " +  datastoreIdHeaderName);
-            
+
+            originalRequestUriHeaderName = config.getStringProperty(FHIRConfiguration.PROPERTY_ORIGINAL_REQUEST_URI_HEADER_NAME,
+                    null);
+            log.info("Configured original-request-uri header name is: " +  datastoreIdHeaderName);
+
             defaultTenantId = 
-                    FHIRConfiguration.getInstance().loadConfiguration()
-                    .getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID);
+                    config.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID);
             log.info("Configured default tenant-id value is: " +  defaultTenantId);
         } catch (Exception e) {
             throw new ServletException("Servlet filter initialization error.", e);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
@@ -184,7 +184,7 @@ public class FHIRServletContextListener implements ServletContextListener {
             // Set our "initComplete" flag back to false.
             event.getServletContext().setAttribute(FHIR_SERVER_INIT_COMPLETE, Boolean.FALSE);
 
-            // If we previously intialized the Kafka publisher, then shut it down now.
+            // If we previously initialized the Kafka publisher, then shut it down now.
             if (kafkaPublisher != null) {
                 kafkaPublisher.shutdown();
                 kafkaPublisher = null;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -1826,7 +1826,8 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIRSearchContext searchContext = null;
             if (queryParameters != null) {
-                searchContext = SearchUtil.parseQueryParameters(null, null, resourceType, queryParameters, httpServletRequest.getQueryString(), HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+                searchContext = SearchUtil.parseQueryParameters(null, null, resourceType, queryParameters, 
+                        HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
             }
 
             // Start a new txn in the persistence layer if one is not already active.
@@ -2138,8 +2139,8 @@ public class FHIRResource implements FHIRResourceHelpers {
                     new FHIRPersistenceEvent(contextResource, buildPersistenceEventProperties(type, null, null, requestProperties));
             getInterceptorMgr().fireBeforeSearchEvent(event);
 
-            FHIRSearchContext searchContext =
-                    SearchUtil.parseQueryParameters(compartment, compartmentId, resourceType, queryParameters, httpServletRequest.getQueryString(), HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+            FHIRSearchContext searchContext = SearchUtil.parseQueryParameters(compartment, compartmentId, resourceType, queryParameters,
+                    HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
 
             FHIRPersistenceContext persistenceContext =
                     FHIRPersistenceContextFactory.createPersistenceContext(event, searchContext);
@@ -3560,10 +3561,9 @@ public class FHIRResource implements FHIRResourceHelpers {
         }
     }
 
-    private synchronized CapabilityStatement getCapabilityStatement() throws Exception {
+    private synchronized CapabilityStatement getCapabilityStatement() throws FHIROperationException {
         try {
-            CapabilityStatement capability = buildCapabilityStatement();
-            return capability;
+            return buildCapabilityStatement();
         } catch (Throwable t) {
             String msg = "An error occurred while constructing the Conformance statement.";
             log.log(Level.SEVERE, msg, t);
@@ -4060,8 +4060,7 @@ public class FHIRResource implements FHIRResourceHelpers {
      * @throws FHIRPersistenceException
      */
     private Map<String, Object> buildPersistenceEventProperties(String type, String id,
-        String version, Map<String, String> requestProperties)
-        throws FHIRPersistenceException {
+            String version, Map<String, String> requestProperties) throws FHIRPersistenceException {
         Map<String, Object> props = new HashMap<>();
         props.put(FHIRPersistenceEvent.PROPNAME_PERSISTENCE_IMPL, getPersistenceImpl());
         props.put(FHIRPersistenceEvent.PROPNAME_URI_INFO, uriInfo);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -4091,38 +4091,7 @@ public class FHIRResource implements FHIRResourceHelpers {
      * @throws Exception if an error occurs while reading the config 
      */
     private String getRequestUri() throws Exception {
-        String requestUri = null;
-        
-        // First, check the configured header for the original request URI (in case any proxies have overwritten the user-facing URL)
-        String requestUriHeader = fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_ORIGINAL_REQUEST_URI_HEADER_NAME, null);
-        if (requestUriHeader != null) {
-            requestUri = httpServletRequest.getHeader(requestUriHeader);
-            if (requestUri != null && !requestUri.isEmpty()) {
-                // Try to parse it as a URI to ensure its valid
-                try {
-                    URI originalRequestUri = new URI(requestUri);
-                    // If its not absolute, then construct an absolute URI (or else JAX-RS will append the path to the current baseUri)
-                    if (!originalRequestUri.isAbsolute()) {
-                        requestUri = uriInfo.getBaseUriBuilder()
-                            .replacePath(originalRequestUri.getPath()).build().toString();
-                    }
-                } catch (Exception e) {
-                    log.log(Level.WARNING, "Error while computing the original request URI", e);
-                    requestUri = null;
-                }
-            }
-        }
-        
-        // If there was no configured header or the header wasn't present, construct it from the HttpServletRequest
-        if (requestUri == null || requestUri.isEmpty()) {
-            StringBuilder requestUriBuilder = new StringBuilder(httpServletRequest.getRequestURL());
-            String queryString = httpServletRequest.getQueryString();
-            if (queryString != null && !queryString.isEmpty()) {
-                requestUriBuilder.append("?").append(queryString);
-            }
-            requestUri = requestUriBuilder.toString();
-        }
-        return requestUri;
+        return FHIRRequestContext.get().getOriginalRequestUri();
     }
 
     /**


### PR DESCRIPTION
1. added originalRequestUri to FHIRRequestContext
2. set it from FHIRRestServletFilter
3. use it from FHIRResource
4. remove unused `queryString` parm from SearchUtil.parseQueryParameters


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>