### PR TITLE
issue #833 - add db2 migration test and fix issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,57 +266,56 @@ jobs:
       with:
         name: integration-test-results-db2-${{ matrix.java }}
         path: integration-test-results
-db2-migration:
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      java: [ 'openjdk11' ]
-    fail-fast: false
-  steps:
-  - uses: actions/checkout@v2
-  - name: Set up OpenJDK
-    uses: joschi/setup-jdk@v1
-    with:
-      java-version: ${{ matrix.java }}
-  - name: Build samples
-    run: mvn -B install --file fhir-examples --no-transfer-progress
-  - name: Build parent without tests
-    run: |
-      mvn -B install --file fhir-parent -DskipTests -P integration --no-transfer-progress
-  - name: Server Integration Tests
-    env:
-      # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
-      LC_ALL: en_US.UTF-8
-    run: |
-      export WORKSPACE=${GITHUB_WORKSPACE}
-      build/pre-migration-test-docker.sh
-      env
-      mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress
-      build/post-integration-test-docker.sh
-  - name: Gather error logs
-    if: failure()
-    run: |
-      it_results=integration-test-results
-      rm -fr ${it_results} 2>/dev/null
-      mkdir -p ${it_results}/server-logs
-      mkdir -p ${it_results}/fhir-server-test
-      containerId=$(docker ps -a | grep fhir | cut -d ' ' -f 1)
-      if [[ -z "${containerId}" ]]; then
-          echo "Warning: Could not find fhir container!!!"
-      else
-          echo "fhir container id: $containerId"
+  db2-migration:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 'openjdk8' ]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up OpenJDK
+      uses: joschi/setup-jdk@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Build samples
+      run: mvn -B install --file fhir-examples --no-transfer-progress
+    - name: Build parent without tests
+      run: |
+        mvn -B install --file fhir-parent -DskipTests -P integration --no-transfer-progress
+    - name: Server Integration Tests
+      env:
+        # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
+        LC_ALL: en_US.UTF-8
+      run: |
+        export WORKSPACE=${GITHUB_WORKSPACE}
+        build/db2-migration-test-docker.sh
+        mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress
+        build/post-integration-test-docker.sh
+    - name: Gather error logs
+      if: failure()
+      run: |
+        it_results=integration-test-results
+        rm -fr ${it_results} 2>/dev/null
+        mkdir -p ${it_results}/server-logs
+        mkdir -p ${it_results}/fhir-server-test
+        containerId=$(docker ps -a | grep fhir | cut -d ' ' -f 1)
+        if [[ -z "${containerId}" ]]; then
+            echo "Warning: Could not find fhir container!!!"
+        else
+            echo "fhir container id: $containerId"
 
-          # Grab the container's console log
-          docker logs $containerId  >& ${it_results}/docker-console.txt
+            # Grab the container's console log
+            docker logs $containerId  >& ${it_results}/docker-console.txt
 
-          echo "Gathering post-test server logs from docker container: $containerId"
-          docker cp -L $containerId:/logs ${it_results}/server-logs
-      fi
-      echo "Gathering integration test output"
-      cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
-  - name: Upload logs
-    if: always()
-    uses: actions/upload-artifact@master
-    with:
-      name: integration-test-results-db2-${{ matrix.java }}
-      path: integration-test-results
+            echo "Gathering post-test server logs from docker container: $containerId"
+            docker cp -L $containerId:/logs ${it_results}/server-logs
+        fi
+        echo "Gathering integration test output"
+        cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
+    - name: Upload logs
+      if: always()
+      uses: actions/upload-artifact@master
+      with:
+        name: db2-migration-test-results-${{ matrix.java }}
+        path: integration-test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,3 +266,57 @@ jobs:
       with:
         name: integration-test-results-db2-${{ matrix.java }}
         path: integration-test-results
