### PR TITLE
Issue #17 - Split JAX-RS methods from business logic and refactor exception handling

### DIFF
--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
@@ -69,22 +69,22 @@ public class WhcAuditCadfLogService implements AuditLogService {
     private boolean isEnabled = false;
 
     private static final Map<String, Action> fhir2CadfMap = new HashMap<String, Action>() {
-
         private static final long serialVersionUID = 1L;
         {
             put("C", Action.create);
-            put("D", Action.delete);
-            put("U", Action.update);
             put("R", Action.read);
+            put("U", Action.update);
+            put("D", Action.delete);
         }
     };
 
     // Initialize CADF OBSERVER resource object once
     private static CadfResource observerRsrc =
-            new CadfResource.Builder("fhir-server",
-                    ResourceType.compute_node)
+            new CadfResource.Builder("fhir-server", ResourceType.compute_node)
                             .geolocation(new CadfGeolocation.Builder(geoCity, geoState, geoCountry, null).build())
-                            .name("Fhir Audit").host(System.getenv("HOSTNAME")).build();
+                            .name("Fhir Audit")
+                            .host(System.getenv("HOSTNAME"))
+                            .build();
 
     public WhcAuditCadfLogService() {
         super();
@@ -96,7 +96,7 @@ public class WhcAuditCadfLogService implements AuditLogService {
         logger.entering(CLASSNAME, METHODNAME);
 
         // Check environment: EVENT_STREAMS_AUDIT_BINDING to obtain configuration parameters for
-        // kafka (Kub Container)
+        // kafka (Kubernetes Container)
         if (System.getenv(Environment.KUB_EVENTSTREAMS_BINDING) != null) {
             logger.log(Level.INFO, "Using env var " + Environment.KUB_EVENTSTREAMS_BINDING + " to find credentials.");
             EventStreamsCredentials credentials = Environment.getEventStreamsCredentials();
@@ -106,8 +106,7 @@ public class WhcAuditCadfLogService implements AuditLogService {
             }
         }
 
-        // If fails to get config from environment, then try to get them from FHIR
-        // config
+        // If fails to get config from environment, then try to get them from FHIR config
         if (bootstrapServers == null || bootstrapServers.length() < 10 || apiKey == null || apiKey.length() < 10) {
             Objects.requireNonNull(auditLogProperties, "Audit log properties cannot be null.");
             logger.log(Level.INFO, "Using FHIR config to find credentials.");
@@ -120,8 +119,7 @@ public class WhcAuditCadfLogService implements AuditLogService {
             throw new FHIRException("Can not get kafka settings!");
         }
 
-        // Now, let's get the audit topic from FHIR config, if not found, then use the
-        // default topic
+        // Now, let's get the audit topic from FHIR config, if not found, then use the default topic
         if (auditLogProperties != null) {
             auditTopic = auditLogProperties.getStringProperty(PROPERTY_AUDIT_KAFKA_TOPIC, DEFAULT_AUDIT_KAFKA_TOPIC);
             geoCity    = auditLogProperties.getStringProperty(PROPERTY_AUDIT_GEO_CITY, DEFAULT_AUDIT_GEO_CITY);
@@ -189,7 +187,6 @@ public class WhcAuditCadfLogService implements AuditLogService {
      * @return
      * @throws IllegalStateException
      * @throws IOException 
-     * @throws JsonProcessingException
      */
     public static CadfEvent createCadfEvent(AuditLogEntry logEntry)
             throws IllegalStateException, IOException {
@@ -231,7 +228,8 @@ public class WhcAuditCadfLogService implements AuditLogService {
             fhirContext.setLocation(logEntry.getLocation());
             fhirContext.setDescription(logEntry.getDescription());
 
-            if (logEntry.getContext().getStartTime().equalsIgnoreCase(logEntry.getContext().getEndTime())) {
+            if (logEntry.getContext().getEndTime() == null ||
+                    logEntry.getContext().getStartTime().equalsIgnoreCase(logEntry.getContext().getEndTime())) {
                 cadfEventOutCome = Outcome.pending;
             } else if (logEntry.getContext().getApiParameters().getStatus() < 400) {
                 cadfEventOutCome = Outcome.success;
@@ -239,17 +237,19 @@ public class WhcAuditCadfLogService implements AuditLogService {
                 cadfEventOutCome = Outcome.failure;
             }
 
-            event =
-                    new CadfEvent.Builder(
+            event = new CadfEvent.Builder(
                             logEntry.getContext().getRequestUniqueId() == null ? UUID.randomUUID().toString()
                                     : logEntry.getContext().getRequestUniqueId(),
-                            EventType.activity, logEntry.getTimestamp(),
-                            fhir2CadfMap.getOrDefault(logEntry.getContext().getAction(), Action.unknown),
-                            cadfEventOutCome).observer(observerRsrc).initiator(initiator)
-                                    .target(target).tag(logEntry.getCorrelationId())
-                                    .attachment(new CadfAttachment("application/json",
+                                    EventType.activity, logEntry.getTimestamp(),
+                                    fhir2CadfMap.getOrDefault(logEntry.getContext().getAction(), Action.unknown),
+                                    cadfEventOutCome)
+                            .observer(observerRsrc)
+                            .initiator(initiator)
+                            .target(target)
+                            .tag(logEntry.getCorrelationId())
+                            .attachment(new CadfAttachment("application/json",
                                             FHIRContext.FHIRWriter.generate(fhirContext)))
-                                    .build();
+                            .build();
         }
 
         logger.exiting(CLASSNAME, METHODNAME);

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
@@ -7,6 +7,8 @@
 package com.ibm.fhir.config;
 
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -33,6 +35,7 @@ public class FHIRRequestContext {
     private String dataStoreId;
     private String requestUniqueId;
     private String originalRequestUri;
+    private Map<String, List<String>> httpHeaders;
     
     // Default to the "strict" handling which means the server will reject unrecognized search parameters and elements
     private HTTPHandlingPreference handlingPreference = HTTPHandlingPreference.STRICT;
@@ -199,5 +202,19 @@ public class FHIRRequestContext {
      */
     public void setOriginalRequestUri(String originalRequestUri) {
         this.originalRequestUri = originalRequestUri;
+    }
+
+    /**
+     * @return the httpHeaders
+     */
+    public Map<String, List<String>> getHttpHeaders() {
+        return httpHeaders;
+    }
+
+    /**
+     * @param httpHeaders the httpHeaders to set
+     */
+    public void setHttpHeaders(Map<String, List<String>> httpHeaders) {
+        this.httpHeaders = httpHeaders;
     }
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -206,10 +206,9 @@ public class FHIRUtil {
      * Build an OperationOutcome for the specified exception.
      */
     public static OperationOutcome buildOperationOutcome(Exception exception, IssueType issueType, IssueSeverity severity,
-        boolean includeCausedByClauses) {
+            boolean includeCausedByClauses) {
         // First, build a set of exception messages to be included in the OperationOutcome.
-        // We'll include the exception message from each exception in the hierarchy,
-        // following the "causedBy" exceptions.
+        // We'll include the exception message from each exception in the hierarchy, following the "causedBy" exceptions.
         StringBuilder msgs = new StringBuilder();
         Throwable e = exception;
         String causedBy = "";
@@ -236,14 +235,17 @@ public class FHIRUtil {
      */
     public static OperationOutcome buildOperationOutcome(String message, IssueType issueType, IssueSeverity severity) {
         if (issueType == null) {
-            issueType = IssueType.PROCESSING;
+            issueType = IssueType.EXCEPTION;
         }
         if (severity == null) {
             severity = IssueSeverity.FATAL;
         }
         // Build an OperationOutcomeIssue that contains the exception messages.
-        OperationOutcome.Issue ooi =
-                OperationOutcome.Issue.builder().severity(severity).code(issueType).details(CodeableConcept.builder().text(string(message)).build()).build();
+        OperationOutcome.Issue ooi = OperationOutcome.Issue.builder()
+                .severity(severity)
+                .code(issueType)
+                .details(CodeableConcept.builder().text(string(message)).build())
+                .build();
 
         // Next, build the OperationOutcome.
         OperationOutcome oo = OperationOutcome.builder().issue(Collections.singletonList(ooi)).build();

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationEvent.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationEvent.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationEvent.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationEvent.java
@@ -6,8 +6,6 @@
 
 package com.ibm.fhir.notification;
 
-import javax.ws.rs.core.HttpHeaders;
-
 import com.ibm.fhir.model.resource.Resource;
 
 public class FHIRNotificationEvent {
@@ -16,7 +14,6 @@ public class FHIRNotificationEvent {
     private String operationType = null;
     private String resourceId = null;
     private Resource resource = null;
-    private HttpHeaders httpHeaders = null;
 
     public FHIRNotificationEvent() {
     }
@@ -61,7 +58,6 @@ public class FHIRNotificationEvent {
                 + ", resourceId=" + getResourceId()
                 + ", location=" + getLocation()
                 + ", lastUpdated=" + getLastUpdated()
-                + ", httpHeaders=" + getHttpHeaders()
                 + "]");
         return sb.toString();
     }
@@ -72,13 +68,5 @@ public class FHIRNotificationEvent {
 
     public void setResource(Resource resource) {
         this.resource = resource;
-    }
-
-    public HttpHeaders getHttpHeaders() {
-        return this.httpHeaders;
-    }
-
-    public void setHttpHeaders(HttpHeaders httpHeaders) {
-        this.httpHeaders = httpHeaders;
     }
 }

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationService.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationService.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationService.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/FHIRNotificationService.java
@@ -226,7 +226,6 @@ public class FHIRNotificationService implements FHIRPersistenceInterceptor {
             event.setLocation((String) pEvent.getProperty(FHIRPersistenceEvent.PROPNAME_RESOURCE_LOCATION_URI));
             event.setResourceId(resource.getId());
             event.setResource(resource);
-            event.setHttpHeaders(pEvent.getHttpHeaders());
 
             return event;
         } catch (Exception e) {

--- a/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/processor/DummyImportExportImplTest.java
+++ b/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/processor/DummyImportExportImplTest.java
@@ -295,7 +295,7 @@ public class DummyImportExportImplTest {
             }
 
             @Override
-            public Bundle doBundle(Resource bundle, Map<String, String> requestProperties) throws Exception {
+            public Bundle doBundle(Bundle bundle, Map<String, String> requestProperties) throws Exception {
                 return null;
             }
 

--- a/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -42,7 +42,7 @@ public class DocumentOperation extends AbstractOperation {
     @Override
     protected OperationDefinition buildOperationDefinition() {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream("document.json");){
-            return FHIRParser.parser(Format.JSON).parse(in);            
+            return FHIRParser.parser(Format.JSON).parse(in);
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -61,7 +61,7 @@ public class DocumentOperation extends AbstractOperation {
             
             composition = (Composition) resource;
             
-            Bundle bundle = buildDocument(operationContext, composition, resourceHelper);            
+            Bundle bundle = buildDocument(operationContext, composition, resourceHelper);
             Parameter persistParameter = getParameter(parameters, "persist");
             
             if (persistParameter != null) {

--- a/fhir-operation-healthcheck/src/main/java/com/ibm/fhir/operation/healthcheck/HealthcheckOperation.java
+++ b/fhir-operation-healthcheck/src/main/java/com/ibm/fhir/operation/healthcheck/HealthcheckOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-operation-healthcheck/src/main/java/com/ibm/fhir/operation/healthcheck/HealthcheckOperation.java
+++ b/fhir-operation-healthcheck/src/main/java/com/ibm/fhir/operation/healthcheck/HealthcheckOperation.java
@@ -32,7 +32,7 @@ public class HealthcheckOperation extends AbstractOperation {
     @Override
     protected OperationDefinition buildOperationDefinition() {
         try (InputStream in = getClass().getClassLoader().getResourceAsStream("healthcheck.json")) {
-            return FHIRParser.parser(Format.JSON).parse(in);            
+            return FHIRParser.parser(Format.JSON).parse(in);
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/fhir-operation/src/main/java/com/ibm/fhir/operation/context/FHIROperationContext.java
+++ b/fhir-operation/src/main/java/com/ibm/fhir/operation/context/FHIROperationContext.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-operation/src/main/java/com/ibm/fhir/operation/context/FHIROperationContext.java
+++ b/fhir-operation/src/main/java/com/ibm/fhir/operation/context/FHIROperationContext.java
@@ -29,13 +29,6 @@ public class FHIROperationContext {
     public static final String PROPNAME_LOCATION_URI = "LOCATION_URI";
     
     /**
-     * This property is of type FHIRResourceHelper and is the handle to the 
-     * FHIR REST API layer.   This interface provides methods to perform various
-     * operations on FHIR resources (e.g. create, update, read, etc.)
-     */
-    public static final String PROPNAME_RESOURCE_HELPER = "RESOURCE_HELPER";
-    
-    /**
      * This property is of type FHIRPersistence and is the handle to the persistence layer implementation
      * being used by the FHIR Server while processing the current request.
      * It is recommended that custom operation implementors use the RESOURCE_HELPER property instead of
@@ -106,9 +99,8 @@ public class FHIROperationContext {
     }
     
     /**
-     * Returns the HttpHeaders instance associated with the FHIR REST API request that triggered the
-     * interceptor invocation.
-     * Note that this HttpHeaders instance is only valid within the scope of the REST API request.
+     * Returns the HttpHeaders instance associated with the request that triggered the operation.
+     * Note that this HttpHeaders instance is only valid within the scope of a single request.
      */
     public HttpHeaders getHttpHeaders() {
         return (HttpHeaders) getProperty(PROPNAME_HTTP_HEADERS);

--- a/fhir-operation/src/main/java/com/ibm/fhir/rest/FHIRResourceHelpers.java
+++ b/fhir-operation/src/main/java/com/ibm/fhir/rest/FHIRResourceHelpers.java
@@ -141,7 +141,7 @@ public interface FHIRResourceHelpers {
      *            the request Bundle
      * @return the response Bundle
      */
-    public Bundle doBundle(Resource bundle, Map<String, String> requestProperties) throws Exception;
+    public Bundle doBundle(Bundle bundle, Map<String, String> requestProperties) throws Exception;
     
     public FHIRPersistenceTransaction getTransaction() throws Exception;
 }

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>javax.ws.rs</groupId>
                 <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cxf</groupId>

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/FHIRPersistenceEvent.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/FHIRPersistenceEvent.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/FHIRPersistenceEvent.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/FHIRPersistenceEvent.java
@@ -9,10 +9,6 @@ package com.ibm.fhir.persistence.interceptor;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.UriInfo;
-
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.persistence.FHIRPersistence;
@@ -21,45 +17,19 @@ import com.ibm.fhir.persistence.FHIRPersistence;
  * This class represents an event fired by the FHIR persistence interceptor framework.
  */
 public class FHIRPersistenceEvent {
-
-    /**
-     * This property is of type javax.ws.rs.core.UriInfo and contains Application and Request
-     * URI information associated with the REST API request for which the interceptor is being invoked.
-     */
-    public static final String PROPNAME_URI_INFO = "URI_INFO";
-    
     /**
      * This property is of type FHIRPersistence and is the handle to the persistence layer implementation
      * being used by the FHIR Server while processing the current request.
      * Persistence interceptors can use this handle to invoke persistence operations.
      */
     public static final String PROPNAME_PERSISTENCE_IMPL = "PERSISTENCE_IMPL";
-    
-    /**
-     * This property is of type javax.ws.rs.core.HttpHeaders and contains the set of HTTP headers
-     * associated with the REST API request for which the interceptor is being invoked.
-     */
-    public static final String PROPNAME_HTTP_HEADERS = "HTTP_HEADERS";
-    
-    /**
-     * This property is of type {@link java.util.Map<String,String> } and contains the
-     * set of additional request properties associated with the REST API request for which the interceptor 
-     * is being invoked.
-     */
-    public static final String PROPNAME_REQUEST_PROPERTIES = "REQUEST_PROPERTIES";
 
-    /**
-     * This property is of type javax.ws.rs.core.SecurityContext and contains security-related information
-     * associated with the REST API request for which the interceptor is being invoked.
-     */
-    public static final String PROPNAME_SECURITY_CONTEXT = "SECURITY_CONTEXT";
-    
     /**
      * This property is of type String and contains the location URI that can be used to 
      * retrieve the resource via a GET request.
      */
     public static final String PROPNAME_RESOURCE_LOCATION_URI = "LOCATION_URI";
-    
+
     /**
      * This property is of type String and contains the resource type associated with a
      * create, update, read, vread, history, search, or delete operation.
@@ -194,42 +164,6 @@ public class FHIRPersistenceEvent {
     }
     
     /**
-     * Returns the HttpHeaders instance associated with the FHIR REST API request that triggered the
-     * interceptor invocation.
-     * Note that this HttpHeaders instance is only valid within the scope of the REST API request.
-     */
-    public HttpHeaders getHttpHeaders() {
-        return (HttpHeaders) getProperty(PROPNAME_HTTP_HEADERS);
-    }
-    
-    /**
-     * Returns the Map containing additional request properties associated with the 
-     * FHIR REST API request that triggered the interceptor invocation.
-     */
-    @SuppressWarnings("unchecked")
-    public Map<String, String> getRequestProperties() {
-        return (Map<String, String>) getProperty(PROPNAME_REQUEST_PROPERTIES);
-    }
-   
-    /**
-     * Returns the SecurityContext instance associated with the FHIR REST API request that triggered the
-     * interceptor invocation.
-     * Note that this SecurityContext instance is only valid within the scope of the REST API request.
-     */
-    public SecurityContext getSecurityContext() {
-        return (SecurityContext) getProperty(PROPNAME_SECURITY_CONTEXT);
-    }
-    
-    /**
-     * Returns the UriInfo instance associated with the FHIR REST API request that triggered the
-     * interceptor invocation.  
-     * Note that this UriInfo instance is only valid within the scope of the REST API request.
-     */
-    public UriInfo getUriInfo() {
-        return (UriInfo) getProperty(PROPNAME_URI_INFO);
-    }
-    
-    /**
      * Returns the FHIRPersistence instance currently being used by the FHIR REST API layer
      * to process the current request.
      */
@@ -246,7 +180,7 @@ public class FHIRPersistenceEvent {
     }
     
     /**
-     * Retrieves the set of properties associated with the FHIR REST API request that triggered
+     * Retrieves the set of properties associated with the event that triggered
      * the interceptor invocation.
      */
     public Map<String, Object> getProperties() {
@@ -254,23 +188,5 @@ public class FHIRPersistenceEvent {
             properties = new HashMap<String, Object>();
         }
         return properties;
-    }
-    
-    /**
-     * Retrieves the specified header from the combined list of request headers
-     * and additional request properties associated with the request.
-     * @param headerName the name of the header to retrieve
-     * @return the value of the request header or null if not present
-     */
-    public String getHeaderString(String headerName) {
-        String value = null;
-        Map<String, String> props = getRequestProperties();
-        if (props != null) {
-            value = props.get(headerName);
-        }
-        if (value == null && getHttpHeaders() != null) {
-            value = getHttpHeaders().getHeaderString(headerName);
-        }
-        return value;
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
@@ -32,10 +32,6 @@ public class FHIRPersistenceEventTest {
         assertNull(pe.getFhirResourceId());
         assertNull(pe.getFhirVersionId());
         assertFalse(pe.isStandardResourceType());
-        assertNull(pe.getHttpHeaders());
-        assertNull(pe.getRequestProperties());
-        assertNull(pe.getSecurityContext());
-        assertNull(pe.getUriInfo());
         assertNull(pe.getPersistenceImpl());
     }
     
@@ -70,21 +66,5 @@ public class FHIRPersistenceEventTest {
         assertEquals("id1", pe.getFhirResourceId());
         assertEquals("v1", pe.getFhirVersionId());
         
-    }
-    
-    @Test
-    public void testGetHeaderString() throws Exception {
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
-        Map<String, Object> properties = new HashMap<>();
-        
-        Map<String, String> reqProps = new HashMap<String, String>();
-        reqProps.put("X-Custom-Header", "value1");
-        
-        properties.put(FHIRPersistenceEvent.PROPNAME_REQUEST_PROPERTIES, reqProps);
-        
-        FHIRPersistenceEvent pe = new FHIRPersistenceEvent(patient, properties);
-        
-        assertEquals("value1", pe.getHeaderString("X-Custom-Header"));
-        assertNull(pe.getHeaderString("X-Fake-Header"));
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/exception/SearchExceptionUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/exception/SearchExceptionUtil.java
@@ -19,7 +19,6 @@ public class SearchExceptionUtil {
     private static final String ILLEGAL_ARGUMENT_EXCEPTION = "No constant with value '%s' found.";
     private static final String PARSE_PARAMETER_EXCEPTION = "An error occurred while parsing parameter '%s'.";
     private static final String CHAINED_PARAMETER_EXCEPTION = "Unable to parse chained parameter: '%s'";
-    private static final String GET_SEARCH_FAILED = "Unable to process getSearch ";
     private static final String BADFORMAT_EXCEPTION = "Invalid Date Time Format found please use 'yyyy-mm-ddThh:mm:ss[Z|(+|-)hh:mm].'";
     
     private SearchExceptionUtil() {
@@ -45,7 +44,9 @@ public class SearchExceptionUtil {
      * @return
      */
     public static FHIRSearchException buildNewParseParameterException(final String name, Exception e) {
-        return new FHIRSearchException(String.format(PARSE_PARAMETER_EXCEPTION, name), e);
+        String msg = String.format(PARSE_PARAMETER_EXCEPTION, name);
+        OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.INVALID);
+        return new FHIRSearchException(msg, e).withIssue(ooi);
     }
 
     /**
@@ -56,7 +57,9 @@ public class SearchExceptionUtil {
      * @return
      */
     public static FHIRSearchException buildNewChainedParameterException(final String name, Exception e) {
-        return new FHIRSearchException(String.format(CHAINED_PARAMETER_EXCEPTION, name), e);
+        String msg = String.format(CHAINED_PARAMETER_EXCEPTION, name);
+        OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.INVALID);
+        return new FHIRSearchException(msg, e).withIssue(ooi);
     }
 
     /**
@@ -79,21 +82,13 @@ public class SearchExceptionUtil {
     }
     
     /**
-     * builds a fhir search exception. 
-     * 
-     * @param e
-     * @return
-     */
-    public static FHIRSearchException buildNewFHIRSearchExecption(Exception e) {
-        return new FHIRSearchException(GET_SEARCH_FAILED, e);
-    }
-    
-    /**
      * build data time format exception
+     * 
      * @param exception e
      * @return
      */
     public static FHIRSearchException buildNewDateTimeFormatException(Exception e) {
-        return new FHIRSearchException(BADFORMAT_EXCEPTION, e);
+        OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue(BADFORMAT_EXCEPTION, IssueType.INVALID);
+        return new FHIRSearchException(BADFORMAT_EXCEPTION, e).withIssue(ooi);
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -166,7 +166,7 @@ public final class ParametersUtil {
         // Code is the code used in the URL or the parameter name in a parameters resource for this search parameter.
         // @see https://www.hl7.org/fhir/searchparameter-definitions.html#SearchParameter.code
 
-        if (code != null && name != null && code.compareTo(name) != 0 && log.isLoggable(Level.WARNING)) {
+        if (code != null && name != null && !code.equals(name) && log.isLoggable(Level.WARNING)) {
             // Note, this is conditionally output, while the code assist complains it is not.
             log.warning(String.format(NO_MATCH_ON_NAME_CODE, code, name));
         }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -370,8 +370,7 @@ public class SearchUtil {
 
     /**
      * Returns the SearchParameter map (keyed by resource type) for the specified
-     * tenant-id. If , or null if there are
-     * no SearchParameters for the tenant.
+     * tenant-id, or null if there are no SearchParameters for the tenant.
      *
      * @param tenantId
      *                 the tenant-id whose SearchParameters should be returned.

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRHealthcheckOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRHealthcheckOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 
-public class FHIRHealthcheckOperationTest extends FHIRServerTestBase {    
+public class FHIRHealthcheckOperationTest extends FHIRServerTestBase {
     @Test
     public void testHealthcheck() {
         WebTarget target = getWebTarget();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRHealthcheckOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRHealthcheckOperationTest.java
@@ -18,7 +18,7 @@ import com.ibm.fhir.model.type.code.IssueSeverity;
 
 public class FHIRHealthcheckOperationTest extends FHIRServerTestBase {    
     @Test
-    public void testHealthcheck() {        
+    public void testHealthcheck() {
         WebTarget target = getWebTarget();
         Response response = target.path("$healthcheck").request().get(Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
@@ -778,5 +778,4 @@ public class ServerSpecTest extends FHIRServerTestBase {
         assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), 
                 "An error occurred while parsing parameter '_summary'");
     }
- 
 }

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -170,7 +170,7 @@
         <jdbcDriver libraryRef="derbyLib"/>
         <properties.derby.embedded createDatabase="create" databaseName="derby/oauth2db"/>
     </dataSource>
-    -->    
+    -->
      
     <!-- DB2-related configuration
     <library id="db2Lib">

--- a/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
@@ -16,7 +16,17 @@ import javax.ws.rs.core.Application;
 import com.ibm.fhir.provider.FHIRJsonPatchProvider;
 import com.ibm.fhir.provider.FHIRJsonProvider;
 import com.ibm.fhir.provider.FHIRProvider;
-import com.ibm.fhir.server.resources.FHIRResource;
+import com.ibm.fhir.server.resources.Batch;
+import com.ibm.fhir.server.resources.Capabilities;
+import com.ibm.fhir.server.resources.Create;
+import com.ibm.fhir.server.resources.Delete;
+import com.ibm.fhir.server.resources.History;
+import com.ibm.fhir.server.resources.Operation;
+import com.ibm.fhir.server.resources.Patch;
+import com.ibm.fhir.server.resources.Read;
+import com.ibm.fhir.server.resources.Search;
+import com.ibm.fhir.server.resources.Update;
+import com.ibm.fhir.server.resources.VRead;
 
 public class FHIRApplication extends Application {
     private static final Logger log = Logger.getLogger(FHIRApplication.class.getName());
@@ -39,7 +49,17 @@ public class FHIRApplication extends Application {
         try {
             if (classes == null) {
                 classes = new HashSet<Class<?>>();
-                classes.add(FHIRResource.class);
+                classes.add(Batch.class);
+                classes.add(Capabilities.class);
+                classes.add(Create.class);
+                classes.add(Delete.class);
+                classes.add(History.class);
+                classes.add(Operation.class);
+                classes.add(Patch.class);
+                classes.add(Read.class);
+                classes.add(Search.class);
+                classes.add(Update.class);
+                classes.add(VRead.class);
             }
             return classes;
         } finally {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
@@ -9,6 +9,10 @@ package com.ibm.fhir.server.filter.rest;
 import java.io.IOException;
 import java.net.URI;
 import java.security.Principal;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -126,6 +130,10 @@ public class FHIRRestServletFilter extends HttpFilter {
             HTTPReturnPreference returnPref = computeReturnPref(request, handlingPref);
             context.setReturnPreference(returnPref);
 
+            // Set the request headers.
+            Map<String, List<String>> requestHeaders = extractRequestHeaders(request);
+            context.setHttpHeaders(requestHeaders);
+
             // Pass the request through to the next filter in the chain.
             chain.doFilter(request, response);
         } catch (Exception e) {
@@ -183,6 +191,21 @@ public class FHIRRestServletFilter extends HttpFilter {
                 log.exiting(this.getClass().getName(), "doFilter");
             }
         }
+    }
+
+    /**
+     * @return a map of HTTP request headers, keyed by header name
+     */
+    private Map<String, List<String>> extractRequestHeaders(HttpServletRequest request) {
+        // Uses LinkedHashMap just to preserve the order.
+        Map<String, List<String>> requestHeaders = new LinkedHashMap<String, List<String>>();
+
+        List<String> headerNames = Collections.list(request.getHeaderNames());
+        for (String headerName : headerNames) {
+            requestHeaders.put(headerName, Collections.list(request.getHeaders(headerName)));
+        }
+
+        return requestHeaders;
     }
 
     private HTTPHandlingPreference computeHandlingPref(ServletRequest request) throws FHIRException {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Batch extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Batch.class.getName());
+
+    public Batch() throws Exception {
+        super();
+    }
+
+    @POST
+    public Response bundle(Resource resource) {
+        log.entering(this.getClass().getName(), "bundle(Bundle)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        Bundle responseBundle = null;
+
+        try {
+            checkInitComplete();
+
+            Bundle inputBundle = null;
+            if (resource instanceof Bundle) {
+                inputBundle = (Bundle) resource;
+            } else {
+                String msg = "A 'Bundle' resource type is required but a '"
+                        + resource.getClass().getSimpleName() + "' resource type was sent.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            responseBundle = helper.doBundle(inputBundle, null);
+            status = Status.OK;
+            return Response.ok(responseBundle).build();
+        } catch (FHIRRestBundledRequestException e) {
+            Response exceptionResponse = exceptionResponse(e);
+            status = Response.Status.fromStatusCode(exceptionResponse.getStatus());
+            return exceptionResponse;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logBundle(httpServletRequest, responseBundle, startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "bundle(Bundle)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -1,0 +1,356 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_AUTHURL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_REGURL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_TOKENURL;
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.PropertyGroup;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.resource.CapabilityStatement.Rest;
+import com.ibm.fhir.model.resource.CapabilityStatement.Rest.Resource.Interaction;
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.Markdown;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.Url;
+import com.ibm.fhir.model.type.code.CapabilityStatementKind;
+import com.ibm.fhir.model.type.code.ConditionalDeleteStatus;
+import com.ibm.fhir.model.type.code.ConditionalReadStatus;
+import com.ibm.fhir.model.type.code.FHIRVersion;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.model.type.code.PublicationStatus;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.model.type.code.RestfulCapabilityMode;
+import com.ibm.fhir.model.type.code.SystemRestfulInteraction;
+import com.ibm.fhir.model.type.code.TypeRestfulInteraction;
+import com.ibm.fhir.search.util.SearchUtil;
+import com.ibm.fhir.server.FHIRBuildIdentifier;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Capabilities extends FHIRResource {
+    private static final Logger log =
+            java.util.logging.Logger.getLogger(Capabilities.class.getName());
+
+    public Capabilities() throws Exception {
+        super();
+    }
+
+    private static final String FHIR_SERVER_NAME = "IBM FHIR Server";
+    private static final String FHIR_COPYRIGHT = "(C) Copyright IBM Corporation 2016, 2020";
+    private static final String EXTENSION_URL = "http://ibm.com/fhir/extension";
+
+    @GET
+    @Path("metadata")
+    public Response capabilities() throws ClassNotFoundException {
+        log.entering(this.getClass().getName(), "metadata()");
+        Date startTime = new Date();
+        String errMsg = "Caught exception while processing 'metadata' request.";
+
+        try {
+            checkInitComplete();
+
+            CapabilityStatement capabilityStatement = getCapabilityStatement();
+            RestAuditLogger.logMetadata(httpServletRequest, startTime, new Date(), Response.Status.OK);
+
+            return Response.ok().entity(capabilityStatement).build();
+        } catch (FHIROperationException e) {
+            log.log(Level.SEVERE, errMsg, e);
+            return exceptionResponse(e, issueListToStatus(e.getIssues()));
+        } catch (Exception e) {
+            log.log(Level.SEVERE, errMsg, e);
+            return exceptionResponse(e, Response.Status.INTERNAL_SERVER_ERROR);
+        } finally {
+            log.exiting(this.getClass().getName(), "metadata()");
+        }
+    }
+
+    private synchronized CapabilityStatement getCapabilityStatement() throws FHIROperationException {
+        try {
+            return buildCapabilityStatement();
+        } catch (Throwable t) {
+            String msg = "An error occurred while constructing the Conformance statement.";
+            log.log(Level.SEVERE, msg, t);
+            throw buildRestException(msg, IssueType.EXCEPTION);
+        }
+    }
+
+    /**
+     * Builds a CapabilityStatement resource instance which describes this server.
+     *
+     * @throws Exception
+     */
+    private CapabilityStatement buildCapabilityStatement() throws Exception {
+        // Build the list of interactions that are supported for each resource type.
+
+        List<Rest.Resource.Interaction> interactions = new ArrayList<>();
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.CREATE));
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.UPDATE));
+        if (isDeleteSupported()) {
+            interactions.add(buildInteractionStatement(TypeRestfulInteraction.DELETE));
+        }
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.READ));
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.VREAD));
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.HISTORY_INSTANCE));
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.SEARCH_TYPE));
+        interactions.add(buildInteractionStatement(TypeRestfulInteraction.PATCH));
+
+        // Build the list of supported resources.
+        List<Rest.Resource> resources = new ArrayList<>();
+        ResourceType.ValueSet[] resourceTypes = ResourceType.ValueSet.values();
+        for (ResourceType.ValueSet resourceType : resourceTypes) {
+            String resourceTypeName = resourceType.value();
+            // Build the set of ConformanceSearchParams for this resource type.
+            List<Rest.Resource.SearchParam> conformanceSearchParams = new ArrayList<>();
+            List<SearchParameter> searchParameters = SearchUtil.getSearchParameters(resourceTypeName);
+            if (searchParameters != null) {
+                for (SearchParameter searchParameter : searchParameters) {
+                    // The name here is a natural language name, and intentionally not replaced with code.
+                    Rest.Resource.SearchParam.Builder conformanceSearchParamBuilder =
+                            Rest.Resource.SearchParam.builder()
+                                .name(searchParameter.getName())
+                                .type(searchParameter.getType());
+                    if (searchParameter.getDescription() != null) {
+                        conformanceSearchParamBuilder.documentation(searchParameter.getDescription());
+                    }
+
+                    Rest.Resource.SearchParam conformanceSearchParam =
+                            conformanceSearchParamBuilder.build();
+                    conformanceSearchParams.add(conformanceSearchParam);
+                }
+            }
+
+            // Build the ConformanceResource for this resource type.
+            Rest.Resource cr = Rest.Resource.builder()
+                    .type(ResourceType.of(resourceType))
+                    .profile(Canonical.of("http://hl7.org/fhir/profiles/" + resourceTypeName))
+                    .interaction(interactions)
+                    .conditionalCreate(com.ibm.fhir.model.type.Boolean.of(true))
+                    .conditionalUpdate(com.ibm.fhir.model.type.Boolean.of(true))
+                    .updateCreate(com.ibm.fhir.model.type.Boolean.of(isUpdateCreateEnabled()))
+                    .conditionalDelete(ConditionalDeleteStatus.SINGLE)
+                    .conditionalRead(ConditionalReadStatus.FULL_SUPPORT)
+                    .searchParam(conformanceSearchParams)
+                    .build();
+
+            resources.add(cr);
+        }
+
+        // Determine if transactions are supported for this FHIR Server configuration.
+        SystemRestfulInteraction transactionMode = SystemRestfulInteraction.BATCH;
+        try {
+            boolean txnSupported = getPersistenceImpl().isTransactional();
+            transactionMode = (txnSupported ? SystemRestfulInteraction.TRANSACTION
+                    : SystemRestfulInteraction.BATCH);
+        } catch (Throwable t) {
+            log.log(Level.WARNING, "Unexcepted error while reading server transaction mode setting", t);
+        }
+
+        String actualHost = new URI(getRequestUri()).getHost();
+
+        String regURLTemplate = null;
+        String authURLTemplate = null;
+        String tokenURLTemplate = null;
+        try {
+            regURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_REGURL, "");
+            authURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_AUTHURL, "");
+            tokenURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_TOKENURL, "");
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "An error occurred while adding OAuth URLs to the conformance statement", e);
+        }
+        String tokenURL = tokenURLTemplate.replaceAll("<host>", actualHost);
+
+        String authURL = authURLTemplate.replaceAll("<host>", actualHost);
+
+        String regURL = regURLTemplate.replaceAll("<host>", actualHost);
+
+        CapabilityStatement.Rest.Security restSecurity = CapabilityStatement.Rest.Security.builder()
+                .service(CodeableConcept.builder()
+                    .coding(Coding.builder()
+                        .code(Code.of("SMART-on-FHIR"))
+                        .system(Uri.of("http://terminology.hl7.org/CodeSystem/restful-security-service"))
+                        .build())
+                    .text(string("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"))
+                    .build())
+                .extension(Extension.builder()
+                    .url("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris")
+                    .extension(
+                        Extension.builder().url("token").value(Url.of(tokenURL)).build(),
+                        Extension.builder().url("authorize").value(Url.of(authURL)).build(),
+                        Extension.builder().url("register").value(Url.of(regURL)).build())
+                    .build())
+                .build();
+
+        CapabilityStatement.Rest rest = CapabilityStatement.Rest.builder()
+                .mode(RestfulCapabilityMode.SERVER)
+                .security(restSecurity)
+                .resource(resources)
+                .interaction(CapabilityStatement.Rest.Interaction.builder()
+                    .code(transactionMode)
+                    .build())
+                .build();
+
+        FHIRBuildIdentifier buildInfo = new FHIRBuildIdentifier();
+        String buildDescription = FHIR_SERVER_NAME + " version " + buildInfo.getBuildVersion()
+                + " build id " + buildInfo.getBuildId() + "";
+
+        List<Code> format = new ArrayList<Code>();
+        format.add(Code.of(Format.JSON.toString().toLowerCase()));
+        format.add(Code.of(Format.XML.toString().toLowerCase()));
+        format.add(Code.of(FHIRMediaType.APPLICATION_JSON));
+        format.add(Code.of(FHIRMediaType.APPLICATION_FHIR_JSON));
+        format.add(Code.of(FHIRMediaType.APPLICATION_XML));
+        format.add(Code.of(FHIRMediaType.APPLICATION_FHIR_XML));
+
+        // Finally, create the CapabilityStatement resource itself.
+        CapabilityStatement conformance = CapabilityStatement.builder()
+                .status(PublicationStatus.ACTIVE)
+                .date(DateTime.of(ZonedDateTime.now(ZoneOffset.UTC)))
+                .kind(CapabilityStatementKind.CAPABILITY)
+                .fhirVersion(FHIRVersion.VERSION_4_0_1)
+                .format(format)
+                .patchFormat(Code.of(FHIRMediaType.APPLICATION_JSON_PATCH),
+                             Code.of(FHIRMediaType.APPLICATION_FHIR_JSON),
+                             Code.of(FHIRMediaType.APPLICATION_FHIR_XML))
+                .version(string(buildInfo.getBuildVersion()))
+                .name(string(FHIR_SERVER_NAME))
+                .description(Markdown.of(buildDescription))
+                .copyright(Markdown.of(FHIR_COPYRIGHT))
+                .publisher(string("IBM Corporation"))
+                .software(CapabilityStatement.Software.builder()
+                          .name(string(FHIR_SERVER_NAME))
+                          .version(string(buildInfo.getBuildVersion()))
+                          .id(buildInfo.getBuildId())
+                          .build())
+                .rest(rest)
+                .build();
+
+        try {
+            conformance = addExtensionElements(conformance);
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "An error occurred while adding extension elements to the conformance statement", e);
+        }
+
+        return conformance;
+    }
+
+    private CapabilityStatement addExtensionElements(CapabilityStatement capabilityStatement)
+        throws Exception {
+        List<Extension> extentions = new ArrayList<Extension>();
+        Extension extension = Extension.builder()
+                .url(EXTENSION_URL + "/defaultTenantId")
+                .value(string(fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID)))
+                .build();
+        extentions.add(extension);
+
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/websocketNotificationsEnabled")
+                .value(com.ibm.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_WEBSOCKET_ENABLED, Boolean.FALSE)))
+                .build();
+        extentions.add(extension);
+
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/kafkaNotificationsEnabled")
+                .value(com.ibm.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_ENABLED, Boolean.FALSE)))
+                .build();
+        extentions.add(extension);
+
+        String notificationResourceTypes = getNotificationResourceTypes();
+        if ("".equals(notificationResourceTypes)) {
+            notificationResourceTypes = "<not specified - all resource types>";
+        }
+
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/notificationResourceTypes")
+                .value(string(notificationResourceTypes))
+                .build();
+        extentions.add(extension);
+
+        String auditLogServiceName =
+                fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_AUDIT_SERVICE_CLASS_NAME);
+
+        if (auditLogServiceName == null || "".equals(auditLogServiceName)) {
+            auditLogServiceName = "<not specified>";
+        } else {
+            int lastDelimeter = auditLogServiceName.lastIndexOf(".");
+            auditLogServiceName = auditLogServiceName.substring(lastDelimeter + 1);
+        }
+
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/auditLogServiceName")
+                .value(string(auditLogServiceName))
+                .build();
+        extentions.add(extension);
+
+        PropertyGroup auditLogProperties =
+                fhirConfig.getPropertyGroup(FHIRConfiguration.PROPERTY_AUDIT_SERVICE_PROPERTIES);
+        String auditLogPropertiesString =
+                auditLogProperties != null ? auditLogProperties.toString() : "<not specified>";
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/auditLogProperties")
+                .value(string(auditLogPropertiesString))
+                .build();
+        extentions.add(extension);
+
+        extension = Extension.builder()
+                .url(EXTENSION_URL + "/persistenceType")
+                .value(string(getPersistenceImpl().getClass().getSimpleName()))
+                .build();
+        extentions.add(extension);
+
+        return capabilityStatement.toBuilder().extension(extentions).build();
+
+    }
+
+    private String getNotificationResourceTypes() throws Exception {
+        Object[] notificationResourceTypes =
+                fhirConfig.getArrayProperty(FHIRConfiguration.PROPERTY_NOTIFICATION_RESOURCE_TYPES);
+        if (notificationResourceTypes == null) {
+            notificationResourceTypes = new Object[0];
+        }
+        return Arrays.asList(notificationResourceTypes).toString().replace("[", "").replace("]", "").replace(" ", "");
+    }
+
+    private Interaction buildInteractionStatement(TypeRestfulInteraction value) {
+        Interaction ci = Interaction.builder().code(value).build();
+        return ci;
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -1,0 +1,95 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.core.HTTPReturnPreference;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Create extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Create.class.getName());
+
+    public Create() throws Exception {
+        super();
+    }
+
+    @POST
+    @Path("{type}")
+    public Response create(@PathParam("type") String type, Resource resource) {
+        log.entering(this.getClass().getName(), "create(String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            String ifNoneExist = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_EXIST);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doCreate(type, resource, ifNoneExist, null);
+
+            ResponseBuilder response =
+                    Response.created(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+            resource = ior.getResource();
+
+            HTTPReturnPreference returnPreference = FHIRRequestContext.get().getReturnPreference();
+            if (resource != null && HTTPReturnPreference.REPRESENTATION == returnPreference) {
+                response.entity(resource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == returnPreference) {
+                response.entity(ior.getOperationOutcome());
+            }
+            response = addHeaders(response, resource);
+            status = ior.getStatus();
+            response.status(status);
+
+            return response.build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logCreate(httpServletRequest,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "create(String,Resource)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Delete extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Delete.class.getName());
+
+    public Delete() throws Exception {
+        super();
+    }
+
+    @DELETE
+    @Path("{type}/{id}")
+    public Response delete(@PathParam("type") String type, @PathParam("id") String id) throws Exception {
+        log.entering(this.getClass().getName(), "delete(String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doDelete(type, id, null, null);
+
+            status = Status.NO_CONTENT;
+            ResponseBuilder response = Response.noContent();
+
+            if (ior.getResource() != null) {
+                response = addHeaders(response, ior.getResource());
+            }
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            // Overwrite the exception response status because we want NOT_FOUND to be success for delete
+            status = Status.OK;
+            return exceptionResponse(e, status);
+        } catch (FHIRPersistenceNotSupportedException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logDelete(httpServletRequest,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "delete(String,String)");
+        }
+    }
+
+    @DELETE
+    @Path("{type}")
+    public Response conditionalDelete(@PathParam("type") String type) throws Exception {
+        log.entering(this.getClass().getName(), "conditionalDelete(String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            String searchQueryString = httpServletRequest.getQueryString();
+            if (searchQueryString == null || searchQueryString.isEmpty()) {
+                String msg =
+                        "A search query string is required for a conditional delete operation.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doDelete(type, null, searchQueryString, null);
+            status = ior.getStatus();
+            ResponseBuilder response = Response.status(status);
+            if (ior.getOperationOutcome() != null) {
+                response.entity(ior.getOperationOutcome());
+            }
+            if (ior.getResource() != null) {
+                response = addHeaders(response, ior.getResource());
+            }
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            // Return 200 instead of 404 to pass TouchStone test
+            status = Status.OK;
+            return exceptionResponse(e, status);
+        } catch (FHIRPersistenceNotSupportedException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logDelete(httpServletRequest,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "conditionalDelete(String)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -11,11 +11,6 @@ import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_REGURL;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_TOKENURL;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_UPDATE_CREATE_ENABLED;
 import static com.ibm.fhir.model.type.String.string;
-import static com.ibm.fhir.model.util.ModelSupport.getResourceType;
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_GONE;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
 
 import java.io.StringWriter;
 import java.net.URI;
@@ -30,17 +25,10 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.json.JsonArray;
 import javax.json.JsonPatch;
@@ -66,15 +54,11 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
-import org.owasp.encoder.Encode;
-
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.core.HTTPHandlingPreference;
 import com.ibm.fhir.core.HTTPReturnPreference;
-import com.ibm.fhir.core.context.FHIRPagingContext;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
@@ -96,15 +80,12 @@ import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.Markdown;
-import com.ibm.fhir.model.type.UnsignedInt;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.Url;
-import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.CapabilityStatementKind;
 import com.ibm.fhir.model.type.code.ConditionalDeleteStatus;
 import com.ibm.fhir.model.type.code.ConditionalReadStatus;
 import com.ibm.fhir.model.type.code.FHIRVersion;
-import com.ibm.fhir.model.type.code.HTTPVerb;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.PublicationStatus;
@@ -113,51 +94,30 @@ import com.ibm.fhir.model.type.code.RestfulCapabilityMode;
 import com.ibm.fhir.model.type.code.SystemRestfulInteraction;
 import com.ibm.fhir.model.type.code.TypeRestfulInteraction;
 import com.ibm.fhir.model.util.FHIRUtil;
-import com.ibm.fhir.model.util.ModelSupport;
-import com.ibm.fhir.model.util.ReferenceMappingVisitor;
-import com.ibm.fhir.operation.FHIROperation;
 import com.ibm.fhir.operation.context.FHIROperationContext;
-import com.ibm.fhir.operation.registry.FHIROperationRegistry;
-import com.ibm.fhir.operation.util.FHIROperationUtil;
 import com.ibm.fhir.path.patch.FHIRPathPatch;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
-import com.ibm.fhir.persistence.context.FHIRHistoryContext;
-import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
-import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
-import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
 import com.ibm.fhir.persistence.helper.PersistenceHelper;
-import com.ibm.fhir.persistence.interceptor.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.interceptor.impl.FHIRPersistenceInterceptorMgr;
-import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
-import com.ibm.fhir.rest.FHIRResourceHelpers;
 import com.ibm.fhir.rest.FHIRRestOperationResponse;
-import com.ibm.fhir.search.SearchConstants;
-import com.ibm.fhir.search.SummaryValueSet;
-import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.util.SearchUtil;
 import com.ibm.fhir.server.FHIRBuildIdentifier;
 import com.ibm.fhir.server.annotation.PATCH;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
-import com.ibm.fhir.server.helper.FHIRUrlParser;
 import com.ibm.fhir.server.listener.FHIRServletContextListener;
 import com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper;
 import com.ibm.fhir.server.util.RestAuditLogger;
-import com.ibm.fhir.validation.FHIRValidator;
-import com.ibm.fhir.validation.exception.FHIRValidationException;
 
 @Path("/")
 @Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
-public class FHIRResource implements FHIRResourceHelpers {
+public class FHIRResource {
     private static final Logger log =
             java.util.logging.Logger.getLogger(FHIRResource.class.getName());
 
@@ -165,7 +125,6 @@ public class FHIRResource implements FHIRResourceHelpers {
     private static final String FHIR_COPYRIGHT = "(C) Copyright IBM Corporation 2016, 2020";
     private static final String EXTENSION_URL = "http://ibm.com/fhir/extension";
 
-    private static final String LOCAL_REF_PREFIX = "urn:";
     private static final String HEADERNAME_IF_NONE_EXIST = "If-None-Exist";
     private static final String HEADERNAME_IF_MODIFIED_SINCE = "If-Modified-Since";
     private static final String HEADERNAME_IF_NONE_MATCH = "If-None-Match";
@@ -194,7 +153,7 @@ public class FHIRResource implements FHIRResourceHelpers {
 
     /**
      * UriInfo injected by the JAXRS framework.
-     * 
+     *
      * <p>Use {@link #getRequestUri()} instead to get the original request URI
      * when constructing URIs that will be sent back to the end user.
      */
@@ -208,10 +167,6 @@ public class FHIRResource implements FHIRResourceHelpers {
     private SecurityContext securityContext;
 
     private PropertyGroup fhirConfig = null;
-
-    // These values are used for correlating requests within a bundle.
-    private String bundleTransactionCorrelationId = null;
-    private String bundleRequestCorrelationId = null;
 
     /**
      * This method will do a quick check of the "initCompleted" flag in the servlet context. If the flag is FALSE, then
@@ -278,7 +233,8 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             String ifNoneExist = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_EXIST);
 
-            FHIRRestOperationResponse ior = doCreate(type, resource, ifNoneExist, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            FHIRRestOperationResponse ior = helper.doCreate(type, resource, ifNoneExist, null);
 
             ResponseBuilder response =
                     Response.created(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -312,7 +268,8 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
-            ior = doUpdate(type, id, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doUpdate(type, id, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -329,7 +286,7 @@ public class FHIRResource implements FHIRResourceHelpers {
             response = addHeaders(response, updatedResource);
             return response.build();
         } catch (FHIRPersistenceResourceNotFoundException e) {
-            // By default, NOT_FOUND is mapped to HTTP 404, so explicitly set it to HTTP 405 
+            // By default, NOT_FOUND is mapped to HTTP 404, so explicitly set it to HTTP 405
             return exceptionResponse(e, Response.Status.METHOD_NOT_ALLOWED);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -361,7 +318,8 @@ public class FHIRResource implements FHIRResourceHelpers {
                 throw buildRestException(msg, IssueType.INVALID);
             }
 
-            ior = doUpdate(type, null, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doUpdate(type, null, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -411,7 +369,8 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIRPatch patch = createPatch(array);
 
-            ior = doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -451,7 +410,8 @@ public class FHIRResource implements FHIRResourceHelpers {
                 throw buildRestException(e.getMessage(), IssueType.INVALID);
             }
 
-            ior = doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -503,7 +463,8 @@ public class FHIRResource implements FHIRResourceHelpers {
                 throw buildRestException(msg, IssueType.INVALID);
             }
 
-            ior = doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -552,7 +513,7 @@ public class FHIRResource implements FHIRResourceHelpers {
             try {
                 patch = FHIRPathPatch.from(parameters);
             } catch(IllegalArgumentException e) {
-                RestAuditLogger.logPatch(httpServletRequest, (ior != null ? ior.getPrevResource() : null), 
+                RestAuditLogger.logPatch(httpServletRequest, (ior != null ? ior.getPrevResource() : null),
                     (ior != null ? ior.getResource() : null), startTime, new Date(), Status.BAD_REQUEST);
                 throw buildRestException(e.getMessage(), IssueType.INVALID);
             }
@@ -561,12 +522,13 @@ public class FHIRResource implements FHIRResourceHelpers {
             if (searchQueryString == null || searchQueryString.isEmpty()) {
                 String msg =
                         "Cannot PATCH to resource type endpoint unless a search query string is provided for a conditional patch.";
-                RestAuditLogger.logPatch(httpServletRequest, (ior != null ? ior.getPrevResource() : null), 
+                RestAuditLogger.logPatch(httpServletRequest, (ior != null ? ior.getPrevResource() : null),
                     (ior != null ? ior.getResource() : null), startTime, new Date(), Status.BAD_REQUEST);
                 throw buildRestException(msg, IssueType.INVALID);
             }
 
-            ior = doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -626,7 +588,8 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
-            ior = doDelete(type, id, null, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doDelete(type, id, null, null);
 
             ResponseBuilder response = Response.noContent();
 
@@ -672,7 +635,8 @@ public class FHIRResource implements FHIRResourceHelpers {
                 throw buildRestException(msg, IssueType.INVALID);
             }
 
-            ior = doDelete(type, null, searchQueryString, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doDelete(type, null, searchQueryString, null);
             ResponseBuilder response = Response.status(ior.getStatus());
             if (ior.getOperationOutcome() != null) {
                 response.entity(ior.getOperationOutcome());
@@ -730,7 +694,8 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             String ifNoneMatch = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_MATCH);
 
-            Resource resource = doRead(type, id, true, false, null, null, queryParameters);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource resource = helper.doRead(type, id, true, false, null, null, queryParameters);
             int version2Match = -1;
             // Support ETag value with or without " (and W/)
             // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)
@@ -793,7 +758,8 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
-            Resource resource = doVRead(type, id, vid, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource resource = helper.doVRead(type, id, vid, null);
             ResponseBuilder response = Response.ok().entity(resource);
             response = addHeaders(response, resource);
             return response.build();
@@ -814,8 +780,9 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Bundle bundle =
-                    doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri(), null);
+                    helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri(), null);
             return Response.ok(bundle).build();
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -838,7 +805,8 @@ public class FHIRResource implements FHIRResourceHelpers {
             checkInitComplete();
 
             queryParameters = uriInfo.getQueryParameters();
-            bundle = doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
             return Response.ok(bundle).build();
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -860,8 +828,9 @@ public class FHIRResource implements FHIRResourceHelpers {
             checkInitComplete();
 
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Bundle bundle =
-                    doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null, null);
+                    helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null, null);
             return Response.ok(bundle).build();
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -882,8 +851,9 @@ public class FHIRResource implements FHIRResourceHelpers {
             checkInitComplete();
 
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Bundle bundle =
-                    doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
+                    helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
             return Response.ok(bundle).build();
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -894,6 +864,18 @@ public class FHIRResource implements FHIRResourceHelpers {
         }
     }
 
+    @GET
+    @Path("/")
+    public Response searchAllGet() {
+        return doSearchAll();
+    }
+
+    @POST
+    @Consumes("application/x-www-form-urlencoded")
+    @Path("_search")
+    public Response searchAllPost() {
+        return doSearchAll();
+    }
 
     private Response doSearchAll() {
         log.entering(this.getClass().getName(), "doSearchAll");
@@ -901,8 +883,9 @@ public class FHIRResource implements FHIRResourceHelpers {
             checkInitComplete();
 
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Bundle bundle =
-                    doSearch("Resource", null, null, queryParameters, getRequestUri(), null, null);
+                    helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null, null);
             return Response.ok(bundle).build();
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -914,21 +897,6 @@ public class FHIRResource implements FHIRResourceHelpers {
     }
 
     @GET
-    @Path("/")
-    public Response searchAllGet() {
-        return doSearchAll();
-    }
-
-
-    @POST
-    @Consumes("application/x-www-form-urlencoded")
-    @Path("_search")
-    public Response searchAllPost() {
-        return doSearchAll();
-    }
-
-
-    @GET
     @Path("${operationName}")
     public Response invoke(@PathParam("operationName") String operationName) {
         log.entering(this.getClass().getName(), "invoke(String)");
@@ -937,10 +905,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createSystemOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, null, null, null, operationName, null, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, null, null, null, operationName, null, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, null, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -960,10 +931,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createSystemOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, null, null, null, operationName, resource, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, null, null, null, operationName, resource, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, null, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -984,10 +958,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createResourceTypeOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, null, null, operationName, null, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, null, null, operationName, null, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -1008,10 +985,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createResourceTypeOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, null, null, operationName, resource, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, null, null, operationName, resource, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             // response 200 OK if no failure issue found.
@@ -1045,10 +1025,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, logicalId, null, operationName, null, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName, null, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -1070,10 +1053,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, logicalId, null, operationName, resource, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName, resource, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -1096,10 +1082,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, null, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, null, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -1122,10 +1111,13 @@ public class FHIRResource implements FHIRResourceHelpers {
 
             FHIROperationContext operationContext =
                     FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
 
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, resource, uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, resource, uriInfo.getQueryParameters(), null);
             return buildResponse(operationContext, resourceTypeName, result);
         } catch (FHIROperationException e) {
             return exceptionResponse(e);
@@ -1144,7 +1136,8 @@ public class FHIRResource implements FHIRResourceHelpers {
         try {
             checkInitComplete();
 
-            Bundle responseBundle = doBundle(resource, null);
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Bundle responseBundle = helper.doBundle(resource, null);
             ResponseBuilder response = Response.ok(responseBundle);
             return response.build();
         } catch (FHIRRestBundledRequestException e) {
@@ -1156,1522 +1149,6 @@ public class FHIRResource implements FHIRResourceHelpers {
         } finally {
             log.exiting(this.getClass().getName(), "bundle(Bundle)");
         }
-    }
-
-    /**
-     * Performs the heavy lifting associated with a 'create' interaction.
-     *
-     * @param type
-     *            the resource type specified as part of the request URL
-     * @param resource
-     *            the Resource to be stored.
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return a FHIRRestOperationResponse object containing the results of the operation
-     * @throws Exception
-     */
-    @Override
-    public FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist,
-            Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "doCreate");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'create' request.";
-
-        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        // Pass end time the same as start time to tell cadf log service that this is a pending request.
-        RestAuditLogger.logCreate(httpServletRequest, resource, startTime, startTime, Response.Status.OK);
-
-        try {
-
-            // Make sure the expected type (specified in the URL string) is congruent with the actual type
-            // of the resource.
-            String resourceType = ModelSupport.getTypeName(resource.getClass()); 
-            if (!resourceType.equals(type)) {
-                String msg = "Resource type '" + resourceType
-                        + "' does not match type specified in request URI: " + type;
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            // Check to see if we're supposed to perform a conditional 'create'.
-            if (ifNoneExist != null && !ifNoneExist.isEmpty()) {
-                log.fine("Performing conditional create with search criteria: " + ifNoneExist);
-                Bundle responseBundle = null;
-
-                // Perform the search using the "If-None-Exist" header value.
-                try {
-                    MultivaluedMap<String, String> searchParameters = getQueryParameterMap(ifNoneExist);
-                    responseBundle =
-                            doSearch(type, null, null, searchParameters, null, requestProperties, resource);
-                } catch (FHIROperationException e) {
-                    throw e;
-                } catch (Throwable t) {
-                    String msg =
-                            "An error occurred while performing the search for a conditional create operation.";
-                    log.log(Level.WARNING, msg, t);
-                    throw new FHIROperationException(msg, t);
-                }
-
-                // Check the search results to determine whether or not to perform the create operation.
-                int resultCount = responseBundle.getEntry().size();
-                log.fine("Conditional create search yielded " + resultCount + " results.");
-
-                if (resultCount == 0) {
-                    // Do nothing and fall through to process the 'create' request.
-                } else if (resultCount == 1) {
-                    // If we found a single match, bypass the 'create' request and return information
-                    // for the matched resource.
-                    Resource matchedResource = responseBundle.getEntry().get(0).getResource();
-                    ior.setLocationURI(FHIRUtil.buildLocationURI(type, matchedResource));
-                    ior.setStatus(Response.Status.OK);
-                    ior.setResource(matchedResource);
-                    log.fine("Returning location URI of matched resource: " + ior.getLocationURI());
-                    status = ior.getStatus();
-                    return ior;
-                } else {
-                    String msg =
-                            "The search criteria specified for a conditional create operation returned multiple matches.";
-                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
-                }
-            }
-
-            // For R4, resources may contain an id. For create, this should be ignored and
-            // we no longer reject the request.
-            if (resource.getId() != null && log.isLoggable(Level.FINE)) {
-                log.fine(String.format("create request resource includes id: '%s'", resource.getId()));
-            }
-
-            // Validate the input resource and return any validation errors, but warnings are OK
-            List<Issue> validationWarnings = validateInput(resource);
-            ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(validationWarnings));
-
-            // If there were no validation errors, then create the resource and return the location header.
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeCreate' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(resource, buildPersistenceEventProperties(type, null, null, requestProperties));
-            getInterceptorMgr().fireBeforeCreateEvent(event);
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event);
-
-            // R4: remember model objects are immutable, so we get back a new resource with the id/meta stuff
-            resource = getPersistenceImpl().create(persistenceContext, resource).getResource();
-            event.setFhirResource(resource); // update event with latest
-            ior.setStatus(Response.Status.CREATED);
-            ior.setResource(resource);
-
-            // Build our location URI and add it to the interceptor event structure since it is now known.
-            ior.setLocationURI(FHIRUtil.buildLocationURI(ModelSupport.getTypeName(resource.getClass()), resource));
-            event.getProperties().put(FHIRPersistenceEvent.PROPNAME_RESOURCE_LOCATION_URI, ior.getLocationURI().toString());
-
-            // Invoke the 'afterCreate' interceptor methods.
-            getInterceptorMgr().fireAfterCreateEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            status = ior.getStatus();
-            return ior;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logCreate(httpServletRequest, resource, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-            log.exiting(this.getClass().getName(), "doCreate");
-        }
-    }
-
-    /**
-     * Validate the input resource and throw if there are validation errors
-     *
-     * @param resource
-     * @throws FHIRValidationException
-     * @throws FHIROperationException
-     */
-    private List<OperationOutcome.Issue> validateInput(Resource resource)
-            throws FHIRValidationException, FHIROperationException {
-        List<OperationOutcome.Issue> issues = FHIRValidator.validator().validate(resource);
-        if (!issues.isEmpty()) {
-            boolean includesFailure = false;
-            for (OperationOutcome.Issue issue : issues) {
-                if (FHIRUtil.isFailure(issue.getSeverity())) {
-                    includesFailure = true;
-                }
-            }
-
-            if (includesFailure) {
-                throw new FHIROperationException("Input resource failed validation.").withIssue(issues);
-            } else {
-                if (log.isLoggable(Level.FINE)) {
-                    String info = issues.stream()
-                                .flatMap(issue -> Stream.of(issue.getDetails()))
-                                .flatMap(details -> Stream.of(details.getText()))
-                                .flatMap(text -> Stream.of(text.getValue()))
-                                .collect(Collectors.joining(", "));
-                    log.fine("Validation warnings for input resource: " + info);
-                }
-            }
-        }
-        return issues;
-    }
-
-    @Override
-    public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue,
-            String searchQueryString, Map<String, String> requestProperties) throws Exception {
-
-        return doPatchOrUpdate(type, id, patch, null, ifMatchValue, searchQueryString, requestProperties);
-    }
-
-    @Override
-    public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
-            String searchQueryString, Map<String, String> requestProperties) throws Exception {
-
-        return doPatchOrUpdate(type, id, null, newResource, ifMatchValue, searchQueryString, requestProperties);
-    }
-
-    private FHIRRestOperationResponse doPatchOrUpdate(String type, String id, FHIRPatch patch,
-            Resource newResource, String ifMatchValue, String searchQueryString,
-            Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "doPatchOrUpdate");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'update/patch' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
-
-        // Pass end time the same as start time to tell cadf log service that this is a pending request.
-        if (patch != null) {
-            RestAuditLogger.logPatch(httpServletRequest, null, null, startTime, startTime, Response.Status.OK);
-        } else {
-            // At this time point, we don't have the updated resource, so use the input resource as the updated resource
-            // in the pending request.
-            RestAuditLogger.logUpdate(httpServletRequest, newResource, newResource, startTime, startTime, Response.Status.OK);
-        }
-
-        try {
-            // Make sure the type specified in the URL string matches the resource type obtained from the new resource.
-            if (patch == null) {
-                String resourceType =  ModelSupport.getTypeName(newResource.getClass());
-                if (!resourceType.equals(type)) {
-                    String msg = "Resource type '" + resourceType
-                            + "' does not match type specified in request URI: " + type;
-                    throw buildRestException(msg, IssueType.INVALID);
-                }
-            }
-
-            // Next, if a conditional update was invoked then use the search criteria to find the
-            // resource to be updated. Otherwise, we'll use the id value to retrieve the current
-            // version of the resource.
-            if (searchQueryString != null) {
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("Performing conditional update/patch with search criteria: "
-                            + Encode.forHtml(searchQueryString));
-                }
-                Bundle responseBundle = null;
-                try {
-                    MultivaluedMap<String, String> searchParameters =
-                            getQueryParameterMap(searchQueryString);
-                    responseBundle =
-                            doSearch(type, null, null, searchParameters, null, requestProperties, newResource);
-                } catch (FHIROperationException e) {
-                    throw e;
-                } catch (Throwable t) {
-                    String msg =
-                            "An error occurred while performing the search for a conditional update/patch operation.";
-                    throw new FHIROperationException(msg, t);
-                }
-
-                // Check the search results to determine whether or not to perform the update operation.
-                int resultCount = responseBundle.getEntry().size();
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("Conditional update/patch search yielded " + resultCount + " results.");
-                }
-
-                if (resultCount == 0) {
-                    if (patch != null) {
-                        String msg =
-                                "The search criteria specified for a conditional patch operation did not return any results.";
-                        throw buildRestException(msg, IssueType.NOT_FOUND);
-                    }
-                    // Search yielded no matches, so we'll do an update/create operation below.
-                    ior.setPrevResource(null);
-
-                    // if no id provided, then generate an id for the input resource
-                    if (newResource.getId() == null || newResource.getId() == null) {
-                        id = UUID.randomUUID().toString();
-                        newResource = newResource.toBuilder().id(id).build();
-                    } else {
-                        id = newResource.getId();
-                    }
-                } else if (resultCount == 1) {
-                    // If we found a single match, then we'll perform a normal update on the matched resource.
-                    ior.setPrevResource(responseBundle.getEntry().get(0).getResource());
-                    id = ior.getPrevResource().getId();
-
-                    // If the id of the input resource is different from the id of the search result,
-                    // then throw exception.
-                    if (newResource.getId() != null && newResource.getId() != null
-                            && !newResource.getId().equalsIgnoreCase(id)) {
-                        String msg = "Input resource 'id' attribute must match the id of the search result resource.";
-                        throw buildRestException(msg, IssueType.VALUE);
-                    }
-                    // Make sure the id of the newResource is not null and is the same as the id of the found resource.
-                    newResource = newResource.toBuilder().id(id).build();
-                } else {
-                    String msg =
-                            "The search criteria specified for a conditional update/patch operation returned multiple matches.";
-                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
-                }
-            } else {
-                // Make sure an id value was passed in.
-                if (id == null) {
-                    String msg = "The 'id' parameter is required for an update/pach operation.";
-                    throw buildRestException(msg, IssueType.REQUIRED);
-                }
-
-                // If an id value was passed in (i.e. the id specified in the REST API URL string),
-                // then make sure it's the same as the value in the resource.
-                if (patch == null) {
-                    // Make sure the resource has an 'id' attribute.
-                    if (newResource.getId() == null) {
-                        String msg = "Input resource must contain an 'id' attribute.";
-                        throw buildRestException(msg, IssueType.INVALID);
-                    }
-
-                    if (!newResource.getId().equals(id)) {
-                        String msg = "Input resource 'id' attribute must match 'id' parameter.";
-                        throw buildRestException(msg, IssueType.VALUE);
-                    }
-                }
-
-                // Retrieve the resource to be updated using the type and id values.
-                ior.setPrevResource(doRead(type, id, (patch != null), true, requestProperties, newResource));
-            }
-
-            if (patch != null) {
-                newResource = patch.apply(ior.getPrevResource());
-            }
-
-            // Validate the input resource and return any validation errors.
-            List<Issue> validationWarnings = validateInput(newResource);
-            ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(validationWarnings));
-
-            // Perform the "version-aware" update check, and also find out if the resource was deleted.
-            boolean isDeleted = false;
-            if (ior.getPrevResource() != null) {
-                performVersionAwareUpdateCheck(ior.getPrevResource(), ifMatchValue);
-
-                try {
-                    doRead(type, id, (patch != null), false, requestProperties, newResource);
-                } catch (FHIRPersistenceResourceDeletedException e) {
-                    isDeleted = true;
-                }
-            }
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, create the persistence event.
-            FHIRPersistenceEvent event = new FHIRPersistenceEvent(newResource, 
-                    buildPersistenceEventProperties(type, newResource.getId(), null, requestProperties));
-
-            // Next, set the "previous resource" in the persistence event.
-            event.setPrevFhirResource(ior.getPrevResource());
-
-            // Next, invoke the 'beforeUpdate' or 'beforeCreate' interceptor methods as appropriate.
-            boolean updateCreate = (ior.getPrevResource() == null);
-            if (updateCreate) {
-                getInterceptorMgr().fireBeforeCreateEvent(event);
-            } else {
-                if (patch != null) {
-                    event.getProperties().put(FHIRPersistenceEvent.PROPNAME_PATCH, patch);
-                    getInterceptorMgr().fireBeforePatchEvent(event);
-                } else {
-                    getInterceptorMgr().fireBeforeUpdateEvent(event);
-                }
-            }
-
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event);
-            newResource = getPersistenceImpl().update(persistenceContext, id, newResource).getResource();
-            event.setFhirResource(newResource); // update event with latest
-            ior.setResource(newResource);
-
-            // Build our location URI and add it to the interceptor event structure since it is now known.
-            ior.setLocationURI(FHIRUtil.buildLocationURI(ModelSupport.getTypeName(newResource.getClass()), newResource));
-            event.getProperties().put(FHIRPersistenceEvent.PROPNAME_RESOURCE_LOCATION_URI, ior.getLocationURI().toString());
-
-            // Invoke the 'afterUpdate' interceptor methods.
-            if (updateCreate) {
-                ior.setStatus(Response.Status.CREATED);
-                getInterceptorMgr().fireAfterCreateEvent(event);
-            } else {
-                ior.setStatus(Response.Status.OK);
-                if (patch != null) {
-                    getInterceptorMgr().fireAfterPatchEvent(event);
-                } else {
-                    getInterceptorMgr().fireAfterUpdateEvent(event);
-                }
-            }
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            // If the deleted resource is updated, then simply return 201 instead of 200 to pass Touchstone test.
-            // We don't set the previous resource to null in above codes if the resource was deleted, otherwise
-            // it will break the code logic of the resource versioning.
-            if (isDeleted && ior.getStatus() == Response.Status.OK) {
-                ior.setStatus(Response.Status.CREATED);
-            }
-
-            status = ior.getStatus();
-            return ior;
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.METHOD_NOT_ALLOWED;
-            throw e;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we still have a transaction at this point, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            if (status == Response.Status.CREATED) {
-                // Now Audit log the final status of the request,
-                // if fails to log, then log the error in local log file and ignore.
-                try {
-                    RestAuditLogger.logCreate(httpServletRequest, (ior != null ? ior.getResource()
-                            : null), startTime, new Date(), status);
-                } catch (Exception e) {
-                    log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-                }
-            } else {
-                // Now Audit log the final status of the request,
-                // if fails to log, then log the error in local log file and ignore.
-                try {
-                    if (patch != null) {
-                        RestAuditLogger.logPatch(httpServletRequest, (ior != null
-                                ? ior.getPrevResource() : null), (ior != null ? ior.getResource()
-                                        : null), startTime, new Date(), status);
-                    } else {
-                        RestAuditLogger.logUpdate(httpServletRequest, (ior != null
-                                ? ior.getPrevResource() : null), (ior != null ? ior.getResource()
-                                        : null), startTime, new Date(), status);
-                    }
-                } catch (Exception e) {
-                    log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-                }
-            }
-            log.exiting(this.getClass().getName(), "doPatchOrUpdate");
-        }
-    }
-
-    /**
-     * Performs a 'delete' operation on the specified resource.
-     *
-     * @param type
-     *            the resource type associated with the Resource to be deleted
-     * @param id
-     *            the id of the Resource to be deleted
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return a FHIRRestOperationResponse that contains the results of the operation
-     * @throws Exception
-     */
-    @Override
-    public FHIRRestOperationResponse doDelete(String type, String id, String searchQueryString,
-            Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "doDelete");
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'delete' request.";
-
-        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
-
-        // Pass end time the same as start time to tell cadf log service that this is a pending request.
-        RestAuditLogger.logDelete(httpServletRequest, null, startTime, startTime, Response.Status.OK);
-
-        try {
-            String resourceTypeName = type;
-            if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
-            }
-
-            Class<? extends Resource> resourceType =
-                    getResourceType(resourceTypeName);
-
-            // Next, if a conditional delete was invoked then use the search criteria to find the
-            // resource to be deleted. Otherwise, we'll use the id value to identify the resource
-            // to be deleted.
-            Resource resourceToDelete = null;
-            if (searchQueryString != null) {
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("Performing conditional delete with search criteria: "
-                            + Encode.forHtml(searchQueryString));
-                }
-                Bundle responseBundle = null;
-                try {
-                    MultivaluedMap<String, String> searchParameters =
-                            getQueryParameterMap(searchQueryString);
-                    responseBundle =
-                            doSearch(type, null, null, searchParameters, null, requestProperties, null);
-                } catch (FHIROperationException e) {
-                    throw e;
-                } catch (Throwable t) {
-                    String msg =
-                            "An error occurred while performing the search for a conditional delete operation.";
-                    log.log(Level.SEVERE, msg, t);
-                    throw new FHIROperationException(msg, t);
-                }
-
-                // Check the search results to determine whether or not to perform the update operation.
-                int resultCount = responseBundle.getEntry().size();
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("Conditional delete search yielded " + resultCount + " results.");
-                }
-
-                if (resultCount == 0) {
-                    // Search yielded no matches
-                    String msg = "Search criteria for a conditional delete operation yielded no matches.";
-                    if (log.isLoggable(Level.FINE)) {
-                        log.fine(msg);
-                    }
-                    status = Response.Status.OK;
-                    ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(msg, IssueType.NOT_FOUND, IssueSeverity.WARNING));
-                    ior.setStatus(status);
-                    return ior;
-                } else if (resultCount == 1) {
-                    // If we found a single match, then we'll delete this one.
-                    Resource resource = responseBundle.getEntry().get(0).getResource();
-                    id = resource.getId();
-                    resourceToDelete = resource;
-                } else {
-                    String msg =
-                            "The search criteria specified for a conditional delete operation returned multiple matches.";
-                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
-                }
-            } else {
-                // Make sure an id value was passed in.
-                if (id == null) {
-                    String msg = "The 'id' parameter is required for a delete operation.";
-                    throw buildRestException(msg, IssueType.REQUIRED);
-                }
-
-                // Read the resource so it will be available to the beforeDelete interceptor methods.
-                try {
-                    resourceToDelete = doRead(type, id, false, false, requestProperties, null);
-                } catch (FHIRPersistenceResourceDeletedException e) {
-                    // Absorb this exception.
-                    resourceToDelete = null;
-                }
-            }
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeDelete' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, null, requestProperties));
-            event.setFhirResource(resourceToDelete);
-            getInterceptorMgr().fireBeforeDeleteEvent(event);
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event);
-
-            Resource resource = getPersistenceImpl().delete(persistenceContext, resourceType, id).getResource();
-            ior.setResource(resource);
-            event.setFhirResource(resource);
-            ior.setStatus(Response.Status.NO_CONTENT);
-
-            // Invoke the 'afterDelete' interceptor methods.
-            getInterceptorMgr().fireAfterDeleteEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-            status = ior.getStatus();
-
-            return ior;
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.OK;
-            throw e;
-        } catch (FHIRPersistenceNotSupportedException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.METHOD_NOT_ALLOWED;
-            throw e;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logDelete(httpServletRequest, ior != null ? ior.getResource() : null, 
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doDelete");
-        }
-    }
-
-    @Override
-    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
-            Map<String, String> requestProperties, Resource contextResource) throws Exception {
-        return doRead(type, id, throwExcOnNull, includeDeleted, requestProperties, contextResource, null);
-    }
-
-    /**
-     * Performs a 'read' operation to retrieve a Resource.
-     *
-     * @param type
-     *            the resource type associated with the Resource to be retrieved
-     * @param id
-     *            the id of the Resource to be retrieved
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return the Resource
-     * @throws Exception
-     */
-    @Override
-    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
-            Map<String, String> requestProperties, Resource contextResource, MultivaluedMap<String, String> queryParameters)
-            throws Exception {
-        log.entering(this.getClass().getName(), "doRead");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Resource resource = null;
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'read' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        try {
-            String resourceTypeName = type;
-            if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
-            }
-
-            Class<? extends Resource> resourceType = getResourceType(resourceTypeName);
-
-            FHIRSearchContext searchContext = null;
-            if (queryParameters != null) {
-                searchContext = SearchUtil.parseQueryParameters(null, null, resourceType, queryParameters, 
-                        HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
-            }
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeRead' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(contextResource, buildPersistenceEventProperties(type, id, null, requestProperties));
-            getInterceptorMgr().fireBeforeReadEvent(event);
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event, includeDeleted, searchContext);
-            resource = getPersistenceImpl().read(persistenceContext, resourceType, id).getResource();
-            if (resource == null && throwExcOnNull) {
-                throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
-            }
-
-            event.setFhirResource(resource);
-
-            // Invoke the 'afterRead' interceptor methods.
-            getInterceptorMgr().fireAfterReadEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            status = Response.Status.OK;
-
-            return resource;
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.NOT_FOUND;
-            throw e;
-        } catch (FHIRPersistenceResourceDeletedException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.GONE;
-            throw e;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logRead(httpServletRequest, resource, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doRead");
-        }
-    }
-
-    /**
-     * Performs a 'vread' operation by retrieving the specified version of a Resource.
-     *
-     * @param type
-     *            the resource type associated with the Resource to be retrieved
-     * @param id
-     *            the id of the Resource to be retrieved
-     * @param versionId
-     *            the version id of the Resource to be retrieved
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return the Resource
-     * @throws Exception
-     */
-    @Override
-    public Resource doVRead(String type, String id, String versionId,
-        Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "doVRead");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Resource resource = null;
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'vread' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        try {
-            String resourceTypeName = type;
-            if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
-            }
-
-            Class<? extends Resource> resourceType =
-                    getResourceType(resourceTypeName);
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeVread' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, versionId, requestProperties));
-            getInterceptorMgr().fireBeforeVreadEvent(event);
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event);
-            resource = getPersistenceImpl().vread(persistenceContext, resourceType, id, versionId).getResource();
-            if (resource == null) {
-                throw new FHIRPersistenceResourceNotFoundException("Resource '"
-                        + resourceType.getSimpleName() + "/" + id + "' version " + versionId + " not found.");
-            }
-
-            event.setFhirResource(resource);
-
-            // Invoke the 'afterVread' interceptor methods.
-            getInterceptorMgr().fireAfterVreadEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            status = Response.Status.OK;
-
-            return resource;
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.NOT_FOUND;
-            throw e;
-        } catch (FHIRPersistenceResourceDeletedException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = Response.Status.GONE;
-            throw e;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logVersionRead(httpServletRequest, resource, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doVRead");
-        }
-    }
-
-    /**
-     * Performs the work of retrieving versions of a Resource.
-     *
-     * @param type
-     *            the resource type associated with the Resource to be retrieved
-     * @param id
-     *            the id of the Resource to be retrieved
-     * @param queryParameters
-     *            a Map containing the query parameters from the request URL
-     * @param requestUri the URI from the request
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return a Bundle containing the history of the specified Resource
-     * @throws Exception
-     */
-    @Override
-    public Bundle doHistory(String type, String id, MultivaluedMap<String, String> queryParameters,
-        String requestUri, Map<String, String> requestProperties)
-        throws Exception {
-        log.entering(this.getClass().getName(), "doHistory");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Bundle bundle = null;
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'history' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        try {
-            String resourceTypeName = type;
-            if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
-            }
-
-            Class<? extends Resource> resourceType =
-                    getResourceType(resourceTypeName);
-            FHIRHistoryContext historyContext =
-                    FHIRPersistenceUtil.parseHistoryParameters(queryParameters, HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeHistory' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, null, requestProperties));
-            getInterceptorMgr().fireBeforeHistoryEvent(event);
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event, historyContext);
-            List<? extends Resource> resources =
-                    getPersistenceImpl().history(persistenceContext, resourceType, id).getResource();
-            bundle = createHistoryBundle(resources, historyContext, type);
-            bundle = addLinks(historyContext, bundle, requestUri);
-
-            event.setFhirResource(bundle);
-
-            // Invoke the 'afterHistory' interceptor methods.
-            getInterceptorMgr().fireAfterHistoryEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            status = Response.Status.OK;
-            return bundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logHistory(httpServletRequest, bundle, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doHistory");
-        }
-    }
-
-    /**
-     * Performs heavy lifting associated with a 'search' operation.
-     *
-     * @param type
-     *            the resource type associated with the search
-     * @param queryParameters
-     *            a Map containing the query parameters from the request URL
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return a Bundle containing the search result set
-     * @throws Exception
-     */
-    @Override
-    public Bundle doSearch(String type, String compartment, String compartmentId,
-            MultivaluedMap<String, String> queryParameters, String requestUri,
-            Map<String, String> requestProperties, Resource contextResource) throws Exception {
-        log.entering(this.getClass().getName(), "doSearch");
-
-        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Bundle bundle = null;
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'search' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        try {
-            String resourceTypeName = type;
-
-            // Check to see if it's supported, else, throw a bad request.
-            // If this is removed, it'll result in nullpointer when processing the request
-            if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
-            }
-
-            Class<? extends Resource> resourceType =
-                    getResourceType(resourceTypeName);
-
-            // Start a new txn in the persistence layer if one is not already active.
-            txn.begin();
-
-            // First, invoke the 'beforeSearch' interceptor methods.
-            FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(contextResource, buildPersistenceEventProperties(type, null, null, requestProperties));
-            getInterceptorMgr().fireBeforeSearchEvent(event);
-
-            FHIRSearchContext searchContext = SearchUtil.parseQueryParameters(compartment, compartmentId, resourceType, queryParameters,
-                    HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
-
-            FHIRPersistenceContext persistenceContext =
-                    FHIRPersistenceContextFactory.createPersistenceContext(event, searchContext);
-            List<Resource> resources =
-                    getPersistenceImpl().search(persistenceContext, resourceType).getResource();
-
-            bundle = createSearchBundle(resources, searchContext, type);
-            if (requestUri != null) {
-                bundle = addLinks(searchContext, bundle, requestUri);
-            }
-            event.setFhirResource(bundle);
-
-            // Invoke the 'afterSearch' interceptor methods.
-            getInterceptorMgr().fireAfterSearchEvent(event);
-
-            // Commit our transaction if we started one before.
-            txn.commit();
-            txn = null;
-
-            status = Response.Status.OK;
-
-            return bundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // If we previously started a transaction and it's still active, we need to rollback due to an error.
-            if (txn != null) {
-                txn.rollback();
-            }
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doSearch");
-        }
-    }
-
-    /**
-     * Helper method which invokes a custom operation.
-     *
-     * @param operationContext
-     *            the FHIROperationContext associated with the request
-     * @param resourceTypeName
-     *            the resource type associated with the request
-     * @param logicalId
-     *            the resource logical id associated with the request
-     * @param versionId
-     *            the resource version id associated with the request
-     * @param operationName
-     *            the name of the custom operation to be invoked
-     * @param resource
-     *            the input resource associated with the custom operation to be invoked
-     * @param queryParameters
-     *            query parameters may be passed instead of a Parameters resource for certain custom operations invoked
-     *            via GET
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return a Resource that represents the response to the custom operation
-     * @throws Exception
-     */
-    @Override
-    public Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName,
-            String logicalId, String versionId, String operationName,
-            Resource resource, MultivaluedMap<String, String> queryParameters,
-            Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "doInvoke");
-
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'invoke' request.";
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        // Pass end time the same as start time to tell cadf log service that this is a pending request.
-        RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId, startTime, startTime, Response.Status.OK);
-
-        try {
-            Class<? extends Resource> resourceType = null;
-            if (resourceTypeName != null) {
-                resourceType = getResourceType(resourceTypeName);
-            }
-            String operationKey = (resourceTypeName == null ? operationName : operationName + ":" + resourceTypeName);
-
-            FHIROperation operation =
-                    FHIROperationRegistry.getInstance().getOperation(operationKey);
-            Parameters parameters = null;
-            if (resource instanceof Parameters) {
-                parameters = (Parameters) resource;
-            } else {
-                if (resource == null) {
-                    // build parameters object from query parameters
-                    parameters =
-                            FHIROperationUtil.getInputParameters(operation.getDefinition(), queryParameters);
-                } else {
-                    // wrap resource in a parameters object
-                    parameters =
-                            FHIROperationUtil.getInputParameters(operation.getDefinition(), resource);
-                }
-            }
-
-            // Add properties to the FHIR operation context
-            setOperationContextProperties(operationContext, resourceTypeName, requestProperties);
-
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Invoking operation '" + operationName + "', context=\n"
-                        + operationContext.toString());
-            }
-            Parameters result =
-                    operation.invoke(operationContext, resourceType, logicalId, versionId, parameters, this);
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Returned from invocation of operation '" + operationName + "'...");
-            }
-
-            status = Response.Status.OK;
-
-            // if single resource output parameter, return the resource
-            if (FHIROperationUtil.hasSingleResourceOutputParameter(result)) {
-                return FHIROperationUtil.getSingleResourceOutputParameter(result);
-            }
-
-            return result;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doInvoke");
-        }
-    }
-
-    /**
-     * Processes a bundled request.
-     *
-     * @param bundleResource
-     *            the request Bundle
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return the response Bundle
-     */
-    @Override
-    public Bundle doBundle(Resource bundleResource, Map<String, String> requestProperties)
-        throws Exception {
-        log.entering(this.getClass().getName(), "doBundle");
-
-        Date startTime = new Date();
-        Response.Status status = null;
-        String errMsg = "Caught exception while processing 'bundle' request.";
-        Bundle inputBundle = null;
-
-        // Save the current request context.
-        FHIRRequestContext requestContext = FHIRRequestContext.get();
-
-        // Pass end time the same as start time to tell cadf log service that this is a pending request.
-        RestAuditLogger.logBundle(httpServletRequest, bundleResource instanceof Bundle ?
-                (Bundle) bundleResource
-                : null, startTime, startTime, Response.Status.OK);
-
-        try {
-            if (bundleResource instanceof Bundle) {
-                inputBundle = (Bundle) bundleResource;
-            } else {
-                String msg = "A 'Bundle' resource type is required but a '"
-                        + bundleResource.getClass().getSimpleName() + "' resource type was sent.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-            // First, validate the bundle and create the response bundle.
-            Bundle responseBundle = validateBundle(inputBundle);
-
-            // Next, process each of the entries in the bundle.
-            responseBundle = processBundleEntries(inputBundle, responseBundle, requestProperties);
-
-            status = Response.Status.OK;
-
-            return responseBundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
-        } finally {
-            // Restore the original request context.
-            FHIRRequestContext.set(requestContext);
-
-            // Now Audit log the final status of the request,
-            // if fails to log, then log the error in local log file and ignore.
-            try {
-                RestAuditLogger.logBundle(httpServletRequest, inputBundle, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.WARNING, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doBundle");
-        }
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see com.ibm.fhir.rest.FHIRResourceHelpers#getTransaction()
-     */
-    @Override
-    public FHIRPersistenceTransaction getTransaction() throws Exception {
-        return getPersistenceImpl().getTransaction();
-    }
-
-    /**
-     * Sets various properties on the FHIROperationContext instance.
-     *
-     * @param operationContext
-     *            the FHIROperationContext on which to set the properties
-     * @throws Exception 
-     */
-    private void setOperationContextProperties(FHIROperationContext operationContext, String resourceTypeName,
-            Map<String, String> requestProperties) throws Exception {
-        operationContext.setProperty(FHIROperationContext.PROPNAME_REQUEST_BASE_URI, getRequestBaseUri(resourceTypeName));
-        operationContext.setProperty(FHIROperationContext.PROPNAME_RESOURCE_HELPER, this);
-        operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, getPersistenceImpl());
-        operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-        operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-        operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
-        operationContext.setProperty(FHIROperationContext.PROPNAME_REQUEST_PROPERTIES, requestProperties);
-    }
-
-    /**
-     * @param issues
-     * @return
-     */
-    private boolean anyFailureInIssues(List<OperationOutcome.Issue> issues) {
-        boolean hasFailure = false;
-        for (OperationOutcome.Issue issue : issues) {
-            if (FHIRUtil.isFailure(issue.getSeverity())) {
-                hasFailure = true;
-            }
-        }
-        return hasFailure;
-    }
-
-    /**
-     * Performs validation of a request Bundle and returns a Bundle containing response entries corresponding to the
-     * request entries in the request Bundle. holding the responses for the requests contained in the request Bundle.
-     *
-     * @param bundle
-     *            the bundle to be validated
-     * @return a response Bundle
-     * @throws Exception
-     */
-    private Bundle validateBundle(Bundle bundle) throws Exception {
-        log.entering(this.getClass().getName(), "validateBundle");
-
-        try {
-            // Make sure the bundle isn't empty
-            if (bundle == null) {
-                String msg = "Bundle parameter is missing or empty.";
-                throw buildRestException(msg, IssueType.REQUIRED);
-            }
-
-            BundleType.ValueSet requestType = bundle.getType().getValueAsEnumConstant();
-            
-            // Determine the bundle type of the response bundle.
-            BundleType responseBundleType = null;
-
-            if (requestType == BundleType.ValueSet.BATCH) {
-                // For 'batch' interactions, return a 'batch-response'
-                responseBundleType = BundleType.BATCH_RESPONSE;
-            } else if (requestType == BundleType.ValueSet.TRANSACTION) {
-                responseBundleType = BundleType.TRANSACTION_RESPONSE;
-                // For a 'transaction' interaction, if the underlying persistence layer doesn't support
-                // transactions, then throw an error.
-                if (!getPersistenceImpl().isTransactional()) {
-                    String msg = "Bundled 'transaction' request cannot be processed because "
-                            + "the configured persistence layer does not support transactions.";
-                    IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
-                            .extension(Extension.builder()
-                                .url(EXTENSION_URL +  "/not-supported-detail")
-                                .value(string("interaction"))
-                                .build())
-                            .build();
-                    throw buildRestException(msg, extendedIssueType);
-                }
-            } else {
-                // For any other bundle type, throw an error.
-                // TODO add support for posting history bundles
-                String msg = "Bundle.type must be either 'batch' or 'transaction'.";
-                throw buildRestException(msg, IssueType.VALUE);
-            }
-
-            // For 'transaction' bundle requests, keep a list of issues in case of failure
-            List<OperationOutcome.Issue> issueList = new ArrayList<OperationOutcome.Issue>();
-
-            List<Bundle.Entry> responseList = new ArrayList<Bundle.Entry>();
-
-            for (Bundle.Entry requestEntry : bundle.getEntry()) {
-                // Create a corresponding response entry and add it to the response bundle.
-                Bundle.Entry.Response response;
-                Bundle.Entry responseEntry = null;
-
-                // Validate 'requestEntry' and update 'responseEntry' with any errors.
-                try {
-                    Bundle.Entry.Request request = requestEntry.getRequest();
-                    // Verify that the request field is present.
-                    if (request == null) {
-                        String msg = "Bundle.Entry is missing the 'request' field.";
-                        throw buildRestException(msg, IssueType.REQUIRED);
-                    }
-
-                    // Verify that a method was specified.
-                    if (request.getMethod() == null || request.getMethod().getValue() == null) {
-                        String msg = "Bundle.Entry.request is missing the 'method' field";
-                        throw buildRestException(msg, IssueType.REQUIRED);
-                    }
-
-                    // Verify that a URL was specified.
-                    if (request.getUrl() == null || request.getUrl().getValue() == null) {
-                        String msg = "Bundle.Entry.request is missing the 'url' field";
-                        throw buildRestException(msg, IssueType.REQUIRED);
-                    }
-
-                    // Retrieve the resource from the request entry to prepare for some validations below.
-                    Resource resource = requestEntry.getResource();
-
-                    // Validate the resource for the requested HTTP method.
-                    methodValidation(request.getMethod(), resource);
-
-                    // If the request entry contains a resource, then validate it now.
-                    if (resource != null) {
-                        List<OperationOutcome.Issue> issues =
-                                FHIRValidator.validator().validate(resource);
-                        if (!issues.isEmpty()) {
-                            if (anyFailureInIssues(issues)) {
-                                if (requestType == BundleType.ValueSet.TRANSACTION) {
-                                    issueList.addAll(issues);
-                                } else {
-                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
-                                    response = Bundle.Entry.Response.builder()
-                                                .status(string(Integer.toString(SC_BAD_REQUEST)))
-                                                .build();
-                                    responseEntry = Bundle.Entry.builder()
-                                                .response(response)
-                                                .resource(oo)
-                                                .build();
-                                }
-                            } else {
-                                response = Bundle.Entry.Response.builder()
-                                            .status(string(Integer.toString(SC_OK)))
-                                            .build();
-                                Bundle.Entry.Builder responseEntryBuilder = Bundle.Entry.builder().response(response);
-                                // Only add hints/warnings if the return preference was "OperationOutcome"
-                                if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
-                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
-                                    responseEntryBuilder.resource(oo);
-                                }
-                                responseEntry = responseEntryBuilder.build();
-                            }
-                            continue;
-                        }
-                    }
-                    response =
-                            Bundle.Entry.Response.builder().status(string(Integer.toString(SC_OK))).build();
-                    responseEntry = Bundle.Entry.builder().response(response).build();
-                } catch (FHIROperationException e) {
-                    if (log.isLoggable(Level.FINE)) {
-                        log.log(Level.FINE, "Failed to process BundleEntry ["
-                                + bundle.getEntry().indexOf(requestEntry) + "]", e);
-                    }
-                    if (requestType == BundleType.ValueSet.TRANSACTION) {
-                        issueList.addAll(e.getIssues());
-                    } else {
-                        response = Bundle.Entry.Response.builder()
-                                .status(string(Integer.toString(SC_BAD_REQUEST)))
-                                .build();
-                        responseEntry = Bundle.Entry.builder()
-                                .response(response)
-                                .resource(FHIRUtil.buildOperationOutcome(e, false))
-                                .build();
-                    }
-                } finally {
-                    if (responseEntry != null) {
-                        responseList.add(responseEntry);
-                    }
-                }
-            } // End foreach requestEntry
-
-            // If this is a "transaction" interaction and we encountered any errors, then we'll
-            // abort processing this request right now since a transaction interaction is supposed to be
-            // all or nothing.
-            if (requestType == BundleType.ValueSet.TRANSACTION && issueList.size() > 0) {
-                String msg =
-                        "One or more errors were encountered while validating a 'transaction' request bundle.";
-                throw buildRestException(msg, IssueType.INVALID).withIssue(issueList);
-            }
-            
-            // Create the response bundle with the appropriate type.
-            Bundle responseBundle = Bundle.builder().type(responseBundleType).entry(responseList).build();
-
-            return responseBundle;
-        } finally {
-            log.exiting(this.getClass().getName(), "validateBundle");
-        }
-    }
-
-    /**
-     * Perform method-specific validation of the resource
-     */
-    private void methodValidation(HTTPVerb method, Resource resource) throws FHIRPersistenceException, FHIROperationException {
-        switch(method.getValueAsEnumConstant()) {
-        case PATCH:
-        case POST:
-            break;
-        case DELETE:
-            // If the "delete" operation isn't supported by the configured persistence layer,
-            // then we need to fail validation of this bundle entry.
-            if (!isDeleteSupported()) {
-                String msg = "Bundle.Entry.request contains unsupported HTTP method: "
-                        + method.getValue();
-                IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
-                        .extension(Extension.builder()
-                            .url(EXTENSION_URL +  "/not-supported-detail")
-                            .value(string("interaction"))
-                            .build())
-                        .build();
-                throw buildRestException(msg, extendedIssueType);
-            }
-            // Purposefully fall through to next clause
-        case HEAD:
-        case GET:
-            if (resource != null) {
-                String msg =
-                        "Bundle.Entry.resource not allowed for BundleEntry with " + method.getValue() + " method.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-            break;
-        case PUT:
-            if (resource == null) {
-                String msg =
-                        "Bundle.Entry.resource is required for BundleEntry with PUT method.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-            if (resource.getId() == null) {
-                String msg =
-                        "Bundle.Entry.resource must contain an id field for a PUT operation.";
-                throw buildRestException(msg, IssueType.REQUIRED);
-            }
-            break;
-        default:
-            String msg = "Bundle.Entry.request contains unsupported HTTP method: " + method.getValue();
-            throw buildRestException(msg, IssueType.INVALID);
-        }
-    }
-
-    /**
-     * This function will perform the version-aware update check by making sure that the If-Match request header value
-     * (if present) specifies a version # equal to the current latest version of the resource. If the check fails, then
-     * a FHIRRestException will be thrown. If the check succeeds then nothing occurs and processing continues.
-     *
-     * @param currentResource
-     *            the current latest version of the resource
-     */
-    private void performVersionAwareUpdateCheck(Resource currentResource, String ifMatchValue)
-            throws FHIROperationException {
-        if (ifMatchValue != null) {
-            log.fine("Performing a version aware update. ETag value =  " + ifMatchValue);
-
-            String ifMatchVersion = getVersionIdFromETagValue(ifMatchValue);
-
-            // Make sure that we got a version # from the request header.
-            // If not, then return a 400 Bad Request status code.
-            if (ifMatchVersion == null || ifMatchVersion.isEmpty()) {
-                throw buildRestException("Invalid ETag value specified in request: "
-                        + ifMatchValue, IssueType.PROCESSING);
-            }
-
-            log.fine("Version id from ETag value specified in request: " + ifMatchVersion);
-
-            // Retrieve the version #'s from the current and updated resources.
-            String currentVersion = null;
-            if (currentResource.getMeta() != null
-                    && currentResource.getMeta().getVersionId() != null) {
-                currentVersion = currentResource.getMeta().getVersionId().getValue();
-            }
-
-            // Next, make sure that the If-Match version matches the version # found
-            // in the current latest version of the resource.
-            // If they don't match we'll return an HTTP 412 (Precondition Failed) status code.
-            if (!ifMatchVersion.equals(currentVersion)) {
-                String msg = "If-Match version '" + ifMatchVersion
-                        + "' does not match current latest version of resource: " + currentVersion;
-                IssueType extendedIssueType = IssueType.CONFLICT.toBuilder()
-                        .extension(Extension.builder()
-                            .url(EXTENSION_URL + "/http-failed-precondition")
-                            .value(string("If-Match"))
-                            .build())
-                        .build();
-                throw buildRestException(msg, extendedIssueType);
-            }
-        }
-    }
-
-    private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName, IssueType issueType) 
-            throws FHIROperationException {
-        return buildRestException("'" + resourceTypeName + "' is not a valid resource type.", issueType);
     }
 
     private FHIROperationException buildRestException(String msg, IssueType issueType) {
@@ -2694,714 +1171,6 @@ public class FHIRResource implements FHIRResourceHelpers {
     }
 
     /**
-     * Retrieves the version id value from an ETag header value. The ETag header value will be of the form:
-     * W/"<version-id>".
-     *
-     * @param ifMatchValue
-     *            the value of the If-Match request header.
-     */
-    private String getVersionIdFromETagValue(String ifMatchValue) {
-        String result = null;
-        if (ifMatchValue != null) {
-            if (ifMatchValue.startsWith("W/")) {
-                String s = ifMatchValue.substring(2);
-                // If the part after "W/" starts and ends with a ",
-                // then extract the part between the " characters and we're done.
-                if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
-                    result = s.substring(1, s.length() - 1);
-                }
-            }
-        }
-        return result;
-    }
-
-    /**
-     * This function will process each request contained in the specified request bundle, and update the response bundle
-     * with the appropriate response information.
-     *
-     * @param requestBundle
-     *            the bundle containing the requests
-     * @param responseBundle
-     *            the bundle containing the responses
-     */
-    private Bundle processBundleEntries(Bundle requestBundle, Bundle responseBundle,
-            Map<String, String> requestProperties) throws Exception {
-        log.entering(this.getClass().getName(), "processBundleEntries");
-
-        FHIRTransactionHelper txn = null;
-
-        // Generate a request correlation id for this request bundle.
-        bundleRequestCorrelationId = UUID.randomUUID().toString();
-        log.fine("Processing request bundle, request-correlation-id=" + bundleRequestCorrelationId);
-
-        try {
-            // If we're working on a 'transaction' type interaction, then start a new transaction now
-            // and sort the request bundle entries by their "url" field.
-            if (responseBundle.getType() == BundleType.TRANSACTION_RESPONSE) {
-                bundleTransactionCorrelationId = bundleRequestCorrelationId;
-                txn = new FHIRTransactionHelper(getTransaction());
-                txn.begin();
-                log.fine("Started new transaction for transaction bundle, txn-correlation-id="
-                        + bundleTransactionCorrelationId);
-            }
-
-            Map<String, String> localRefMap = new HashMap<>();
-
-            // Next, process entries in the correct order.
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.DELETE,
-                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.POST,
-                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.PUT,
-                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.GET,
-                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
-
-            if (txn != null) {
-                log.fine("Committing transaction for transaction bundle, txn-correlation-id="
-                        + bundleTransactionCorrelationId);
-                txn.commit();
-                txn = null;
-            }
-            return responseBundle;
-
-        } finally {
-            log.fine("Finished processing request bundle, request-correlation-id="
-                    + bundleRequestCorrelationId);
-
-            // Clear both correlation id fields since we're done processing the bundle.
-            bundleRequestCorrelationId = null;
-            bundleTransactionCorrelationId = null;
-
-            if (txn != null) {
-                txn.rollback();
-                txn = null;
-            }
-            log.exiting(this.getClass().getName(), "processBundleEntries");
-        }
-    }
-
-    /**
-     * Processes request entries in the specified request bundle whose method matches 'httpMethod'.
-     *
-     * @param requestBundle
-     *            the bundle containing the request entries
-     * @param responseBundle
-     *            the bundle containing the corresponding response entries
-     * @param httpMethod
-     *            the HTTP method (GET, POST, PUT, etc.) to be processed
-     */
-    private Bundle processEntriesForMethod(Bundle requestBundle, Bundle responseBundle,
-            HTTPVerb httpMethod, boolean failFast, Map<String, String> localRefMap,
-            Map<String, String> bundleRequestProperties, String bundleRequestCorrelationId)
-            throws Exception {
-        log.entering(this.getClass().getName(), "processEntriesForMethod", new Object[] {
-                "httpMethod", httpMethod });
-        try {
-            // First, obtain a list of request entry indices for the entries that we'll process.
-            // This list will contain the indices associated with only the entries for the specified http method.
-            List<Integer> entryIndices =
-                    getBundleRequestIndicesForMethod(requestBundle, responseBundle, httpMethod);
-            if (log.isLoggable(Level.FINER)) {
-                log.finer("Bundle request indices to be processed: " + entryIndices.toString());
-            }
-
-            // Next, for PUT (update) requests, extract any local identifiers and resolve them ahead of time.
-            // We do this to prevent any local reference problems from occurring due to our re-ordering
-            // of the PUT request entries.
-            if (httpMethod.equals(HTTPVerb.PUT)) {
-                if (log.isLoggable(Level.FINER)) {
-                    log.finer("Pre-processing bundle request entries for PUT method...");
-                }
-                for (Integer index : entryIndices) {
-                    Bundle.Entry requestEntry = requestBundle.getEntry().get(index);
-
-                    // Retrieve the local identifier from the request entry (if present).
-                    String localIdentifier = retrieveLocalIdentifier(requestEntry, localRefMap);
-
-                    // Since this is for a PUT request (update) we should be able to resolve the local identifier
-                    // prior to processing the request since the resource's id must already be contained in the resource
-                    // within the request entry.
-                    if (localIdentifier != null) {
-                        Resource resource = requestEntry.getResource();
-                        addLocalRefMapping(localRefMap, localIdentifier, resource);
-                    }
-                }
-            }
-
-            // Next, for PUT and DELETE requests, we need to sort the indices by the request url path value.
-            if (httpMethod.equals(HTTPVerb.PUT) || httpMethod.equals(HTTPVerb.DELETE)) {
-                sortBundleRequestEntries(requestBundle, entryIndices);
-                if (log.isLoggable(Level.FINER)) {
-                    log.finer("Sorted bundle request indices to be processed: "
-                            + entryIndices.toString());
-                }
-            }
-
-            // Now visit each of the request entries using the list of indices obtained above.
-            // Use hashmap to store both the index and the according updated response bundle entry.
-            HashMap<Integer, Bundle.Entry> responseIndexAndEntries =
-                    new HashMap<Integer, Bundle.Entry>();
-            for (Integer entryIndex : entryIndices) {
-                Bundle.Entry requestEntry = requestBundle.getEntry().get(entryIndex);
-                Bundle.Entry responseEntry = responseBundle.getEntry().get(entryIndex);
-                Bundle.Entry.Builder responseEntryBuilder = responseEntry.toBuilder();
-
-                Bundle.Entry.Request request = requestEntry.getRequest();
-                Bundle.Entry.Response response = responseEntry.getResponse();
-
-                StringBuffer requestDescription = new StringBuffer();
-                long initialTime = System.currentTimeMillis();
-                try {
-                    FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
-
-                    String path = requestURL.getPath();
-                    String query = requestURL.getQuery();
-                    if (log.isLoggable(Level.FINER)) {
-                        log.finer("Processing bundle request entry " + entryIndex + "; method="
-                                + request.getMethod().getValue() + ", url="
-                                + request.getUrl().getValue());
-                        log.finer("--> path: " + path);
-                        log.finer("--> query: " + query);
-                    }
-
-                    // Log our initial info message for this request.
-                    requestDescription.append("entryIndex:[");
-                    requestDescription.append(entryIndex);
-                    requestDescription.append("] correlationId:[");
-                    requestDescription.append(bundleRequestCorrelationId);
-                    requestDescription.append("] method:[");
-                    requestDescription.append(request.getMethod().getValue());
-                    requestDescription.append("] uri:[");
-                    requestDescription.append(request.getUrl().getValue());
-                    requestDescription.append("]");
-                    log.info("Received bundle request: " + requestDescription.toString());
-
-                    String[] pathTokens = requestURL.getPathTokens();
-                    MultivaluedMap<String, String> queryParams = requestURL.getQueryParameters();
-
-                    // Construct the absolute requestUri to be used for any response bundles associated
-                    // with history and search requests.
-                    String absoluteUri =
-                            getAbsoluteUri(getRequestUri(), request.getUrl().getValue());
-
-                    if (request.getMethod().equals(HTTPVerb.GET)) {
-                        Resource resource = null;
-                        int httpStatus = SC_OK;
-
-                        // Process a GET (read, vread, history, search, etc.).
-                        // Determine the type of request from the path tokens.
-                        if (pathTokens.length > 0
-                                && pathTokens[pathTokens.length - 1].startsWith("$")) {
-                            // This is a custom operation request
-                            checkInitComplete();
-
-                            // Chop off the '$' and save the name
-                            String operationName = pathTokens[pathTokens.length - 1].substring(1);
-
-                            // FHIROperationContext operationContext;
-                            switch (pathTokens.length) {
-                            case 1: {
-                                FHIROperationContext operationContext =
-                                        FHIROperationContext.createSystemOperationContext();
-                                resource =
-                                        doInvoke(operationContext, null, null, null, operationName, null, queryParams, null);
-                            }
-                                break;
-                            case 2: {
-                                FHIROperationContext operationContext =
-                                        FHIROperationContext.createResourceTypeOperationContext();
-                                resource =
-                                        doInvoke(operationContext, pathTokens[0], null, null, operationName, null, queryParams, null);
-                            }
-                                break;
-                            case 3: {
-                                FHIROperationContext operationContext =
-                                        FHIROperationContext.createInstanceOperationContext();
-                                resource =
-                                        doInvoke(operationContext, pathTokens[0], pathTokens[1], null, operationName, null, queryParams, null);
-                            }
-                                break;
-                            default:
-                                String msg = "Invalid URL for custom operation '"
-                                        + pathTokens[pathTokens.length - 1] + "'";
-                                throw buildRestException(msg, IssueType.NOT_FOUND);
-                            }
-                        } else if (pathTokens.length == 1) {
-                            // This is a 'search' request.
-                            if ("_search".equals(pathTokens[0])) {
-                                resource =
-                                        doSearch("Resource", null, null, queryParams, absoluteUri, null, null);
-                            } else {
-                                resource =
-                                        doSearch(pathTokens[0], null, null, queryParams, absoluteUri, null, null);
-                            }
-                        } else if (pathTokens.length == 2) {
-                            // This is a 'read' request.
-                            resource =
-                                    doRead(pathTokens[0], pathTokens[1], true, false, null, null);
-                        } else if (pathTokens.length == 3) {
-                            if ("_history".equals(pathTokens[2])) {
-                                // This is a 'history' request.
-                                resource =
-                                        doHistory(pathTokens[0], pathTokens[1], queryParams, absoluteUri, null);
-                            } else {
-                                // This is a compartment based search
-                                resource =
-                                        doSearch(pathTokens[2], pathTokens[0], pathTokens[1], queryParams, absoluteUri, null, null);
-                            }
-                        } else if (pathTokens.length == 4 && pathTokens[2].equals("_history")) {
-                            // This is a 'vread' request.
-                            resource = doVRead(pathTokens[0], pathTokens[1], pathTokens[3], null);
-                        } else {
-                            String msg = "Unrecognized path in request URL: " + path;
-                            throw buildRestException(msg, IssueType.NOT_FOUND);
-                        }
-
-                        // Save the results of the operation in the bundle response field.
-                        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                        responseBuilder.status(string(Integer.toString(httpStatus)));
-                        setBundleResponseStatus(response, httpStatus, requestDescription.toString(), initialTime);
-
-                        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(resource).response(responseBuilder.build()).build());
-                    } else if (request.getMethod().equals(HTTPVerb.POST)) {
-                        // Process a POST (create or search, or custom operation).
-                        if (pathTokens.length > 0
-                                && pathTokens[pathTokens.length - 1].startsWith("$")) {
-                            // This is a custom operation request
-                            checkInitComplete();
-
-                            // Chop off the '$' and save the name
-                            String operationName = pathTokens[pathTokens.length - 1].substring(1);
-
-                            // Retrieve the resource from the request entry.
-                            Resource resource = requestEntry.getResource();
-
-                            FHIROperationContext operationContext;
-                            Resource result;
-                            switch (pathTokens.length) {
-                            case 1:
-                                operationContext =
-                                        FHIROperationContext.createSystemOperationContext();
-                                result = doInvoke(operationContext, null, null, null, operationName, resource, queryParams, null);
-                                break;
-                            case 2:
-                                operationContext =
-                                        FHIROperationContext.createResourceTypeOperationContext();
-                                result = doInvoke(operationContext, pathTokens[0], null, null, operationName, resource, queryParams, null);
-                                break;
-                            case 3:
-                                operationContext =
-                                        FHIROperationContext.createInstanceOperationContext();
-                                result = doInvoke(operationContext, pathTokens[0], pathTokens[1], null, operationName, resource, queryParams, null);
-                                break;
-                            default:
-                                String msg = "Invalid URL for custom operation '"
-                                        + pathTokens[pathTokens.length - 1] + "'";
-                                throw buildRestException(msg, IssueType.NOT_FOUND);
-                            }
-
-                            Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                            // Add warning and hint issues to response outcome if any.
-                            if (result instanceof OperationOutcome) {
-                                if (((OperationOutcome) result).getIssue() != null) {
-                                    responseBuilder.outcome(result);
-                                }
-                            }
-
-                            responseBuilder.status(string(Integer.toString(SC_OK)));
-                            responseIndexAndEntries.put(entryIndex, responseEntryBuilder
-                                    .resource(result)
-                                    .response(responseBuilder.build())
-                                    .build());
-                            setBundleResponseStatus(response, SC_OK, requestDescription.toString(), initialTime);
-
-                        } else if (pathTokens.length == 2 && "_search".equals(pathTokens[1])) {
-                            // This is a 'search' request.
-                            Bundle searchResults =
-                                    doSearch(pathTokens[0], null, null, queryParams, absoluteUri, null, null);
-
-                            // Save the results of the operation in the bundle response field.
-                            Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                            responseBuilder.status(string(Integer.toString(SC_OK)));
-
-                            responseIndexAndEntries.put(entryIndex, responseEntryBuilder
-                                    .resource(searchResults)
-                                    .response(responseBuilder.build())
-                                    .build());
-
-                            setBundleResponseStatus(response, SC_OK, requestDescription.toString(), initialTime);
-                        } else if (pathTokens.length == 1) {
-                            // This is a 'create' request.
-
-                            // Retrieve the local identifier from the request entry (if present).
-                            String localIdentifier =
-                                    retrieveLocalIdentifier(requestEntry, localRefMap);
-
-                            // Retrieve the resource from the request entry.
-                            Resource resource = requestEntry.getResource();
-                            if (resource == null) {
-                                String msg =
-                                        "BundleEntry.resource is required for bundled create requests.";
-                                throw buildRestException(msg, IssueType.NOT_FOUND);
-                            }
-
-                            // Convert any local references found within the resource to their
-                            // corresponding external reference.
-
-                            ReferenceMappingVisitor<Resource> visitor =
-                                    new ReferenceMappingVisitor<Resource>(localRefMap);
-                            resource.accept(visitor);
-                            resource = visitor.getResult();
-
-                            // Perform the 'create' operation.
-                            String ifNoneExist = request.getIfNoneExist() != null
-                                    ? request.getIfNoneExist().getValue() : null;
-                            FHIRRestOperationResponse ior =
-                                    doCreate(pathTokens[0], resource, ifNoneExist, null);
-
-                            // Get the updated resource from FHIRRestOperationResponse which has the correct ID, meta
-                            // etc.
-                            resource = ior.getResource();
-
-                            // Process and replace bundler Entry
-                            Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, resource, ior.getOperationOutcome(), 
-                                    ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
-
-                            responseIndexAndEntries.put(entryIndex, resultEntry);
-
-                            // Next, if a local identifier was present, we'll need to map this to the
-                            // correct external identifier (e.g. Patient/12345).
-                            addLocalRefMapping(localRefMap, localIdentifier, resource);
-                        } else {
-                            String msg =
-                                    "Request URL for bundled create requests should have a path with exactly one token (<resourceType>).";
-                            throw buildRestException(msg, IssueType.NOT_FOUND);
-                        }
-                    } else if (request.getMethod().equals(HTTPVerb.PUT)) {
-                        String type = null;
-                        String id = null;
-
-                        // Process a PUT (update).
-                        if (pathTokens.length == 1) {
-                            // A single-part url would be a conditional update: <type>?<query>
-                            type = pathTokens[0];
-                            if (query == null || query.isEmpty()) {
-                                String msg =
-                                        "A search query string is required for a conditional update operation.";
-                                throw buildRestException(msg, IssueType.INVALID);
-                            }
-                        } else if (pathTokens.length == 2) {
-                            // A two-part url would be a normal update: <type>/<id>.
-                            type = pathTokens[0];
-                            id = pathTokens[1];
-                        } else {
-                            // A url with any other pattern is an error.
-                            String msg = "Request URL for bundled PUT request should have path part with either one or two tokens "
-                                    + "(<resourceType> or <resourceType>/<id>).";
-                            throw buildRestException(msg, IssueType.INVALID);
-                        }
-
-                        // Retrieve the resource from the request entry.
-                        Resource resource = requestEntry.getResource();
-
-                        // Convert any local references found within the resource to their
-                        // corresponding external reference.
-                        ReferenceMappingVisitor<Resource> visitor =
-                                new ReferenceMappingVisitor<Resource>(localRefMap);
-                        resource.accept(visitor);
-                        resource = visitor.getResult();
-
-                        // Perform the 'update' operation.
-                        String ifMatchBundleValue = null;
-                        if (request.getIfMatch() != null) {
-                            ifMatchBundleValue = request.getIfMatch().getValue();
-                        }
-                        FHIRRestOperationResponse ior =
-                                doUpdate(type, id, resource, ifMatchBundleValue, query, null);
-
-                        // Process and replace bundler Entry
-                        Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), 
-                                ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
-
-                        responseIndexAndEntries.put(entryIndex, resultEntry);
-
-                    } else if (request.getMethod().equals(HTTPVerb.DELETE)) {
-                        String type = null;
-                        String id = null;
-
-                        // Process a DELETE.
-                        if (pathTokens.length == 1) {
-                            // A single-part url would be a conditional delete: <type>?<query>
-                            type = pathTokens[0];
-                            if (query == null || query.isEmpty()) {
-                                String msg =
-                                        "A search query string is required for a conditional delete operation.";
-                                throw buildRestException(msg, IssueType.INVALID);
-                            }
-                        } else if (pathTokens.length == 2) {
-                            type = pathTokens[0];
-                            id = pathTokens[1];
-                        } else {
-                            String msg = "Request URL for bundled DELETE request should have path part with one or two tokens "
-                                    + "(<resourceType> or <resourceType>/<id>).";
-                            throw buildRestException(msg, IssueType.INVALID);
-                        }
-
-                        // Perform the 'delete' operation.
-                        FHIRRestOperationResponse ior = doDelete(type, id, query, null);
-
-                        // Process and replace bundler Entry
-                        Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), 
-                                null, ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
-
-                        responseIndexAndEntries.put(entryIndex, resultEntry);
-                    } else {
-                        // Internal error, should not get here!
-                        throw new IllegalStateException("Internal Server Error: reached an unexpected code location.");
-                    }
-                } catch (FHIRPersistenceResourceNotFoundException e) {
-                    if (failFast) {
-                        String msg = "Error while processing request bundle.";
-                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
-                    }
-                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                    responseBuilder.status(string(Integer.toString(SC_NOT_FOUND)));
-
-                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder
-                            .resource(FHIRUtil.buildOperationOutcome(e, false))
-                            .response(responseBuilder.build())
-                            .build());
-
-                    setBundleResponseStatus(response, SC_NOT_FOUND, requestDescription.toString(), initialTime);
-                } catch (FHIRPersistenceResourceDeletedException e) {
-                    if (failFast) {
-                        String msg = "Error while processing request bundle.";
-                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
-                    }
-                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                    responseBuilder.status(string(Integer.toString(SC_GONE)));
-
-                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder
-                            .resource(FHIRUtil.buildOperationOutcome(e, false))
-                            .response(responseBuilder.build())
-                            .build());
-
-                    setBundleResponseStatus(response, SC_GONE, requestDescription.toString(), initialTime);
-                } catch (FHIROperationException e) {
-                    if (failFast) {
-                        String msg = "Error while processing request bundle.";
-                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
-                    }
-                    
-                    Status status;
-                    if (e instanceof FHIRSearchException) {
-                        status = Status.BAD_REQUEST;
-                    } else {
-                        status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
-                    }
-
-                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                    responseBuilder.status(string(Integer.toString(status.getStatusCode())));
-
-                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(FHIRUtil.buildOperationOutcome(e, false))
-                            .response(responseBuilder.build()).build());
-
-                    setBundleResponseStatus(response, status.getStatusCode(), requestDescription.toString(), initialTime);
-                }
-            } // end foreach entry
-            
-            // Now, let's re-construct the responseBundle
-            responseBundle = reconstructResponseBundle(responseBundle, responseIndexAndEntries);
-            return responseBundle;
-
-        } finally {
-            log.exiting(this.getClass().getName(), "processEntriesForMethod");
-        }
-    }
-
-    /**
-     * @param responseBundle
-     * @param responseIndexAndEntries
-     * @return
-     */
-    private Bundle reconstructResponseBundle(Bundle responseBundle,
-        HashMap<Integer, Bundle.Entry> responseIndexAndEntries) {
-        // Re-construct the responseBundle
-        List<Bundle.Entry> responseEntries = new ArrayList<Bundle.Entry>();
-        for (int i = 0; i < responseBundle.getEntry().size(); i++) {
-            Bundle.Entry bundleEntry = responseIndexAndEntries.get(Integer.valueOf(i)) == null
-                    ? responseBundle.getEntry().get(i)
-                    : responseIndexAndEntries.get(Integer.valueOf(i));
-            responseEntries.add(bundleEntry);
-        }
-
-        responseBundle = responseBundle.toBuilder().entry(responseEntries).build();
-        return responseBundle;
-    }
-
-    /**
-     * Returns a list of Integers that provide the indices of the bundle entries associated with the specified http
-     * method.
-     *
-     * @param requestBundle
-     *            the request bundle
-     * @param httpMethod
-     *            the http method to look for
-     * @return
-     */
-    private List<Integer> getBundleRequestIndicesForMethod(Bundle requestBundle,
-        Bundle responseBundle, HTTPVerb httpMethod) {
-        List<Integer> indices = new ArrayList<>();
-        for (int i = 0; i < requestBundle.getEntry().size(); i++) {
-            Bundle.Entry requestEntry = requestBundle.getEntry().get(i);
-            Bundle.Entry.Request request = requestEntry.getRequest();
-            
-            Bundle.Entry responseEntry = responseBundle.getEntry().get(i);
-            Bundle.Entry.Response response = responseEntry.getResponse();
-
-            // If the response status is SC_OK which means the request passed the validation,
-            // and this request entry's http method is the one we're looking for,
-            // then record the index in our list.
-            // (please notice that status can not be null since R4, So we set the response status as SC_OK
-            // after the resource validation. )
-            if (response.getStatus().equals(string(Integer.toString(SC_OK)))
-                    && request.getMethod().equals(httpMethod)) {
-                indices.add(Integer.valueOf(i));
-            }
-        }
-        return indices;
-    }
-
-    /**
-     * This function sorts the request entries in the specified bundle, based on the path part of the entry's 'url'
-     * field.
-     *
-     * @param bundle
-     *            the bundle containing the request entries to be sorted.
-     * @return an array of Integer which provides the "sorted" ordering of request entry index values.
-     */
-    private void sortBundleRequestEntries(Bundle bundle, List<Integer> indices) {
-        // Sort the list of indices based on the contents of their entries in the bundle.
-        Collections.sort(indices, new BundleEntryComparator(bundle.getEntry()));
-    }
-
-    public static class BundleEntryComparator implements Comparator<Integer> {
-        private List<Bundle.Entry> entries;
-
-        public BundleEntryComparator(List<Bundle.Entry> entries) {
-            this.entries = entries;
-        }
-
-        /*
-         * (non-Javadoc)
-         * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-         */
-        @Override
-        public int compare(Integer indexA, Integer indexB) {
-            Bundle.Entry a = entries.get(indexA);
-            Bundle.Entry b = entries.get(indexB);
-            String pathA = getUrlPath(a);
-            String pathB = getUrlPath(b);
-
-            log.fine("Comparing request entry URL paths: " + pathA + ", " + pathB);
-            if (pathA != null && pathB != null) {
-                return pathA.compareTo(pathB);
-            } else if (pathA != null) {
-                return 1;
-            } else if (pathB != null) {
-                return -1;
-            }
-            return 0;
-        }
-    }
-
-    /**
-     * This function converts the specified query string (a String) into an equivalent MultivaluedMap<String,String>
-     * containing the query parameters defined in the query string.
-     *
-     * @param queryString
-     *            the query string to be processed
-     * @return
-     */
-    private MultivaluedMap<String, String> getQueryParameterMap(String queryString) {
-        MultivaluedMap<String, String> result = null;
-        FHIRUrlParser parser = new FHIRUrlParser("foo?" + queryString);
-        result = parser.getQueryParameters();
-        return result;
-    }
-
-    /**
-     * Returns the specified BundleEntry's path component of the 'url' field.
-     *
-     * @param entry
-     *            the bundle entry
-     * @return the bundle entry's 'url' field's path component
-     */
-    private static String getUrlPath(Bundle.Entry entry) {
-        String path = null;
-        Bundle.Entry.Request request = entry.getRequest();
-        if (request != null) {
-            if (request.getUrl() != null && request.getUrl().getValue() != null) {
-                FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
-                path = requestURL.getPath();
-            }
-        }
-
-        return path;
-    }
-
-    /**
-     * This method will add a mapping to the local-to-external identifier map if the specified localIdentifier is
-     * non-null.
-     *
-     * @param localRefMap
-     *            the map containing the local-to-external identifier mappings
-     * @param localIdentifier
-     *            the localIdentifier previously obtained for the resource
-     * @param resource
-     *            the resource for which an external identifier will be built
-     */
-    private void addLocalRefMapping(Map<String, String> localRefMap, String localIdentifier,
-        Resource resource) {
-        if (localIdentifier != null) {
-            String externalIdentifier =
-                    ModelSupport.getTypeName(resource.getClass()) + "/" + resource.getId();
-            localRefMap.put(localIdentifier, externalIdentifier);
-            log.finer("Added local/ext identifier mapping: " + localIdentifier + " --> "
-                    + externalIdentifier);
-        }
-    }
-
-    /**
-     * This method will retrieve the local identifier associated with the specified bundle request entry, or return null
-     * if the fullUrl field is not specified or doesn't contain a local identifier.
-     *
-     * @param requestEntry
-     *            the bundle request entry
-     * @param localRefMap
-     *            the Map containing the local-to-external reference mappings
-     * @return
-     */
-    private String retrieveLocalIdentifier(Bundle.Entry requestEntry,
-            Map<String, String> localRefMap) throws Exception {
-        String localIdentifier = null;
-        if (requestEntry.getFullUrl() != null) {
-            String fullUrl = requestEntry.getFullUrl().getValue();
-            if (fullUrl != null && fullUrl.startsWith(LOCAL_REF_PREFIX)) {
-                localIdentifier = fullUrl;
-                log.finer("Request entry contains local identifier: " + localIdentifier);
-                if (localRefMap.get(localIdentifier) != null) {
-                    String msg = "Duplicate local identifier encountered in bundled request entry: "
-                            + localIdentifier;
-                    throw buildRestException(msg, IssueType.DUPLICATE);
-                }
-            }
-        }
-        return localIdentifier;
-    }
-
-    /**
      * This function will build an absolute URI from the specified base URI and relative URI.
      *
      * @param baseUri
@@ -3418,47 +1187,6 @@ public class FHIRResource implements FHIRResourceHelpers {
         }
         fullUri.append((relativeUri.startsWith("/") ? relativeUri.substring(1) : relativeUri));
         return fullUri.toString();
-    }
-
-    private Bundle.Entry setBundleResponseFields(Bundle.Entry responseEntry, Resource resource,
-        OperationOutcome operationOutcome, URI locationURI, int httpStatus, String requestDescription, long initialTime) throws FHIROperationException {
-
-        Bundle.Entry.Response response = responseEntry.getResponse();
-        Bundle.Entry.Response.Builder resBuilder = response.toBuilder();
-        resBuilder.status(string(Integer.toString(httpStatus)));
-
-        Bundle.Entry.Builder bundleEntryBuilder = responseEntry.toBuilder();
-
-        if (resource != null) {
-            resBuilder =
-                    resBuilder.id(resource.getId()).lastModified(resource.getMeta().getLastUpdated()).etag(string(getEtagValue(resource)));
-
-            if (HTTPReturnPreference.REPRESENTATION.equals(FHIRRequestContext.get().getReturnPreference())) {
-                bundleEntryBuilder.resource(resource);
-            } else if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
-                bundleEntryBuilder.resource(operationOutcome);
-            }
-        }
-        if (locationURI != null) {
-            resBuilder = resBuilder.location(Uri.of(locationURI.toString()));
-        }
-
-        logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
-        return bundleEntryBuilder.response(resBuilder.build()).build();
-    }
-
-    private void setBundleResponseStatus(Bundle.Entry.Response response, int httpStatus,
-        String requestDescription, long initialTime) {
-        logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
-    }
-
-    private void logBundleRequestCompletedMsg(String requestDescription, long initialTime,
-        int httpStatus) {
-        StringBuffer statusMsg = new StringBuffer();
-        statusMsg.append(" status:[" + httpStatus + "]");
-        double elapsedSecs = (System.currentTimeMillis() - initialTime) / 1000.0;
-        log.info("Completed bundle request[" + elapsedSecs + " secs]: "
-                + requestDescription.toString() + statusMsg.toString());
     }
 
     /**
@@ -3812,127 +1540,6 @@ public class FHIRResource implements FHIRResourceHelpers {
     }
 
     /**
-     * Creates a bundle that will hold results for a search operation.
-     *
-     * @param resources
-     *            the list of resources to include in the bundle
-     * @param searchContext
-     *            the FHIRSearchContext object associated with the search
-     * @param type 
-     *            the name of the resource type being searched
-     * @return the bundle
-     * @throws Exception 
-     */
-    private Bundle createSearchBundle(List<Resource> resources, FHIRSearchContext searchContext, String type)
-        throws Exception {
-
-        // throws if we have a count of more than 2,147,483,647 resources
-        UnsignedInt totalCount = UnsignedInt.of(searchContext.getTotalCount());
-        // generate ID for this bundle and set total
-        Bundle.Builder bundleBuider = Bundle.builder()
-                                            .type(BundleType.SEARCHSET)
-                                            .id(UUID.randomUUID().toString())
-                                            .total(totalCount);
-
-        for (Resource resource : resources) {
-            if (resource.getId() == null) {
-                throw new IllegalStateException("Returned resources must have an id.");
-            }
-            Bundle.Entry entry = Bundle.Entry.builder().fullUrl(Uri.of(getRequestBaseUri(type) + "/"
-                    + resource.getClass().getSimpleName() + "/"
-                    + resource.getId())).resource(resource).build();
-
-            bundleBuider.entry(entry);
-        }
-
-        Bundle bundle = bundleBuider.build();
-
-        // Add the SUBSETTED tag, if the _elements search result parameter was applied to limit elements included in
-        // returned resources or _summary is required.
-        if (searchContext.hasElementsParameters()
-                || (searchContext.hasSummaryParameter() && !searchContext.getSummaryParameter().equals(SummaryValueSet.FALSE))) {
-            bundle = FHIRUtil.addTag(bundle, SearchConstants.SUBSETTED_TAG);
-        }
-
-        return bundle;
-    }
-
-    /**
-     * Creates a bundle that will hold the results of a history operation.
-     *
-     * @param resources
-     *            the list of resources to include in the bundle
-     * @param historyContext
-     *            the FHIRHistoryContext associated with the history operation
-     * @param type
-     *            the name of the resource type on which the history operation was requested
-     * @return the bundle
-     * @throws Exception 
-     */
-    private Bundle createHistoryBundle(List<? extends Resource> resources, FHIRHistoryContext historyContext, String type)
-        throws Exception {
-
-        // throws if we have a count of more than 2,147,483,647 resources
-        UnsignedInt totalCount = UnsignedInt.of(historyContext.getTotalCount());
-        // generate ID for this bundle and set the "total" field for the bundle
-        Bundle.Builder bundleBuilder = Bundle.builder()
-                                             .type(BundleType.HISTORY)
-                                             .id(UUID.randomUUID().toString())
-                                             .total(totalCount);
-
-        Map<String, List<Integer>> deletedResourcesMap = historyContext.getDeletedResources();
-
-        for (int i = 0; i < resources.size(); i++) {
-            Resource resource = resources.get(i);
-
-            if (resource.getId() == null) {
-                throw new IllegalStateException("Returned resources must have an id.");
-            }
-
-            Integer versionId = Integer.valueOf(resource.getMeta().getVersionId().getValue());
-            String logicalId = resource.getId();
-            String resourceType = ModelSupport.getTypeName(resource.getClass());
-            List<Integer> deletedVersions = deletedResourcesMap.get(logicalId);
-
-            // Determine the correct method to include in this history entry (POST, PUT, DELETE).
-            HTTPVerb method;
-            if (deletedVersions != null && deletedVersions.contains(versionId)) {
-                method = HTTPVerb.DELETE;
-            } else if (versionId == 1) {
-                method = HTTPVerb.POST;
-            } else {
-                method = HTTPVerb.PUT;
-            }
-
-            // Create the 'request' entry, and set the request.url field.
-            // 'create' --> url = "<resourceType>"
-            // 'update'/'delete' --> url = "<resourceType>/<logicalId>"
-            Bundle.Entry.Request request =
-                    Bundle.Entry.Request.builder().method(method).url(Url.of(method == HTTPVerb.POST
-                            ? resourceType : resourceType + "/" + logicalId)).build();
-
-            Bundle.Entry.Response response =
-                    Bundle.Entry.Response.builder().status(string("200")).build();
-
-            Bundle.Entry entry =
-                    Bundle.Entry.builder().request(request).fullUrl(Uri.of(getRequestBaseUri(type) + "/"
-                            + resource.getClass().getSimpleName() + "/"
-                            + resource.getId())).response(response).resource(resource).build();
-
-            bundleBuilder.entry(entry);
-        }
-
-        return bundleBuilder.build();
-    }
-
-    /**
-     * Retrieves the shared interceptor mgr instance from the servlet context.
-     */
-    private FHIRPersistenceInterceptorMgr getInterceptorMgr() {
-        return FHIRPersistenceInterceptorMgr.getInstance();
-    }
-
-    /**
      * Retrieves the shared persistence helper object from the servlet context.
      */
     private synchronized PersistenceHelper getPersistenceHelper() {
@@ -3965,129 +1572,16 @@ public class FHIRResource implements FHIRResourceHelpers {
         return fhirConfig.getBooleanProperty(PROPERTY_UPDATE_CREATE_ENABLED, Boolean.TRUE);
     }
 
-    private Bundle addLinks(FHIRPagingContext context, Bundle responseBundle, String requestUri) throws Exception {
-        String selfUri = null;
-        SummaryValueSet summaryParameter = null;
-        Bundle.Builder bundleBuilder = responseBundle.toBuilder();
-        
-        if (context instanceof FHIRSearchContext) {
-            FHIRSearchContext searchContext = (FHIRSearchContext) context;
-            summaryParameter = searchContext.getSummaryParameter();
-            try {
-                selfUri = SearchUtil.buildSearchSelfUri(requestUri, searchContext);
-            } catch (Exception e) {
-                log.log(Level.WARNING, "Unable to construct self link for search result bundle; using the request URI instead.", e);
-            }
-        }
-        if (selfUri == null) {
-            selfUri = requestUri;
-        }
-        // create 'self' link
-        Bundle.Link selfLink =
-                Bundle.Link.builder().relation(string("self")).url(Url.of(selfUri)).build();
-        bundleBuilder.link(selfLink);
-
-        // If for search with _summary=count or pageSize == 0, then don't add previous and next links.
-        if (!SummaryValueSet.COUNT.equals(summaryParameter) && context.getPageSize() > 0) {
-            int nextPageNumber = context.getPageNumber() + 1;
-            if (nextPageNumber <= context.getLastPageNumber()) {
-
-                // starting with the self URI
-                String nextLinkUrl = selfUri;
-
-                // remove existing _page parameters from the query string
-                nextLinkUrl =
-                        nextLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
-                                + context.getPageNumber() + "&", "").replace("_page="
-                                        + context.getPageNumber(), "");
-
-                if (nextLinkUrl.contains("?")) {
-                    if (!nextLinkUrl.endsWith("?")) {
-                        // there are other parameters in the query string
-                        nextLinkUrl += "&";
-                    }
-                } else {
-                    nextLinkUrl += "?";
-                }
-
-                // add new _page parameter to the query string
-                nextLinkUrl += "_page=" + nextPageNumber;
-
-                // create 'next' link
-                Bundle.Link nextLink =
-                        Bundle.Link.builder().relation(string("next")).url(Url.of(nextLinkUrl)).build();
-                bundleBuilder.link(nextLink);
-            }
-
-            int prevPageNumber = context.getPageNumber() - 1;
-            if (prevPageNumber > 0) {
-
-                // starting with the original request URI
-                String prevLinkUrl = requestUri;
-
-                // remove existing _page parameters from the query string
-                prevLinkUrl =
-                        prevLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
-                                + context.getPageNumber() + "&", "").replace("_page="
-                                        + context.getPageNumber(), "");
-
-                if (prevLinkUrl.contains("?")) {
-                    if (!prevLinkUrl.endsWith("?")) {
-                        // there are other parameters in the query string
-                        prevLinkUrl += "&";
-                    }
-                } else {
-                    prevLinkUrl += "?";
-                }
-
-                // add new _page parameter to the query string
-                prevLinkUrl += "_page=" + prevPageNumber;
-
-                // create 'previous' link
-                Bundle.Link prevLink =
-                        Bundle.Link.builder().relation(string("previous")).url(Url.of(prevLinkUrl)).build();
-                bundleBuilder.link(prevLink);
-            }
-        }
-
-        return bundleBuilder.build();
-    }
-
-    /**
-     * Builds a collection of properties that will be passed to the persistence interceptors.
-     *
-     * @throws FHIRPersistenceException
-     */
-    private Map<String, Object> buildPersistenceEventProperties(String type, String id,
-            String version, Map<String, String> requestProperties) throws FHIRPersistenceException {
-        Map<String, Object> props = new HashMap<>();
-        props.put(FHIRPersistenceEvent.PROPNAME_PERSISTENCE_IMPL, getPersistenceImpl());
-        props.put(FHIRPersistenceEvent.PROPNAME_URI_INFO, uriInfo);
-        props.put(FHIRPersistenceEvent.PROPNAME_HTTP_HEADERS, httpHeaders);
-        props.put(FHIRPersistenceEvent.PROPNAME_REQUEST_PROPERTIES, requestProperties);
-        props.put(FHIRPersistenceEvent.PROPNAME_SECURITY_CONTEXT, securityContext);
-        if (type != null) {
-            props.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, type);
-        }
-        if (id != null) {
-            props.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, id);
-        }
-        if (version != null) {
-            props.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, version);
-        }
-        return props;
-    }
-
     /**
      * Get the original request URI from either the HttpServletRequest or a configured Header (in case of re-writing proxies).
-     * 
+     *
      * <p>When the 'fhirServer/core/originalRequestUriHeaderName' property is empty, this method returns the equivalent of
-     * uriInfo.getRequestUri().toString(), except that uriInfo.getRequestUri() will throw an IllegalArgumentException 
-     * when the query string portion contains a vertical bar | character. The vertical bar is one known case of a special character 
+     * uriInfo.getRequestUri().toString(), except that uriInfo.getRequestUri() will throw an IllegalArgumentException
+     * when the query string portion contains a vertical bar | character. The vertical bar is one known case of a special character
      * causing the exception. There could be others.
      *
      * @return String The complete request URI
-     * @throws Exception if an error occurs while reading the config 
+     * @throws Exception if an error occurs while reading the config
      */
     private String getRequestUri() throws Exception {
         return FHIRRequestContext.get().getOriginalRequestUri();
@@ -4100,7 +1594,7 @@ public class FHIRResource implements FHIRResourceHelpers {
      *
      * @return The base endpoint URI associated with the current request.
      * @throws Exception if an error occurs while reading the config
-     * @implNote This method uses {@link #getRequestUri()} to get the original request URI and then strips it to the  
+     * @implNote This method uses {@link #getRequestUri()} to get the original request URI and then strips it to the
      *           <a href="https://www.hl7.org/fhir/http.html#general">Service Base URL</a>
      */
     private String getRequestBaseUri(String type) throws Exception {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -6,9 +6,6 @@
 
 package com.ibm.fhir.server.resources;
 
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_AUTHURL;
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_REGURL;
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_TOKENURL;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_UPDATE_CREATE_ENABLED;
 import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
@@ -16,39 +13,21 @@ import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToSt
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.json.JsonArray;
-import javax.json.JsonPatch;
-import javax.json.JsonValue;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -58,78 +37,31 @@ import javax.ws.rs.core.UriInfo;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
-import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
-import com.ibm.fhir.model.patch.FHIRJsonPatch;
-import com.ibm.fhir.model.patch.FHIRPatch;
 import com.ibm.fhir.model.resource.Bundle;
-import com.ibm.fhir.model.resource.CapabilityStatement;
-import com.ibm.fhir.model.resource.CapabilityStatement.Rest;
-import com.ibm.fhir.model.resource.CapabilityStatement.Rest.Resource.Interaction;
 import com.ibm.fhir.model.resource.OperationOutcome;
-import com.ibm.fhir.model.resource.OperationOutcome.Issue;
-import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.resource.SearchParameter;
-import com.ibm.fhir.model.type.Canonical;
-import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
-import com.ibm.fhir.model.type.Coding;
-import com.ibm.fhir.model.type.DateTime;
-import com.ibm.fhir.model.type.Extension;
-import com.ibm.fhir.model.type.Markdown;
-import com.ibm.fhir.model.type.Uri;
-import com.ibm.fhir.model.type.Url;
-import com.ibm.fhir.model.type.code.CapabilityStatementKind;
-import com.ibm.fhir.model.type.code.ConditionalDeleteStatus;
-import com.ibm.fhir.model.type.code.ConditionalReadStatus;
-import com.ibm.fhir.model.type.code.FHIRVersion;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
-import com.ibm.fhir.model.type.code.PublicationStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
-import com.ibm.fhir.model.type.code.RestfulCapabilityMode;
-import com.ibm.fhir.model.type.code.SystemRestfulInteraction;
-import com.ibm.fhir.model.type.code.TypeRestfulInteraction;
 import com.ibm.fhir.model.util.FHIRUtil;
-import com.ibm.fhir.operation.context.FHIROperationContext;
-import com.ibm.fhir.path.patch.FHIRPathPatch;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
 import com.ibm.fhir.persistence.helper.PersistenceHelper;
-import com.ibm.fhir.rest.FHIRRestOperationResponse;
-import com.ibm.fhir.search.util.SearchUtil;
-import com.ibm.fhir.server.FHIRBuildIdentifier;
-import com.ibm.fhir.server.annotation.PATCH;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.listener.FHIRServletContextListener;
-import com.ibm.fhir.server.util.FHIRRestHelper;
-import com.ibm.fhir.server.util.RestAuditLogger;
 
-@Path("/")
-@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
-        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
-@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
-        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 public class FHIRResource {
-    private static final Logger log =
-            java.util.logging.Logger.getLogger(FHIRResource.class.getName());
+    private static final Logger log = java.util.logging.Logger.getLogger(FHIRResource.class.getName());
 
-    private static final String FHIR_SERVER_NAME = "IBM FHIR Server";
-    private static final String FHIR_COPYRIGHT = "(C) Copyright IBM Corporation 2016, 2020";
-    private static final String EXTENSION_URL = "http://ibm.com/fhir/extension";
+    protected static final String HEADERNAME_IF_NONE_EXIST = "If-None-Exist";
+    protected static final String HEADERNAME_IF_MODIFIED_SINCE = "If-Modified-Since";
+    protected static final String HEADERNAME_IF_NONE_MATCH = "If-None-Match";
 
-    private static final String HEADERNAME_IF_NONE_EXIST = "If-None-Exist";
-    private static final String HEADERNAME_IF_MODIFIED_SINCE = "If-Modified-Since";
-    private static final String HEADERNAME_IF_NONE_MATCH = "If-None-Match";
-
-    private static final String AUDIT_LOGGING_ERR_MSG = "An error occurred while writing the audit log message.";
+    protected static final String AUDIT_LOGGING_ERR_MSG = "An error occurred while writing the audit log message.";
 
     public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder()
             .appendPattern("EEE")
@@ -149,7 +81,7 @@ public class FHIRResource {
     private ServletContext context;
 
     @Context
-    private HttpServletRequest httpServletRequest;
+    protected HttpServletRequest httpServletRequest;
 
     /**
      * UriInfo injected by the JAXRS framework.
@@ -158,21 +90,21 @@ public class FHIRResource {
      * when constructing URIs that will be sent back to the end user.
      */
     @Context
-    private UriInfo uriInfo;
+    protected UriInfo uriInfo;
 
     @Context
-    private HttpHeaders httpHeaders;
+    protected HttpHeaders httpHeaders;
 
     @Context
-    private SecurityContext securityContext;
+    protected SecurityContext securityContext;
 
-    private PropertyGroup fhirConfig = null;
+    protected PropertyGroup fhirConfig = null;
 
     /**
      * This method will do a quick check of the "initCompleted" flag in the servlet context. If the flag is FALSE, then
      * we'll throw an error to short-circuit the current in-progress REST API invocation.
      */
-    private void checkInitComplete() throws FHIROperationException {
+    protected void checkInitComplete() throws FHIROperationException {
         Boolean fhirServerInitComplete =
                 (Boolean) context.getAttribute(FHIRServletContextListener.FHIR_SERVER_INIT_COMPLETE);
         if (Boolean.FALSE.equals(fhirServerInitComplete)) {
@@ -198,1255 +130,15 @@ public class FHIRResource {
         }
     }
 
-    @GET
-    @Path("metadata")
-    public Response metadata() throws ClassNotFoundException {
-        log.entering(this.getClass().getName(), "metadata()");
-        Date startTime = new Date();
-        String errMsg = "Caught exception while processing 'metadata' request.";
-
-        try {
-            checkInitComplete();
-
-            CapabilityStatement capabilityStatement = getCapabilityStatement();
-            RestAuditLogger.logMetadata(httpServletRequest, startTime, new Date(), Response.Status.OK);
-
-            return Response.ok().entity(capabilityStatement).build();
-        } catch (FHIROperationException e) {
-            log.log(Level.SEVERE, errMsg, e);
-            return exceptionResponse(e, issueListToStatus(e.getIssues()));
-        } catch (Exception e) {
-            log.log(Level.SEVERE, errMsg, e);
-            return exceptionResponse(e, Response.Status.INTERNAL_SERVER_ERROR);
-        } finally {
-            log.exiting(this.getClass().getName(), "metadata()");
-        }
-    }
-
-    @POST
-    @Path("{type}")
-    public Response create(@PathParam("type") String type, Resource resource) {
-        log.entering(this.getClass().getName(), "create(String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            String ifNoneExist = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_EXIST);
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doCreate(type, resource, ifNoneExist, null);
-
-            ResponseBuilder response =
-                    Response.created(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-            resource = ior.getResource();
-
-            HTTPReturnPreference returnPreference = FHIRRequestContext.get().getReturnPreference();
-            if (resource != null && HTTPReturnPreference.REPRESENTATION == returnPreference) {
-                response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == returnPreference) {
-                response.entity(ior.getOperationOutcome());
-            }
-            response = addHeaders(response, resource);
-            status = ior.getStatus();
-            response.status(status);
-
-            return response.build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logCreate(httpServletRequest,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "create(String,Resource)");
-        }
-    }
-
-    @PUT
-    @Path("{type}/{id}")
-    public Response update(@PathParam("type") String type, @PathParam("id") String id, Resource resource) {
-        log.entering(this.getClass().getName(), "update(String,String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, id, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
-
-            ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-            status = ior.getStatus();
-            response.status(status);
-
-            Resource updatedResource = ior.getResource();
-            HTTPReturnPreference returnPreference = FHIRRequestContext.get().getReturnPreference();
-            if (updatedResource != null && HTTPReturnPreference.REPRESENTATION == returnPreference) {
-                response.entity(updatedResource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == returnPreference) {
-                response.entity(ior.getOperationOutcome());
-            }
-            response = addHeaders(response, updatedResource);
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            // By default, NOT_FOUND is mapped to HTTP 404, so explicitly set it to HTTP 405
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logUpdate(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "update(String,String,Resource)");
-        }
-    }
-
-    @PUT
-    @Path("{type}")
-    public Response conditionalUpdate(@PathParam("type") String type, Resource resource) {
-        log.entering(this.getClass().getName(), "conditionalUpdate(String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            String searchQueryString = httpServletRequest.getQueryString();
-            if (searchQueryString == null || searchQueryString.isEmpty()) {
-                String msg =
-                        "Cannot PUT to resource type endpoint unless a search query string is provided for a conditional update.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, null, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
-
-            ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-            status = ior.getStatus();
-            response.status(status);
-
-            Resource updatedResource = ior.getResource();
-            if (updatedResource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(updatedResource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(ior.getOperationOutcome());
-            }
-            response = addHeaders(response, updatedResource);
-
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logUpdate(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "conditionalUpdate(String,Resource)");
-        }
-    }
-
-    @PATCH
-    @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
-    @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
-    @Path("{type}/{id}")
-    public Response patch(@PathParam("type") String type, @PathParam("id") String id, JsonArray array) {
-        log.entering(this.getClass().getName(), "patch(String,String,JsonArray)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRPatch patch = createPatch(array);
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
-
-            status = ior.getStatus();
-            ResponseBuilder response = Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-
-            Resource resource = ior.getResource();
-            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(ior.getOperationOutcome());
-            }
-            response = addHeaders(response, resource);
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logPatch(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "patch(String,String,JsonArray)");
-        }
-    }
-
-    @PATCH
-    @Path("{type}/{id}")
-    public Response patch(@PathParam("type") String type, @PathParam("id") String id, Parameters parameters) {
-        log.entering(this.getClass().getName(), "patch(String,String,Parameters)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRPatch patch;
-            try {
-                patch = FHIRPathPatch.from(parameters);
-            } catch(IllegalArgumentException e) {
-                throw buildRestException(e.getMessage(), IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
-
-            ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-            status = ior.getStatus();
-            response.status(status);
-
-            Resource resource = ior.getResource();
-            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(resource);
-            } else if (ior.getOperationOutcome() != null &&
-                       HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(ior.getOperationOutcome());
-            }
-            response = addHeaders(response, resource);
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logPatch(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "patch(String,String,Parameters)");
-        }
-    }
-
-    @PATCH
-    @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
-    @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
-    @Path("{type}")
-    public Response conditionalPatch(@PathParam("type") String type, JsonArray array) {
-        log.entering(this.getClass().getName(), "conditionalPatch(String,String,JsonArray)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRPatch patch = createPatch(array);
-
-            String searchQueryString = httpServletRequest.getQueryString();
-            if (searchQueryString == null || searchQueryString.isEmpty()) {
-                String msg =
-                        "Cannot PATCH to resource type endpoint unless a search query string is provided for a conditional patch.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
-
-            ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-            status = ior.getStatus();
-            response.status(status);
-
-            Resource resource = ior.getResource();
-            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(ior.getOperationOutcome());
-            }
-
-            response = addHeaders(response, ior.getResource());
-
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logPatch(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "conditionalPatch(String,String,JsonArray)");
-        }
-    }
-
-    @PATCH
-    @Path("{type}")
-    public Response conditionalPatch(@PathParam("type") String type, Parameters parameters) {
-        log.entering(this.getClass().getName(), "conditionalPatch(String,String,Parameters)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRPatch patch;
-            try {
-                patch = FHIRPathPatch.from(parameters);
-            } catch(IllegalArgumentException e) {
-                throw buildRestException(e.getMessage(), IssueType.INVALID);
-            }
-
-            String searchQueryString = httpServletRequest.getQueryString();
-            if (searchQueryString == null || searchQueryString.isEmpty()) {
-                String msg =
-                        "Cannot PATCH to resource type endpoint unless a search query string is provided for a conditional patch.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
-
-            status = ior.getStatus();
-            ResponseBuilder response = Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
-
-            Resource resource = ior.getResource();
-            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
-                response.entity(ior.getOperationOutcome());
-            }
-
-            response = addHeaders(response, ior.getResource());
-
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logPatch(httpServletRequest,
-                        ior != null ? ior.getPrevResource() : null,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "conditionalPatch(String,String,Parameters)");
-        }
-    }
-
-    private FHIRPatch createPatch(JsonArray array) throws FHIROperationException {
-        try {
-            FHIRPatch patch = FHIRPatch.patch(array);
-            JsonPatch jsonPatch = patch.as(FHIRJsonPatch.class).getJsonPatch();
-            for (JsonValue value : jsonPatch.toJsonArray()) {
-                // validate path
-                String path = value.asJsonObject().getString("path");
-                if ("/id".equals(path) ||
-                        "/meta/versionId".equals(path) ||
-                        "/meta/lastUpdated".equals(path)) {
-                    throw new IllegalArgumentException("Path: '" + path
-                            + "' is not allowed in a patch operation.");
-                }
-            }
-            return patch;
-        } catch (Exception e) {
-            String msg = "Invalid patch: " + e.getMessage();
-            throw new FHIROperationException(msg, e)
-                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.INVALID));
-        }
-    }
-
-    @DELETE
-    @Path("{type}/{id}")
-    public Response delete(@PathParam("type") String type, @PathParam("id") String id) throws Exception {
-        log.entering(this.getClass().getName(), "delete(String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doDelete(type, id, null, null);
-
-            status = Status.NO_CONTENT;
-            ResponseBuilder response = Response.noContent();
-
-            if (ior.getResource() != null) {
-                response = addHeaders(response, ior.getResource());
-            }
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            // Overwrite the exception response status because we want NOT_FOUND to be success for delete
-            status = Status.OK;
-            return exceptionResponse(e, status);
-        } catch (FHIRPersistenceNotSupportedException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logDelete(httpServletRequest,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "delete(String,String)");
-        }
-    }
-
-    @DELETE
-    @Path("{type}")
-    public Response conditionalDelete(@PathParam("type") String type) throws Exception {
-        log.entering(this.getClass().getName(), "conditionalDelete(String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            String searchQueryString = httpServletRequest.getQueryString();
-            if (searchQueryString == null || searchQueryString.isEmpty()) {
-                String msg =
-                        "A search query string is required for a conditional delete operation.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doDelete(type, null, searchQueryString, null);
-            status = ior.getStatus();
-            ResponseBuilder response = Response.status(status);
-            if (ior.getOperationOutcome() != null) {
-                response.entity(ior.getOperationOutcome());
-            }
-            if (ior.getResource() != null) {
-                response = addHeaders(response, ior.getResource());
-            }
-            return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
-            // Return 200 instead of 404 to pass TouchStone test
-            status = Status.OK;
-            return exceptionResponse(e, status);
-        } catch (FHIRPersistenceNotSupportedException e) {
-            status = Status.METHOD_NOT_ALLOWED;
-            return exceptionResponse(e, status);
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logDelete(httpServletRequest,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "conditionalDelete(String)");
-        }
-    }
-
-    @GET
-    @Path("{type}/{id}")
-    public Response read(@PathParam("type") String type, @PathParam("id") String id) throws Exception {
-        log.entering(this.getClass().getName(), "read(String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-            MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
-            long modifiedSince = parseIfModifiedSince();
-
-            String ifNoneMatch = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_MATCH);
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource resource = helper.doRead(type, id, true, false, null, null, queryParameters);
-            int version2Match = -1;
-            // Support ETag value with or without " (and W/)
-            // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)
-            if (ifNoneMatch != null) {
-                ifNoneMatch = ifNoneMatch.replaceAll("\"", "").replaceAll("W/", "").trim();
-                if (!ifNoneMatch.isEmpty()) {
-                    try {
-                        version2Match = Integer.parseInt(ifNoneMatch);
-                    }
-                    catch (NumberFormatException e)
-                    {
-                        // ignore invalid version
-                        version2Match = -1;
-                    }
-                }
-            }
-            Instant modifiedTime2Compare = null;
-            if (modifiedSince > 0 ) {
-                modifiedTime2Compare = Instant.ofEpochMilli(modifiedSince);
-            }
-
-            boolean isModified = true;
-            // check if-not-match first
-            if (version2Match != -1) {
-                if (version2Match == Integer.parseInt(resource.getMeta().getVersionId().getValue())) {
-                    isModified = false;
-                }
-            }
-            // then check if-modified-since
-            if(isModified && modifiedTime2Compare != null) {
-                if (resource.getMeta().getLastUpdated().getValue().toInstant().isBefore(modifiedTime2Compare)) {
-                    isModified = false;
-                }
-            }
-
-            ResponseBuilder response;
-            if (isModified) {
-                status = Status.OK;
-                response = Response.ok().entity(resource);
-                response = addHeaders(response, resource);
-            } else {
-                status = Status.NOT_MODIFIED;
-                response = Response.status(Response.Status.NOT_MODIFIED);
-            }
-            return response.build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logRead(httpServletRequest,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "read(String,String)");
-        }
-    }
-
-    @GET
-    @Path("{type}/{id}/_history/{vid}")
-    public Response vread(@PathParam("type") String type, @PathParam("id") String id, @PathParam("vid") String vid) {
-        log.entering(this.getClass().getName(), "vread(String,String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        FHIRRestOperationResponse ior = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource resource = helper.doVRead(type, id, vid, null);
-            status = Status.OK;
-            ResponseBuilder response = Response.ok().entity(resource);
-            response = addHeaders(response, resource);
-            return response.build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logVersionRead(httpServletRequest,
-                        ior != null ? ior.getResource() : null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "vread(String,String,String)");
-        }
-    }
-
-    @GET
-    @Path("{type}/{id}/_history")
-    public Response history(@PathParam("type") String type, @PathParam("id") String id) {
-        log.entering(this.getClass().getName(), "history(String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        Bundle bundle = null;
-
-        try {
-            checkInitComplete();
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri(), null);
-            status = Status.OK;
-            return Response.status(status).entity(bundle).build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logHistory(httpServletRequest, bundle,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "history(String,String)");
-        }
-    }
-
-    @GET
-    @Path("{type}")
-    public Response search(@PathParam("type") String type) {
-        log.entering(this.getClass().getName(), "search(String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        MultivaluedMap<String, String> queryParameters = null;
-        Bundle bundle = null;
-
-        try {
-            checkInitComplete();
-
-            queryParameters = uriInfo.getQueryParameters();
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
-            status = Status.OK;
-            return Response.status(status).entity(bundle).build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "search(String)");
-        }
-    }
-
-    @GET
-    @Path("{compartment}/{compartmentId}/{type}")
-    public Response searchCompartment(@PathParam("compartment") String compartment,
-            @PathParam("compartmentId") String compartmentId, @PathParam("type") String type) {
-        log.entering(this.getClass().getName(), "search(String,String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        MultivaluedMap<String, String> queryParameters = null;
-        Bundle bundle = null;
-
-        try {
-            checkInitComplete();
-
-            queryParameters = uriInfo.getQueryParameters();
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null, null);
-            status = Status.OK;
-            return Response.status(status).entity(bundle).build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "search(String,String,String)");
-        }
-    }
-
-    @POST
-    @Consumes("application/x-www-form-urlencoded")
-    @Path("{type}/_search")
-    public Response _search(@PathParam("type") String type) {
-        log.entering(this.getClass().getName(), "_search(String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        MultivaluedMap<String, String> queryParameters = null;
-        Bundle bundle = null;
-
-        try {
-            checkInitComplete();
-
-            queryParameters = uriInfo.getQueryParameters();
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
-            status = Status.OK;
-            return Response.status(status).entity(bundle).build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "_search(String)");
-        }
-    }
-
-    @GET
-    @Path("/")
-    public Response searchAllGet() {
-        return doSearchAll();
-    }
-
-    @POST
-    @Consumes("application/x-www-form-urlencoded")
-    @Path("_search")
-    public Response searchAllPost() {
-        return doSearchAll();
-    }
-
-    private Response doSearchAll() {
-        log.entering(this.getClass().getName(), "doSearchAll");
-        Date startTime = new Date();
-        Response.Status status = null;
-        MultivaluedMap<String, String> queryParameters = null;
-        Bundle bundle = null;
-
-        try {
-            checkInitComplete();
-
-            queryParameters = uriInfo.getQueryParameters();
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null, null);
-            status = Status.OK;
-            return Response.status(status).entity(bundle).build();
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "doSearchAll");
-        }
-    }
-
-    @GET
-    @Path("${operationName}")
-    public Response invoke(@PathParam("operationName") String operationName) {
-        log.entering(this.getClass().getName(), "invoke(String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createSystemOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, null, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String)");
-        }
-    }
-
-    @POST
-    @Path("${operationName}")
-    public Response invoke(@PathParam("operationName") String operationName, Resource resource) {
-        log.entering(this.getClass().getName(), "invoke(String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createSystemOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, null, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,Resource)");
-        }
-    }
-
-    @GET
-    @Path("{resourceTypeName}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("operationName") String operationName) {
-        log.entering(this.getClass().getName(), "invoke(String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createResourceTypeOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, null, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String)");
-        }
-    }
-
-    @POST
-    @Path("{resourceTypeName}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("operationName") String operationName, Resource resource) {
-        log.entering(this.getClass().getName(), "invoke(String,String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createResourceTypeOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            // response 200 OK if no failure issue found.
-            boolean isFailure = false;
-            for (Issue issue : e.getIssues()) {
-                if (FHIRUtil.isFailure(issue.getSeverity())) {
-                    isFailure = true;
-                    break;
-                }
-            }
-            if (isFailure) {
-                status = issueListToStatus(e.getIssues());
-                return exceptionResponse(e, status);
-            } else {
-                status = Status.OK;
-                return exceptionResponse(e, Response.Status.OK);
-            }
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, null, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String,Resource)");
-        }
-    }
-
-    @GET
-    @Path("{resourceTypeName}/{logicalId}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("logicalId") String logicalId,
-            @PathParam("operationName") String operationName) {
-        log.entering(this.getClass().getName(), "invoke(String,String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String,String)");
-        }
-    }
-
-    @POST
-    @Path("{resourceTypeName}/{logicalId}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("logicalId") String logicalId,
-            @PathParam("operationName") String operationName, Resource resource) {
-        log.entering(this.getClass().getName(), "invoke(String,String,String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, null,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String,String,Resource)");
-        }
-    }
-
-    @GET
-    @Path("{resourceTypeName}/{logicalId}/_history/{versionId}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("logicalId") String logicalId,
-            @PathParam("versionId") String versionId,
-            @PathParam("operationName") String operationName) {
-        log.entering(this.getClass().getName(), "invoke(String,String,String,String)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, 
-                    null, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String,String,String)");
-        }
-    }
-
-    @POST
-    @Path("{resourceTypeName}/{logicalId}/_history/{versionId}/${operationName}")
-    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
-            @PathParam("logicalId") String logicalId,
-            @PathParam("versionId") String versionId,
-            @PathParam("operationName") String operationName, Resource resource) {
-        log.entering(this.getClass().getName(), "invoke(String,String,String,String,Resource)");
-        Date startTime = new Date();
-        Response.Status status = null;
-
-        try {
-            checkInitComplete();
-
-            FHIROperationContext operationContext =
-                    FHIROperationContext.createInstanceOperationContext();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
-            Response response = buildResponse(operationContext, resourceTypeName, result);
-            status = Response.Status.fromStatusCode(response.getStatus());
-            return response;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId,
-                        startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "invoke(String,String,String,String,Resource)");
-        }
-    }
-
-    @POST
-    public Response bundle(Resource resource) {
-        log.entering(this.getClass().getName(), "bundle(Bundle)");
-        Date startTime = new Date();
-        Response.Status status = null;
-        Bundle responseBundle = null;
-
-        try {
-            checkInitComplete();
-
-            Bundle inputBundle = null;
-            if (resource instanceof Bundle) {
-                inputBundle = (Bundle) resource;
-            } else {
-                String msg = "A 'Bundle' resource type is required but a '"
-                        + resource.getClass().getSimpleName() + "' resource type was sent.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
-
-            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            responseBundle = helper.doBundle(inputBundle, null);
-            status = Status.OK;
-            return Response.ok(responseBundle).build();
-        } catch (FHIRRestBundledRequestException e) {
-            Response exceptionResponse = exceptionResponse(e);
-            status = Response.Status.fromStatusCode(exceptionResponse.getStatus());
-            return exceptionResponse;
-        } catch (FHIROperationException e) {
-            status = issueListToStatus(e.getIssues());
-            return exceptionResponse(e, status);
-        } catch (Exception e) {
-            status = Status.INTERNAL_SERVER_ERROR;
-            return exceptionResponse(e, status);
-        } finally {
-            try {
-                RestAuditLogger.logBundle(httpServletRequest, responseBundle, startTime, new Date(), status);
-            } catch (Exception e) {
-                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
-            }
-
-            log.exiting(this.getClass().getName(), "bundle(Bundle)");
-        }
-    }
-
-    private FHIROperationException buildRestException(String msg, IssueType issueType) {
+    protected FHIROperationException buildRestException(String msg, IssueType issueType) {
         return buildRestException(msg, issueType, IssueSeverity.FATAL);
     }
 
-    private FHIROperationException buildRestException(String msg, IssueType issueType, IssueSeverity severity) {
+    protected FHIROperationException buildRestException(String msg, IssueType issueType, IssueSeverity severity) {
         return new FHIROperationException(msg).withIssue(buildOperationOutcomeIssue(severity, issueType, msg));
     }
 
-    private long parseIfModifiedSince() {
+    protected long parseIfModifiedSince() {
         // Modified since date time in EpochMilli
         long modifiedSince = -1;
         try {
@@ -1471,7 +163,7 @@ public class FHIRResource {
     /**
      * Builds an OperationOutcomeIssue with the respective values for some of the fields.
      */
-    private OperationOutcome.Issue buildOperationOutcomeIssue(IssueSeverity severity, IssueType type, String msg) {
+    protected OperationOutcome.Issue buildOperationOutcomeIssue(IssueSeverity severity, IssueType type, String msg) {
         return OperationOutcome.Issue.builder()
                 .severity(severity)
                 .code(type)
@@ -1488,7 +180,7 @@ public class FHIRResource {
      *            the path and query parts
      * @return the full URI value as a String
      */
-    private String getAbsoluteUri(String baseUri, String relativeUri) {
+    protected String getAbsoluteUri(String baseUri, String relativeUri) {
         StringBuilder fullUri = new StringBuilder();
         fullUri.append(baseUri);
         if (!baseUri.endsWith("/")) {
@@ -1501,7 +193,7 @@ public class FHIRResource {
     /**
      * Adds the Etag and Last-Modified headers to the specified response object.
      */
-    private ResponseBuilder addHeaders(ResponseBuilder rb, Resource resource) {
+    protected ResponseBuilder addHeaders(ResponseBuilder rb, Resource resource) {
         return rb.header(HttpHeaders.ETAG, getEtagValue(resource))
                 // According to 3.3.1 of RTC2616(HTTP/1.1), we MUST only generate the RFC 1123 format for representing HTTP-date values
                 // in header fields, e.g Sat, 28 Sep 2019 16:11:14 GMT
@@ -1512,7 +204,7 @@ public class FHIRResource {
         return "W/\"" + resource.getMeta().getVersionId().getValue() + "\"";
     }
 
-    private Response exceptionResponse(FHIRRestBundledRequestException e) {
+    protected Response exceptionResponse(FHIRRestBundledRequestException e) {
         Response response;
         if (e.getResponseBundle() != null) {
             if (e.getIssues().size() > 0) {
@@ -1554,7 +246,7 @@ public class FHIRResource {
         return response;
     }
 
-    private Response exceptionResponse(FHIROperationException e, Status status) {
+    protected Response exceptionResponse(FHIROperationException e, Status status) {
         if (status == null) {
             status = issueListToStatus(e.getIssues());
         }
@@ -1571,13 +263,13 @@ public class FHIRResource {
         return exceptionResponse(operationOutcome, status);
     }
 
-    private Response exceptionResponse(Exception e, Status status) {
-        log.log(Level.SEVERE, "An unexpected exeption occurred while processing the request", e);
+    protected Response exceptionResponse(Exception e, Status status) {
+        log.log(Level.SEVERE, "An unexpected exception occurred while processing the request", e);
         OperationOutcome oo = FHIRUtil.buildOperationOutcome(e, false);
         return this.exceptionResponse(oo, status);
     }
 
-    private Response exceptionResponse(OperationOutcome oo, Status status) {
+    protected Response exceptionResponse(OperationOutcome oo, Status status) {
         if (log.isLoggable(Level.FINE)) {
             StringBuilder sb = new StringBuilder();
             sb.append("\nOperationOutcome:\n").append(serializeOperationOutcome(oo));
@@ -1597,257 +289,6 @@ public class FHIRResource {
         }
     }
 
-    private synchronized CapabilityStatement getCapabilityStatement() throws FHIROperationException {
-        try {
-            return buildCapabilityStatement();
-        } catch (Throwable t) {
-            String msg = "An error occurred while constructing the Conformance statement.";
-            log.log(Level.SEVERE, msg, t);
-            throw buildRestException(msg, IssueType.EXCEPTION);
-        }
-    }
-
-    /**
-     * Builds a CapabilityStatement resource instance which describes this server.
-     *
-     * @throws Exception
-     */
-    private CapabilityStatement buildCapabilityStatement() throws Exception {
-        // Build the list of interactions that are supported for each resource type.
-
-        List<Rest.Resource.Interaction> interactions = new ArrayList<>();
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.CREATE));
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.UPDATE));
-        if (isDeleteSupported()) {
-            interactions.add(buildInteractionStatement(TypeRestfulInteraction.DELETE));
-        }
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.READ));
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.VREAD));
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.HISTORY_INSTANCE));
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.SEARCH_TYPE));
-        interactions.add(buildInteractionStatement(TypeRestfulInteraction.PATCH));
-
-        // Build the list of supported resources.
-        List<Rest.Resource> resources = new ArrayList<>();
-        ResourceType.ValueSet[] resourceTypes = ResourceType.ValueSet.values();
-        for (ResourceType.ValueSet resourceType : resourceTypes) {
-            String resourceTypeName = resourceType.value();
-            // Build the set of ConformanceSearchParams for this resource type.
-            List<Rest.Resource.SearchParam> conformanceSearchParams = new ArrayList<>();
-            List<SearchParameter> searchParameters = SearchUtil.getSearchParameters(resourceTypeName);
-            if (searchParameters != null) {
-                for (SearchParameter searchParameter : searchParameters) {
-                    // The name here is a natural language name, and intentionally not replaced with code.
-                    Rest.Resource.SearchParam.Builder conformanceSearchParamBuilder =
-                            Rest.Resource.SearchParam.builder()
-                                .name(searchParameter.getName())
-                                .type(searchParameter.getType());
-                    if (searchParameter.getDescription() != null) {
-                        conformanceSearchParamBuilder.documentation(searchParameter.getDescription());
-                    }
-
-                    Rest.Resource.SearchParam conformanceSearchParam =
-                            conformanceSearchParamBuilder.build();
-                    conformanceSearchParams.add(conformanceSearchParam);
-                }
-            }
-
-            // Build the ConformanceResource for this resource type.
-            Rest.Resource cr = Rest.Resource.builder()
-                    .type(ResourceType.of(resourceType))
-                    .profile(Canonical.of("http://hl7.org/fhir/profiles/" + resourceTypeName))
-                    .interaction(interactions)
-                    .conditionalCreate(com.ibm.fhir.model.type.Boolean.of(true))
-                    .conditionalUpdate(com.ibm.fhir.model.type.Boolean.of(true))
-                    .updateCreate(com.ibm.fhir.model.type.Boolean.of(isUpdateCreateEnabled()))
-                    .conditionalDelete(ConditionalDeleteStatus.SINGLE)
-                    .conditionalRead(ConditionalReadStatus.FULL_SUPPORT)
-                    .searchParam(conformanceSearchParams)
-                    .build();
-
-            resources.add(cr);
-        }
-
-        // Determine if transactions are supported for this FHIR Server configuration.
-        SystemRestfulInteraction transactionMode = SystemRestfulInteraction.BATCH;
-        try {
-            boolean txnSupported = getPersistenceImpl().isTransactional();
-            transactionMode = (txnSupported ? SystemRestfulInteraction.TRANSACTION
-                    : SystemRestfulInteraction.BATCH);
-        } catch (Throwable t) {
-            log.log(Level.WARNING, "Unexcepted error while reading server transaction mode setting", t);
-        }
-
-        String actualHost = new URI(getRequestUri()).getHost();
-
-        String regURLTemplate = null;
-        String authURLTemplate = null;
-        String tokenURLTemplate = null;
-        try {
-            regURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_REGURL, "");
-            authURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_AUTHURL, "");
-            tokenURLTemplate = fhirConfig.getStringProperty(PROPERTY_OAUTH_TOKENURL, "");
-        } catch (Exception e) {
-            log.log(Level.SEVERE, "An error occurred while adding OAuth URLs to the conformance statement", e);
-        }
-        String tokenURL = tokenURLTemplate.replaceAll("<host>", actualHost);
-
-        String authURL = authURLTemplate.replaceAll("<host>", actualHost);
-
-        String regURL = regURLTemplate.replaceAll("<host>", actualHost);
-
-        CapabilityStatement.Rest.Security restSecurity = CapabilityStatement.Rest.Security.builder()
-                .service(CodeableConcept.builder()
-                    .coding(Coding.builder()
-                        .code(Code.of("SMART-on-FHIR"))
-                        .system(Uri.of("http://terminology.hl7.org/CodeSystem/restful-security-service"))
-                        .build())
-                    .text(string("OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"))
-                    .build())
-                .extension(Extension.builder()
-                    .url("http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris")
-                    .extension(
-                        Extension.builder().url("token").value(Url.of(tokenURL)).build(),
-                        Extension.builder().url("authorize").value(Url.of(authURL)).build(),
-                        Extension.builder().url("register").value(Url.of(regURL)).build())
-                    .build())
-                .build();
-
-        CapabilityStatement.Rest rest = CapabilityStatement.Rest.builder()
-                .mode(RestfulCapabilityMode.SERVER)
-                .security(restSecurity)
-                .resource(resources)
-                .interaction(CapabilityStatement.Rest.Interaction.builder()
-                    .code(transactionMode)
-                    .build())
-                .build();
-
-        FHIRBuildIdentifier buildInfo = new FHIRBuildIdentifier();
-        String buildDescription = FHIR_SERVER_NAME + " version " + buildInfo.getBuildVersion()
-                + " build id " + buildInfo.getBuildId() + "";
-
-        List<Code> format = new ArrayList<Code>();
-        format.add(Code.of(Format.JSON.toString().toLowerCase()));
-        format.add(Code.of(Format.XML.toString().toLowerCase()));
-        format.add(Code.of(FHIRMediaType.APPLICATION_JSON));
-        format.add(Code.of(FHIRMediaType.APPLICATION_FHIR_JSON));
-        format.add(Code.of(FHIRMediaType.APPLICATION_XML));
-        format.add(Code.of(FHIRMediaType.APPLICATION_FHIR_XML));
-
-        // Finally, create the CapabilityStatement resource itself.
-        CapabilityStatement conformance = CapabilityStatement.builder()
-                .status(PublicationStatus.ACTIVE)
-                .date(DateTime.of(ZonedDateTime.now(ZoneOffset.UTC)))
-                .kind(CapabilityStatementKind.CAPABILITY)
-                .fhirVersion(FHIRVersion.VERSION_4_0_1)
-                .format(format)
-                .patchFormat(Code.of(FHIRMediaType.APPLICATION_JSON_PATCH),
-                             Code.of(FHIRMediaType.APPLICATION_FHIR_JSON),
-                             Code.of(FHIRMediaType.APPLICATION_FHIR_XML))
-                .version(string(buildInfo.getBuildVersion()))
-                .name(string(FHIR_SERVER_NAME))
-                .description(Markdown.of(buildDescription))
-                .copyright(Markdown.of(FHIR_COPYRIGHT))
-                .publisher(string("IBM Corporation"))
-                .software(CapabilityStatement.Software.builder()
-                          .name(string(FHIR_SERVER_NAME))
-                          .version(string(buildInfo.getBuildVersion()))
-                          .id(buildInfo.getBuildId())
-                          .build())
-                .rest(rest)
-                .build();
-
-        try {
-            conformance = addExtensionElements(conformance);
-        } catch (Exception e) {
-            log.log(Level.SEVERE, "An error occurred while adding extension elements to the conformance statement", e);
-        }
-
-        return conformance;
-    }
-
-    private CapabilityStatement addExtensionElements(CapabilityStatement capabilityStatement)
-        throws Exception {
-        List<Extension> extentions = new ArrayList<Extension>();
-        Extension extension = Extension.builder()
-                .url(EXTENSION_URL + "/defaultTenantId")
-                .value(string(fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_DEFAULT_TENANT_ID, FHIRConfiguration.DEFAULT_TENANT_ID)))
-                .build();
-        extentions.add(extension);
-
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/websocketNotificationsEnabled")
-                .value(com.ibm.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_WEBSOCKET_ENABLED, Boolean.FALSE)))
-                .build();
-        extentions.add(extension);
-
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/kafkaNotificationsEnabled")
-                .value(com.ibm.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_ENABLED, Boolean.FALSE)))
-                .build();
-        extentions.add(extension);
-
-        String notificationResourceTypes = getNotificationResourceTypes();
-        if ("".equals(notificationResourceTypes)) {
-            notificationResourceTypes = "<not specified - all resource types>";
-        }
-
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/notificationResourceTypes")
-                .value(string(notificationResourceTypes))
-                .build();
-        extentions.add(extension);
-
-        String auditLogServiceName =
-                fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_AUDIT_SERVICE_CLASS_NAME);
-
-        if (auditLogServiceName == null || "".equals(auditLogServiceName)) {
-            auditLogServiceName = "<not specified>";
-        } else {
-            int lastDelimeter = auditLogServiceName.lastIndexOf(".");
-            auditLogServiceName = auditLogServiceName.substring(lastDelimeter + 1);
-        }
-
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/auditLogServiceName")
-                .value(string(auditLogServiceName))
-                .build();
-        extentions.add(extension);
-
-        PropertyGroup auditLogProperties =
-                fhirConfig.getPropertyGroup(FHIRConfiguration.PROPERTY_AUDIT_SERVICE_PROPERTIES);
-        String auditLogPropertiesString =
-                auditLogProperties != null ? auditLogProperties.toString() : "<not specified>";
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/auditLogProperties")
-                .value(string(auditLogPropertiesString))
-                .build();
-        extentions.add(extension);
-
-        extension = Extension.builder()
-                .url(EXTENSION_URL + "/persistenceType")
-                .value(string(getPersistenceImpl().getClass().getSimpleName()))
-                .build();
-        extentions.add(extension);
-
-        return capabilityStatement.toBuilder().extension(extentions).build();
-
-    }
-
-    private String getNotificationResourceTypes() throws Exception {
-        Object[] notificationResourceTypes =
-                fhirConfig.getArrayProperty(FHIRConfiguration.PROPERTY_NOTIFICATION_RESOURCE_TYPES);
-        if (notificationResourceTypes == null) {
-            notificationResourceTypes = new Object[0];
-        }
-        return Arrays.asList(notificationResourceTypes).toString().replace("[", "").replace("]", "").replace(" ", "");
-    }
-
-    private Interaction buildInteractionStatement(TypeRestfulInteraction value) {
-        Interaction ci = Interaction.builder().code(value).build();
-        return ci;
-    }
-
     /**
      * Retrieves the shared persistence helper object from the servlet context.
      */
@@ -1863,7 +304,11 @@ public class FHIRResource {
         return persistenceHelper;
     }
 
-    private synchronized FHIRPersistence getPersistenceImpl() throws FHIRPersistenceException {
+    /**
+     * Retrieves the persistence implementation to use for the current request.
+     * @see {@link PersistenceHelper#getFHIRPersistenceImplementation()}
+     */
+    protected synchronized FHIRPersistence getPersistenceImpl() throws FHIRPersistenceException {
         if (persistence == null) {
             persistence = getPersistenceHelper().getFHIRPersistenceImplementation();
             if (log.isLoggable(Level.FINE)) {
@@ -1873,11 +318,11 @@ public class FHIRResource {
         return persistence;
     }
 
-    private boolean isDeleteSupported() throws FHIRPersistenceException {
+    protected boolean isDeleteSupported() throws FHIRPersistenceException {
         return getPersistenceImpl().isDeleteSupported();
     }
 
-    private Boolean isUpdateCreateEnabled() {
+    protected Boolean isUpdateCreateEnabled() {
         return fhirConfig.getBooleanProperty(PROPERTY_UPDATE_CREATE_ENABLED, Boolean.TRUE);
     }
 
@@ -1892,7 +337,7 @@ public class FHIRResource {
      * @return String The complete request URI
      * @throws Exception if an error occurs while reading the config
      */
-    private String getRequestUri() throws Exception {
+    protected String getRequestUri() throws Exception {
         return FHIRRequestContext.get().getOriginalRequestUri();
     }
 
@@ -1906,7 +351,7 @@ public class FHIRResource {
      * @implNote This method uses {@link #getRequestUri()} to get the original request URI and then strips it to the
      *           <a href="https://www.hl7.org/fhir/http.html#general">Service Base URL</a>
      */
-    private String getRequestBaseUri(String type) throws Exception {
+    protected String getRequestBaseUri(String type) throws Exception {
         String baseUri = null;
 
         String requestUri = getRequestUri();
@@ -1948,34 +393,7 @@ public class FHIRResource {
      *            the URI string for which the URI object will be created
      * @throws URISyntaxException
      */
-    private URI toUri(String uriString) throws URISyntaxException {
+    protected URI toUri(String uriString) throws URISyntaxException {
         return new URI(uriString);
-    }
-
-    private Response buildResponse(FHIROperationContext operationContext, String resourceTypeName, Resource resource)
-            throws Exception {
-        // The following code allows the downstream application to change the response code
-        // This enables the 202 accepted to be sent back
-        Response.Status status = Response.Status.OK;
-        Object o = operationContext.getProperty(FHIROperationContext.PROPNAME_STATUS_TYPE);
-        if (o != null) {
-            status = (Response.Status) o;
-            if (Response.Status.ACCEPTED.equals(status)) {
-                // This change is for BulkData operations which manipulate the response code.
-                // Operations that return Accepted need to implement their own approach.
-                Object ox = operationContext.getProperty(FHIROperationContext.PROPNAME_RESPONSE);
-                return (Response) ox;
-            }
-        }
-
-        URI locationURI =
-                (URI) operationContext.getProperty(FHIROperationContext.PROPNAME_LOCATION_URI);
-        if (locationURI != null) {
-            return Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(resourceTypeName), locationURI.toString())))
-                    .entity(resource)
-                    .build();
-        }
-        return Response.status(status).entity(resource).build();
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -11,6 +11,7 @@ import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_REGURL;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_OAUTH_TOKENURL;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_UPDATE_CREATE_ENABLED;
 import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.io.StringWriter;
 import java.net.URI;
@@ -108,7 +109,7 @@ import com.ibm.fhir.server.FHIRBuildIdentifier;
 import com.ibm.fhir.server.annotation.PATCH;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.listener.FHIRServletContextListener;
-import com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper;
+import com.ibm.fhir.server.util.FHIRRestHelper;
 import com.ibm.fhir.server.util.RestAuditLogger;
 
 @Path("/")
@@ -213,7 +214,7 @@ public class FHIRResource {
             return Response.ok().entity(capabilityStatement).build();
         } catch (FHIROperationException e) {
             log.log(Level.SEVERE, errMsg, e);
-            return exceptionResponse(e, IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues()));
+            return exceptionResponse(e, issueListToStatus(e.getIssues()));
         } catch (Exception e) {
             log.log(Level.SEVERE, errMsg, e);
             return exceptionResponse(e, Response.Status.INTERNAL_SERVER_ERROR);
@@ -254,7 +255,7 @@ public class FHIRResource {
 
             return response.build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -305,7 +306,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -363,7 +364,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -416,7 +417,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -474,7 +475,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -537,7 +538,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -602,7 +603,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -672,7 +673,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -727,7 +728,7 @@ public class FHIRResource {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -808,7 +809,7 @@ public class FHIRResource {
             }
             return response.build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -844,7 +845,7 @@ public class FHIRResource {
             response = addHeaders(response, resource);
             return response.build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -878,7 +879,7 @@ public class FHIRResource {
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -913,7 +914,7 @@ public class FHIRResource {
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -949,7 +950,7 @@ public class FHIRResource {
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -985,7 +986,7 @@ public class FHIRResource {
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1031,7 +1032,7 @@ public class FHIRResource {
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1071,7 +1072,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1111,7 +1112,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1152,7 +1153,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1202,7 +1203,7 @@ public class FHIRResource {
                 }
             }
             if (isFailure) {
-                status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+                status = issueListToStatus(e.getIssues());
                 return exceptionResponse(e, status);
             } else {
                 status = Status.OK;
@@ -1248,7 +1249,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1290,7 +1291,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1333,7 +1334,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1376,7 +1377,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1421,7 +1422,7 @@ public class FHIRResource {
             status = Response.Status.fromStatusCode(exceptionResponse.getStatus());
             return exceptionResponse;
         } catch (FHIROperationException e) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
             return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
@@ -1542,7 +1543,7 @@ public class FHIRResource {
             response = Response.status(Status.OK).entity(responseBundle).build();
         } else {
             // Override the status code with a generic client (400) or server (500) error code
-            Status status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            Status status = issueListToStatus(e.getIssues());
             if (status.getFamily() == Status.Family.CLIENT_ERROR) {
                 status = Status.BAD_REQUEST;
             } else {
@@ -1555,7 +1556,7 @@ public class FHIRResource {
 
     private Response exceptionResponse(FHIROperationException e, Status status) {
         if (status == null) {
-            status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+            status = issueListToStatus(e.getIssues());
         }
 
         if (status.getFamily() == Status.Family.SERVER_ERROR) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRRestHelper.java
@@ -1,0 +1,2516 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.model.util.ModelSupport.getResourceType;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_GONE;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.net.URI;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.owasp.encoder.Encode;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.HTTPHandlingPreference;
+import com.ibm.fhir.core.HTTPReturnPreference;
+import com.ibm.fhir.core.context.FHIRPagingContext;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.patch.FHIRPatch;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.UnsignedInt;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.Url;
+import com.ibm.fhir.model.type.code.BundleType;
+import com.ibm.fhir.model.type.code.HTTPVerb;
+import com.ibm.fhir.model.type.code.IssueSeverity;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.model.util.ModelSupport;
+import com.ibm.fhir.model.util.ReferenceMappingVisitor;
+import com.ibm.fhir.operation.FHIROperation;
+import com.ibm.fhir.operation.context.FHIROperationContext;
+import com.ibm.fhir.operation.registry.FHIROperationRegistry;
+import com.ibm.fhir.operation.util.FHIROperationUtil;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
+import com.ibm.fhir.persistence.context.FHIRHistoryContext;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
+import com.ibm.fhir.persistence.interceptor.FHIRPersistenceEvent;
+import com.ibm.fhir.persistence.interceptor.impl.FHIRPersistenceInterceptorMgr;
+import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
+import com.ibm.fhir.rest.FHIRResourceHelpers;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.search.SearchConstants;
+import com.ibm.fhir.search.SummaryValueSet;
+import com.ibm.fhir.search.context.FHIRSearchContext;
+import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.search.util.SearchUtil;
+import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
+import com.ibm.fhir.server.helper.FHIRUrlParser;
+import com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper;
+import com.ibm.fhir.validation.FHIRValidator;
+import com.ibm.fhir.validation.exception.FHIRValidationException;
+
+public class FHIRRestHelper implements FHIRResourceHelpers {
+    private static final Logger log =
+            java.util.logging.Logger.getLogger(FHIRRestHelper.class.getName());
+
+    private static final String EXTENSION_URL = "http://ibm.com/fhir/extension";
+    private static final String LOCAL_REF_PREFIX = "urn:";
+
+    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("EEE")
+            .optionalStart()
+            // ANSIC date time format for If-Modified-Since
+            .appendPattern(" MMM dd HH:mm:ss yyyy")
+            .optionalEnd()
+            .optionalStart()
+            // Touchstone date time format for If-Modified-Since
+            .appendPattern(", dd-MMM-yy HH:mm:ss")
+            .optionalEnd().toFormatter();
+
+    private FHIRPersistence persistence = null;
+
+    // These values are used for correlating requests within a bundle.
+    private String bundleTransactionCorrelationId = null;
+    private String bundleRequestCorrelationId = null;
+
+    public FHIRRestHelper(FHIRPersistence persistence) {
+        this.persistence = persistence;
+    }
+
+    /**
+     * Performs the heavy lifting associated with a 'create' interaction.
+     *
+     * @param type
+     *            the resource type specified as part of the request URL
+     * @param resource
+     *            the Resource to be stored.
+     * @param ifNoneExist
+     *            whether to create the resource if none exists
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return a FHIRRestOperationResponse object containing the results of the operation
+     * @throws Exception
+     */
+    @Override
+    public FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist,
+            Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "doCreate");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        String errMsg = "Caught exception while processing 'create' request.";
+
+        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+
+            // Make sure the expected type (specified in the URL string) is congruent with the actual type
+            // of the resource.
+            String resourceType = ModelSupport.getTypeName(resource.getClass()); 
+            if (!resourceType.equals(type)) {
+                String msg = "Resource type '" + resourceType
+                        + "' does not match type specified in request URI: " + type;
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            // Check to see if we're supposed to perform a conditional 'create'.
+            if (ifNoneExist != null && !ifNoneExist.isEmpty()) {
+                log.fine("Performing conditional create with search criteria: " + ifNoneExist);
+                Bundle responseBundle = null;
+
+                // Perform the search using the "If-None-Exist" header value.
+                try {
+                    MultivaluedMap<String, String> searchParameters = getQueryParameterMap(ifNoneExist);
+                    responseBundle =
+                            doSearch(type, null, null, searchParameters, null, requestProperties, resource);
+                } catch (FHIROperationException e) {
+                    throw e;
+                } catch (Throwable t) {
+                    String msg =
+                            "An error occurred while performing the search for a conditional create operation.";
+                    log.log(Level.WARNING, msg, t);
+                    throw new FHIROperationException(msg, t);
+                }
+
+                // Check the search results to determine whether or not to perform the create operation.
+                int resultCount = responseBundle.getEntry().size();
+                log.fine("Conditional create search yielded " + resultCount + " results.");
+
+                if (resultCount == 0) {
+                    // Do nothing and fall through to process the 'create' request.
+                } else if (resultCount == 1) {
+                    // If we found a single match, bypass the 'create' request and return information
+                    // for the matched resource.
+                    Resource matchedResource = responseBundle.getEntry().get(0).getResource();
+                    ior.setLocationURI(FHIRUtil.buildLocationURI(type, matchedResource));
+                    ior.setStatus(Response.Status.OK);
+                    ior.setResource(matchedResource);
+                    log.fine("Returning location URI of matched resource: " + ior.getLocationURI());
+                    return ior;
+                } else {
+                    String msg =
+                            "The search criteria specified for a conditional create operation returned multiple matches.";
+                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
+                }
+            }
+
+            // For R4, resources may contain an id. For create, this should be ignored and
+            // we no longer reject the request.
+            if (resource.getId() != null && log.isLoggable(Level.FINE)) {
+                log.fine(String.format("create request resource includes id: '%s'", resource.getId()));
+            }
+
+            // Validate the input resource and return any validation errors, but warnings are OK
+            List<Issue> validationWarnings = validateInput(resource);
+            ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(validationWarnings));
+
+            // If there were no validation errors, then create the resource and return the location header.
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeCreate' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(resource, buildPersistenceEventProperties(type, null, null, requestProperties));
+            getInterceptorMgr().fireBeforeCreateEvent(event);
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event);
+
+            // R4: remember model objects are immutable, so we get back a new resource with the id/meta stuff
+            resource = persistence.create(persistenceContext, resource).getResource();
+            event.setFhirResource(resource); // update event with latest
+            ior.setStatus(Response.Status.CREATED);
+            ior.setResource(resource);
+
+            // Build our location URI and add it to the interceptor event structure since it is now known.
+            ior.setLocationURI(FHIRUtil.buildLocationURI(ModelSupport.getTypeName(resource.getClass()), resource));
+            event.getProperties().put(FHIRPersistenceEvent.PROPNAME_RESOURCE_LOCATION_URI, ior.getLocationURI().toString());
+
+            // Invoke the 'afterCreate' interceptor methods.
+            getInterceptorMgr().fireAfterCreateEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            return ior;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doCreate");
+        }
+    }
+
+    @Override
+    public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue,
+            String searchQueryString, Map<String, String> requestProperties) throws Exception {
+
+        return doPatchOrUpdate(type, id, patch, null, ifMatchValue, searchQueryString, requestProperties);
+    }
+
+    @Override
+    public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
+            String searchQueryString, Map<String, String> requestProperties) throws Exception {
+
+        return doPatchOrUpdate(type, id, null, newResource, ifMatchValue, searchQueryString, requestProperties);
+    }
+
+    private FHIRRestOperationResponse doPatchOrUpdate(String type, String id, FHIRPatch patch,
+            Resource newResource, String ifMatchValue, String searchQueryString,
+            Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "doPatchOrUpdate");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        String errMsg = "Caught exception while processing 'update/patch' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
+
+        try {
+            // Make sure the type specified in the URL string matches the resource type obtained from the new resource.
+            if (patch == null) {
+                String resourceType =  ModelSupport.getTypeName(newResource.getClass());
+                if (!resourceType.equals(type)) {
+                    String msg = "Resource type '" + resourceType
+                            + "' does not match type specified in request URI: " + type;
+                    throw buildRestException(msg, IssueType.INVALID);
+                }
+            }
+
+            // Next, if a conditional update was invoked then use the search criteria to find the
+            // resource to be updated. Otherwise, we'll use the id value to retrieve the current
+            // version of the resource.
+            if (searchQueryString != null) {
+                if (log.isLoggable(Level.FINE)) {
+                    log.fine("Performing conditional update/patch with search criteria: "
+                            + Encode.forHtml(searchQueryString));
+                }
+                Bundle responseBundle = null;
+                try {
+                    MultivaluedMap<String, String> searchParameters =
+                            getQueryParameterMap(searchQueryString);
+                    responseBundle =
+                            doSearch(type, null, null, searchParameters, null, requestProperties, newResource);
+                } catch (FHIROperationException e) {
+                    throw e;
+                } catch (Throwable t) {
+                    String msg =
+                            "An error occurred while performing the search for a conditional update/patch operation.";
+                    throw new FHIROperationException(msg, t);
+                }
+
+                // Check the search results to determine whether or not to perform the update operation.
+                int resultCount = responseBundle.getEntry().size();
+                if (log.isLoggable(Level.FINE)) {
+                    log.fine("Conditional update/patch search yielded " + resultCount + " results.");
+                }
+
+                if (resultCount == 0) {
+                    if (patch != null) {
+                        String msg =
+                                "The search criteria specified for a conditional patch operation did not return any results.";
+                        throw buildRestException(msg, IssueType.NOT_FOUND);
+                    }
+                    // Search yielded no matches, so we'll do an update/create operation below.
+                    ior.setPrevResource(null);
+
+                    // if no id provided, then generate an id for the input resource
+                    if (newResource.getId() == null || newResource.getId() == null) {
+                        id = UUID.randomUUID().toString();
+                        newResource = newResource.toBuilder().id(id).build();
+                    } else {
+                        id = newResource.getId();
+                    }
+                } else if (resultCount == 1) {
+                    // If we found a single match, then we'll perform a normal update on the matched resource.
+                    ior.setPrevResource(responseBundle.getEntry().get(0).getResource());
+                    id = ior.getPrevResource().getId();
+
+                    // If the id of the input resource is different from the id of the search result,
+                    // then throw exception.
+                    if (newResource.getId() != null && newResource.getId() != null
+                            && !newResource.getId().equalsIgnoreCase(id)) {
+                        String msg = "Input resource 'id' attribute must match the id of the search result resource.";
+                        throw buildRestException(msg, IssueType.VALUE);
+                    }
+                    // Make sure the id of the newResource is not null and is the same as the id of the found resource.
+                    newResource = newResource.toBuilder().id(id).build();
+                } else {
+                    String msg =
+                            "The search criteria specified for a conditional update/patch operation returned multiple matches.";
+                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
+                }
+            } else {
+                // Make sure an id value was passed in.
+                if (id == null) {
+                    String msg = "The 'id' parameter is required for an update/pach operation.";
+                    throw buildRestException(msg, IssueType.REQUIRED);
+                }
+
+                // If an id value was passed in (i.e. the id specified in the REST API URL string),
+                // then make sure it's the same as the value in the resource.
+                if (patch == null) {
+                    // Make sure the resource has an 'id' attribute.
+                    if (newResource.getId() == null) {
+                        String msg = "Input resource must contain an 'id' attribute.";
+                        throw buildRestException(msg, IssueType.INVALID);
+                    }
+
+                    if (!newResource.getId().equals(id)) {
+                        String msg = "Input resource 'id' attribute must match 'id' parameter.";
+                        throw buildRestException(msg, IssueType.VALUE);
+                    }
+                }
+
+                // Retrieve the resource to be updated using the type and id values.
+                ior.setPrevResource(doRead(type, id, (patch != null), true, requestProperties, newResource));
+            }
+
+            if (patch != null) {
+                newResource = patch.apply(ior.getPrevResource());
+            }
+
+            // Validate the input resource and return any validation errors.
+            List<Issue> validationWarnings = validateInput(newResource);
+            ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(validationWarnings));
+
+            // Perform the "version-aware" update check, and also find out if the resource was deleted.
+            boolean isDeleted = false;
+            if (ior.getPrevResource() != null) {
+                performVersionAwareUpdateCheck(ior.getPrevResource(), ifMatchValue);
+
+                try {
+                    doRead(type, id, (patch != null), false, requestProperties, newResource);
+                } catch (FHIRPersistenceResourceDeletedException e) {
+                    isDeleted = true;
+                }
+            }
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, create the persistence event.
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(newResource, 
+                    buildPersistenceEventProperties(type, newResource.getId(), null, requestProperties));
+
+            // Next, set the "previous resource" in the persistence event.
+            event.setPrevFhirResource(ior.getPrevResource());
+
+            // Next, invoke the 'beforeUpdate' or 'beforeCreate' interceptor methods as appropriate.
+            boolean updateCreate = (ior.getPrevResource() == null);
+            if (updateCreate) {
+                getInterceptorMgr().fireBeforeCreateEvent(event);
+            } else {
+                if (patch != null) {
+                    event.getProperties().put(FHIRPersistenceEvent.PROPNAME_PATCH, patch);
+                    getInterceptorMgr().fireBeforePatchEvent(event);
+                } else {
+                    getInterceptorMgr().fireBeforeUpdateEvent(event);
+                }
+            }
+
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event);
+            newResource = persistence.update(persistenceContext, id, newResource).getResource();
+            event.setFhirResource(newResource); // update event with latest
+            ior.setResource(newResource);
+
+            // Build our location URI and add it to the interceptor event structure since it is now known.
+            ior.setLocationURI(FHIRUtil.buildLocationURI(ModelSupport.getTypeName(newResource.getClass()), newResource));
+            event.getProperties().put(FHIRPersistenceEvent.PROPNAME_RESOURCE_LOCATION_URI, ior.getLocationURI().toString());
+
+            // Invoke the 'afterUpdate' interceptor methods.
+            if (updateCreate) {
+                ior.setStatus(Response.Status.CREATED);
+                getInterceptorMgr().fireAfterCreateEvent(event);
+            } else {
+                ior.setStatus(Response.Status.OK);
+                if (patch != null) {
+                    getInterceptorMgr().fireAfterPatchEvent(event);
+                } else {
+                    getInterceptorMgr().fireAfterUpdateEvent(event);
+                }
+            }
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            // If the deleted resource is updated, then simply return 201 instead of 200 to pass Touchstone test.
+            // We don't set the previous resource to null in above codes if the resource was deleted, otherwise
+            // it will break the code logic of the resource versioning.
+            if (isDeleted && ior.getStatus() == Response.Status.OK) {
+                ior.setStatus(Response.Status.CREATED);
+            }
+
+            return ior;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we still have a transaction at this point, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doPatchOrUpdate");
+        }
+    }
+
+    /**
+     * Performs a 'delete' operation on the specified resource.
+     *
+     * @param type
+     *            the resource type associated with the Resource to be deleted
+     * @param id
+     *            the id of the Resource to be deleted
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return a FHIRRestOperationResponse that contains the results of the operation
+     * @throws Exception
+     */
+    @Override
+    public FHIRRestOperationResponse doDelete(String type, String id, String searchQueryString,
+            Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "doDelete");
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        Response.Status status = null;
+        String errMsg = "Caught exception while processing 'delete' request.";
+
+        FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
+
+        try {
+            String resourceTypeName = type;
+            if (!ModelSupport.isResourceType(type)) {
+                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+            }
+
+            Class<? extends Resource> resourceType =
+                    getResourceType(resourceTypeName);
+
+            // Next, if a conditional delete was invoked then use the search criteria to find the
+            // resource to be deleted. Otherwise, we'll use the id value to identify the resource
+            // to be deleted.
+            Resource resourceToDelete = null;
+            if (searchQueryString != null) {
+                if (log.isLoggable(Level.FINE)) {
+                    log.fine("Performing conditional delete with search criteria: "
+                            + Encode.forHtml(searchQueryString));
+                }
+                Bundle responseBundle = null;
+                try {
+                    MultivaluedMap<String, String> searchParameters =
+                            getQueryParameterMap(searchQueryString);
+                    responseBundle =
+                            doSearch(type, null, null, searchParameters, null, requestProperties, null);
+                } catch (FHIROperationException e) {
+                    throw e;
+                } catch (Throwable t) {
+                    String msg =
+                            "An error occurred while performing the search for a conditional delete operation.";
+                    log.log(Level.SEVERE, msg, t);
+                    throw new FHIROperationException(msg, t);
+                }
+
+                // Check the search results to determine whether or not to perform the update operation.
+                int resultCount = responseBundle.getEntry().size();
+                if (log.isLoggable(Level.FINE)) {
+                    log.fine("Conditional delete search yielded " + resultCount + " results.");
+                }
+
+                if (resultCount == 0) {
+                    // Search yielded no matches
+                    String msg = "Search criteria for a conditional delete operation yielded no matches.";
+                    if (log.isLoggable(Level.FINE)) {
+                        log.fine(msg);
+                    }
+                    status = Response.Status.OK;
+                    ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(msg, IssueType.NOT_FOUND, IssueSeverity.WARNING));
+                    ior.setStatus(status);
+                    return ior;
+                } else if (resultCount == 1) {
+                    // If we found a single match, then we'll delete this one.
+                    Resource resource = responseBundle.getEntry().get(0).getResource();
+                    id = resource.getId();
+                    resourceToDelete = resource;
+                } else {
+                    String msg =
+                            "The search criteria specified for a conditional delete operation returned multiple matches.";
+                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
+                }
+            } else {
+                // Make sure an id value was passed in.
+                if (id == null) {
+                    String msg = "The 'id' parameter is required for a delete operation.";
+                    throw buildRestException(msg, IssueType.REQUIRED);
+                }
+
+                // Read the resource so it will be available to the beforeDelete interceptor methods.
+                try {
+                    resourceToDelete = doRead(type, id, false, false, requestProperties, null);
+                } catch (FHIRPersistenceResourceDeletedException e) {
+                    // Absorb this exception.
+                    resourceToDelete = null;
+                }
+            }
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeDelete' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, null, requestProperties));
+            event.setFhirResource(resourceToDelete);
+            getInterceptorMgr().fireBeforeDeleteEvent(event);
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event);
+
+            Resource resource = persistence.delete(persistenceContext, resourceType, id).getResource();
+            ior.setResource(resource);
+            event.setFhirResource(resource);
+            ior.setStatus(Response.Status.NO_CONTENT);
+
+            // Invoke the 'afterDelete' interceptor methods.
+            getInterceptorMgr().fireAfterDeleteEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+            status = ior.getStatus();
+
+            return ior;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            status = Response.Status.INTERNAL_SERVER_ERROR;
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doDelete");
+        }
+    }
+
+    @Override
+    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            Map<String, String> requestProperties, Resource contextResource) throws Exception {
+        return doRead(type, id, throwExcOnNull, includeDeleted, requestProperties, contextResource, null);
+    }
+
+    /**
+     * Performs a 'read' operation to retrieve a Resource.
+     *
+     * @param type
+     *            the resource type associated with the Resource to be retrieved
+     * @param id
+     *            the id of the Resource to be retrieved
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return the Resource
+     * @throws Exception
+     */
+    @Override
+    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            Map<String, String> requestProperties, Resource contextResource, MultivaluedMap<String, String> queryParameters)
+            throws Exception {
+        log.entering(this.getClass().getName(), "doRead");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        Resource resource = null;
+        String errMsg = "Caught exception while processing 'read' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            String resourceTypeName = type;
+            if (!ModelSupport.isResourceType(type)) {
+                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+            }
+
+            Class<? extends Resource> resourceType = getResourceType(resourceTypeName);
+
+            FHIRSearchContext searchContext = null;
+            if (queryParameters != null) {
+                searchContext = SearchUtil.parseQueryParameters(null, null, resourceType, queryParameters, 
+                        HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+            }
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeRead' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(contextResource, buildPersistenceEventProperties(type, id, null, requestProperties));
+            getInterceptorMgr().fireBeforeReadEvent(event);
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event, includeDeleted, searchContext);
+            resource = persistence.read(persistenceContext, resourceType, id).getResource();
+            if (resource == null && throwExcOnNull) {
+                throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
+            }
+
+            event.setFhirResource(resource);
+
+            // Invoke the 'afterRead' interceptor methods.
+            getInterceptorMgr().fireAfterReadEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            return resource;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doRead");
+        }
+    }
+
+    /**
+     * Performs a 'vread' operation by retrieving the specified version of a Resource.
+     *
+     * @param type
+     *            the resource type associated with the Resource to be retrieved
+     * @param id
+     *            the id of the Resource to be retrieved
+     * @param versionId
+     *            the version id of the Resource to be retrieved
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return the Resource
+     * @throws Exception
+     */
+    @Override
+    public Resource doVRead(String type, String id, String versionId,
+        Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "doVRead");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        Resource resource = null;
+        String errMsg = "Caught exception while processing 'vread' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            String resourceTypeName = type;
+            if (!ModelSupport.isResourceType(type)) {
+                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+            }
+
+            Class<? extends Resource> resourceType =
+                    getResourceType(resourceTypeName);
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeVread' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, versionId, requestProperties));
+            getInterceptorMgr().fireBeforeVreadEvent(event);
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event);
+            resource = persistence.vread(persistenceContext, resourceType, id, versionId).getResource();
+            if (resource == null) {
+                throw new FHIRPersistenceResourceNotFoundException("Resource '"
+                        + resourceType.getSimpleName() + "/" + id + "' version " + versionId + " not found.");
+            }
+
+            event.setFhirResource(resource);
+
+            // Invoke the 'afterVread' interceptor methods.
+            getInterceptorMgr().fireAfterVreadEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            return resource;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doVRead");
+        }
+    }
+
+    /**
+     * Performs the work of retrieving versions of a Resource.
+     *
+     * @param type
+     *            the resource type associated with the Resource to be retrieved
+     * @param id
+     *            the id of the Resource to be retrieved
+     * @param queryParameters
+     *            a Map containing the query parameters from the request URL
+     * @param requestUri the URI from the request
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return a Bundle containing the history of the specified Resource
+     * @throws Exception
+     */
+    @Override
+    public Bundle doHistory(String type, String id, MultivaluedMap<String, String> queryParameters,
+        String requestUri, Map<String, String> requestProperties)
+        throws Exception {
+        log.entering(this.getClass().getName(), "doHistory");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        Bundle bundle = null;
+        String errMsg = "Caught exception while processing 'history' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            String resourceTypeName = type;
+            if (!ModelSupport.isResourceType(type)) {
+                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+            }
+
+            Class<? extends Resource> resourceType =
+                    getResourceType(resourceTypeName);
+            FHIRHistoryContext historyContext =
+                    FHIRPersistenceUtil.parseHistoryParameters(queryParameters, HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeHistory' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(null, buildPersistenceEventProperties(type, id, null, requestProperties));
+            getInterceptorMgr().fireBeforeHistoryEvent(event);
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event, historyContext);
+            List<? extends Resource> resources =
+                    persistence.history(persistenceContext, resourceType, id).getResource();
+            bundle = createHistoryBundle(resources, historyContext, type);
+            bundle = addLinks(historyContext, bundle, requestUri);
+
+            event.setFhirResource(bundle);
+
+            // Invoke the 'afterHistory' interceptor methods.
+            getInterceptorMgr().fireAfterHistoryEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            return bundle;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doHistory");
+        }
+    }
+
+    /**
+     * Performs heavy lifting associated with a 'search' operation.
+     *
+     * @param type
+     *            the resource type associated with the search
+     * @param queryParameters
+     *            a Map containing the query parameters from the request URL
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return a Bundle containing the search result set
+     * @throws Exception
+     */
+    @Override
+    public Bundle doSearch(String type, String compartment, String compartmentId,
+            MultivaluedMap<String, String> queryParameters, String requestUri,
+            Map<String, String> requestProperties, Resource contextResource) throws Exception {
+        log.entering(this.getClass().getName(), "doSearch");
+
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
+        Bundle bundle = null;
+        String errMsg = "Caught exception while processing 'search' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            String resourceTypeName = type;
+
+            // Check to see if it's supported, else, throw a bad request.
+            // If this is removed, it'll result in nullpointer when processing the request
+            if (!ModelSupport.isResourceType(type)) {
+                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+            }
+
+            Class<? extends Resource> resourceType =
+                    getResourceType(resourceTypeName);
+
+            // Start a new txn in the persistence layer if one is not already active.
+            txn.begin();
+
+            // First, invoke the 'beforeSearch' interceptor methods.
+            FHIRPersistenceEvent event =
+                    new FHIRPersistenceEvent(contextResource, buildPersistenceEventProperties(type, null, null, requestProperties));
+            getInterceptorMgr().fireBeforeSearchEvent(event);
+
+            FHIRSearchContext searchContext = SearchUtil.parseQueryParameters(compartment, compartmentId, resourceType, queryParameters,
+                    HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+
+            FHIRPersistenceContext persistenceContext =
+                    FHIRPersistenceContextFactory.createPersistenceContext(event, searchContext);
+            List<Resource> resources =
+                    persistence.search(persistenceContext, resourceType).getResource();
+
+            bundle = createSearchBundle(resources, searchContext, type);
+            if (requestUri != null) {
+                bundle = addLinks(searchContext, bundle, requestUri);
+            }
+            event.setFhirResource(bundle);
+
+            // Invoke the 'afterSearch' interceptor methods.
+            getInterceptorMgr().fireAfterSearchEvent(event);
+
+            // Commit our transaction if we started one before.
+            txn.commit();
+            txn = null;
+
+            return bundle;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            // If we previously started a transaction and it's still active, we need to rollback due to an error.
+            if (txn != null) {
+                txn.rollback();
+            }
+
+            log.exiting(this.getClass().getName(), "doSearch");
+        }
+    }
+
+    /**
+     * Helper method which invokes a custom operation.
+     *
+     * @param operationContext
+     *            the FHIROperationContext associated with the request
+     * @param resourceTypeName
+     *            the resource type associated with the request
+     * @param logicalId
+     *            the resource logical id associated with the request
+     * @param versionId
+     *            the resource version id associated with the request
+     * @param operationName
+     *            the name of the custom operation to be invoked
+     * @param resource
+     *            the input resource associated with the custom operation to be invoked
+     * @param queryParameters
+     *            query parameters may be passed instead of a Parameters resource for certain custom operations invoked
+     *            via GET
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return a Resource that represents the response to the custom operation
+     * @throws Exception
+     */
+    @Override
+    public Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName,
+            String logicalId, String versionId, String operationName,
+            Resource resource, MultivaluedMap<String, String> queryParameters,
+            Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "doInvoke");
+
+        String errMsg = "Caught exception while processing 'invoke' request.";
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            Class<? extends Resource> resourceType = null;
+            if (resourceTypeName != null) {
+                resourceType = getResourceType(resourceTypeName);
+            }
+            String operationKey = (resourceTypeName == null ? operationName : operationName + ":" + resourceTypeName);
+
+            FHIROperation operation =
+                    FHIROperationRegistry.getInstance().getOperation(operationKey);
+            Parameters parameters = null;
+            if (resource instanceof Parameters) {
+                parameters = (Parameters) resource;
+            } else {
+                if (resource == null) {
+                    // build parameters object from query parameters
+                    parameters =
+                            FHIROperationUtil.getInputParameters(operation.getDefinition(), queryParameters);
+                } else {
+                    // wrap resource in a parameters object
+                    parameters =
+                            FHIROperationUtil.getInputParameters(operation.getDefinition(), resource);
+                }
+            }
+
+            // Add properties to the FHIR operation context
+            setOperationContextProperties(operationContext, resourceTypeName, requestProperties);
+
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("Invoking operation '" + operationName + "', context=\n"
+                        + operationContext.toString());
+            }
+            Parameters result =
+                    operation.invoke(operationContext, resourceType, logicalId, versionId, parameters, this);
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("Returned from invocation of operation '" + operationName + "'...");
+            }
+
+            // if single resource output parameter, return the resource
+            if (FHIROperationUtil.hasSingleResourceOutputParameter(result)) {
+                return FHIROperationUtil.getSingleResourceOutputParameter(result);
+            }
+
+            return result;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            log.exiting(this.getClass().getName(), "doInvoke");
+        }
+    }
+
+    /**
+     * Processes a bundled request.
+     *
+     * @param bundleResource
+     *            the request Bundle
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @return the response Bundle
+     */
+    @Override
+    public Bundle doBundle(Resource bundleResource, Map<String, String> requestProperties)
+        throws Exception {
+        log.entering(this.getClass().getName(), "doBundle");
+
+        String errMsg = "Caught exception while processing 'bundle' request.";
+        Bundle inputBundle = null;
+
+        // Save the current request context.
+        FHIRRequestContext requestContext = FHIRRequestContext.get();
+
+        try {
+            if (bundleResource instanceof Bundle) {
+                inputBundle = (Bundle) bundleResource;
+            } else {
+                String msg = "A 'Bundle' resource type is required but a '"
+                        + bundleResource.getClass().getSimpleName() + "' resource type was sent.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+            // First, validate the bundle and create the response bundle.
+            Bundle responseBundle = validateBundle(inputBundle);
+
+            // Next, process each of the entries in the bundle.
+            responseBundle = processBundleEntries(inputBundle, responseBundle, requestProperties);
+
+            return responseBundle;
+        } catch (FHIROperationException e) {
+            log.log(Level.WARNING, errMsg, e);
+            throw e;
+        } catch (Throwable t) {
+            log.log(Level.SEVERE, errMsg, t);
+            throw t;
+        } finally {
+            // Restore the original request context.
+            FHIRRequestContext.set(requestContext);
+
+            log.exiting(this.getClass().getName(), "doBundle");
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.ibm.fhir.rest.FHIRResourceHelpers#getTransaction()
+     */
+    @Override
+    public FHIRPersistenceTransaction getTransaction() throws Exception {
+        return persistence.getTransaction();
+    }
+
+    /**
+     * Validate the input resource and throw if there are validation errors
+     *
+     * @param resource
+     * @throws FHIRValidationException
+     * @throws FHIROperationException
+     */
+    private List<OperationOutcome.Issue> validateInput(Resource resource)
+            throws FHIRValidationException, FHIROperationException {
+        List<OperationOutcome.Issue> issues = FHIRValidator.validator().validate(resource);
+        if (!issues.isEmpty()) {
+            boolean includesFailure = false;
+            for (OperationOutcome.Issue issue : issues) {
+                if (FHIRUtil.isFailure(issue.getSeverity())) {
+                    includesFailure = true;
+                }
+            }
+
+            if (includesFailure) {
+                throw new FHIROperationException("Input resource failed validation.").withIssue(issues);
+            } else {
+                if (log.isLoggable(Level.FINE)) {
+                    String info = issues.stream()
+                                .flatMap(issue -> Stream.of(issue.getDetails()))
+                                .flatMap(details -> Stream.of(details.getText()))
+                                .flatMap(text -> Stream.of(text.getValue()))
+                                .collect(Collectors.joining(", "));
+                    log.fine("Validation warnings for input resource: " + info);
+                }
+            }
+        }
+        return issues;
+    }
+
+    /**
+     * @param issues
+     * @return
+     */
+    private boolean anyFailureInIssues(List<OperationOutcome.Issue> issues) {
+        boolean hasFailure = false;
+        for (OperationOutcome.Issue issue : issues) {
+            if (FHIRUtil.isFailure(issue.getSeverity())) {
+                hasFailure = true;
+            }
+        }
+        return hasFailure;
+    }
+
+    /**
+     * Performs validation of a request Bundle and returns a Bundle containing response entries corresponding to the
+     * request entries in the request Bundle. holding the responses for the requests contained in the request Bundle.
+     *
+     * @param bundle
+     *            the bundle to be validated
+     * @return a response Bundle
+     * @throws Exception
+     */
+    private Bundle validateBundle(Bundle bundle) throws Exception {
+        log.entering(this.getClass().getName(), "validateBundle");
+
+        try {
+            // Make sure the bundle isn't empty
+            if (bundle == null) {
+                String msg = "Bundle parameter is missing or empty.";
+                throw buildRestException(msg, IssueType.REQUIRED);
+            }
+
+            BundleType.ValueSet requestType = bundle.getType().getValueAsEnumConstant();
+            
+            // Determine the bundle type of the response bundle.
+            BundleType responseBundleType = null;
+
+            if (requestType == BundleType.ValueSet.BATCH) {
+                // For 'batch' interactions, return a 'batch-response'
+                responseBundleType = BundleType.BATCH_RESPONSE;
+            } else if (requestType == BundleType.ValueSet.TRANSACTION) {
+                responseBundleType = BundleType.TRANSACTION_RESPONSE;
+                // For a 'transaction' interaction, if the underlying persistence layer doesn't support
+                // transactions, then throw an error.
+                if (!persistence.isTransactional()) {
+                    String msg = "Bundled 'transaction' request cannot be processed because "
+                            + "the configured persistence layer does not support transactions.";
+                    IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
+                            .extension(Extension.builder()
+                                .url(EXTENSION_URL +  "/not-supported-detail")
+                                .value(string("interaction"))
+                                .build())
+                            .build();
+                    throw buildRestException(msg, extendedIssueType);
+                }
+            } else {
+                // For any other bundle type, throw an error.
+                // TODO add support for posting history bundles
+                String msg = "Bundle.type must be either 'batch' or 'transaction'.";
+                throw buildRestException(msg, IssueType.VALUE);
+            }
+
+            // For 'transaction' bundle requests, keep a list of issues in case of failure
+            List<OperationOutcome.Issue> issueList = new ArrayList<OperationOutcome.Issue>();
+
+            List<Bundle.Entry> responseList = new ArrayList<Bundle.Entry>();
+
+            for (Bundle.Entry requestEntry : bundle.getEntry()) {
+                // Create a corresponding response entry and add it to the response bundle.
+                Bundle.Entry.Response response;
+                Bundle.Entry responseEntry = null;
+
+                // Validate 'requestEntry' and update 'responseEntry' with any errors.
+                try {
+                    Bundle.Entry.Request request = requestEntry.getRequest();
+                    // Verify that the request field is present.
+                    if (request == null) {
+                        String msg = "Bundle.Entry is missing the 'request' field.";
+                        throw buildRestException(msg, IssueType.REQUIRED);
+                    }
+
+                    // Verify that a method was specified.
+                    if (request.getMethod() == null || request.getMethod().getValue() == null) {
+                        String msg = "Bundle.Entry.request is missing the 'method' field";
+                        throw buildRestException(msg, IssueType.REQUIRED);
+                    }
+
+                    // Verify that a URL was specified.
+                    if (request.getUrl() == null || request.getUrl().getValue() == null) {
+                        String msg = "Bundle.Entry.request is missing the 'url' field";
+                        throw buildRestException(msg, IssueType.REQUIRED);
+                    }
+
+                    // Retrieve the resource from the request entry to prepare for some validations below.
+                    Resource resource = requestEntry.getResource();
+
+                    // Validate the resource for the requested HTTP method.
+                    methodValidation(request.getMethod(), resource);
+
+                    // If the request entry contains a resource, then validate it now.
+                    if (resource != null) {
+                        List<OperationOutcome.Issue> issues =
+                                FHIRValidator.validator().validate(resource);
+                        if (!issues.isEmpty()) {
+                            if (anyFailureInIssues(issues)) {
+                                if (requestType == BundleType.ValueSet.TRANSACTION) {
+                                    issueList.addAll(issues);
+                                } else {
+                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
+                                    response = Bundle.Entry.Response.builder()
+                                                .status(string(Integer.toString(SC_BAD_REQUEST)))
+                                                .build();
+                                    responseEntry = Bundle.Entry.builder()
+                                                .response(response)
+                                                .resource(oo)
+                                                .build();
+                                }
+                            } else {
+                                response = Bundle.Entry.Response.builder()
+                                            .status(string(Integer.toString(SC_OK)))
+                                            .build();
+                                Bundle.Entry.Builder responseEntryBuilder = Bundle.Entry.builder().response(response);
+                                // Only add hints/warnings if the return preference was "OperationOutcome"
+                                if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
+                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
+                                    responseEntryBuilder.resource(oo);
+                                }
+                                responseEntry = responseEntryBuilder.build();
+                            }
+                            continue;
+                        }
+                    }
+                    response =
+                            Bundle.Entry.Response.builder().status(string(Integer.toString(SC_OK))).build();
+                    responseEntry = Bundle.Entry.builder().response(response).build();
+                } catch (FHIROperationException e) {
+                    if (log.isLoggable(Level.FINE)) {
+                        log.log(Level.FINE, "Failed to process BundleEntry ["
+                                + bundle.getEntry().indexOf(requestEntry) + "]", e);
+                    }
+                    if (requestType == BundleType.ValueSet.TRANSACTION) {
+                        issueList.addAll(e.getIssues());
+                    } else {
+                        response = Bundle.Entry.Response.builder()
+                                .status(string(Integer.toString(SC_BAD_REQUEST)))
+                                .build();
+                        responseEntry = Bundle.Entry.builder()
+                                .response(response)
+                                .resource(FHIRUtil.buildOperationOutcome(e, false))
+                                .build();
+                    }
+                } finally {
+                    if (responseEntry != null) {
+                        responseList.add(responseEntry);
+                    }
+                }
+            } // End foreach requestEntry
+
+            // If this is a "transaction" interaction and we encountered any errors, then we'll
+            // abort processing this request right now since a transaction interaction is supposed to be
+            // all or nothing.
+            if (requestType == BundleType.ValueSet.TRANSACTION && issueList.size() > 0) {
+                String msg =
+                        "One or more errors were encountered while validating a 'transaction' request bundle.";
+                throw buildRestException(msg, IssueType.INVALID).withIssue(issueList);
+            }
+            
+            // Create the response bundle with the appropriate type.
+            Bundle responseBundle = Bundle.builder().type(responseBundleType).entry(responseList).build();
+
+            return responseBundle;
+        } finally {
+            log.exiting(this.getClass().getName(), "validateBundle");
+        }
+    }
+
+    /**
+     * Perform method-specific validation of the resource
+     */
+    private void methodValidation(HTTPVerb method, Resource resource) throws FHIRPersistenceException, FHIROperationException {
+        switch(method.getValueAsEnumConstant()) {
+        case PATCH:
+        case POST:
+            break;
+        case DELETE:
+            // If the "delete" operation isn't supported by the configured persistence layer,
+            // then we need to fail validation of this bundle entry.
+            if (!persistence.isDeleteSupported()) {
+                String msg = "Bundle.Entry.request contains unsupported HTTP method: "
+                        + method.getValue();
+                IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
+                        .extension(Extension.builder()
+                            .url(EXTENSION_URL +  "/not-supported-detail")
+                            .value(string("interaction"))
+                            .build())
+                        .build();
+                throw buildRestException(msg, extendedIssueType);
+            }
+            // Purposefully fall through to next clause
+        case HEAD:
+        case GET:
+            if (resource != null) {
+                String msg =
+                        "Bundle.Entry.resource not allowed for BundleEntry with " + method.getValue() + " method.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+            break;
+        case PUT:
+            if (resource == null) {
+                String msg =
+                        "Bundle.Entry.resource is required for BundleEntry with PUT method.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+            if (resource.getId() == null) {
+                String msg =
+                        "Bundle.Entry.resource must contain an id field for a PUT operation.";
+                throw buildRestException(msg, IssueType.REQUIRED);
+            }
+            break;
+        default:
+            String msg = "Bundle.Entry.request contains unsupported HTTP method: " + method.getValue();
+            throw buildRestException(msg, IssueType.INVALID);
+        }
+    }
+
+    /**
+     * This function will perform the version-aware update check by making sure that the If-Match request header value
+     * (if present) specifies a version # equal to the current latest version of the resource. If the check fails, then
+     * a FHIRRestException will be thrown. If the check succeeds then nothing occurs and processing continues.
+     *
+     * @param currentResource
+     *            the current latest version of the resource
+     */
+    private void performVersionAwareUpdateCheck(Resource currentResource, String ifMatchValue)
+            throws FHIROperationException {
+        if (ifMatchValue != null) {
+            log.fine("Performing a version aware update. ETag value =  " + ifMatchValue);
+
+            String ifMatchVersion = getVersionIdFromETagValue(ifMatchValue);
+
+            // Make sure that we got a version # from the request header.
+            // If not, then return a 400 Bad Request status code.
+            if (ifMatchVersion == null || ifMatchVersion.isEmpty()) {
+                throw buildRestException("Invalid ETag value specified in request: "
+                        + ifMatchValue, IssueType.PROCESSING);
+            }
+
+            log.fine("Version id from ETag value specified in request: " + ifMatchVersion);
+
+            // Retrieve the version #'s from the current and updated resources.
+            String currentVersion = null;
+            if (currentResource.getMeta() != null
+                    && currentResource.getMeta().getVersionId() != null) {
+                currentVersion = currentResource.getMeta().getVersionId().getValue();
+            }
+
+            // Next, make sure that the If-Match version matches the version # found
+            // in the current latest version of the resource.
+            // If they don't match we'll return an HTTP 412 (Precondition Failed) status code.
+            if (!ifMatchVersion.equals(currentVersion)) {
+                String msg = "If-Match version '" + ifMatchVersion
+                        + "' does not match current latest version of resource: " + currentVersion;
+                IssueType extendedIssueType = IssueType.CONFLICT.toBuilder()
+                        .extension(Extension.builder()
+                            .url(EXTENSION_URL + "/http-failed-precondition")
+                            .value(string("If-Match"))
+                            .build())
+                        .build();
+                throw buildRestException(msg, extendedIssueType);
+            }
+        }
+    }
+
+    private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName, IssueType issueType) 
+            throws FHIROperationException {
+        return buildRestException("'" + resourceTypeName + "' is not a valid resource type.", issueType);
+    }
+
+    private FHIROperationException buildRestException(String msg, IssueType issueType) {
+        return buildRestException(msg, issueType, IssueSeverity.FATAL);
+    }
+
+    private FHIROperationException buildRestException(String msg, IssueType issueType, IssueSeverity severity) {
+        return new FHIROperationException(msg).withIssue(buildOperationOutcomeIssue(severity, issueType, msg));
+    }
+
+    /**
+     * Builds an OperationOutcomeIssue with the respective values for some of the fields.
+     */
+    private OperationOutcome.Issue buildOperationOutcomeIssue(IssueSeverity severity, IssueType type, String msg) {
+        return OperationOutcome.Issue.builder()
+                .severity(severity)
+                .code(type)
+                .details(CodeableConcept.builder().text(string(msg)).build())
+                .build();
+    }
+
+    /**
+     * Retrieves the version id value from an ETag header value. The ETag header value will be of the form:
+     * W/"<version-id>".
+     *
+     * @param ifMatchValue
+     *            the value of the If-Match request header.
+     */
+    private String getVersionIdFromETagValue(String ifMatchValue) {
+        String result = null;
+        if (ifMatchValue != null) {
+            if (ifMatchValue.startsWith("W/")) {
+                String s = ifMatchValue.substring(2);
+                // If the part after "W/" starts and ends with a ",
+                // then extract the part between the " characters and we're done.
+                if (s.charAt(0) == '\"' && s.charAt(s.length() - 1) == '\"') {
+                    result = s.substring(1, s.length() - 1);
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * This function will process each request contained in the specified request bundle, and update the response bundle
+     * with the appropriate response information.
+     *
+     * @param requestBundle
+     *            the bundle containing the requests
+     * @param responseBundle
+     *            the bundle containing the responses
+     */
+    private Bundle processBundleEntries(Bundle requestBundle, Bundle responseBundle,
+            Map<String, String> requestProperties) throws Exception {
+        log.entering(this.getClass().getName(), "processBundleEntries");
+
+        FHIRTransactionHelper txn = null;
+
+        // Generate a request correlation id for this request bundle.
+        bundleRequestCorrelationId = UUID.randomUUID().toString();
+        log.fine("Processing request bundle, request-correlation-id=" + bundleRequestCorrelationId);
+
+        try {
+            // If we're working on a 'transaction' type interaction, then start a new transaction now
+            // and sort the request bundle entries by their "url" field.
+            if (responseBundle.getType() == BundleType.TRANSACTION_RESPONSE) {
+                bundleTransactionCorrelationId = bundleRequestCorrelationId;
+                txn = new FHIRTransactionHelper(getTransaction());
+                txn.begin();
+                log.fine("Started new transaction for transaction bundle, txn-correlation-id="
+                        + bundleTransactionCorrelationId);
+            }
+
+            Map<String, String> localRefMap = new HashMap<>();
+
+            // Next, process entries in the correct order.
+            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.DELETE,
+                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
+            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.POST,
+                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
+            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.PUT,
+                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
+            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.GET,
+                    txn != null, localRefMap, requestProperties, bundleRequestCorrelationId);
+
+            if (txn != null) {
+                log.fine("Committing transaction for transaction bundle, txn-correlation-id="
+                        + bundleTransactionCorrelationId);
+                txn.commit();
+                txn = null;
+            }
+            return responseBundle;
+
+        } finally {
+            log.fine("Finished processing request bundle, request-correlation-id="
+                    + bundleRequestCorrelationId);
+
+            // Clear both correlation id fields since we're done processing the bundle.
+            bundleRequestCorrelationId = null;
+            bundleTransactionCorrelationId = null;
+
+            if (txn != null) {
+                txn.rollback();
+                txn = null;
+            }
+            log.exiting(this.getClass().getName(), "processBundleEntries");
+        }
+    }
+
+    /**
+     * Processes request entries in the specified request bundle whose method matches 'httpMethod'.
+     *
+     * @param requestBundle
+     *            the bundle containing the request entries
+     * @param responseBundle
+     *            the bundle containing the corresponding response entries
+     * @param httpMethod
+     *            the HTTP method (GET, POST, PUT, etc.) to be processed
+     */
+    private Bundle processEntriesForMethod(Bundle requestBundle, Bundle responseBundle,
+            HTTPVerb httpMethod, boolean failFast, Map<String, String> localRefMap,
+            Map<String, String> bundleRequestProperties, String bundleRequestCorrelationId)
+            throws Exception {
+        log.entering(this.getClass().getName(), "processEntriesForMethod", new Object[] {
+                "httpMethod", httpMethod });
+        try {
+            // First, obtain a list of request entry indices for the entries that we'll process.
+            // This list will contain the indices associated with only the entries for the specified http method.
+            List<Integer> entryIndices =
+                    getBundleRequestIndicesForMethod(requestBundle, responseBundle, httpMethod);
+            if (log.isLoggable(Level.FINER)) {
+                log.finer("Bundle request indices to be processed: " + entryIndices.toString());
+            }
+
+            // Next, for PUT (update) requests, extract any local identifiers and resolve them ahead of time.
+            // We do this to prevent any local reference problems from occurring due to our re-ordering
+            // of the PUT request entries.
+            if (httpMethod.equals(HTTPVerb.PUT)) {
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Pre-processing bundle request entries for PUT method...");
+                }
+                for (Integer index : entryIndices) {
+                    Bundle.Entry requestEntry = requestBundle.getEntry().get(index);
+
+                    // Retrieve the local identifier from the request entry (if present).
+                    String localIdentifier = retrieveLocalIdentifier(requestEntry, localRefMap);
+
+                    // Since this is for a PUT request (update) we should be able to resolve the local identifier
+                    // prior to processing the request since the resource's id must already be contained in the resource
+                    // within the request entry.
+                    if (localIdentifier != null) {
+                        Resource resource = requestEntry.getResource();
+                        addLocalRefMapping(localRefMap, localIdentifier, resource);
+                    }
+                }
+            }
+
+            // Next, for PUT and DELETE requests, we need to sort the indices by the request url path value.
+            if (httpMethod.equals(HTTPVerb.PUT) || httpMethod.equals(HTTPVerb.DELETE)) {
+                sortBundleRequestEntries(requestBundle, entryIndices);
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Sorted bundle request indices to be processed: "
+                            + entryIndices.toString());
+                }
+            }
+
+            // Now visit each of the request entries using the list of indices obtained above.
+            // Use hashmap to store both the index and the according updated response bundle entry.
+            HashMap<Integer, Bundle.Entry> responseIndexAndEntries =
+                    new HashMap<Integer, Bundle.Entry>();
+            for (Integer entryIndex : entryIndices) {
+                Bundle.Entry requestEntry = requestBundle.getEntry().get(entryIndex);
+                Bundle.Entry responseEntry = responseBundle.getEntry().get(entryIndex);
+                Bundle.Entry.Builder responseEntryBuilder = responseEntry.toBuilder();
+
+                Bundle.Entry.Request request = requestEntry.getRequest();
+                Bundle.Entry.Response response = responseEntry.getResponse();
+
+                StringBuffer requestDescription = new StringBuffer();
+                long initialTime = System.currentTimeMillis();
+                try {
+                    FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
+
+                    String path = requestURL.getPath();
+                    String query = requestURL.getQuery();
+                    if (log.isLoggable(Level.FINER)) {
+                        log.finer("Processing bundle request entry " + entryIndex + "; method="
+                                + request.getMethod().getValue() + ", url="
+                                + request.getUrl().getValue());
+                        log.finer("--> path: " + path);
+                        log.finer("--> query: " + query);
+                    }
+
+                    // Log our initial info message for this request.
+                    requestDescription.append("entryIndex:[");
+                    requestDescription.append(entryIndex);
+                    requestDescription.append("] correlationId:[");
+                    requestDescription.append(bundleRequestCorrelationId);
+                    requestDescription.append("] method:[");
+                    requestDescription.append(request.getMethod().getValue());
+                    requestDescription.append("] uri:[");
+                    requestDescription.append(request.getUrl().getValue());
+                    requestDescription.append("]");
+                    log.info("Received bundle request: " + requestDescription.toString());
+
+                    String[] pathTokens = requestURL.getPathTokens();
+                    MultivaluedMap<String, String> queryParams = requestURL.getQueryParameters();
+
+                    // Construct the absolute requestUri to be used for any response bundles associated
+                    // with history and search requests.
+                    String absoluteUri =
+                            getAbsoluteUri(getRequestUri(), request.getUrl().getValue());
+
+                    if (request.getMethod().equals(HTTPVerb.GET)) {
+                        Resource resource = null;
+                        int httpStatus = SC_OK;
+
+                        // Process a GET (read, vread, history, search, etc.).
+                        // Determine the type of request from the path tokens.
+                        if (pathTokens.length > 0
+                                && pathTokens[pathTokens.length - 1].startsWith("$")) {
+                            // This is a custom operation request
+
+                            // Chop off the '$' and save the name
+                            String operationName = pathTokens[pathTokens.length - 1].substring(1);
+
+                            // FHIROperationContext operationContext;
+                            switch (pathTokens.length) {
+                            case 1: {
+                                FHIROperationContext operationContext =
+                                        FHIROperationContext.createSystemOperationContext();
+                                resource =
+                                        doInvoke(operationContext, null, null, null, operationName, null, queryParams, null);
+                            }
+                                break;
+                            case 2: {
+                                FHIROperationContext operationContext =
+                                        FHIROperationContext.createResourceTypeOperationContext();
+                                resource =
+                                        doInvoke(operationContext, pathTokens[0], null, null, operationName, null, queryParams, null);
+                            }
+                                break;
+                            case 3: {
+                                FHIROperationContext operationContext =
+                                        FHIROperationContext.createInstanceOperationContext();
+                                resource =
+                                        doInvoke(operationContext, pathTokens[0], pathTokens[1], null, operationName, null, queryParams, null);
+                            }
+                                break;
+                            default:
+                                String msg = "Invalid URL for custom operation '"
+                                        + pathTokens[pathTokens.length - 1] + "'";
+                                throw buildRestException(msg, IssueType.NOT_FOUND);
+                            }
+                        } else if (pathTokens.length == 1) {
+                            // This is a 'search' request.
+                            if ("_search".equals(pathTokens[0])) {
+                                resource =
+                                        doSearch("Resource", null, null, queryParams, absoluteUri, null, null);
+                            } else {
+                                resource =
+                                        doSearch(pathTokens[0], null, null, queryParams, absoluteUri, null, null);
+                            }
+                        } else if (pathTokens.length == 2) {
+                            // This is a 'read' request.
+                            resource =
+                                    doRead(pathTokens[0], pathTokens[1], true, false, null, null);
+                        } else if (pathTokens.length == 3) {
+                            if ("_history".equals(pathTokens[2])) {
+                                // This is a 'history' request.
+                                resource =
+                                        doHistory(pathTokens[0], pathTokens[1], queryParams, absoluteUri, null);
+                            } else {
+                                // This is a compartment based search
+                                resource =
+                                        doSearch(pathTokens[2], pathTokens[0], pathTokens[1], queryParams, absoluteUri, null, null);
+                            }
+                        } else if (pathTokens.length == 4 && pathTokens[2].equals("_history")) {
+                            // This is a 'vread' request.
+                            resource = doVRead(pathTokens[0], pathTokens[1], pathTokens[3], null);
+                        } else {
+                            String msg = "Unrecognized path in request URL: " + path;
+                            throw buildRestException(msg, IssueType.NOT_FOUND);
+                        }
+
+                        // Save the results of the operation in the bundle response field.
+                        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                        responseBuilder.status(string(Integer.toString(httpStatus)));
+                        setBundleResponseStatus(response, httpStatus, requestDescription.toString(), initialTime);
+
+                        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(resource).response(responseBuilder.build()).build());
+                    } else if (request.getMethod().equals(HTTPVerb.POST)) {
+                        // Process a POST (create or search, or custom operation).
+                        if (pathTokens.length > 0
+                                && pathTokens[pathTokens.length - 1].startsWith("$")) {
+                            // This is a custom operation request
+
+                            // Chop off the '$' and save the name
+                            String operationName = pathTokens[pathTokens.length - 1].substring(1);
+
+                            // Retrieve the resource from the request entry.
+                            Resource resource = requestEntry.getResource();
+
+                            FHIROperationContext operationContext;
+                            Resource result;
+                            switch (pathTokens.length) {
+                            case 1:
+                                operationContext =
+                                        FHIROperationContext.createSystemOperationContext();
+                                result = doInvoke(operationContext, null, null, null, operationName, resource, queryParams, null);
+                                break;
+                            case 2:
+                                operationContext =
+                                        FHIROperationContext.createResourceTypeOperationContext();
+                                result = doInvoke(operationContext, pathTokens[0], null, null, operationName, resource, queryParams, null);
+                                break;
+                            case 3:
+                                operationContext =
+                                        FHIROperationContext.createInstanceOperationContext();
+                                result = doInvoke(operationContext, pathTokens[0], pathTokens[1], null, operationName, resource, queryParams, null);
+                                break;
+                            default:
+                                String msg = "Invalid URL for custom operation '"
+                                        + pathTokens[pathTokens.length - 1] + "'";
+                                throw buildRestException(msg, IssueType.NOT_FOUND);
+                            }
+
+                            Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                            // Add warning and hint issues to response outcome if any.
+                            if (result instanceof OperationOutcome) {
+                                if (((OperationOutcome) result).getIssue() != null) {
+                                    responseBuilder.outcome(result);
+                                }
+                            }
+
+                            responseBuilder.status(string(Integer.toString(SC_OK)));
+                            responseIndexAndEntries.put(entryIndex, responseEntryBuilder
+                                    .resource(result)
+                                    .response(responseBuilder.build())
+                                    .build());
+                            setBundleResponseStatus(response, SC_OK, requestDescription.toString(), initialTime);
+
+                        } else if (pathTokens.length == 2 && "_search".equals(pathTokens[1])) {
+                            // This is a 'search' request.
+                            Bundle searchResults =
+                                    doSearch(pathTokens[0], null, null, queryParams, absoluteUri, null, null);
+
+                            // Save the results of the operation in the bundle response field.
+                            Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                            responseBuilder.status(string(Integer.toString(SC_OK)));
+
+                            responseIndexAndEntries.put(entryIndex, responseEntryBuilder
+                                    .resource(searchResults)
+                                    .response(responseBuilder.build())
+                                    .build());
+
+                            setBundleResponseStatus(response, SC_OK, requestDescription.toString(), initialTime);
+                        } else if (pathTokens.length == 1) {
+                            // This is a 'create' request.
+
+                            // Retrieve the local identifier from the request entry (if present).
+                            String localIdentifier =
+                                    retrieveLocalIdentifier(requestEntry, localRefMap);
+
+                            // Retrieve the resource from the request entry.
+                            Resource resource = requestEntry.getResource();
+                            if (resource == null) {
+                                String msg =
+                                        "BundleEntry.resource is required for bundled create requests.";
+                                throw buildRestException(msg, IssueType.NOT_FOUND);
+                            }
+
+                            // Convert any local references found within the resource to their
+                            // corresponding external reference.
+
+                            ReferenceMappingVisitor<Resource> visitor =
+                                    new ReferenceMappingVisitor<Resource>(localRefMap);
+                            resource.accept(visitor);
+                            resource = visitor.getResult();
+
+                            // Perform the 'create' operation.
+                            String ifNoneExist = request.getIfNoneExist() != null
+                                    ? request.getIfNoneExist().getValue() : null;
+                            FHIRRestOperationResponse ior =
+                                    doCreate(pathTokens[0], resource, ifNoneExist, null);
+
+                            // Get the updated resource from FHIRRestOperationResponse which has the correct ID, meta
+                            // etc.
+                            resource = ior.getResource();
+
+                            // Process and replace bundler Entry
+                            Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, resource, ior.getOperationOutcome(), 
+                                    ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
+
+                            responseIndexAndEntries.put(entryIndex, resultEntry);
+
+                            // Next, if a local identifier was present, we'll need to map this to the
+                            // correct external identifier (e.g. Patient/12345).
+                            addLocalRefMapping(localRefMap, localIdentifier, resource);
+                        } else {
+                            String msg =
+                                    "Request URL for bundled create requests should have a path with exactly one token (<resourceType>).";
+                            throw buildRestException(msg, IssueType.NOT_FOUND);
+                        }
+                    } else if (request.getMethod().equals(HTTPVerb.PUT)) {
+                        String type = null;
+                        String id = null;
+
+                        // Process a PUT (update).
+                        if (pathTokens.length == 1) {
+                            // A single-part url would be a conditional update: <type>?<query>
+                            type = pathTokens[0];
+                            if (query == null || query.isEmpty()) {
+                                String msg =
+                                        "A search query string is required for a conditional update operation.";
+                                throw buildRestException(msg, IssueType.INVALID);
+                            }
+                        } else if (pathTokens.length == 2) {
+                            // A two-part url would be a normal update: <type>/<id>.
+                            type = pathTokens[0];
+                            id = pathTokens[1];
+                        } else {
+                            // A url with any other pattern is an error.
+                            String msg = "Request URL for bundled PUT request should have path part with either one or two tokens "
+                                    + "(<resourceType> or <resourceType>/<id>).";
+                            throw buildRestException(msg, IssueType.INVALID);
+                        }
+
+                        // Retrieve the resource from the request entry.
+                        Resource resource = requestEntry.getResource();
+
+                        // Convert any local references found within the resource to their
+                        // corresponding external reference.
+                        ReferenceMappingVisitor<Resource> visitor =
+                                new ReferenceMappingVisitor<Resource>(localRefMap);
+                        resource.accept(visitor);
+                        resource = visitor.getResult();
+
+                        // Perform the 'update' operation.
+                        String ifMatchBundleValue = null;
+                        if (request.getIfMatch() != null) {
+                            ifMatchBundleValue = request.getIfMatch().getValue();
+                        }
+                        FHIRRestOperationResponse ior =
+                                doUpdate(type, id, resource, ifMatchBundleValue, query, null);
+
+                        // Process and replace bundler Entry
+                        Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), 
+                                ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
+
+                        responseIndexAndEntries.put(entryIndex, resultEntry);
+
+                    } else if (request.getMethod().equals(HTTPVerb.DELETE)) {
+                        String type = null;
+                        String id = null;
+
+                        // Process a DELETE.
+                        if (pathTokens.length == 1) {
+                            // A single-part url would be a conditional delete: <type>?<query>
+                            type = pathTokens[0];
+                            if (query == null || query.isEmpty()) {
+                                String msg =
+                                        "A search query string is required for a conditional delete operation.";
+                                throw buildRestException(msg, IssueType.INVALID);
+                            }
+                        } else if (pathTokens.length == 2) {
+                            type = pathTokens[0];
+                            id = pathTokens[1];
+                        } else {
+                            String msg = "Request URL for bundled DELETE request should have path part with one or two tokens "
+                                    + "(<resourceType> or <resourceType>/<id>).";
+                            throw buildRestException(msg, IssueType.INVALID);
+                        }
+
+                        // Perform the 'delete' operation.
+                        FHIRRestOperationResponse ior = doDelete(type, id, query, null);
+
+                        // Process and replace bundler Entry
+                        Bundle.Entry resultEntry = setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), 
+                                null, ior.getStatus().getStatusCode(), requestDescription.toString(), initialTime);
+
+                        responseIndexAndEntries.put(entryIndex, resultEntry);
+                    } else {
+                        // Internal error, should not get here!
+                        throw new IllegalStateException("Internal Server Error: reached an unexpected code location.");
+                    }
+                } catch (FHIRPersistenceResourceNotFoundException e) {
+                    if (failFast) {
+                        String msg = "Error while processing request bundle.";
+                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
+                    }
+                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                    responseBuilder.status(string(Integer.toString(SC_NOT_FOUND)));
+
+                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder
+                            .resource(FHIRUtil.buildOperationOutcome(e, false))
+                            .response(responseBuilder.build())
+                            .build());
+
+                    setBundleResponseStatus(response, SC_NOT_FOUND, requestDescription.toString(), initialTime);
+                } catch (FHIRPersistenceResourceDeletedException e) {
+                    if (failFast) {
+                        String msg = "Error while processing request bundle.";
+                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
+                    }
+                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                    responseBuilder.status(string(Integer.toString(SC_GONE)));
+
+                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder
+                            .resource(FHIRUtil.buildOperationOutcome(e, false))
+                            .response(responseBuilder.build())
+                            .build());
+
+                    setBundleResponseStatus(response, SC_GONE, requestDescription.toString(), initialTime);
+                } catch (FHIROperationException e) {
+                    if (failFast) {
+                        String msg = "Error while processing request bundle.";
+                        throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
+                    }
+                    
+                    Status status;
+                    if (e instanceof FHIRSearchException) {
+                        status = Status.BAD_REQUEST;
+                    } else {
+                        status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
+                    }
+
+                    Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+                    responseBuilder.status(string(Integer.toString(status.getStatusCode())));
+
+                    responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(FHIRUtil.buildOperationOutcome(e, false))
+                            .response(responseBuilder.build()).build());
+
+                    setBundleResponseStatus(response, status.getStatusCode(), requestDescription.toString(), initialTime);
+                }
+            } // end foreach entry
+            
+            // Now, let's re-construct the responseBundle
+            responseBundle = reconstructResponseBundle(responseBundle, responseIndexAndEntries);
+            return responseBundle;
+
+        } finally {
+            log.exiting(this.getClass().getName(), "processEntriesForMethod");
+        }
+    }
+
+    /**
+     * @param responseBundle
+     * @param responseIndexAndEntries
+     * @return
+     */
+    private Bundle reconstructResponseBundle(Bundle responseBundle,
+        HashMap<Integer, Bundle.Entry> responseIndexAndEntries) {
+        // Re-construct the responseBundle
+        List<Bundle.Entry> responseEntries = new ArrayList<Bundle.Entry>();
+        for (int i = 0; i < responseBundle.getEntry().size(); i++) {
+            Bundle.Entry bundleEntry = responseIndexAndEntries.get(Integer.valueOf(i)) == null
+                    ? responseBundle.getEntry().get(i)
+                    : responseIndexAndEntries.get(Integer.valueOf(i));
+            responseEntries.add(bundleEntry);
+        }
+
+        responseBundle = responseBundle.toBuilder().entry(responseEntries).build();
+        return responseBundle;
+    }
+
+    /**
+     * Returns a list of Integers that provide the indices of the bundle entries associated with the specified http
+     * method.
+     *
+     * @param requestBundle
+     *            the request bundle
+     * @param httpMethod
+     *            the http method to look for
+     * @return
+     */
+    private List<Integer> getBundleRequestIndicesForMethod(Bundle requestBundle,
+        Bundle responseBundle, HTTPVerb httpMethod) {
+        List<Integer> indices = new ArrayList<>();
+        for (int i = 0; i < requestBundle.getEntry().size(); i++) {
+            Bundle.Entry requestEntry = requestBundle.getEntry().get(i);
+            Bundle.Entry.Request request = requestEntry.getRequest();
+            
+            Bundle.Entry responseEntry = responseBundle.getEntry().get(i);
+            Bundle.Entry.Response response = responseEntry.getResponse();
+
+            // If the response status is SC_OK which means the request passed the validation,
+            // and this request entry's http method is the one we're looking for,
+            // then record the index in our list.
+            // (please notice that status can not be null since R4, So we set the response status as SC_OK
+            // after the resource validation. )
+            if (response.getStatus().equals(string(Integer.toString(SC_OK)))
+                    && request.getMethod().equals(httpMethod)) {
+                indices.add(Integer.valueOf(i));
+            }
+        }
+        return indices;
+    }
+
+    /**
+     * This function sorts the request entries in the specified bundle, based on the path part of the entry's 'url'
+     * field.
+     *
+     * @param bundle
+     *            the bundle containing the request entries to be sorted.
+     * @return an array of Integer which provides the "sorted" ordering of request entry index values.
+     */
+    private void sortBundleRequestEntries(Bundle bundle, List<Integer> indices) {
+        // Sort the list of indices based on the contents of their entries in the bundle.
+        Collections.sort(indices, new BundleEntryComparator(bundle.getEntry()));
+    }
+
+    private static class BundleEntryComparator implements Comparator<Integer> {
+        private List<Bundle.Entry> entries;
+
+        public BundleEntryComparator(List<Bundle.Entry> entries) {
+            this.entries = entries;
+        }
+
+        @Override
+        public int compare(Integer indexA, Integer indexB) {
+            Bundle.Entry a = entries.get(indexA);
+            Bundle.Entry b = entries.get(indexB);
+            String pathA = getUrlPath(a);
+            String pathB = getUrlPath(b);
+
+            log.fine("Comparing request entry URL paths: " + pathA + ", " + pathB);
+            if (pathA != null && pathB != null) {
+                return pathA.compareTo(pathB);
+            } else if (pathA != null) {
+                return 1;
+            } else if (pathB != null) {
+                return -1;
+            }
+            return 0;
+        }
+    }
+
+    /**
+     * This function converts the specified query string (a String) into an equivalent MultivaluedMap<String,String>
+     * containing the query parameters defined in the query string.
+     *
+     * @param queryString
+     *            the query string to be processed
+     * @return
+     */
+    private MultivaluedMap<String, String> getQueryParameterMap(String queryString) {
+        MultivaluedMap<String, String> result = null;
+        FHIRUrlParser parser = new FHIRUrlParser("foo?" + queryString);
+        result = parser.getQueryParameters();
+        return result;
+    }
+
+    /**
+     * Returns the specified BundleEntry's path component of the 'url' field.
+     *
+     * @param entry
+     *            the bundle entry
+     * @return the bundle entry's 'url' field's path component
+     */
+    private static String getUrlPath(Bundle.Entry entry) {
+        String path = null;
+        Bundle.Entry.Request request = entry.getRequest();
+        if (request != null) {
+            if (request.getUrl() != null && request.getUrl().getValue() != null) {
+                FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
+                path = requestURL.getPath();
+            }
+        }
+
+        return path;
+    }
+
+    /**
+     * This method will add a mapping to the local-to-external identifier map if the specified localIdentifier is
+     * non-null.
+     *
+     * @param localRefMap
+     *            the map containing the local-to-external identifier mappings
+     * @param localIdentifier
+     *            the localIdentifier previously obtained for the resource
+     * @param resource
+     *            the resource for which an external identifier will be built
+     */
+    private void addLocalRefMapping(Map<String, String> localRefMap, String localIdentifier,
+        Resource resource) {
+        if (localIdentifier != null) {
+            String externalIdentifier =
+                    ModelSupport.getTypeName(resource.getClass()) + "/" + resource.getId();
+            localRefMap.put(localIdentifier, externalIdentifier);
+            log.finer("Added local/ext identifier mapping: " + localIdentifier + " --> "
+                    + externalIdentifier);
+        }
+    }
+
+    /**
+     * This method will retrieve the local identifier associated with the specified bundle request entry, or return null
+     * if the fullUrl field is not specified or doesn't contain a local identifier.
+     *
+     * @param requestEntry
+     *            the bundle request entry
+     * @param localRefMap
+     *            the Map containing the local-to-external reference mappings
+     * @return
+     */
+    private String retrieveLocalIdentifier(Bundle.Entry requestEntry,
+            Map<String, String> localRefMap) throws Exception {
+        String localIdentifier = null;
+        if (requestEntry.getFullUrl() != null) {
+            String fullUrl = requestEntry.getFullUrl().getValue();
+            if (fullUrl != null && fullUrl.startsWith(LOCAL_REF_PREFIX)) {
+                localIdentifier = fullUrl;
+                log.finer("Request entry contains local identifier: " + localIdentifier);
+                if (localRefMap.get(localIdentifier) != null) {
+                    String msg = "Duplicate local identifier encountered in bundled request entry: "
+                            + localIdentifier;
+                    throw buildRestException(msg, IssueType.DUPLICATE);
+                }
+            }
+        }
+        return localIdentifier;
+    }
+
+    /**
+     * This function will build an absolute URI from the specified base URI and relative URI.
+     *
+     * @param baseUri
+     *            the base URI to be used; this will be of the form <scheme>://<host>:<port>/<context-root>
+     * @param relativeUri
+     *            the path and query parts
+     * @return the full URI value as a String
+     */
+    private String getAbsoluteUri(String baseUri, String relativeUri) {
+        StringBuilder fullUri = new StringBuilder();
+        fullUri.append(baseUri);
+        if (!baseUri.endsWith("/")) {
+            fullUri.append("/");
+        }
+        fullUri.append((relativeUri.startsWith("/") ? relativeUri.substring(1) : relativeUri));
+        return fullUri.toString();
+    }
+
+    private Bundle.Entry setBundleResponseFields(Bundle.Entry responseEntry, Resource resource,
+        OperationOutcome operationOutcome, URI locationURI, int httpStatus, String requestDescription, long initialTime) throws FHIROperationException {
+
+        Bundle.Entry.Response response = responseEntry.getResponse();
+        Bundle.Entry.Response.Builder resBuilder = response.toBuilder();
+        resBuilder.status(string(Integer.toString(httpStatus)));
+
+        Bundle.Entry.Builder bundleEntryBuilder = responseEntry.toBuilder();
+
+        if (resource != null) {
+            resBuilder =
+                    resBuilder.id(resource.getId()).lastModified(resource.getMeta().getLastUpdated()).etag(string(getEtagValue(resource)));
+
+            if (HTTPReturnPreference.REPRESENTATION.equals(FHIRRequestContext.get().getReturnPreference())) {
+                bundleEntryBuilder.resource(resource);
+            } else if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
+                bundleEntryBuilder.resource(operationOutcome);
+            }
+        }
+        if (locationURI != null) {
+            resBuilder = resBuilder.location(Uri.of(locationURI.toString()));
+        }
+
+        logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
+        return bundleEntryBuilder.response(resBuilder.build()).build();
+    }
+
+    private void setBundleResponseStatus(Bundle.Entry.Response response, int httpStatus,
+        String requestDescription, long initialTime) {
+        logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
+    }
+
+    private void logBundleRequestCompletedMsg(String requestDescription, long initialTime,
+        int httpStatus) {
+        StringBuffer statusMsg = new StringBuffer();
+        statusMsg.append(" status:[" + httpStatus + "]");
+        double elapsedSecs = (System.currentTimeMillis() - initialTime) / 1000.0;
+        log.info("Completed bundle request[" + elapsedSecs + " secs]: "
+                + requestDescription.toString() + statusMsg.toString());
+    }
+
+    private String getEtagValue(Resource resource) {
+        return "W/\"" + resource.getMeta().getVersionId().getValue() + "\"";
+    }
+
+    /**
+     * Creates a bundle that will hold results for a search operation.
+     *
+     * @param resources
+     *            the list of resources to include in the bundle
+     * @param searchContext
+     *            the FHIRSearchContext object associated with the search
+     * @param type 
+     *            the name of the resource type being searched
+     * @return the bundle
+     * @throws Exception 
+     */
+    private Bundle createSearchBundle(List<Resource> resources, FHIRSearchContext searchContext, String type)
+        throws Exception {
+
+        // throws if we have a count of more than 2,147,483,647 resources
+        UnsignedInt totalCount = UnsignedInt.of(searchContext.getTotalCount());
+        // generate ID for this bundle and set total
+        Bundle.Builder bundleBuider = Bundle.builder()
+                                            .type(BundleType.SEARCHSET)
+                                            .id(UUID.randomUUID().toString())
+                                            .total(totalCount);
+
+        for (Resource resource : resources) {
+            if (resource.getId() == null) {
+                throw new IllegalStateException("Returned resources must have an id.");
+            }
+            Bundle.Entry entry = Bundle.Entry.builder().fullUrl(Uri.of(getRequestBaseUri(type) + "/"
+                    + resource.getClass().getSimpleName() + "/"
+                    + resource.getId())).resource(resource).build();
+
+            bundleBuider.entry(entry);
+        }
+
+        Bundle bundle = bundleBuider.build();
+
+        // Add the SUBSETTED tag, if the _elements search result parameter was applied to limit elements included in
+        // returned resources or _summary is required.
+        if (searchContext.hasElementsParameters()
+                || (searchContext.hasSummaryParameter() && !searchContext.getSummaryParameter().equals(SummaryValueSet.FALSE))) {
+            bundle = FHIRUtil.addTag(bundle, SearchConstants.SUBSETTED_TAG);
+        }
+
+        return bundle;
+    }
+
+    /**
+     * Creates a bundle that will hold the results of a history operation.
+     *
+     * @param resources
+     *            the list of resources to include in the bundle
+     * @param historyContext
+     *            the FHIRHistoryContext associated with the history operation
+     * @param type
+     *            the name of the resource type on which the history operation was requested
+     * @return the bundle
+     * @throws Exception 
+     */
+    private Bundle createHistoryBundle(List<? extends Resource> resources, FHIRHistoryContext historyContext, String type)
+        throws Exception {
+
+        // throws if we have a count of more than 2,147,483,647 resources
+        UnsignedInt totalCount = UnsignedInt.of(historyContext.getTotalCount());
+        // generate ID for this bundle and set the "total" field for the bundle
+        Bundle.Builder bundleBuilder = Bundle.builder()
+                                             .type(BundleType.HISTORY)
+                                             .id(UUID.randomUUID().toString())
+                                             .total(totalCount);
+
+        Map<String, List<Integer>> deletedResourcesMap = historyContext.getDeletedResources();
+
+        for (int i = 0; i < resources.size(); i++) {
+            Resource resource = resources.get(i);
+
+            if (resource.getId() == null) {
+                throw new IllegalStateException("Returned resources must have an id.");
+            }
+
+            Integer versionId = Integer.valueOf(resource.getMeta().getVersionId().getValue());
+            String logicalId = resource.getId();
+            String resourceType = ModelSupport.getTypeName(resource.getClass());
+            List<Integer> deletedVersions = deletedResourcesMap.get(logicalId);
+
+            // Determine the correct method to include in this history entry (POST, PUT, DELETE).
+            HTTPVerb method;
+            if (deletedVersions != null && deletedVersions.contains(versionId)) {
+                method = HTTPVerb.DELETE;
+            } else if (versionId == 1) {
+                method = HTTPVerb.POST;
+            } else {
+                method = HTTPVerb.PUT;
+            }
+
+            // Create the 'request' entry, and set the request.url field.
+            // 'create' --> url = "<resourceType>"
+            // 'update'/'delete' --> url = "<resourceType>/<logicalId>"
+            Bundle.Entry.Request request =
+                    Bundle.Entry.Request.builder().method(method).url(Url.of(method == HTTPVerb.POST
+                            ? resourceType : resourceType + "/" + logicalId)).build();
+
+            Bundle.Entry.Response response =
+                    Bundle.Entry.Response.builder().status(string("200")).build();
+
+            Bundle.Entry entry =
+                    Bundle.Entry.builder().request(request).fullUrl(Uri.of(getRequestBaseUri(type) + "/"
+                            + resource.getClass().getSimpleName() + "/"
+                            + resource.getId())).response(response).resource(resource).build();
+
+            bundleBuilder.entry(entry);
+        }
+
+        return bundleBuilder.build();
+    }
+
+    /**
+     * Retrieves the shared interceptor mgr instance from the servlet context.
+     */
+    private FHIRPersistenceInterceptorMgr getInterceptorMgr() {
+        return FHIRPersistenceInterceptorMgr.getInstance();
+    }
+
+    private Bundle addLinks(FHIRPagingContext context, Bundle responseBundle, String requestUri) throws Exception {
+        String selfUri = null;
+        SummaryValueSet summaryParameter = null;
+        Bundle.Builder bundleBuilder = responseBundle.toBuilder();
+        
+        if (context instanceof FHIRSearchContext) {
+            FHIRSearchContext searchContext = (FHIRSearchContext) context;
+            summaryParameter = searchContext.getSummaryParameter();
+            try {
+                selfUri = SearchUtil.buildSearchSelfUri(requestUri, searchContext);
+            } catch (Exception e) {
+                log.log(Level.WARNING, "Unable to construct self link for search result bundle; using the request URI instead.", e);
+            }
+        }
+        if (selfUri == null) {
+            selfUri = requestUri;
+        }
+        // create 'self' link
+        Bundle.Link selfLink =
+                Bundle.Link.builder().relation(string("self")).url(Url.of(selfUri)).build();
+        bundleBuilder.link(selfLink);
+
+        // If for search with _summary=count or pageSize == 0, then don't add previous and next links.
+        if (!SummaryValueSet.COUNT.equals(summaryParameter) && context.getPageSize() > 0) {
+            int nextPageNumber = context.getPageNumber() + 1;
+            if (nextPageNumber <= context.getLastPageNumber()) {
+
+                // starting with the self URI
+                String nextLinkUrl = selfUri;
+
+                // remove existing _page parameters from the query string
+                nextLinkUrl =
+                        nextLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
+                                + context.getPageNumber() + "&", "").replace("_page="
+                                        + context.getPageNumber(), "");
+
+                if (nextLinkUrl.contains("?")) {
+                    if (!nextLinkUrl.endsWith("?")) {
+                        // there are other parameters in the query string
+                        nextLinkUrl += "&";
+                    }
+                } else {
+                    nextLinkUrl += "?";
+                }
+
+                // add new _page parameter to the query string
+                nextLinkUrl += "_page=" + nextPageNumber;
+
+                // create 'next' link
+                Bundle.Link nextLink =
+                        Bundle.Link.builder().relation(string("next")).url(Url.of(nextLinkUrl)).build();
+                bundleBuilder.link(nextLink);
+            }
+
+            int prevPageNumber = context.getPageNumber() - 1;
+            if (prevPageNumber > 0) {
+
+                // starting with the original request URI
+                String prevLinkUrl = requestUri;
+
+                // remove existing _page parameters from the query string
+                prevLinkUrl =
+                        prevLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
+                                + context.getPageNumber() + "&", "").replace("_page="
+                                        + context.getPageNumber(), "");
+
+                if (prevLinkUrl.contains("?")) {
+                    if (!prevLinkUrl.endsWith("?")) {
+                        // there are other parameters in the query string
+                        prevLinkUrl += "&";
+                    }
+                } else {
+                    prevLinkUrl += "?";
+                }
+
+                // add new _page parameter to the query string
+                prevLinkUrl += "_page=" + prevPageNumber;
+
+                // create 'previous' link
+                Bundle.Link prevLink =
+                        Bundle.Link.builder().relation(string("previous")).url(Url.of(prevLinkUrl)).build();
+                bundleBuilder.link(prevLink);
+            }
+        }
+
+        return bundleBuilder.build();
+    }
+
+    /**
+     * Get the original request URI from either the HttpServletRequest or a configured Header (in case of re-writing proxies).
+     * 
+     * <p>When the 'fhirServer/core/originalRequestUriHeaderName' property is empty, this method returns the equivalent of
+     * uriInfo.getRequestUri().toString(), except that uriInfo.getRequestUri() will throw an IllegalArgumentException 
+     * when the query string portion contains a vertical bar | character. The vertical bar is one known case of a special character 
+     * causing the exception. There could be others.
+     *
+     * @return String The complete request URI
+     * @throws Exception if an error occurs while reading the config 
+     */
+    private String getRequestUri() throws Exception {
+        return FHIRRequestContext.get().getOriginalRequestUri();
+    }
+
+    /**
+     * This method returns the "base URI" associated with the current request. For example, if a client invoked POST
+     * https://myhost:9443/fhir-server/api/v4/Patient to create a Patient resource, this method would return
+     * "https://myhost:9443/fhir-server/api/v4".
+     *
+     * @return The base endpoint URI associated with the current request.
+     * @throws Exception if an error occurs while reading the config
+     * @implNote This method uses {@link #getRequestUri()} to get the original request URI and then strips it to the  
+     *           <a href="https://www.hl7.org/fhir/http.html#general">Service Base URL</a>
+     */
+    private String getRequestBaseUri(String type) throws Exception {
+        String baseUri = null;
+
+        String requestUri = getRequestUri();
+
+        // Strip off everything after the path
+        int queryPathSeparatorLoc = requestUri.indexOf("?");
+        if (queryPathSeparatorLoc != -1) {
+            baseUri = requestUri.substring(0, queryPathSeparatorLoc);
+        } else {
+            baseUri = requestUri;
+        }
+
+        // Strip off any path elements after the base
+        if (type != null && !type.isEmpty()) {
+            int resourceNamePathLocation = baseUri.lastIndexOf("/" + type);
+            if (resourceNamePathLocation != -1) {
+                baseUri = requestUri.substring(0, resourceNamePathLocation);
+            } else {
+                // Assume the request was a batch/transaction and just use the requestUri as the base
+                baseUri = requestUri;
+            }
+        } else {
+            if (baseUri.endsWith("/_history")) {
+                baseUri = baseUri.substring(0, baseUri.length() - "/_history".length());
+            } else if (baseUri.endsWith("/_search")) {
+                baseUri = baseUri.substring(0, baseUri.length() - "/_search".length());
+            } else if (baseUri.contains("/$")) {
+                baseUri = baseUri.substring(0, baseUri.lastIndexOf("/$"));
+            }
+        }
+
+        return baseUri;
+    }
+
+    /**
+     * Builds a collection of properties that will be passed to the persistence interceptors.
+     *
+     * @throws FHIRPersistenceException
+     */
+    private Map<String, Object> buildPersistenceEventProperties(String type, String id,
+            String version, Map<String, String> requestProperties) throws FHIRPersistenceException {
+        Map<String, Object> props = new HashMap<>();
+        props.put(FHIRPersistenceEvent.PROPNAME_PERSISTENCE_IMPL, persistence);
+        if (type != null) {
+            props.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, type);
+        }
+        if (id != null) {
+            props.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, id);
+        }
+        if (version != null) {
+            props.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, version);
+        }
+        return props;
+    }
+
+    /**
+     * Sets various properties on the FHIROperationContext instance.
+     *
+     * @param operationContext
+     *            the FHIROperationContext on which to set the properties
+     * @throws Exception 
+     */
+    private void setOperationContextProperties(FHIROperationContext operationContext, String resourceTypeName,
+            Map<String, String> requestProperties) throws Exception {
+        operationContext.setProperty(FHIROperationContext.PROPNAME_REQUEST_BASE_URI, getRequestBaseUri(resourceTypeName));
+        operationContext.setProperty(FHIROperationContext.PROPNAME_PERSISTENCE_IMPL, persistence);
+        operationContext.setProperty(FHIROperationContext.PROPNAME_REQUEST_PROPERTIES, requestProperties);
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRRestHelper.java
@@ -134,8 +134,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         log.entering(this.getClass().getName(), "doCreate");
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        String errMsg = "Caught exception while processing 'create' request.";
-
         FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
 
         // Save the current request context.
@@ -234,12 +232,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             txn = null;
 
             return ior;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -273,7 +265,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         log.entering(this.getClass().getName(), "doPatchOrUpdate");
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        String errMsg = "Caught exception while processing 'update/patch' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -459,12 +450,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
 
             return ior;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -499,7 +484,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         FHIRRequestContext requestContext = FHIRRequestContext.get();
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         Response.Status status = null;
-        String errMsg = "Caught exception while processing 'delete' request.";
 
         FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
 
@@ -532,7 +516,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 } catch (Throwable t) {
                     String msg =
                             "An error occurred while performing the search for a conditional delete operation.";
-                    log.log(Level.SEVERE, msg, t);
                     throw new FHIROperationException(msg, t);
                 }
 
