### PR TITLE
remove erroneous log message for conditional update/patch

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -1413,7 +1413,7 @@ public class FHIRResource implements FHIRResourceHelpers {
                 } catch (Throwable t) {
                     String msg =
                             "An error occurred while performing the search for a conditional update/patch operation.";
-                    log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, t);
+                    log.log(Level.WARNING, msg, t);
                     throw new FHIROperationException(msg, t);
                 }
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -1413,7 +1413,6 @@ public class FHIRResource implements FHIRResourceHelpers {
                 } catch (Throwable t) {
                     String msg =
                             "An error occurred while performing the search for a conditional update/patch operation.";
-                    log.log(Level.WARNING, msg, t);
                     throw new FHIROperationException(msg, t);
                 }
 


### PR DESCRIPTION
I must've overwritten this error message with the "unable to audit" one by mistake...
but after looking at it a bit, I don't even think we want this log message, it already gets logged in the catch near the bottom of this method.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>