+db2-migration:
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      java: [ 'openjdk11' ]
+    fail-fast: false
+  steps:
+  - uses: actions/checkout@v2
+  - name: Set up OpenJDK
+    uses: joschi/setup-jdk@v1
+    with:
+      java-version: ${{ matrix.java }}
+  - name: Build samples
+    run: mvn -B install --file fhir-examples --no-transfer-progress
+  - name: Build parent without tests
+    run: |
+      mvn -B install --file fhir-parent -DskipTests -P integration --no-transfer-progress
+  - name: Server Integration Tests
+    env:
+      # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
+      LC_ALL: en_US.UTF-8
+    run: |
+      export WORKSPACE=${GITHUB_WORKSPACE}
+      build/pre-migration-test-docker.sh
+      env
+      mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress
+      build/post-integration-test-docker.sh
+  - name: Gather error logs
+    if: failure()
+    run: |
+      it_results=integration-test-results
+      rm -fr ${it_results} 2>/dev/null
+      mkdir -p ${it_results}/server-logs
+      mkdir -p ${it_results}/fhir-server-test
+      containerId=$(docker ps -a | grep fhir | cut -d ' ' -f 1)
+      if [[ -z "${containerId}" ]]; then
+          echo "Warning: Could not find fhir container!!!"
+      else
+          echo "fhir container id: $containerId"
+
+          # Grab the container's console log
+          docker logs $containerId  >& ${it_results}/docker-console.txt
+
+          echo "Gathering post-test server logs from docker container: $containerId"
+          docker cp -L $containerId:/logs ${it_results}/server-logs
+      fi
+      echo "Gathering integration test output"
+      cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
+  - name: Upload logs
+    if: always()
+    uses: actions/upload-artifact@master
+    with:
+      name: integration-test-results-db2-${{ matrix.java }}
+      path: integration-test-results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,13 +230,9 @@ jobs:
       run: |
         mvn -B install --file fhir-parent -DskipTests -P integration --no-transfer-progress
     - name: Server Integration Tests
-      env:
-        # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
-        LC_ALL: en_US.UTF-8
       run: |
         export WORKSPACE=${GITHUB_WORKSPACE}
         build/pre-integration-test-docker.sh
-        env
         mvn -B test -DskipTests=false -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress
         build/post-integration-test-docker.sh
     - name: Gather error logs
@@ -284,9 +280,6 @@ jobs:
       run: |
         mvn -B install --file fhir-parent -DskipTests -P integration --no-transfer-progress
     - name: Server Integration Tests
-      env:
-        # debian-based linux uses C.UTF-8 by default and Derby doesn't like that
-        LC_ALL: en_US.UTF-8
       run: |
         export WORKSPACE=${GITHUB_WORKSPACE}
         build/db2-migration-test-docker.sh

--- a/build/db2-migration-test-docker.sh
+++ b/build/db2-migration-test-docker.sh
@@ -15,7 +15,6 @@ fi
 # Set up installers and config files where docker processing can see them
 cd ${WORKSPACE}/fhir-install/docker
 ./copy-dependencies-db2-migration.sh
-./copy-test-operations.sh
 
 # Stand up a docker container running the fhir server configured for integration tests
 echo "Bringing down any fhir server containers that might already be running as a precaution"
@@ -30,22 +29,22 @@ echo ">>> Current time: " $(date)
 # TODO wait for it to be healthy instead of just Sleeping
 (docker-compose logs --timestamps --follow db2 & P=$! && sleep 100 && kill $P)
 
-
 echo "Deploying the Db2 schema..."
 ./deploySchemaAndTenant.sh
+
+
+echo "Bringing up the FHIR server... be patient, this will take a minute"
+./copy-test-operations.sh
+docker-compose build --pull fhir
+docker-compose up -d fhir
+echo ">>> Current time: " $(date)
 
 echo "Migrating the schema to the latest version..."
 ./copy-dependencies-db2.sh
 ./updateSchema.sh
 
-
-echo "Bringing up the FHIR server... be patient, this will take a minute"
-docker-compose build --pull fhir
-docker-compose up -d fhir
-echo ">>> Current time: " $(date)
-
 # TODO wait for it to be healthy instead of just Sleeping
-(docker-compose logs --timestamps --follow fhir & P=$! && sleep 100 && kill $P)
+(docker-compose logs --timestamps --follow fhir & P=$! && sleep 60 && kill $P)
 
 # Gather up all the server logs so we can trouble-shoot any problems during startup
 cd -

