### PR TITLE
Issue #765 #768 Bulkdata import metrics and error handling enhancements

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
@@ -223,7 +223,7 @@ public class BulkDataUtils {
                 // Prepare for retry, skip all the processed lines in previous batches and this batch.
                 numOfLinesToSkip = numOfLinesToSkip + fhirResources.size() + parseFailures;
                 cleanupTransientUserData(transientUserData, true);
-                logger.warning("readFhirResourceFromObjectStore: Error proccesing file " + itemName + " - " + ex.getMessage());
+                logger.warning("readFhirResourceFromObjectStore: Error proccesing file [" + itemName + "] - " + ex.getMessage());
                 if ((retryTimes--) > 0) {
                     logger.warning("readFhirResourceFromObjectStore: Retry ...");
                 } else {
@@ -262,7 +262,7 @@ public class BulkDataUtils {
             fhirResources.clear();
             cleanupTransientUserData(transientUserData, true);
             // Log the error and throw exception to fail the job, the job can be continued from the current checkpoint after the problem is solved.
-            logger.warning("readFhirResourceFromLocalFile: Error proccesing file " + filePath + " - " + ex.getMessage());
+            logger.warning("readFhirResourceFromLocalFile: Error proccesing file [" + filePath + "] - " + ex.getMessage());
             throw ex;
         }
 
@@ -299,12 +299,11 @@ public class BulkDataUtils {
                 // Prepare for retry, skip all the processed lines in previous batches and this batch.
                 numOfLinesToSkip = numOfLinesToSkip + fhirResources.size() + parseFailures;
                 cleanupTransientUserData(transientUserData, true);
-                logger.warning("readFhirResourceFromHttps: Error proccesing file " + dataUrl + " - " + ex.getMessage());
+                logger.warning("readFhirResourceFromHttps: Error proccesing file [" + dataUrl + "] - " + ex.getMessage());
                 if ((retryTimes--) > 0) {
-                    logger.warning("readFhirResourceFromLocalFile: Retry ...");
+                    logger.warning("readFhirResourceFromHttps: Retry ...");
                 } else {
                     // Throw exception to fail the job, the job can be continued from the current checkpoint after the problem is solved.
-                    logger.warning("readFhirResourceFromHttps: Error proccesing file " + dataUrl + " - " + ex.getMessage());
                     throw ex;
                 }
             }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
@@ -14,6 +14,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.cloud.objectstorage.ClientConfiguration;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
@@ -167,10 +167,9 @@ public class BulkDataUtils {
                     }
                 } catch (FHIRParserException e) {
                     // Log and skip the invalid FHIR resource.
-                    logger.warning("getFhirResourceFromBufferReader: " + e.getMessage());
                     parseFailures++;
-                    logger.warning("getFhirResourceFromBufferReader: " + "Failed to parse line "
-                            + (numOfProcessedLines + exported + parseFailures) + " of [" + dataSource + "].");
+                    logger.log(Level.INFO, "getFhirResourceFromBufferReader: " + "Failed to parse line "
+                            + (numOfProcessedLines + exported + parseFailures) + " of [" + dataSource + "].", e);
                     continue;
                 }
             }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -48,6 +48,7 @@ public class Constants {
 
     // Control if push OperationOutcomes to COS/S3.
     public static final boolean IMPORT_IS_COLLECT_OPERATIONOUTCOMES = false;
-    // Control if reuse the input stream of the data source across the chunks.
-    public static final boolean IMPORT_IS_REUSE_INPUTSTREAM = true;
+    // Retry times when https or amazon s3 client timeout or other error happens, e.g, timeout can happen if the batch write to DB takes
+    // longer than the socket timeout, set to retry once for now.
+    public static final int IMPORT_RETRY_TIMES = 1;
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -51,4 +51,8 @@ public class Constants {
     // Retry times when https or amazon s3 client timeout or other error happens, e.g, timeout can happen if the batch write to DB takes
     // longer than the socket timeout, set to retry once for now.
     public static final int IMPORT_RETRY_TIMES = 1;
+    public static final int COS_REQUEST_TIMEOUT = 10000;
+    // Batch writing to DB can take long time which can make the idle COS/S3 client connection timeout, so set the client socket timeout
+    // to 120 seconds which is the default DB2 timeout.
+    public static final int COS_SOCKET_TIMEOUT = 120000;
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -144,6 +144,7 @@ public class ChunkReader extends AbstractItemReader {
                     numOfLinesToSkip, loadedFhirResources, chunkData);
             break;
         default:
+            logger.warning("readItem: Data source storage type not found!");
             break;
         }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -132,14 +132,18 @@ public class ChunkReader extends AbstractItemReader {
             break;
         case AWSS3:
         case IBMCOS:
-            cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl,
-                    cosLocation);
+            // Create a COS/S3 client if it's not created yet.
             if (cosClient == null) {
-                logger.warning("readItem: Failed to get CosClient!");
-                return null;
-            } else {
-                logger.finer("readItem: Got CosClient successfully!");
+                cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl, cosLocation);
+
+                if (cosClient == null) {
+                    logger.warning("readItem: Failed to get CosClient!");
+                    throw new Exception("Failed to get CosClient!!");
+                } else {
+                    logger.finer("readItem: Got CosClient successfully!");
+                }
             }