@@ -604,13 +587,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             status = ior.getStatus();
 
             return ior;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            status = Response.Status.INTERNAL_SERVER_ERROR;
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -650,7 +626,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         Resource resource = null;
-        String errMsg = "Caught exception while processing 'read' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -694,12 +669,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             txn = null;
 
             return resource;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -734,7 +703,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         Resource resource = null;
-        String errMsg = "Caught exception while processing 'vread' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -774,12 +742,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             txn = null;
 
             return resource;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -816,7 +778,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         Bundle bundle = null;
-        String errMsg = "Caught exception while processing 'history' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -857,12 +818,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             txn = null;
 
             return bundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -896,7 +851,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         Bundle bundle = null;
-        String errMsg = "Caught exception while processing 'search' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -943,12 +897,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             txn = null;
 
             return bundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -991,8 +939,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             Resource resource, MultivaluedMap<String, String> queryParameters,
             Map<String, String> requestProperties) throws Exception {
         log.entering(this.getClass().getName(), "doInvoke");
-
-        String errMsg = "Caught exception while processing 'invoke' request.";
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
@@ -1040,12 +986,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
 
             return result;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -1064,24 +1004,13 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @return the response Bundle
      */
     @Override
-    public Bundle doBundle(Resource bundleResource, Map<String, String> requestProperties)
-        throws Exception {
+    public Bundle doBundle(Bundle inputBundle, Map<String, String> requestProperties) throws Exception {
         log.entering(this.getClass().getName(), "doBundle");
-
-        String errMsg = "Caught exception while processing 'bundle' request.";
-        Bundle inputBundle = null;
 
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
 
         try {
-            if (bundleResource instanceof Bundle) {
-                inputBundle = (Bundle) bundleResource;
-            } else {
-                String msg = "A 'Bundle' resource type is required but a '"
-                        + bundleResource.getClass().getSimpleName() + "' resource type was sent.";
-                throw buildRestException(msg, IssueType.INVALID);
-            }
             // First, validate the bundle and create the response bundle.
             Bundle responseBundle = validateBundle(inputBundle);
 
@@ -1089,12 +1018,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             responseBundle = processBundleEntries(inputBundle, responseBundle, requestProperties);
 
             return responseBundle;
-        } catch (FHIROperationException e) {
-            log.log(Level.WARNING, errMsg, e);
-            throw e;
-        } catch (Throwable t) {
-            log.log(Level.SEVERE, errMsg, t);
-            throw t;
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -1103,10 +1026,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see com.ibm.fhir.rest.FHIRResourceHelpers#getTransaction()
-     */
     @Override
     public FHIRPersistenceTransaction getTransaction() throws Exception {
         return persistence.getTransaction();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class History extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(History.class.getName());
+
+    public History() throws Exception {
+        super();
+    }
+
+    @GET
+    @Path("{type}/{id}/_history")
+    public Response history(@PathParam("type") String type, @PathParam("id") String id) {
+        log.entering(this.getClass().getName(), "history(String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        Bundle bundle = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri(), null);
+            status = Status.OK;
+            return Response.status(status).entity(bundle).build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logHistory(httpServletRequest, bundle,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "history(String,String)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -1,0 +1,419 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.operation.context.FHIROperationContext;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Operation extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Operation.class.getName());
+
+    public Operation() throws Exception {
+        super();
+    }
+
+    @GET
+    @Path("${operationName}")
+    public Response invoke(@PathParam("operationName") String operationName) {
+        log.entering(this.getClass().getName(), "invoke(String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createSystemOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
+                    null, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, null, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String)");
+        }
+    }
+
+    @POST
+    @Path("${operationName}")
+    public Response invoke(@PathParam("operationName") String operationName, Resource resource) {
+        log.entering(this.getClass().getName(), "invoke(String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createSystemOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
+                    resource, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, null, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,Resource)");
+        }
+    }
+
+    @GET
+    @Path("{resourceTypeName}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("operationName") String operationName) {
+        log.entering(this.getClass().getName(), "invoke(String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createResourceTypeOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
+                    null, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, null, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String)");
+        }
+    }
+
+    @POST
+    @Path("{resourceTypeName}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("operationName") String operationName, Resource resource) {
+        log.entering(this.getClass().getName(), "invoke(String,String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createResourceTypeOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
+                    resource, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            // response 200 OK if no failure issue found.
+            boolean isFailure = false;
+            for (Issue issue : e.getIssues()) {
+                if (FHIRUtil.isFailure(issue.getSeverity())) {
+                    isFailure = true;
+                    break;
+                }
+            }
+            if (isFailure) {
+                status = issueListToStatus(e.getIssues());
+                return exceptionResponse(e, status);
+            } else {
+                status = Status.OK;
+                return exceptionResponse(e, Response.Status.OK);
+            }
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, null, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String,Resource)");
+        }
+    }
+
+    @GET
+    @Path("{resourceTypeName}/{logicalId}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("logicalId") String logicalId,
+            @PathParam("operationName") String operationName) {
+        log.entering(this.getClass().getName(), "invoke(String,String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
+                    null, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String,String)");
+        }
+    }
+
+    @POST
+    @Path("{resourceTypeName}/{logicalId}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("logicalId") String logicalId,
+            @PathParam("operationName") String operationName, Resource resource) {
+        log.entering(this.getClass().getName(), "invoke(String,String,String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
+                    resource, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String,String,Resource)");
+        }
+    }
+
+    @GET
+    @Path("{resourceTypeName}/{logicalId}/_history/{versionId}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("logicalId") String logicalId,
+            @PathParam("versionId") String versionId,
+            @PathParam("operationName") String operationName) {
+        log.entering(this.getClass().getName(), "invoke(String,String,String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName, 
+                    null, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String,String,String)");
+        }
+    }
+
+    @POST
+    @Path("{resourceTypeName}/{logicalId}/_history/{versionId}/${operationName}")
+    public Response invoke(@PathParam("resourceTypeName") String resourceTypeName,
+            @PathParam("logicalId") String logicalId,
+            @PathParam("versionId") String versionId,
+            @PathParam("operationName") String operationName, Resource resource) {
+        log.entering(this.getClass().getName(), "invoke(String,String,String,String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext =
+                    FHIROperationContext.createInstanceOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,
+                    resource, uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, resourceTypeName, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, resourceTypeName, logicalId, versionId,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,String,String,String,Resource)");
+        }
+    }
+
+    private Response buildResponse(FHIROperationContext operationContext, String resourceTypeName, Resource resource)
+            throws Exception {
+        // The following code allows the downstream application to change the response code
+        // This enables the 202 accepted to be sent back
+        Response.Status status = Response.Status.OK;
+        Object o = operationContext.getProperty(FHIROperationContext.PROPNAME_STATUS_TYPE);
+        if (o != null) {
+            status = (Response.Status) o;
+            if (Response.Status.ACCEPTED.equals(status)) {
+                // This change is for BulkData operations which manipulate the response code.
+                // Operations that return Accepted need to implement their own approach.
+                Object ox = operationContext.getProperty(FHIROperationContext.PROPNAME_RESPONSE);
+                return (Response) ox;
+            }
+        }
+
+        URI locationURI =
+                (URI) operationContext.getProperty(FHIROperationContext.PROPNAME_LOCATION_URI);
+        if (locationURI != null) {
+            return Response.status(status)
+                    .location(toUri(getAbsoluteUri(getRequestBaseUri(resourceTypeName), locationURI.toString())))
+                    .entity(resource)
+                    .build();
+        }
+        return Response.status(status).entity(resource).build();
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -20,6 +20,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -44,6 +46,9 @@ public class Operation extends FHIRResource {
     public Operation() throws Exception {
         super();
     }
+
+    @Context
+    protected HttpHeaders httpHeaders;
 
     @GET
     @Path("${operationName}")

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -1,0 +1,317 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.json.JsonArray;
+import javax.json.JsonPatch;
+import javax.json.JsonValue;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.core.HTTPReturnPreference;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.patch.FHIRJsonPatch;
+import com.ibm.fhir.model.patch.FHIRPatch;
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.path.patch.FHIRPathPatch;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.annotation.PATCH;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Patch extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Patch.class.getName());
+
+    public Patch() throws Exception {
+        super();
+    }
+
+    @PATCH
+    @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
+    @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
+    @Path("{type}/{id}")
+    public Response patch(@PathParam("type") String type, @PathParam("id") String id, JsonArray array) {
+        log.entering(this.getClass().getName(), "patch(String,String,JsonArray)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRPatch patch = createPatch(array);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+
+            status = ior.getStatus();
+            ResponseBuilder response = Response.status(status)
+                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+
+            Resource resource = ior.getResource();
+            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(resource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(ior.getOperationOutcome());
+            }
+            response = addHeaders(response, resource);
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logPatch(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "patch(String,String,JsonArray)");
+        }
+    }
+
+    @PATCH
+    @Path("{type}/{id}")
+    public Response patch(@PathParam("type") String type, @PathParam("id") String id, Parameters parameters) {
+        log.entering(this.getClass().getName(), "patch(String,String,Parameters)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRPatch patch;
+            try {
+                patch = FHIRPathPatch.from(parameters);
+            } catch(IllegalArgumentException e) {
+                throw buildRestException(e.getMessage(), IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+
+            ResponseBuilder response =
+                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+            status = ior.getStatus();
+            response.status(status);
+
+            Resource resource = ior.getResource();
+            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(resource);
+            } else if (ior.getOperationOutcome() != null &&
+                       HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(ior.getOperationOutcome());
+            }
+            response = addHeaders(response, resource);
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logPatch(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "patch(String,String,Parameters)");
+        }
+    }
+
+    @PATCH
+    @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
+    @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
+    @Path("{type}")
+    public Response conditionalPatch(@PathParam("type") String type, JsonArray array) {
+        log.entering(this.getClass().getName(), "conditionalPatch(String,String,JsonArray)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRPatch patch = createPatch(array);
+
+            String searchQueryString = httpServletRequest.getQueryString();
+            if (searchQueryString == null || searchQueryString.isEmpty()) {
+                String msg =
+                        "Cannot PATCH to resource type endpoint unless a search query string is provided for a conditional patch.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+
+            ResponseBuilder response =
+                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+            status = ior.getStatus();
+            response.status(status);
+
+            Resource resource = ior.getResource();
+            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(resource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(ior.getOperationOutcome());
+            }
+
+            response = addHeaders(response, ior.getResource());
+
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logPatch(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "conditionalPatch(String,String,JsonArray)");
+        }
+    }
+
+    @PATCH
+    @Path("{type}")
+    public Response conditionalPatch(@PathParam("type") String type, Parameters parameters) {
+        log.entering(this.getClass().getName(), "conditionalPatch(String,String,Parameters)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRPatch patch;
+            try {
+                patch = FHIRPathPatch.from(parameters);
+            } catch(IllegalArgumentException e) {
+                throw buildRestException(e.getMessage(), IssueType.INVALID);
+            }
+
+            String searchQueryString = httpServletRequest.getQueryString();
+            if (searchQueryString == null || searchQueryString.isEmpty()) {
+                String msg =
+                        "Cannot PATCH to resource type endpoint unless a search query string is provided for a conditional patch.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+
+            status = ior.getStatus();
+            ResponseBuilder response = Response.status(status)
+                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+
+            Resource resource = ior.getResource();
+            if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(resource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(ior.getOperationOutcome());
+            }
+
+            response = addHeaders(response, ior.getResource());
+
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logPatch(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "conditionalPatch(String,String,Parameters)");
+        }
+    }
+
+    private FHIRPatch createPatch(JsonArray array) throws FHIROperationException {
+        try {
+            FHIRPatch patch = FHIRPatch.patch(array);
+            JsonPatch jsonPatch = patch.as(FHIRJsonPatch.class).getJsonPatch();
+            for (JsonValue value : jsonPatch.toJsonArray()) {
+                // validate path
+                String path = value.asJsonObject().getString("path");
+                if ("/id".equals(path) ||
+                        "/meta/versionId".equals(path) ||
+                        "/meta/lastUpdated".equals(path)) {
+                    throw new IllegalArgumentException("Path: '" + path
+                            + "' is not allowed in a patch operation.");
+                }
+            }
+            return patch;
+        } catch (Exception e) {
+            String msg = "Invalid patch: " + e.getMessage();
+            throw new FHIROperationException(msg, e)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.INVALID));
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -16,6 +16,7 @@ import javax.json.JsonArray;
 import javax.json.JsonPatch;
 import javax.json.JsonValue;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -58,7 +59,8 @@ public class Patch extends FHIRResource {
     @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
     @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
     @Path("{type}/{id}")
-    public Response patch(@PathParam("type") String type, @PathParam("id") String id, JsonArray array) {
+    public Response patch(@PathParam("type") String type, @PathParam("id") String id, JsonArray array,
+            @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "patch(String,String,JsonArray)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -70,7 +72,7 @@ public class Patch extends FHIRResource {
             FHIRPatch patch = createPatch(array);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            ior = helper.doPatch(type, id, patch, ifMatch, null, null);
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)
@@ -109,7 +111,8 @@ public class Patch extends FHIRResource {
 
     @PATCH
     @Path("{type}/{id}")
-    public Response patch(@PathParam("type") String type, @PathParam("id") String id, Parameters parameters) {
+    public Response patch(@PathParam("type") String type, @PathParam("id") String id, Parameters parameters,
+            @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "patch(String,String,Parameters)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -126,7 +129,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            ior = helper.doPatch(type, id, patch, ifMatch, null, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -169,7 +172,7 @@ public class Patch extends FHIRResource {
     @Consumes({ FHIRMediaType.APPLICATION_JSON_PATCH })
     @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
     @Path("{type}")
-    public Response conditionalPatch(@PathParam("type") String type, JsonArray array) {
+    public Response conditionalPatch(@PathParam("type") String type, JsonArray array, @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "conditionalPatch(String,String,JsonArray)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -188,7 +191,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -198,7 +201,8 @@ public class Patch extends FHIRResource {
             Resource resource = ior.getResource();
             if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
                 response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+            } else if (ior.getOperationOutcome() != null && 
+                    HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
                 response.entity(ior.getOperationOutcome());
             }
 
@@ -230,7 +234,7 @@ public class Patch extends FHIRResource {
 
     @PATCH
     @Path("{type}")
-    public Response conditionalPatch(@PathParam("type") String type, Parameters parameters) {
+    public Response conditionalPatch(@PathParam("type") String type, Parameters parameters, @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "conditionalPatch(String,String,Parameters)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -254,7 +258,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, null);
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -15,9 +15,11 @@ import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
@@ -45,7 +47,8 @@ public class Read extends FHIRResource {
 
     @GET
     @Path("{type}/{id}")
-    public Response read(@PathParam("type") String type, @PathParam("id") String id) throws Exception {
+    public Response read(@PathParam("type") String type, @PathParam("id") String id, 
+            @HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) throws Exception {
         log.entering(this.getClass().getName(), "read(String,String)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -55,8 +58,6 @@ public class Read extends FHIRResource {
             checkInitComplete();
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
             long modifiedSince = parseIfModifiedSince();
-
-            String ifNoneMatch = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_MATCH);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource resource = helper.doRead(type, id, true, false, null, null, queryParameters);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -1,0 +1,126 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Read extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Read.class.getName());
+
+    public Read() throws Exception {
+        super();
+    }
+
+    @GET
+    @Path("{type}/{id}")
+    public Response read(@PathParam("type") String type, @PathParam("id") String id) throws Exception {
+        log.entering(this.getClass().getName(), "read(String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+            MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
+            long modifiedSince = parseIfModifiedSince();
+
+            String ifNoneMatch = httpHeaders.getHeaderString(HEADERNAME_IF_NONE_MATCH);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource resource = helper.doRead(type, id, true, false, null, null, queryParameters);
+            int version2Match = -1;
+            // Support ETag value with or without " (and W/)
+            // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)
+            if (ifNoneMatch != null) {
+                ifNoneMatch = ifNoneMatch.replaceAll("\"", "").replaceAll("W/", "").trim();
+                if (!ifNoneMatch.isEmpty()) {
+                    try {
+                        version2Match = Integer.parseInt(ifNoneMatch);
+                    }
+                    catch (NumberFormatException e)
+                    {
+                        // ignore invalid version
+                        version2Match = -1;
+                    }
+                }
+            }
+            Instant modifiedTime2Compare = null;
+            if (modifiedSince > 0 ) {
+                modifiedTime2Compare = Instant.ofEpochMilli(modifiedSince);
+            }
+
+            boolean isModified = true;
+            // check if-not-match first
+            if (version2Match != -1) {
+                if (version2Match == Integer.parseInt(resource.getMeta().getVersionId().getValue())) {
+                    isModified = false;
+                }
+            }
+            // then check if-modified-since
+            if(isModified && modifiedTime2Compare != null) {
+                if (resource.getMeta().getLastUpdated().getValue().toInstant().isBefore(modifiedTime2Compare)) {
+                    isModified = false;
+                }
+            }
+
+            ResponseBuilder response;
+            if (isModified) {
+                status = Status.OK;
+                response = Response.ok().entity(resource);
+                response = addHeaders(response, resource);
+            } else {
+                status = Status.NOT_MODIFIED;
+                response = Response.status(Response.Status.NOT_MODIFIED);
+            }
+            return response.build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logRead(httpServletRequest,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "read(String,String)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -1,0 +1,196 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Search extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Search.class.getName());
+
+    public Search() throws Exception {
+        super();
+    }
+
+    @GET
+    @Path("{type}")
+    public Response search(@PathParam("type") String type) {
+        log.entering(this.getClass().getName(), "search(String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        MultivaluedMap<String, String> queryParameters = null;
+        Bundle bundle = null;
+
+        try {
+            checkInitComplete();
+
+            queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
+            status = Status.OK;
+            return Response.status(status).entity(bundle).build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "search(String)");
+        }
+    }
+
+    @GET
+    @Path("{compartment}/{compartmentId}/{type}")
+    public Response searchCompartment(@PathParam("compartment") String compartment,
+            @PathParam("compartmentId") String compartmentId, @PathParam("type") String type) {
+        log.entering(this.getClass().getName(), "search(String,String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        MultivaluedMap<String, String> queryParameters = null;
+        Bundle bundle = null;
+
+        try {
+            checkInitComplete();
+
+            queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null, null);
+            status = Status.OK;
+            return Response.status(status).entity(bundle).build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "search(String,String,String)");
+        }
+    }
+
+    @POST
+    @Consumes("application/x-www-form-urlencoded")
+    @Path("{type}/_search")
+    public Response _search(@PathParam("type") String type) {
+        log.entering(this.getClass().getName(), "_search(String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        MultivaluedMap<String, String> queryParameters = null;
+        Bundle bundle = null;
+
+        try {
+            checkInitComplete();
+
+            queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
+            status = Status.OK;
+            return Response.status(status).entity(bundle).build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "_search(String)");
+        }
+    }
+
+    @GET
+    @Path("/")
+    public Response searchAllGet() {
+        return doSearchAll();
+    }
+
+    @POST
+    @Consumes("application/x-www-form-urlencoded")
+    @Path("_search")
+    public Response searchAllPost() {
+        return doSearchAll();
+    }
+
+    private Response doSearchAll() {
+        log.entering(this.getClass().getName(), "doSearchAll");
+        Date startTime = new Date();
+        Response.Status status = null;
+        MultivaluedMap<String, String> queryParameters = null;
+        Bundle bundle = null;
+
+        try {
+            checkInitComplete();
+
+            queryParameters = uriInfo.getQueryParameters();
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null, null);
+            status = Status.OK;
+            return Response.status(status).entity(bundle).build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logSearch(httpServletRequest, queryParameters, bundle,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "doSearchAll");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -1,0 +1,158 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.core.HTTPReturnPreference;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class Update extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(Update.class.getName());
+
+    public Update() throws Exception {
+        super();
+    }
+
+    @PUT
+    @Path("{type}/{id}")
+    public Response update(@PathParam("type") String type, @PathParam("id") String id, Resource resource) {
+        log.entering(this.getClass().getName(), "update(String,String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doUpdate(type, id, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+
+            ResponseBuilder response =
+                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+            status = ior.getStatus();
+            response.status(status);
+
+            Resource updatedResource = ior.getResource();
+            HTTPReturnPreference returnPreference = FHIRRequestContext.get().getReturnPreference();
+            if (updatedResource != null && HTTPReturnPreference.REPRESENTATION == returnPreference) {
+                response.entity(updatedResource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == returnPreference) {
+                response.entity(ior.getOperationOutcome());
+            }
+            response = addHeaders(response, updatedResource);
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            // By default, NOT_FOUND is mapped to HTTP 404, so explicitly set it to HTTP 405
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logUpdate(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "update(String,String,Resource)");
+        }
+    }
+
+    @PUT
+    @Path("{type}")
+    public Response conditionalUpdate(@PathParam("type") String type, Resource resource) {
+        log.entering(this.getClass().getName(), "conditionalUpdate(String,Resource)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            String searchQueryString = httpServletRequest.getQueryString();
+            if (searchQueryString == null || searchQueryString.isEmpty()) {
+                String msg =
+                        "Cannot PUT to resource type endpoint unless a search query string is provided for a conditional update.";
+                throw buildRestException(msg, IssueType.INVALID);
+            }
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            ior = helper.doUpdate(type, null, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+
+            ResponseBuilder response =
+                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+            status = ior.getStatus();
+            response.status(status);
+
+            Resource updatedResource = ior.getResource();
+            if (updatedResource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(updatedResource);
+            } else if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                response.entity(ior.getOperationOutcome());
+            }
+            response = addHeaders(response, updatedResource);
+
+            return response.build();
+        } catch (FHIRPersistenceResourceNotFoundException e) {
+            status = Status.METHOD_NOT_ALLOWED;
+            return exceptionResponse(e, status);
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logUpdate(httpServletRequest,
+                        ior != null ? ior.getPrevResource() : null,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "conditionalUpdate(String,Resource)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -48,7 +49,8 @@ public class Update extends FHIRResource {
 
     @PUT
     @Path("{type}/{id}")
-    public Response update(@PathParam("type") String type, @PathParam("id") String id, Resource resource) {
+    public Response update(@PathParam("type") String type, @PathParam("id") String id, Resource resource,
+            @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "update(String,String,Resource)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -58,7 +60,7 @@ public class Update extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, id, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), null, null);
+            ior = helper.doUpdate(type, id, resource, ifMatch, null, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -100,7 +102,7 @@ public class Update extends FHIRResource {
 
     @PUT
     @Path("{type}")
-    public Response conditionalUpdate(@PathParam("type") String type, Resource resource) {
+    public Response conditionalUpdate(@PathParam("type") String type, Resource resource, @HeaderParam(HttpHeaders.IF_MATCH) String ifMatch) {
         log.entering(this.getClass().getName(), "conditionalUpdate(String,Resource)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -117,7 +119,7 @@ public class Update extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, null, resource, httpHeaders.getHeaderString(HttpHeaders.IF_MATCH), searchQueryString, null);
+            ior = helper.doUpdate(type, null, resource, ifMatch, searchQueryString, null);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright IBM Corp. 2016, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.resources;
+
+import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
+
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.Response.Status;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.rest.FHIRRestOperationResponse;
+import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.server.util.RestAuditLogger;
+
+@Path("/")
+@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
+        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+public class VRead extends FHIRResource {
+    private static final Logger log = java.util.logging.Logger.getLogger(VRead.class.getName());
+
+    public VRead() throws Exception {
+        super();
+    }
+
+    @GET
+    @Path("{type}/{id}/_history/{vid}")
+    public Response vread(@PathParam("type") String type, @PathParam("id") String id, @PathParam("vid") String vid) {
+        log.entering(this.getClass().getName(), "vread(String,String,String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+        FHIRRestOperationResponse ior = null;
+
+        try {
+            checkInitComplete();
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource resource = helper.doVRead(type, id, vid, null);
+            status = Status.OK;
+            ResponseBuilder response = Response.ok().entity(resource);
+            response = addHeaders(response, resource);
+            return response.build();
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logVersionRead(httpServletRequest,
+                        ior != null ? ior.getResource() : null,
+                        startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "vread(String,String,String)");
+        }
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.server.resources;
+package com.ibm.fhir.server.util;
 
 import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.model.util.ModelSupport.getResourceType;
@@ -82,7 +82,6 @@ import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.util.SearchUtil;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.helper.FHIRUrlParser;
-import com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper;
 import com.ibm.fhir.validation.FHIRValidator;
 import com.ibm.fhir.validation.exception.FHIRValidationException;
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -771,8 +771,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      */
     @Override
     public Bundle doHistory(String type, String id, MultivaluedMap<String, String> queryParameters,
-        String requestUri, Map<String, String> requestProperties)
-        throws Exception {
+            String requestUri, Map<String, String> requestProperties) throws Exception {
         log.entering(this.getClass().getName(), "doHistory");
 
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
@@ -2187,7 +2186,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @throws Exception 
      */
     private Bundle createHistoryBundle(List<? extends Resource> resources, FHIRHistoryContext historyContext, String type)
-        throws Exception {
+            throws Exception {
 
         // throws if we have a count of more than 2,147,483,647 resources
         UnsignedInt totalCount = UnsignedInt.of(historyContext.getTotalCount());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
@@ -76,7 +76,7 @@ public class RestAuditLogger {
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_CREATE);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-                
+        
         entry.getContext().setAction("C");
         entry.setDescription("FHIR Create request");
         
@@ -461,7 +461,7 @@ public class RestAuditLogger {
         StringBuffer requestUrl;
         String patientIdExtUrl;
         List<String> userList = new ArrayList<>();
-                
+        
         // Build a list of possible user names. Pick the first non-null user name to include in the audit log entry.
         userList.add(request.getHeader(HEADER_IBM_APP_USER));
         userList.add(request.getHeader(HEADER_CLIENT_CERT_CN));
@@ -476,7 +476,7 @@ public class RestAuditLogger {
                 break;
             }
         }
-         
+        
         entry.setLocation(new StringBuilder()
                             .append(request.getRemoteAddr())
                             .append("/")
@@ -502,7 +502,7 @@ public class RestAuditLogger {
                 entry.getContext().getData().setVersionId(resource.getMeta().getVersionId().getValue());
             }
         }
-         
+        
         entry.setClientCertCn(request.getHeader(HEADER_CLIENT_CERT_CN));
         entry.setClientCertIssuerOu(request.getHeader(HEADER_CLIENT_CERT_ISSUER_OU));
         entry.setCorrelationId(request.getHeader(HEADER_CORRELATION_ID));
@@ -510,7 +510,7 @@ public class RestAuditLogger {
         patientIdExtUrl = FHIRConfigHelper.getStringProperty(FHIRConfiguration.PROPERTY_AUDIT_PATIENT_ID_EXTURL, null);
         entry.setPatientId(FHIRUtil.getExtensionStringValue(resource, patientIdExtUrl));
         entry.getContext().setRequestUniqueId(FHIRRequestContext.get().getRequestUniqueId());
-                
+        
         log.exiting(CLASSNAME, METHODNAME);
         return entry;
     }
@@ -528,7 +528,7 @@ public class RestAuditLogger {
         String componentIp = null;
         AuditLogEntry logEntry;
         String tenantId;
-      
+        
         tenantId = FHIRRequestContext.get().getTenantId();
         timestamp = FHIRUtilities.formatTimestamp(new Date(System.currentTimeMillis()));
         try {
@@ -542,5 +542,4 @@ public class RestAuditLogger {
         log.exiting(CLASSNAME, METHODNAME);
         return logEntry;
     }
-    
 }


### PR DESCRIPTION
1. split FHIRResource in half.  Now `FHIRResource` is just the JAXRS
part.  The "doX" methods that serve as a bridge to FHIRPersistence
methods has been moved to `FHIRRestHelper`.

2. removed http-specific info (uri, http headers, request properties,
and security context) from FHIRPersistenceEvent...the idea is to add
these back in as FHIRRequestContext properties as needed

3. removed PROPNAME_RESOURCE_HELPER from FHIROperationContext...its
already passed directly to the operations as an argument to `doInvoke`

4. removed httpheaders from FHIRNotificationEvent

5. move all exception handling from the `doX` methods into the corresponding JAX-RS method in FHIRResource

6. consolidate exception logging under `FHIRResource.exceptionResponse`; server errors are now logged at level SEVERE whereas client errors are logged at level FINE...this is a big change!

7. audit logging is added to a finally block for each JAX-RS operation...we no longer write an audit message at the start of each request.

8. tweaked FHIRResourceHelpers.doBundle to take a bundle and moved that
validation up to FHIRResource

9. updated SearchExceptionUtil to include OperationOutcome.Issue so that
we don't need to special-case search exceptions

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>