--- a/build/pre-integration-test-docker.sh
+++ b/build/pre-integration-test-docker.sh
@@ -15,7 +15,6 @@ fi
 # Set up installers and config files where docker processing can see them
 cd ${WORKSPACE}/fhir-install/docker
 ./copy-dependencies-db2.sh
-./copy-test-operations.sh
 
 # Stand up a docker container running the fhir server configured for integration tests
 echo "Bringing down any fhir server containers that might already be running as a precaution"
@@ -30,12 +29,12 @@ echo ">>> Current time: " $(date)
 # TODO wait for it to be healthy instead of just Sleeping
 (docker-compose logs --timestamps --follow db2 & P=$! && sleep 100 && kill $P)
 
-
 echo "Deploying the Db2 schema..."
 ./deploySchemaAndTenant.sh
 
 
 echo "Bringing up the FHIR server... be patient, this will take a minute"
+./copy-test-operations.sh
 docker-compose build --pull fhir
 docker-compose up -d fhir
 echo ">>> Current time: " $(date)

--- a/build/pre-migration-test-docker.sh
+++ b/build/pre-migration-test-docker.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+###############################################################################
+# (C) Copyright IBM Corp. 2016, 2020
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+set -ex
+
+echo "Preparing environment for fhir-server integration tests..."
+if [[ -z "${WORKSPACE}" ]]; then
+    echo "ERROR: WORKSPACE environment variable not set!"
+    exit 2
+fi
+
+# Set up installers and config files where docker processing can see them
+cd ${WORKSPACE}/fhir-install/docker
+./copy-dependencies-db2-migration.sh
+./copy-test-operations.sh
+
+# Stand up a docker container running the fhir server configured for integration tests
+echo "Bringing down any fhir server containers that might already be running as a precaution"
+docker-compose kill
+docker-compose rm -f
+
+echo "Bringing up db2... be patient, this will take a minute"
+docker-compose build --pull db2
+docker-compose up -d db2
+echo ">>> Current time: " $(date)
+
+# TODO wait for it to be healthy instead of just Sleeping
+(docker-compose logs --timestamps --follow db2 & P=$! && sleep 100 && kill $P)
+
+
+echo "Deploying the Db2 schema..."
+./deploySchemaAndTenant.sh
+
+echo "Migrating the schema to the latest version..."
+./copy-dependencies-db2.sh
+./updateSchema.sh
+
+
+echo "Bringing up the FHIR server... be patient, this will take a minute"
+docker-compose build --pull fhir
+docker-compose up -d fhir
+echo ">>> Current time: " $(date)
+
+# TODO wait for it to be healthy instead of just Sleeping
+(docker-compose logs --timestamps --follow fhir & P=$! && sleep 100 && kill $P)
+
+# Gather up all the server logs so we can trouble-shoot any problems during startup
+cd -
+pre_it_logs=${WORKSPACE}/pre-it-logs
+zip_file=${WORKSPACE}/pre-it-logs.zip
+rm -fr ${pre_it_logs} 2>/dev/null
+mkdir -p ${pre_it_logs}
+rm -f ${zip_file}
+
+echo "
+Docker container status:"
+docker ps -a
+
+containerId=$(docker ps -a | grep fhir | cut -d ' ' -f 1)
+if [[ -z "${containerId}" ]]; then
+    echo "Warning: Could not find the fhir container!!!"
+else
+    echo "fhir container id: $containerId"
+
+    # Grab the container's console log
+    docker logs $containerId  >& ${pre_it_logs}/docker-console.txt
+
+    echo "Gathering pre-test server logs from docker container: $containerId"
+    docker cp -L $containerId:/opt/ol/wlp/usr/servers/fhir-server/logs ${pre_it_logs}
+
+    echo "Zipping up pre-test server logs"
+    zip -r ${zip_file} ${pre_it_logs}
+fi
+
+# Wait until the fhir server is up and running...
+echo "Waiting for fhir-server to complete initialization..."
+healthcheck_url='https://localhost:9443/fhir-server/api/v4/$healthcheck'
+tries=0
+status=0
+while [ $status -ne 200 -a $tries -lt 3 ]; do
+    tries=$((tries + 1))
+    cmd="curl -k -o ${WORKSPACE}/health.json -I -w "%{http_code}" -u fhiruser:change-password $healthcheck_url"
+    echo "Executing[$tries]: $cmd"
+    status=$($cmd)
+    echo "Status code: $status"
+    if [ $status -ne 200 ]
+    then
+       echo "Sleeping 10 secs..."
+       sleep 10
+    fi
+done
+
+if [ $status -ne 200 ]
+then
+    echo "Could not establish a connection to the fhir-server within $tries REST API invocations!"
+    exit 1
+fi
+
+echo "The fhir-server appears to be running..."
+exit 0

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
@@ -176,7 +176,7 @@ public interface IDatabaseAdapter {
     /**
      *
      * <pre>
-     * CREATE PERMISSION ROW_ACCESS ON ptng.patients FOR ROWS WHERE patients.mt_id =
+     * CREATE OR REPLACE PERMISSION ROW_ACCESS ON ptng.patients FOR ROWS WHERE patients.mt_id =
      * ptng.session_tenant ENFORCED FOR ALL ACCESS ENABLE;
      * </pre>
      *
@@ -185,7 +185,7 @@ public interface IDatabaseAdapter {
      * @param tableName
      * @param predicate
      */
-    public void createPermission(String schemaName, String permissionName, String tableName, String predicate);
+    public void createOrReplacePermission(String schemaName, String permissionName, String tableName, String predicate);
 
     /**
      *

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DateMath.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DateMath.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -49,7 +49,7 @@ public class DateMath {
         gc.add(Calendar.MONTH, howMany);
         return gc.getTime();
     }
-    
+
     /**
      * Parse the date string which is expected to be yyyy-MM-dd
      * @param str
@@ -114,7 +114,7 @@ public class DateMath {
         gc.set(Calendar.MILLISECOND, 0);
         return gc.getTime();
     }
-    
+
     /**
      * Add the requested number of seconds to the given date
      * @param d
@@ -127,7 +127,7 @@ public class DateMath {
         gc.add(Calendar.SECOND, howMany);
         return gc.getTime();
     }
-    
+
     /**
      * Return the max of 2 dates
      * @param d1
@@ -139,9 +139,9 @@ public class DateMath {
             return null;
         }
         if (d1 == null || d2 == null) {
-                return (d1 == null ? d2 : d1);    
+                return (d1 == null ? d2 : d1);
         }
-        return (d1.after(d2)) ? d1 : d2;        
+        return (d1.after(d2)) ? d1 : d2;
     }
 
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DropForeignKeyConstraint.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DropForeignKeyConstraint.java
@@ -31,6 +31,7 @@ public class DropForeignKeyConstraint implements IDatabaseStatement {
     public DropForeignKeyConstraint(String schemaName, String tableName, String... constraintName) {
         DataDefinitionUtil.assertValidName(schemaName);
         DataDefinitionUtil.assertValidName(tableName);
+        Arrays.stream(constraintName).forEach(DataDefinitionUtil::assertValidName);
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.constraintNames = Arrays.asList(constraintName);

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DropForeignKeyConstraint.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/DropForeignKeyConstraint.java
@@ -42,8 +42,7 @@ public class DropForeignKeyConstraint implements IDatabaseStatement {
 
         for (String constraintName : constraintNames) {
             StringBuilder ddl = new StringBuilder("ALTER TABLE " + qTableName);
-            String qConstraintName = DataDefinitionUtil.getQualifiedName(schemaName, constraintName);
-            ddl.append("\n\t" + "DROP FOREIGN KEY " + qConstraintName);
+            ddl.append("\n\t" + "DROP FOREIGN KEY " + constraintName);
 
             try (Statement s = c.createStatement()) {
                 s.executeUpdate(ddl.toString());

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -112,8 +112,8 @@ public class Db2Adapter extends CommonDatabaseAdapter {
 
         final String ddl = ""
                 + "CREATE OR REPLACE PERMISSION " + qualifiedPermissionName
-                + "                          ON " + qualifiedTableName
-                + "              FOR ROWS WHERE " + predicate
+                + " ON " + qualifiedTableName
+                + " FOR ROWS WHERE " + predicate
                 + " ENFORCED FOR ALL ACCESS ENABLE ";
         runStatement(ddl);
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
@@ -456,12 +456,10 @@ public class Db2Adapter extends CommonDatabaseAdapter {
 
             String qname = ((DropColumn) stmt).getSchemaName() + "." + ((DropColumn) stmt).getTableName();
 
-            Db2AdminCommand runstats = new Db2AdminCommand("RUNSTATS ON TABLE " + qname + " WITH DISTRIBUTION AND DETAILED INDEXES ALL");
-            super.runStatement(runstats);
-
             String reorgCommand = "REORG TABLE " + qname;
             super.runStatement(new Db2AdminCommand(reorgCommand));
 
+            Db2AdminCommand runstats = new Db2AdminCommand("RUNSTATS ON TABLE " + qname + " WITH DISTRIBUTION AND DETAILED INDEXES ALL");
             super.runStatement(runstats);
         }
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
@@ -105,15 +105,15 @@ public class Db2Adapter extends CommonDatabaseAdapter {
     }
 
     @Override
-    public void createPermission(String schemaName, String permissionName, String tableName, String predicate) {
+    public void createOrReplacePermission(String schemaName, String permissionName, String tableName, String predicate) {
         final String qualifiedPermissionName = DataDefinitionUtil.getQualifiedName(schemaName, permissionName);
         final String qualifiedTableName = DataDefinitionUtil.getQualifiedName(schemaName, tableName);
         DataDefinitionUtil.assertSecure(predicate);
 
         final String ddl = ""
-                + "       CREATE PERMISSION " + qualifiedPermissionName
-                + "                      ON " + qualifiedTableName
-                + "          FOR ROWS WHERE " + predicate
+                + "CREATE OR REPLACE PERMISSION " + qualifiedPermissionName
+                + "                          ON " + qualifiedTableName
+                + "              FOR ROWS WHERE " + predicate
                 + " ENFORCED FOR ALL ACCESS ENABLE ";
         runStatement(ddl);
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2GetPartitionInfo.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2GetPartitionInfo.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,14 +24,14 @@ import com.ibm.fhir.database.utils.common.DataDefinitionUtil;
 public class Db2GetPartitionInfo implements IDatabaseStatement {
     private final String catalogSchema;
     private final String tableSchema;
-    
+
     // The consumer target for handling results
     private final Consumer<PartitionInfo> consumer;
-    
+
     /**
      * Get partition information for all tables in the tableSchema, using
      * the catalogSchema as the schema containing the DATAPARTITIONS system table
-     * 
+     *
      * @param catalogSchema
      * @param tableSchema
      * @param consumer
@@ -43,18 +43,18 @@ public class Db2GetPartitionInfo implements IDatabaseStatement {
         this.tableSchema = tableSchema;
         this.consumer = consumer;
     }
-    
+
     @Override
     public void run(IDatabaseTranslator translator, Connection c) {
         /**
          * Execute the encapsulated query against the database and stream the result data to the
          * configured target
          */
-        
+
         final String SQL = ""
-                + "   SELECT tabname, datapartitionname, seqno, lowinclusive, lowvalue, highinclusive, highvalue "
-                + "     FROM " + catalogSchema + ".DATAPARTITIONS "
-                + "    WHERE tabschema = UCASE(?) "
+                + "SELECT tabname, datapartitionname, seqno, lowinclusive, lowvalue, highinclusive, highvalue "
+                + " FROM " + catalogSchema + ".DATAPARTITIONS "
+                + " WHERE tabschema = UCASE(?) "
                 + " ORDER BY tabname, seqno";
 
         try (PreparedStatement ps = c.prepareStatement(SQL)) {
@@ -81,7 +81,7 @@ public class Db2GetPartitionInfo implements IDatabaseStatement {
             throw translator.translate(x);
         }
     }
-    
+
     /**
      * The high/low values look like this: '2017-01-01-00.00.00.000000'.
      * We want this: 2017-01-01

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Reorg.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Reorg.java
@@ -16,6 +16,10 @@ import com.ibm.fhir.database.utils.common.DataDefinitionUtil;
 
 /**
  * Reorg the schema.table
+ *
+ * Be sure to complete all database operations and release all locks before you invoke REORG.
+ * @see <a href="https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.cmd.doc/doc/r0001966.html">
+ *      https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.cmd.doc/doc/r0001966.html</a>
  */
 public class Db2Reorg implements IDatabaseStatement {
     private final String schemaName;

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -95,7 +95,7 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
     }
 
     @Override
-    public void createPermission(String schemaName, String permissionName, String tableName, String predicate) {
+    public void createOrReplacePermission(String schemaName, String permissionName, String tableName, String predicate) {
         warnOnce(MessageKey.CREATE_PERM, "Derby does not support CREATE PERMISSION for: " + permissionName);
     }
 

--- a/fhir-install/docker/copy-dependencies-db2-migration.sh
+++ b/fhir-install/docker/copy-dependencies-db2-migration.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+###############################################################################
+# (C) Copyright IBM Corp. 2016, 2020
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+set -ex
+
+SCHEMA_VERSION="4.0.1"
+
+echo "Removing old dependencies..."
+DIST="volumes/dist"
+SCHEMA="volumes/schema"
+rm -rf $DIST/* 2> /dev/null
+rm -rf $SCHEMA/* 2> /dev/null
+mkdir -p $DIST
+mkdir -p $SCHEMA
+
+echo "Copying installation zip files..."
+cp -p ../target/fhir-server-distribution.zip $DIST
+
+echo "Copying fhir configuration files..."
+cp -pr ../../fhir-server/liberty-config/config $DIST
+cp -pr ../../fhir-server/liberty-config-tenants/config/* $DIST/config
+cp -pr ../../fhir-server/liberty-config/config/default/fhir-server-config-db2.json $DIST/config/default/fhir-server-config.json
+
+echo "Copying fhir-persistence-schema tool..." 
+curl https://dl.bintray.com/ibm-watson-health/ibm-fhir-server-releases/com/ibm/fhir/fhir-persistence-schema/${SCHEMA_VERSION}/fhir-persistence-schema-${SCHEMA_VERSION}-cli.jar \
+     --output $SCHEMA/fhir-persistence-schema-${SCHEMA_VERSION}-cli.jar \
+     --location \
+     --fail
+
+echo "Finished copying fhir-server dependencies..."

--- a/fhir-install/docker/deploySchemaAndTenant.sh
+++ b/fhir-install/docker/deploySchemaAndTenant.sh
@@ -10,10 +10,10 @@ java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --create-schemas
 
 java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
-  --prop-file db2.properties --schema-name FHIRDATA --update-schema
+  --prop-file db2.properties --schema-name FHIRDATA --update-schema --pool-size 2
 
 java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
-  --prop-file db2.properties --schema-name FHIRDATA --grant-to FHIRSERVER
+  --prop-file db2.properties --schema-name FHIRDATA --grant-to FHIRSERVER --pool-size 2
 
 java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --allocate-tenant default

--- a/fhir-install/docker/deploySchemaAndTenant.sh
+++ b/fhir-install/docker/deploySchemaAndTenant.sh
@@ -8,12 +8,16 @@ set -ex
 
 java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --create-schemas
-java -jar volumes/schema//fhir-persistence-schema-*-cli.jar \
+
+java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --update-schema
-java -jar volumes/schema//fhir-persistence-schema-*-cli.jar \
+
+java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --grant-to FHIRSERVER
+
 java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
   --prop-file db2.properties --schema-name FHIRDATA --allocate-tenant default
+
 # The regex in the following command will output the capture group between "key=" and "]"
 # With GNU grep, the following would work as well:  grep -oP 'key=\K\S+(?=])'
 tenantKey=$(java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \

--- a/fhir-install/docker/updateSchema.sh
+++ b/fhir-install/docker/updateSchema.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+###############################################################################
+# (C) Copyright IBM Corp. 2020
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################################
+set -ex
+
+java -jar volumes/schema/fhir-persistence-schema-*-cli.jar \
+  --prop-file db2.properties --schema-name FHIRDATA --update-schema

--- a/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
+++ b/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -61,18 +61,18 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
                 log.finer("Kafka publisher is configured with the following properties:\n" + this.kafkaProps.toString());
                 log.finer("Topic name: " + this.topicName);
             }
-            
+
             // We'll hard-code some properties to ensure they are set correctly.
             this.kafkaProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
             this.kafkaProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
             this.kafkaProps.put(ProducerConfig.CLIENT_ID_CONFIG, "fhir-server");
-            
+
             // Make sure that the properties file contains the bootstrap.servers property at a minimum.
             String bootstrapServers = this.kafkaProps.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
             if (bootstrapServers == null) {
                 throw new IllegalStateException("The " + ProducerConfig.BOOTSTRAP_SERVERS_CONFIG + " property was missing from the Kafka connection properties.");
             }
-            
+
             // Create our producer object to be used for publishing.
             producer = new KafkaProducer<String, String>(this.kafkaProps);
 
@@ -96,7 +96,7 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
         log.entering(this.getClass().getName(), "shutdown");
 
         try {
-            if (log.isLoggable(Level.FINE)) {   
+            if (log.isLoggable(Level.FINE)) {
                 log.fine("Shutting down Kafka publisher for topic: '" + topicName + "'.");
             }
             if (producer != null) {
@@ -107,12 +107,6 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * @see
-     * com.ibm.fhir.notification.FHIRNotificationSubscriber#notify(com.ibm.fhir.notification.
-     * util.FHIRNotificationEvent)
-     */
     @Override
     public void notify(FHIRNotificationEvent event) throws FHIRNotificationException {
         log.entering(this.getClass().getName(), "notify");
@@ -121,10 +115,10 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
         try {
             jsonString = FHIRNotificationUtil.toJsonString(event, true);
 
-            if (log.isLoggable(Level.FINE)) { 
+            if (log.isLoggable(Level.FINE)) {
                 log.fine("Publishing kafka notification event to topic '" + topicId + "',\nmessage: " + jsonString);
             }
-            
+
             producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId));
 
             if (log.isLoggable(Level.FINE)) {
@@ -138,7 +132,7 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
             log.exiting(this.getClass().getName(), "notify");
         }
     }
-    
+
     public class KafkaPublisherCallback implements Callback {
         private FHIRNotificationEvent event;
         private String notificationEvent;
@@ -162,8 +156,8 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
                 // No exception implies that the send operation succeeded, so log an info message.
                 if (exception == null) {
                     log.info("Successfully published kafka notification event for resource: " + event.getLocation());
-                } 
-                
+                }
+
                 // If we detected a 'send' failure, then log an error message that includes the notification message
                 // that we tried to send.
                 else {
@@ -175,7 +169,7 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
             }
         }
     }