+
             numOfParseFailures = BulkDataUtils.readFhirResourceFromObjectStore(cosClient, cosBucketName, importPartitionWorkitem,
                     numOfLinesToSkip, loadedFhirResources, chunkData);
             break;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkReader.java
@@ -121,16 +121,14 @@ public class ChunkReader extends AbstractItemReader {
             numOfLinesToSkip = chunkData.getNumOfProcessedResources();
         }
 
-        int imported = 0;
-
+        int numOfLoaded = 0;
+        int numOfParseFailures = 0;
         switch (BulkImportDataSourceStorageType.from(dataSourceStorageType)) {
         case HTTPS:
-            imported = BulkDataUtils.readFhirResourceFromHttps(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources,
-                    Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
+            numOfParseFailures = BulkDataUtils.readFhirResourceFromHttps(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources, chunkData);
             break;
         case FILE:
-            imported = BulkDataUtils.readFhirResourceFromLocalFile(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources,
-                    Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
+            numOfParseFailures = BulkDataUtils.readFhirResourceFromLocalFile(importPartitionWorkitem, numOfLinesToSkip, loadedFhirResources, chunkData);
             break;
         case AWSS3:
         case IBMCOS:
@@ -142,17 +140,20 @@ public class ChunkReader extends AbstractItemReader {
             } else {
                 logger.finer("readItem: Got CosClient successfully!");
             }
-            imported = BulkDataUtils.readFhirResourceFromObjectStore(cosClient, cosBucketName, importPartitionWorkitem,
-                    numOfLinesToSkip, loadedFhirResources, Constants.IMPORT_IS_REUSE_INPUTSTREAM, chunkData);
+            numOfParseFailures = BulkDataUtils.readFhirResourceFromObjectStore(cosClient, cosBucketName, importPartitionWorkitem,
+                    numOfLinesToSkip, loadedFhirResources, chunkData);
             break;
         default:
             break;
         }
+
+        chunkData.setNumOfParseFailures(chunkData.getNumOfParseFailures() + numOfParseFailures);
+        numOfLoaded = loadedFhirResources.size();
         if (logger.isLoggable(Level.FINE)) {
-            logger.fine("readItem: loaded " + imported + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
+            logger.fine("readItem: loaded " + numOfLoaded + " " + importPartitionResourceType + " from " + importPartitionWorkitem);
         }
-        chunkData.setNumOfToBeImported(imported);
-        if (imported == 0) {
+        chunkData.setNumOfToBeImported(numOfLoaded);
+        if (numOfLoaded == 0) {
             return null;
         } else {
             return loadedFhirResources;
@@ -165,7 +166,6 @@ public class ChunkReader extends AbstractItemReader {
             ImportCheckPointData checkPointData = (ImportCheckPointData) checkpoint;
             importPartitionWorkitem = checkPointData.getImportPartitionWorkitem();
             numOfLinesToSkip = checkPointData.getNumOfProcessedResources();
-
             stepCtx.setTransientUserData(ImportTransientUserData.fromImportCheckPointData(checkPointData));
         }
     }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
@@ -38,6 +38,7 @@ import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
  */
 public class ChunkWriter extends AbstractItemWriter {
     private static final Logger logger = Logger.getLogger(ChunkWriter.class.getName());
+    AmazonS3 cosClient = null;
 
     @Inject
     StepContext stepCtx;
@@ -181,14 +182,16 @@ public class ChunkWriter extends AbstractItemWriter {
 
 
     private void pushImportOperationOutcomes2COS(ImportTransientUserData chunkData) throws Exception{
-        AmazonS3 cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl,
-                cosLocation);
-
+        // Create the COS/S3 client if it's not created yet.
         if (cosClient == null) {
-            logger.warning("pushImportOperationOutcomes2COS: Failed to get CosClient!");
-            throw new Exception("pushImportOperationOutcomes2COS: Failed to get CosClient!!");
-        } else {
-            logger.finer("pushImportOperationOutcomes2COS: Got CosClient successfully!");
+            cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl, cosLocation);
+
+            if (cosClient == null) {
+                logger.warning("pushImportOperationOutcomes2COS: Failed to get CosClient!");
+                throw new Exception("Failed to get CosClient!!");
+            } else {
+                logger.finer("pushImportOperationOutcomes2COS: Got CosClient successfully!");
+            }
         }
 
         // Upload OperationOutcomes in buffer if it reaches the minimal size for multiple-parts upload.

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
@@ -151,7 +151,7 @@ public class ChunkWriter extends AbstractItemWriter {
                         }
                     }
                 } catch (FHIRPersistenceException e) {
-                    logger.warning("Failed to import " + fhirResource.getId() + " due to error: " + e.getMessage());
+                    logger.warning("Failed to import '" + fhirResource.getId() + "' due to error: " + e.getMessage());
                     failedNum++;
                     if (Constants.IMPORT_IS_COLLECT_OPERATIONOUTCOMES) {
                         FHIRGenerator.generator(Format.JSON).generate(FHIRUtil.buildOperationOutcome(e, false), chunkData.getBufferStream4ImportError());

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -19,10 +19,17 @@ public class ImportCheckPointData implements Serializable {
     private static final long serialVersionUID = 2189917861035732241L;
     // URL or COS/S3 object name.
     private String importPartitionWorkitem;
+
+    // Values for metrics calculation.
     private int numOfProcessedResources = 0;
     private int numOfImportedResources = 0;
     private int numOfImportFailures = 0;
+
+    // Value used to sign the successful ending of the import.
     private int numOfToBeImported = 0;
+
+    // Parsing failures in current batch.
+    private int numOfParseFailures = 0;
     // Fhir resource type processed in this partition.
     private String importPartitionResourceType;
 
@@ -200,5 +207,13 @@ public class ImportCheckPointData implements Serializable {
 
     public void setDataPacks4FailureOperationOutcomes(List<PartETag> dataPacks4FailureOperationOutcomes) {
         this.dataPacks4FailureOperationOutcomes = dataPacks4FailureOperationOutcomes;
+    }
+
+    public int getNumOfParseFailures() {
+        return numOfParseFailures;
+    }
+
+    public void setNumOfParseFailures(int numOfParseFailures) {
+        this.numOfParseFailures = numOfParseFailures;
     }
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
@@ -27,13 +27,13 @@ public class ImportJobListener implements JobListener {
     }
 
 
-    @SuppressWarnings({"unchecked" })
     @Override
     public void afterJob() {
         // jobExecution.getEndTime() for current execution always returns null, so we use system current time as the end time for current execution.
         long currentExecutionEndTimeInMS = System.currentTimeMillis();;
 
         // Used for generating response for all the import data resources.
+        @SuppressWarnings("unchecked")
         List<ImportCheckPointData> partitionSummaries = (List<ImportCheckPointData>)jobContext.getTransientUserData();
         // Used for generating performance measurement per each resource type.
         HashMap<String, ImportCheckPointData> importedResourceTypeSummaries = new HashMap<>();

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.bulkimport;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.logging.Logger;
 
 import javax.batch.api.listener.JobListener;
 import javax.batch.operations.JobOperator;
@@ -17,6 +18,7 @@ import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
 
 public class ImportJobListener implements JobListener {
+    private static final Logger logger = Logger.getLogger(ImportJobListener.class.getName());
     @Inject
     JobContext jobContext;
 
@@ -68,16 +70,16 @@ public class ImportJobListener implements JobListener {
         double jobProcessingSeconds = (totalJobExecutionMilliSeconds)/1000.0;
         jobProcessingSeconds = jobProcessingSeconds < 1 ? 1.0 : jobProcessingSeconds;
 
-        // Print out the simple metrics to console.
-        System.out.println(" ---- Fhir resources imported in " + jobProcessingSeconds + "seconds ----");
-        System.out.println("ResourceType \t Imported \t Failed");
+        // log the simple metrics.
+        logger.info(" ---- Fhir resources imported in " + jobProcessingSeconds + "seconds ----");
+        logger.info("ResourceType \t Imported \t Failed");
         int totalImportedFhirResources = 0;
         for (ImportCheckPointData importedResourceTypeSummary : importedResourceTypeSummaries.values()) {
-            System.out.println(importedResourceTypeSummary.getImportPartitionResourceType() + "\t" +
+            logger.info(importedResourceTypeSummary.getImportPartitionResourceType() + "\t" +
                         importedResourceTypeSummary.getNumOfImportedResources() + "\t" + importedResourceTypeSummary.getNumOfImportFailures());
             totalImportedFhirResources += importedResourceTypeSummary.getNumOfImportedResources();
         }
-        System.out.println(" ---- Total: " + totalImportedFhirResources
+        logger.info(" ---- Total: " + totalImportedFhirResources
                 + " ImportRate: " + totalImportedFhirResources/jobProcessingSeconds + " ----");
     }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionCollector.java
@@ -78,7 +78,7 @@ public class ImportPartitionCollector implements PartitionCollector {
 
         // If the job is being stopped or in other status except for "started", then do cleanup for the partition.
         if (!batchStatus.equals(BatchStatus.STARTED)) {
-            BulkDataUtils.cleanup4TransientUserData(partitionSummaryData, true);
+            BulkDataUtils.cleanupTransientUserData(partitionSummaryData, true);
             return null;
         }
 
@@ -143,7 +143,7 @@ public class ImportPartitionCollector implements PartitionCollector {
             }
 
             // Clean up.
-            BulkDataUtils.cleanup4TransientUserData(partitionSummaryData, false);
+            BulkDataUtils.cleanupTransientUserData(partitionSummaryData, false);
 
             return ImportCheckPointData.fromImportTransientUserData(partitionSummaryData);
         } else {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
@@ -159,17 +159,19 @@ public class ImportPartitionMapper implements PartitionMapper {
         }
      };
 
-     private List<FhirDataSource> getFhirDataSources4ObjectStore(String DSTypeInfo, String DSDataLocationInfo) {
+     private List<FhirDataSource> getFhirDataSources4ObjectStore(String DSTypeInfo, String DSDataLocationInfo) throws Exception {
          String nextToken = null;
          List<FhirDataSource> fhirDataSources = new ArrayList<>();
-         cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl,
-                 cosLocation);
-
+         // Create a COS/S3 client if it's not created yet.
          if (cosClient == null) {
-             logger.warning("getFhirDataSources4ObjectStore: Failed to get CosClient!");
-             return fhirDataSources;
-         } else {
-             logger.finer("getFhirDataSources4ObjectStore: Succeed get CosClient!");
+             cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpintUrl, cosLocation);
+
+             if (cosClient == null) {
+                 logger.warning("getFhirDataSources4ObjectStore: Failed to get CosClient!");
+                 throw new Exception("Failed to get CosClient!!");
+             } else {
+                 logger.finer("getFhirDataSources4ObjectStore: Succeed get CosClient!");
+             }
          }
          if (cosBucketName == null) {
              logger.warning("getFhirDataSources4ObjectStore: Failed to get BucketName!");
@@ -215,7 +217,7 @@ public class ImportPartitionMapper implements PartitionMapper {
      }
 
 
-     private List<FhirDataSource> getFhirDataSources(JsonArray dataSourceArray, BulkImportDataSourceStorageType type)
+     private List<FhirDataSource> getFhirDataSources(JsonArray dataSourceArray, BulkImportDataSourceStorageType type) throws Exception
      {
          List<FhirDataSource> fhirDataSources = new ArrayList<>();
          for (JsonValue jsonValue : dataSourceArray) {
@@ -242,7 +244,7 @@ public class ImportPartitionMapper implements PartitionMapper {
 
 
     @Override
-    public PartitionPlan mapPartitions() {
+    public PartitionPlan mapPartitions() throws Exception {
         JsonReader reader = Json.createReader(new StringReader(
                 new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)));
         JsonArray dataSourceArray = reader.readArray();


### PR DESCRIPTION
Changes:
(1) Added error handling for fhir parse exception.
(2) Added error handling and retry for https and S3 client timeout/reset exception.
(3) Increase S3 client socket timeout(without activity) to 120 seconds.
(4) Use the sum of job execution times as the job instance time when calculating rate.
(5) Skip the already processed lines after the job is restarted. 