### PR TITLE
issue #781 - skip constraint checking for composite foreign keys

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -247,9 +247,10 @@ public interface IDatabaseAdapter {
      * @param targetTable
      * @param tenantColumnName
      * @param columns
+     * @param enforced
      */
     public void createForeignKeyConstraint(String constraintName, String schemaName, String name, String targetSchema,
-            String targetTable, String tenantColumnName, List<String> columns);
+            String targetTable, String tenantColumnName, List<String> columns, boolean enforced);
 
     /**
      * Allocate a new tenant

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -214,11 +214,12 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
     @Override
     public void createForeignKeyConstraint(String constraintName, String schemaName, String name,
             String targetSchema, String targetTable, String tenantColumnName,
-            List<String> columns) {
+            List<String> columns, boolean enforced) {
 
-        // Make the call, but without the tenantColumnName because Derby doesn't support
-        // our multi-tenant implementation
-        super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns);
+        // Make the call, but
+        // 1. without the tenantColumnName because Derby doesn't support our multi-tenant implementation; and
+        // 2. with enforced=true because Derby doesn't support non-default constraint characteristics
+        super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
     }
 
     @Override

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/ForeignKeyConstraint.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/ForeignKeyConstraint.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,16 +18,19 @@ import com.ibm.fhir.database.utils.common.DataDefinitionUtil;
  * of a parent table
  */
 public class ForeignKeyConstraint extends Constraint {
+    private final boolean enforced;
     private final String targetSchema;
     private final String targetTable;
     private final List<String> columns = new ArrayList<>();
 
     /**
      * @param constraintName
+     * @param enforced
      */
-    protected ForeignKeyConstraint(String constraintName, String targetSchema, String targetTable,
+    protected ForeignKeyConstraint(String constraintName, boolean enforced, String targetSchema, String targetTable,
         Collection<String> columns) {
         super(constraintName);
+        this.enforced = enforced;
         this.targetSchema = targetSchema;
         this.targetTable = targetTable;
         this.columns.addAll(columns);
@@ -48,7 +51,7 @@ public class ForeignKeyConstraint extends Constraint {
     public String getTargetSchema() {
         return this.targetSchema;
     }
-    
+
     public String getQualifiedTargetName() {
         return DataDefinitionUtil.getQualifiedName(targetSchema, targetTable);
     }
@@ -58,7 +61,7 @@ public class ForeignKeyConstraint extends Constraint {
      * @param target
      */
     public void apply(String schemaName, String name, String tenantColumnName, IDatabaseAdapter target) {
-        target.createForeignKeyConstraint(getConstraintName(), schemaName, name, targetSchema, targetTable, tenantColumnName, columns);
+        target.createForeignKeyConstraint(getConstraintName(), schemaName, name, targetSchema, targetTable, tenantColumnName, columns, enforced);
     }
 
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,33 +23,33 @@ import com.ibm.fhir.database.utils.common.DataDefinitionUtil;
  * An immutable definition of a table
  */
 public class Table extends BaseObject {
-    
+
     // The list of columns in this table
     private final List<ColumnBase> columns = new ArrayList<>();
-    
+
     // The primary key definition for this table (optional)
     private final PrimaryKeyDef primaryKey;
-    
+
     // The identity definition for this table (optional)
     private final IdentityDef identity;
-    
+
     // All the indexes defined for this table
     private final List<IndexDef> indexes = new ArrayList<>();
-    
+
     // All the FK constraints used by this table
     private final List<ForeignKeyConstraint> fkConstraints = new ArrayList<>();
-    
+
     // enable access control
     private final SessionVariableDef accessControlVar;
-    
+
     private final Tablespace tablespace;
-    
+
     // The column to use when making this table multi-tenant (if supported by the the target)
     private final String tenantColumnName;
 
     /**
      * Public constructor
-     * 
+     *
      * @param schemaName
      * @param name
      * @param version
@@ -65,7 +65,7 @@ public class Table extends BaseObject {
      * @param tags
      * @param privileges
      */
-    public Table(String schemaName, String name, int version, String tenantColumnName, Collection<ColumnBase> columns, PrimaryKeyDef pk, 
+    public Table(String schemaName, String name, int version, String tenantColumnName, Collection<ColumnBase> columns, PrimaryKeyDef pk,
             IdentityDef identity, Collection<IndexDef> indexes, Collection<ForeignKeyConstraint> fkConstraints,
             SessionVariableDef accessControlVar, Tablespace tablespace, List<IDatabaseObject> dependencies, Map<String,String> tags,
             Collection<GroupPrivilege> privileges) {
@@ -78,13 +78,13 @@ public class Table extends BaseObject {
         this.fkConstraints.addAll(fkConstraints);
         this.accessControlVar = accessControlVar;
         this.tablespace = tablespace;
-        
+
         addDependencies(dependencies);
-        
+
         addTags(tags);
         privileges.forEach(p -> p.addToObject(this));
     }
-    
+
     /**
      * Getter for the primary key definition, or null if there isn't one
      * @return
@@ -141,16 +141,16 @@ public class Table extends BaseObject {
     public void drop(IDatabaseAdapter target) {
         if (this.accessControlVar != null) {
             target.deactivateRowAccessControl(getSchemaName(), getObjectName());
-            
+
             final String tenantPermission = getObjectName() + "_TENANT";
             target.dropPermission(getSchemaName(), tenantPermission);
         }
         target.dropTable(getSchemaName(), getObjectName());
     }
-    
+
     /**
      * Create a builder for {@link Table}.
-     * 
+     *
      * @param schemaName
      * @param tableName
      * @return
@@ -163,43 +163,43 @@ public class Table extends BaseObject {
      * Builder for table
      */
     public static class Builder extends VersionedSchemaObject {
-        
+
         // LinkedHashSet so we can remember order
         private LinkedHashSet<ColumnDef> columns = new LinkedHashSet<>();
 
         // The definition of the primary key, or null if there isn't one
         private PrimaryKeyDef primaryKey;
-        
+
         // The definition of the identity column for the table, or null if there isn't one
         private IdentityDef identity;
-        
+
         // All the indexes defined for the table we are building
         private Map<String,IndexDef> indexes = new HashMap<>();
-        
+
         // All the foreign key constraints defined for this table
         private Map<String, ForeignKeyConstraint> fkConstraints = new HashMap<>();
-        
+
         // other dependencies of this table
         private Set<IDatabaseObject> dependencies = new HashSet<>();
 
         // Is this table multi-tenant when supported?
         private String tenantColumnName;
-        
+
         // A map of tags
         private Map<String,String> tags = new HashMap<>();
 
         // The tablespace to use for this table [optional]
         private Tablespace tablespace;
-        
+
         // The variable to use for access control (when set)
         private SessionVariableDef accessControlVar;
 
         // Privileges to be granted on this table
         private List<GroupPrivilege> privileges = new ArrayList<>();
-        
+
         // schema version
         private int version = 1;
-        
+
         /**
          * Private constructor to force creation through factory method
          * @param schemaName
@@ -208,7 +208,7 @@ public class Table extends BaseObject {
         private Builder(String schemaName, String tableName) {
             super(schemaName, tableName);
         }
-        
+
         /**
          * Set the version
          * @param v
@@ -228,13 +228,13 @@ public class Table extends BaseObject {
             this.tablespace = ts;
             return this;
         }
-        
+
         public Builder addIntColumn(String columnName, boolean nullable) {
             ColumnDef cd = new ColumnDef(columnName);
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.INT);
             columns.add(cd);
@@ -246,7 +246,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.BIGINT);
             columns.add(cd);
@@ -258,7 +258,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.DOUBLE);
             columns.add(cd);
@@ -270,19 +270,19 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.TIMESTAMP);
             columns.add(cd);
             return this;
         }
-        
+
         public Builder addTimestampColumn(String columnName, int numberOfFractionalSecondDigits, boolean nullable) {
             ColumnDef cd = new ColumnDef(columnName);
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.TIMESTAMP);
             cd.setPrecision(numberOfFractionalSecondDigits);
@@ -295,7 +295,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.VARCHAR);
             cd.setSize(size);
@@ -315,7 +315,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.VARBINARY);
             cd.setSize(size);
@@ -335,7 +335,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.CHAR);
             cd.setSize(size);
@@ -348,7 +348,7 @@ public class Table extends BaseObject {
             if (columns.contains(cd)) {
                 throw new IllegalArgumentException("Duplicate column: " + columnName);
             }
-            
+
             cd.setNullable(nullable);
             cd.setColumnType(ColumnType.BLOB);
             cd.setSize(size);
@@ -393,7 +393,7 @@ public class Table extends BaseObject {
             if (this.indexes.containsKey(indexName)) {
                 throw new IllegalStateException("Duplicate index name: " + indexName);
             }
-            
+
             // Make sure all the given column names are valid for this table
             checkColumns(columns);
             indexes.put(indexName, new IndexDef(indexName, Arrays.asList(columns), false));
@@ -441,10 +441,10 @@ public class Table extends BaseObject {
         public Builder addUniqueConstraint(String constraintName, String columnName) {
             throw new IllegalArgumentException("not yet supported");
         }
-        
+
         /**
-         * Add a foreign key constraint pointing to the target table. The list of columns
-         * is expected to match the primary key definition on the target
+         * Add a foreign key constraint pointing to the target table (with enforcement).
+         * The list of columns is expected to match the primary key definition on the target.
          * 
          * @param constraintName
          * @param targetSchema
@@ -453,7 +453,22 @@ public class Table extends BaseObject {
          * @return
          */
         public Builder addForeignKeyConstraint(String constraintName, String targetSchema, String targetTable, String... columns) {
-            this.fkConstraints.put(constraintName, new ForeignKeyConstraint(constraintName, targetSchema, targetTable, Arrays.asList(columns)));
+            return addForeignKeyConstraint(constraintName, true, targetSchema, targetTable, columns);
+        }
+
+        /**
+         * Add a foreign key constraint pointing to the target table. The list of columns
+         * is expected to match the primary key definition on the target
+         *
+         * @param constraintName
+         * @param enforced
+         * @param targetSchema
+         * @param targetTable
+         * @param columns
+         * @return
+         */
+        public Builder addForeignKeyConstraint(String constraintName, boolean enforced, String targetSchema, String targetTable, String... columns) {
+            this.fkConstraints.put(constraintName, new ForeignKeyConstraint(constraintName, enforced, targetSchema, targetTable, Arrays.asList(columns)));
             return this;
         }
 
@@ -464,7 +479,7 @@ public class Table extends BaseObject {
         protected void checkColumns(String[] columns) {
             checkColumns(Arrays.asList(columns));
         }
-        
+
         /**
          * Check each of the columns in the given array are valid column names
          * @param columns
@@ -477,19 +492,19 @@ public class Table extends BaseObject {
                 }
             }
         }
-        
+
         /**
          * Build the immutable table object based on the current configuration
          * @param dataModel
          * @return
          */
         public Table build(IDataModel dataModel) {
-            
+
             // Check the FK references are valid
             List<IDatabaseObject> allDependencies = new ArrayList<>();
             allDependencies.addAll(this.dependencies);
             for (ForeignKeyConstraint c: this.fkConstraints.values()) {
-                
+
                 Table target = dataModel.findTable(c.getTargetSchema(), c.getTargetTable());
                 if (target == null) {
                     String targetName = DataDefinitionUtil.getQualifiedName(c.getTargetSchema(), c.getTargetTable());
@@ -497,18 +512,18 @@ public class Table extends BaseObject {
                 }
                 allDependencies.add(target);
             }
-            
+
             if (this.tablespace != null) {
                 allDependencies.add(tablespace);
             }
-            
+
             // Our schema objects are immutable by design, so all initialization takes place
             // through the constructor
             return new Table(getSchemaName(), getObjectName(), this.version, this.tenantColumnName, buildColumns(), this.primaryKey, this.identity, this.indexes.values(),
                     this.fkConstraints.values(), this.accessControlVar, this.tablespace, allDependencies, tags, privileges);
-            
+
         }
-        
+
         /**
          * Create the columns for the table based on the definitions that have been added
          * @return
@@ -560,19 +575,19 @@ public class Table extends BaseObject {
                 }
                 result.add(column);
             }
-            
+
             return result;
         }
-        
+
         /**
          * Switch on access control for this table
          */
         public Builder enableAccessControl(SessionVariableDef var) {
             this.accessControlVar = var;
-            
+
             // Add the session variable as a dependency for this table
             this.dependencies.add(var);
-            
+
             return this;
         }
 
@@ -585,12 +600,12 @@ public class Table extends BaseObject {
             this.tags.put(tagName, tagValue);
             return this;
         }
-        
+
         public Builder addPrivilege(String groupName, Privilege p) {
             this.privileges.add(new GroupPrivilege(groupName, p));
             return this;
         }
-        
+
         /**
          * Add the collection of group privileges to this table
          * @param gps
@@ -599,8 +614,8 @@ public class Table extends BaseObject {
         public Builder addPrivileges(Collection<GroupPrivilege> gps) {
             this.privileges.addAll(gps);
             return this;
-        }       
-        
+        }
+
         /**
          * Setter to configure this table for multitenancy. Multitenancy support depends on the target
          * ...which in this case means DB2 supports it (using partitioning) but Derby does not...so for
@@ -621,5 +636,5 @@ public class Table extends BaseObject {
     public boolean exists(IDatabaseAdapter target) {
         return target.doesTableExist(getSchemaName(), getObjectName());
     }
-    
+
 }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,7 +19,6 @@ import static com.ibm.fhir.schema.control.FhirSchemaConstants.DATE_END;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.DATE_START;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.FK;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.IDX;
-import static com.ibm.fhir.schema.control.FhirSchemaConstants.PK;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.IS_DELETED;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.ITEM_LOGICAL_ID;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.LAST_UPDATED;
@@ -34,12 +33,13 @@ import static com.ibm.fhir.schema.control.FhirSchemaConstants.LONGITUDE_VALUE;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.MAX_SEARCH_STRING_BYTES;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.MT_ID;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.NUMBER_VALUE;
-import static com.ibm.fhir.schema.control.FhirSchemaConstants.NUMBER_VALUE_LOW;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.NUMBER_VALUE_HIGH;
+import static com.ibm.fhir.schema.control.FhirSchemaConstants.NUMBER_VALUE_LOW;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.PARAMETER_NAMES;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.PARAMETER_NAME_ID;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.PATIENT_CURRENT_REFS;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.PATIENT_LOGICAL_RESOURCES;
+import static com.ibm.fhir.schema.control.FhirSchemaConstants.PK;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.QUANTITY_VALUE;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.QUANTITY_VALUE_HIGH;
 import static com.ibm.fhir.schema.control.FhirSchemaConstants.QUANTITY_VALUE_LOW;
@@ -418,8 +418,8 @@ CREATE TABLE device_number_values  (
 ;
 CREATE INDEX idx_device_number_values_pnnv ON device_number_values(parameter_name_id, number_value, resource_id);
 CREATE INDEX idx_device_number_values_rps ON device_number_values(resource_id, parameter_name_id, number_value);
-ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names ON DELETE CASCADE;
-ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_r  FOREIGN KEY (resource_id)       REFERENCES device_resources ON DELETE CASCADE;
+ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names;
+ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_r  FOREIGN KEY (resource_id)       REFERENCES device_resources;
      * </pre>
      * @param group
      * @param prefix
@@ -524,8 +524,8 @@ CREATE INDEX idx_device_quantity_values_pchlsr  ON device_quantity_values(parame
 CREATE INDEX idx_device_quantity_values_rpclhs  ON device_quantity_values(resource_id, parameter_name_id, code, quantity_value_low, quantity_value_high, code_system_id);
 CREATE INDEX idx_device_quantity_values_rpchls  ON device_quantity_values(resource_id, parameter_name_id, code, quantity_value_high, quantity_value_low, code_system_id);
 
-ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names ON DELETE CASCADE;
-ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  FOREIGN KEY (resource_id)       REFERENCES device_resources ON DELETE CASCADE;
+ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names;
+ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  FOREIGN KEY (resource_id)       REFERENCES device_resources;
      * </pre>
      * @param group
      * @param prefix
@@ -582,15 +582,15 @@ CREATE INDEX idx_device_composites_pttr ON device_composites(parameter_name_id, 
 CREATE INDEX idx_device_composites_ptqr ON device_composites(parameter_name_id, comp1_token, comp2_quantity, resource_id);
 CREATE INDEX idx_device_composites_rptt ON device_composites(resource_id, parameter_name_id, comp1_token, comp2_token);
 CREATE INDEX idx_device_composites_rptq ON device_composites(resource_id, parameter_name_id, comp1_token, comp2_quantity);
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_pnid FOREIGN KEY (comp1_str)      REFERENCES device_str_values;
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_rid  FOREIGN KEY (comp1_number)   REFERENCES device_number_values;
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_rid  FOREIGN KEY (comp1_date)     REFERENCES device_date_values;
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_rid  FOREIGN KEY (comp1_token)    REFERENCES device_token_values;
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_rid  FOREIGN KEY (comp1_quantity) REFERENCES device_quantity_values;
-ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_rid  FOREIGN KEY (comp1_latlng)   REFERENCES device_latlng_values;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_str      FOREIGN KEY (comp1_str)      REFERENCES device_str_values      NOT ENFORCED;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_number   FOREIGN KEY (comp1_number)   REFERENCES device_number_values   NOT ENFORCED;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_date     FOREIGN KEY (comp1_date)     REFERENCES device_date_values     NOT ENFORCED;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_token    FOREIGN KEY (comp1_token)    REFERENCES device_token_values    NOT ENFORCED;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_quantity FOREIGN KEY (comp1_quantity) REFERENCES device_quantity_values NOT ENFORCED;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_comp1_latlng   FOREIGN KEY (comp1_latlng)   REFERENCES device_latlng_values   NOT ENFORCED;
 ...
-ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names ON DELETE CASCADE;
-ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  FOREIGN KEY (resource_id)       REFERENCES device_logical_resources ON DELETE CASCADE;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_pn FOREIGN KEY (parameter_name_id) REFERENCES parameter_names;
+ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_r  FOREIGN KEY (resource_id)       REFERENCES device_logical_resources;
      * </pre>
      * @param group
      * @param prefix
@@ -602,6 +602,7 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
 
         // Parameters are tied to the logical resource
         Table.Builder tbl = Table.builder(schemaName, tableName)
+                .setVersion(2)  // Version 1 used enforced foreign key constraints which lead to issue #781.
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID, false)
@@ -615,12 +616,12 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
                 .addBigIntColumn(   comp + _TOKEN, true)
                 .addBigIntColumn(comp + _QUANTITY, true)
                 .addBigIntColumn(  comp + _LATLNG, true)
-                .addForeignKeyConstraint(FK + tableName + _STR, schemaName, prefix + "_STR_VALUES", comp + _STR)
-                .addForeignKeyConstraint(FK + tableName + _NUMBER, schemaName, prefix + "_NUMBER_VALUES", comp + _NUMBER)
-                .addForeignKeyConstraint(FK + tableName + _DATE, schemaName, prefix + "_DATE_VALUES", comp + _DATE)
-                .addForeignKeyConstraint(FK + tableName + _TOKEN, schemaName, prefix + "_TOKEN_VALUES", comp + _TOKEN)
-                .addForeignKeyConstraint(FK + tableName + _QUANTITY, schemaName, prefix + "_QUANTITY_VALUES", comp + _QUANTITY)
-                .addForeignKeyConstraint(FK + tableName + _LATLNG, schemaName, prefix + "_LATLNG_VALUES", comp + _LATLNG);
+                .addForeignKeyConstraint(     FK + tableName + "_" + comp + _STR, false, schemaName, prefix + "_STR_VALUES", comp + _STR)
+                .addForeignKeyConstraint(  FK + tableName + "_" + comp + _NUMBER, false, schemaName, prefix + "_NUMBER_VALUES", comp + _NUMBER)
+                .addForeignKeyConstraint(    FK + tableName + "_" + comp + _DATE, false, schemaName, prefix + "_DATE_VALUES", comp + _DATE)
+                .addForeignKeyConstraint(   FK + tableName + "_" + comp + _TOKEN, false, schemaName, prefix + "_TOKEN_VALUES", comp + _TOKEN)
+                .addForeignKeyConstraint(FK + tableName + "_" + comp + _QUANTITY, false, schemaName, prefix + "_QUANTITY_VALUES", comp + _QUANTITY)
+                .addForeignKeyConstraint(  FK + tableName + "_" + comp + _LATLNG, false, schemaName, prefix + "_LATLNG_VALUES", comp + _LATLNG);
         }
 
         // add indexes for just the two common cases; token$token and token$quantity


### PR DESCRIPTION
We found that the query plan was doing a full index scan of the
Observation_COMPOSITES table on each delete to each of the
Observation_X_VALUES tables. This is totally unneccessary because we
always delete the composite rows first before we delete the
corresponding X_VALUES rows. Telling Db2 not to enforce this particular
constraint should speed things up nicely.

I also found and fixed an issue where we were only generating the FK 
constraint for component 3 (comp3) of the composites tables. We added 
the FK for each component (all 3), but since we never changed the name 
it was overwriting it instead of adding it for each set of columns (i.e. components).

Also fixed javadoc in FhirResourceTableGroup by:
1. fixing copy-paste issue in addComposites javadoc
2. remove "ON DELETE CASCADE" from everywhere --its simply not used
3. added "NOT ENFORCED" for the addComposites sample FKs

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>