-    
+
     /**
      * Builds a formatted error message to indicate a notification publication failure.
      */

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchCompositeTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchCompositeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -32,7 +32,7 @@ public class JDBCSearchCompositeTest extends AbstractSearchCompositeTest {
             derbyInit.bootstrapDb();
         }
     }
-    
+
     @Override
     public FHIRPersistence getPersistenceImpl() throws Exception {
         return new FHIRPersistenceJDBCImpl(this.testProps);

--- a/fhir-persistence-schema/deployPriorVersions.sh
+++ b/fhir-persistence-schema/deployPriorVersions.sh
@@ -9,8 +9,9 @@ set -e
 
 # Version 4.0.1 of the fhir-persistence-schema cli doesn't support derby, but starting with 4.1.0 we should do something like this:
 #
-# curl https://dl.bintray.com/ibm-watson-health/ibm-fhir-server-releases/com/ibm/fhir/fhir-persistence-schema/4.0.1/:fhir-persistence-schema-4.0.1-cli.jar \
+# curl https://dl.bintray.com/ibm-watson-health/ibm-fhir-server-releases/com/ibm/fhir/fhir-persistence-schema/4.0.1/fhir-persistence-schema-4.0.1-cli.jar \
 #      --output target/fhir-persistence-schema-4.0.1-cli.jar \
+       --location \
 #      --fail
 #
 # java -jar fhir-persistence-schema-4.0.1-cli.jar \

--- a/fhir-persistence-schema/docs/DB2SchemaMigration.md
+++ b/fhir-persistence-schema/docs/DB2SchemaMigration.md
@@ -275,9 +275,25 @@ When the `fhir-persistence-schema` actions are executed with `--grant-to`, the *
 If you change the stored procedure signature, the `fhir-persistence-schema` does not automatically drop the prior stored procedure and signature, and the stored procedure MUST be dropped manually.
 
 ## Managing GRANTS
-The Db2 data definition secures data access using `GRANT` predicates. To update or change, use the `--grant-to` predicate to apply the grants. 
 
-If a grant is removed from the Java code, a manual process must be followed to remove or change the grant for the corresponding tables, procedures and variables. 
+The Db2 data definition secures data access using `GRANT` predicates. To update or change, use the `--grant-to` predicate to apply the grants.
+
+If a grant is removed from the Java code, a manual process must be followed to remove or change the grant for the corresponding tables, procedures and variables.
+
+# Testing migrations
+
+We currently have two migration tests in place; one for Apache Derby which runs with the Maven build and one for Db2 which runs as part of the CI pipeline.
+
+With each release of the IBM FHIR Server, these tests should be expanded to cover [at least] the migrations from the previous version.
+
+## Testing migrations with Apache Derby
+
+The `fhir-persistence-schema` project includes a single DerbyMigrationTest. Currently, this test invokes a copy of the FhirSchemaGenerator that was extracted from version 4.0.1 of the `fhir-persistence-schema` project and added directly to the package.
+
+This was necessary because version 4.0.1 of the fhir-persistence-schema cli doesn't support deploying schemas for Apache Derby. However, starting with 4.1.0, we should use the released cli jar to deploy the previous versions of the schema. This will ensure the validity of the test and improve maintainability.
+
+## Testing migrations with IBM Db2
+The `fhir-install` module contains scripts for building Docker containers of the IBM FHIR Server and IBM Db2 and, optionally, bringing them up via `docker-compose`. When releasing new versions of the IBM FHIR Server, the `SCHEMA_VERSION` variable should be updated within `fhir-install/docker/copy-dependencies-db2-migration.sh` in order to test migrations from the previously released version of the `fhir-persistencne-schema` module.
 
 ## References
 - [Git Issue: Document the schema migration process on the project wiki #270](https://github.com/IBM/FHIR/issues/270)

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -679,12 +679,12 @@ ALTER TABLE device_composites ADD CONSTRAINT fk_device_composites_r  FOREIGN KEY
                 }
 
                 statements.add(new DropForeignKeyConstraint(schemaName, tableName,
-                        "FK_OBSERVATION_COMPOSITES_DATE",
-                        "FK_OBSERVATION_COMPOSITES_LATLNG",
-                        "FK_OBSERVATION_COMPOSITES_NUMBER",
-                        "FK_OBSERVATION_COMPOSITES_QUANTITY",
-                        "FK_OBSERVATION_COMPOSITES_STR",
-                        "FK_OBSERVATION_COMPOSITES_TOKEN"));
+                        FK + tableName + _STR,
+                        FK + tableName + _NUMBER,
+                        FK + tableName + _DATE,
+                        FK + tableName + _TOKEN,
+                        FK + tableName + _QUANTITY,
+                        FK + tableName + _LATLNG));
             }
             return statements;
         });


### PR DESCRIPTION
Introduced variant of e2e-db2 test for testing migration which:
1. creates a db2 instance and deploys the previous version of the schema
2. runs migration
3. executes the e2e tests

This uncovered a couple different issues with our existing migrations:
1. `DB2 SQL Error: SQLCODE=-2310, SQLSTATE=     , SQLERRMC=-668`
    while executing runstats after dropping a column
2. `DB2 SQL Error: SQLCODE=-108, SQLSTATE=42601,
SQLERRMC=FK_OBSERVATION_COMPOSITES_DATE`
    while executing DropForeignKeyConstraint
3. `DB2 SQL Error: SQLCODE=-204, SQLSTATE=42704,
SQLERRMC=FK_OBSERVATION_COMPOSITES_DATE`
    while executing DropForeignKeyConstraint

For number 1, the fix was to avoid executing RUNSTATS until after the
table with the dropped column has been REORGed.

For number 2, the fix was to stop qualifying the constraintName with the
schema name.

For number 3, the fix was to avoid hard-coding Observation in the FK
names being dropped.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>