### PR TITLE
issue #828 - create configDropins/overrides for the fhir-server

### DIFF
--- a/build/pre-integration-test-docker.sh
+++ b/build/pre-integration-test-docker.sh
@@ -23,7 +23,7 @@ docker-compose kill
 docker-compose rm -f
 
 echo "Bringing up db2... be patient, this will take a minute"
-docker-compose build db2
+docker-compose build --pull db2
 docker-compose up -d db2
 echo ">>> Current time: " $(date)
 
@@ -36,7 +36,7 @@ echo "Deploying the Db2 schema..."
 
 
 echo "Bringing up the FHIR server... be patient, this will take a minute"
-docker-compose build fhir
+docker-compose build --pull fhir
 docker-compose up -d fhir
 echo ">>> Current time: " $(date)
 

--- a/fhir-install/docker/Dockerfile-ol
+++ b/fhir-install/docker/Dockerfile-ol
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-FROM openliberty/open-liberty:19.0.0.12-full-java8-openj9-ubi as base
+FROM openliberty/open-liberty as base
 
 ENV LICENSE accept
 
@@ -24,7 +24,7 @@ RUN unzip -qq /dist/fhir-server-distribution.zip -d /tmp && \
     cp -pr /dist/userlib/* /opt/ol/wlp/usr/servers/fhir-server/userlib/
 
 
-FROM openliberty/open-liberty:19.0.0.12-full-java8-openj9-ubi
+FROM openliberty/open-liberty
 COPY --chown=1001:0 --from=base /opt/ol/wlp/ /opt/ol/wlp
 
 MAINTAINER Lee Surprenant <lmsurpre@us.ibm.com>
@@ -48,5 +48,6 @@ RUN ln -sfn ${FHIR} /output && \
     rm -rf /opt/ol/wlp/usr/servers/defaultServer
 
 USER 1001
-RUN ls -l /config/* && mkdir -p /config/configDropins/defaults/
+# Create the configDropins directories for the fhir-server
+RUN mkdir -p /config/configDropins/defaults /config/configDropins/overrides
 CMD ["/opt/ol/wlp/bin/server", "run", "fhir-server"]


### PR DESCRIPTION
Starting with the docker images for liberty 20.0.0.3, open-liberty is expecting both `/config/configDropins/defaults` and `/config/configDrops/overrides` to exist.
Since we delete the `defaultServer` and replace it with our own `fhir-server` server, we also overwrite `/config` to point at this new server.
However, the entrypoint script is expecting these directories to exist like they do for the defaultServer config.
We were already creating `/config/configDropins/defaults`; so now we just create `/config/configDrops/overrides` at the same time.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>