### PR TITLE
issue #664 #884 conditional delete multiple match support and config for disabling bulk export public access

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1422,7 +1422,7 @@ must restart the server for that change to take effect.
 |`fhirServer/core/defaultHandling`|Y|Y|
 |`fhirServer/core/allowClientHandlingPref`|Y|Y|
 |`fhirServer/core/checkReferenceTypes`|N|N|
-|`fhirServer/core/conditionalDeleteMaxNumber`|N|N|
+|`fhirServer/core/conditionalDeleteMaxNumber`|Y|Y|
 |`fhirServer/searchParameterFilter`|Y|Y|
 |`fhirServer/notifications/common/includeResourceTypes`|N|N|
 |`fhirServer/notifications/websocket/enabled`|Y|Y|

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1358,7 +1358,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/jobParameters/credential.ibm`| If use IBM credential, "Y" or "N" |
 |`fhirServer/bulkdata/jobParameters/cos.api.key`|string|API key for accessing IBM COS |
 |`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|string|Service instance Id for accessing IBM COS |
-|`fhirServer/bulkdata/implementation_type`|string|"cos" (Any Amazon S3-compatible object stores including IBM COS) or "dummy" which matches the desired bulk operation implementation type |
+|`fhirServer/bulkdata/implementation_type`|string|Use "cos" for any S3-compatible object store |
 |`fhirServer/bulkdata/batch-uri`|string|The URL to access the FHIR server hosting the batch web application |
 |`fhirServer/bulkdata/batch-user`|string|User for submitting JavaBatch job |
 |`fhirServer/bulkdata/batch-user-password`|string|Password for above batch user |

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1143,7 +1143,30 @@ The *fhir-bulkimportexport-webapp* module is a wrapper for the whole BulkData we
     </webApplication>
 ```
 
-BulkData web application writes the exported FHIR resources to an IBM Cloud Object Storage (COS) or Amazon S3 bucket as configured in the per-tenant server configuration under fhirServer/bulkdata. 
+BulkData web application writes the exported FHIR resources to an IBM Cloud Object Storage (COS) or any Amazon S3-Compatible bucket as configured in the per-tenant server configuration under fhirServer/bulkdata. Following is an example configuration for bulkdata, please refer to section 5 for the detailed description of these properties:
+
+```
+        "bulkdata": {
+            "bulkDataBatchJobIdEncryptionKey": "change-password",
+            "applicationName": "fhir-bulkimportexport-webapp",
+            "moduleName": "fhir-bulkimportexport.war",
+            "jobParameters": {
+                "cos.bucket.name": "fhir-r4-connectathon",
+                "cos.location": "us",
+                "cos.endpointurl": "fake",
+                "cos.credential.ibm": "Y",
+                "cos.api.key": "fake",
+                "cos.srvinst.id": "fake"
+            },
+            "implementation_type": "cos",
+            "batch-uri": "https://localhost:9443/ibm/api/batch/jobinstances",
+            "batch-user": "fhiradmin",
+            "batch-user-password": "change-password",
+            "batch-truststore": "resources/security/fhirTruststore.jks",
+            "batch-truststore-password": "change-password",
+            "isExportPublic": true
+        }
+```
 
 To use Amazon S3 bucket for exporting, please set cos.credential.ibm to "N", set cos.api.key to S3 access key, and set cos.srvinst.id to S3 secret key. The following is a sample path to the exported ndjson file, the full path can be found in the response to the polling location request after the export request (please refer to the FHIR BulkDataAccess spec for details).  
 
@@ -1335,7 +1358,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/jobParameters/credential.ibm`| If use IBM credential, "Y" or "N" |
 |`fhirServer/bulkdata/jobParameters/cos.api.key`|string|API key for accessing IBM COS |
 |`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|string|Service instance Id for accessing IBM COS |
-|`fhirServer/bulkdata/implementation_type`|string|"cos" or "dummy" which matches the desired bulk operation implementation type |
+|`fhirServer/bulkdata/implementation_type`|string|"cos" (Any Amazon S3-compatible object stores including IBM COS) or "dummy" which matches the desired bulk operation implementation type |
 |`fhirServer/bulkdata/batch-uri`|string|The URL to access the FHIR server hosting the batch web application |
 |`fhirServer/bulkdata/batch-user`|string|User for submitting JavaBatch job |
 |`fhirServer/bulkdata/batch-user-password`|string|Password for above batch user |

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1143,50 +1143,7 @@ The *fhir-bulkimportexport-webapp* module is a wrapper for the whole BulkData we
     </webApplication>
 ```
 
-BulkData web application writes the exported FHIR resources to an IBM Cloud Object Storage (COS) or Amazon S3 bucket, as configured in the per-tenant bulkdata.json configuration file. The bulkdata.json file is stored in the tenant configuration directory of each fhir-server instance. The following is a bulkdata.json which is configured to export the FHIR resources into fhir-bulkdata-sample bucket of IBM COS:
-
-```json
-{
-  "applicationName": "fhir-bulkimportexport-webapp",
-  "moduleName": "fhir-bulkimportexport.war",
-  "jobParameters": {
-    "cos.bucket.name": "fhir-bulkdata-sample",
-    "cos.location": "us",
-    "cos.endpointurl": "https://s3.us-south.cloud-object-storage.appdomain.cloud",
-    "cos.credential.ibm": "Y",
-    "cos.api.key": "xxxxxxxxxxxxxxxxxxxxxxx",
-    "cos.srvinst.id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-  },
-  "implementation_type": "cos",
-  "batch-uri": "https://localhost:9443/ibm/api/batch/jobinstances",
-  "batch-user": "fhiradmin",
-  "batch-user-password": "xxxxxxxxxxxx",
-  "batch-truststore" : "resources/security/fhirTruststore.jks",
-  "batch-truststore-password" : "xxxxxxxxxxxx",
-  "serverHostname" : "localhost:9443",
-  "contextRoot" : "/fhir-server/api/v4"
-}
-```
-The following configured parameters are:
-
-|Parameter Name   | Description|
-|--------------| ------------|
-|`applicationName`| fixed value, always set to fhir-bulkimportexport-webapp |
-|`moduleName`| fixed value, always set to fhir-bulkimportexport.war |
-|`jobParameters.cos.bucket.name`| object store bucket name |
-|`jobParameters.cos.location`| object store location |
-|`jobParameters.cos.endpointurl`| object store end point url |
-|`jobParameters.credential.ibm`| if use IBM credential |
-|`jobParameters.cos.api.key`| api key for accessing IBM COS |
-|`jobParameters.cos.srvinst.id`| service instance Id for accessing IBM COS |
-|`implementation_type`| cos or dummy which matches the desired bulk operation implementation type |
-|`batch-uri`| the URL to access the FHIR server hosting the batch web application |
-|`batch-user`| user for submitting JavaBatch job |
-|`batch-user-password`| password for above batch user |
-|`batch-truststore`| trust store for JavaBatch job submission |
-|`batch-truststore-password`| password for above trust store |
-|`serverHostname`| host name part of the server generated polling location url |
-|`contextRoot`| context root part of the server generated polling location url |
+BulkData web application writes the exported FHIR resources to an IBM Cloud Object Storage (COS) or Amazon S3 bucket as configured in the per-tenant server configuration under fhirServer/bulkdata. 
 
 To use Amazon S3 bucket for exporting, please set cos.credential.ibm to "N", set cos.api.key to S3 access key, and set cos.srvinst.id to S3 secret key. The following is a sample path to the exported ndjson file, the full path can be found in the response to the polling location request after the export request (please refer to the FHIR BulkDataAccess spec for details).  
 
@@ -1216,7 +1173,8 @@ Following is the beautified response of sample polling location request after th
 }
 ```
 
-The exported ndjson file is configured with public access automatically and with 2 hours expiration time, the randomly generated secret in the path is used to protect the file. please note that IBM COS does not support expiration time for each single COS object, so please configure retention policy (e.g, 1 day) for the bucket if IBM COS is used. For both Amazon S3 and IBM COS, please remember that public access should never be configured to the bucket itself.  
+By default, the exported ndjson file is configured with public access automatically and with 2 hours expiration time, the randomly generated secret in the path is used to protect the file. please note that IBM COS does not support expiration time for each single COS object, so please configure retention policy (e.g, 1 day) for the bucket if IBM COS is used. For both Amazon S3 and IBM COS, please remember that public access should never be configured to the bucket itself. 
+Note: fhirServer/bulkdata/isExportPublic can be set to "false" to disable public access. 
 
 JavaBatch feature must be enabled in server.xml as following for liberty server:
 
@@ -1369,6 +1327,22 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/audit/serviceProperties/geoState`|string|The Geo State configure for CADF audit logging service.|
 |`fhirServer/audit/serviceProperties/geoCounty`|string|The Geo Country configure for CADF audit logging service.|
 |`fhirServer/search/useBoundingRadius`|boolean|True, the bounding area is a Radius, else the bounding area is a box.|
+|`fhirServer/bulkdata/applicationName`| string|Fixed value, always set to fhir-bulkimportexport-webapp |
+|`fhirServer/bulkdata/moduleName`|string| Fixed value, always set to fhir-bulkimportexport.war |
+|`fhirServer/bulkdata/jobParameters/cos.bucket.name`|string|Object store bucket name |
+|`fhirServer/bulkdata/jobParameters/cos.location`|Object store location |
+|`fhirServer/bulkdata/jobParameters/cos.endpointurl`| Object store end point url |
+|`fhirServer/bulkdata/jobParameters/credential.ibm`| If use IBM credential, "Y" or "N" |
+|`fhirServer/bulkdata/jobParameters/cos.api.key`|string|API key for accessing IBM COS |
+|`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|string|Service instance Id for accessing IBM COS |
+|`fhirServer/bulkdata/implementation_type`|string|"cos" or "dummy" which matches the desired bulk operation implementation type |
+|`fhirServer/bulkdata/batch-uri`|string|The URL to access the FHIR server hosting the batch web application |
+|`fhirServer/bulkdata/batch-user`|string|User for submitting JavaBatch job |
+|`fhirServer/bulkdata/batch-user-password`|string|Password for above batch user |
+|`fhirServer/bulkdata/batch-truststore`|string|Trust store for JavaBatch job submission |
+|`fhirServer/bulkdata/batch-truststore-password`|string|Password for above trust store |
+|`fhirServer/bulkdata/bulkDataBatchJobIdEncryptionKey`|string|Encryption key for JavaBatch job id |
+|`fhirServer/bulkdata/isExportPublic`|boolean|If give public read only access to the exported files |
 
 
 ### 5.1.2 Default property values
@@ -1401,6 +1375,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/audit/serviceProperties/geoCity`|Dallas|
 |`fhirServer/audit/serviceProperties/geoState`|TX|
 |`fhirServer/audit/serviceProperties/geoCounty`|US|
+|`fhirServer/bulkdata/isExportPublic`|true|
 
 
 ### 5.1.3 Property attributes
@@ -1442,6 +1417,14 @@ must restart the server for that change to take effect.
 |`fhirServer/audit/serviceProperties/geoCity`|N|N|
 |`fhirServer/audit/serviceProperties/geoState`|N|N|
 |`fhirServer/audit/serviceProperties/geoCounty`|N|N|
+|`fhirServer/bulkdata/jobParameters/cos.bucket.name`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.location`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.endpointurl`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/credential.ibm`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.api.key`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|Y|Y|
+|`fhirServer/bulkdata/bulkDataBatchJobIdEncryptionKey`|Y|Y|
+|`fhirServer/bulkdata/isExportPublic`|Y|Y|
 
 
 ## 5.2 Keystores, truststores, and the FHIR server

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1348,6 +1348,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/core/defaultHandling`|string|The default handling preference of the server (`strict | lenient`) which determines how the server handles unrecognized search parameters and resource elements.|
 |`fhirServer/core/allowClientHandlingPref`|boolean|Indicates whether the client is allowed to override the server default handling preference using the `Prefer:handling` header value part.|
 |`fhirServer/core/checkReferenceTypes`|boolean|Indicates whether reference type checking is performed by the server during parsing / deserialization.|
+|`fhirServer/core/conditionalDeleteMaxNumber`|integer|The max number of matches supported in conditional delete. |
 |`fhirServer/searchParameterFilter`|property list|A set of inclusion rules for search parameters. See [FHIR Search Configuration](https://ibm.github.io/FHIR/guides/FHIRSearchConfiguration#12-Configuration--Filtering-of-search-parameters) for more information.|
 |`fhirServer/notifications/common/includeResourceTypes`|string list|A comma-separated list of resource types for which notification event messages should be published.|
 |`fhirServer/notifications/websocket/enabled`|boolean|A boolean flag which indicates whether or not websocket notifications are enabled.|
@@ -1380,6 +1381,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/core/defaultHandling`|strict|
 |`fhirServer/core/allowClientHandlingPref`|true|
 |`fhirServer/core/checkReferenceTypes`|true|
+|`fhirServer/core/conditionalDeleteMaxNumber`|10|
 |`fhirServer/searchParameterFilter`|`"*": [*]`|
 |`fhirServer/notifications/common/includeResourceTypes`|`["*"]`|
 |`fhirServer/notifications/websocket/enabled`|false|
@@ -1420,6 +1422,7 @@ must restart the server for that change to take effect.
 |`fhirServer/core/defaultHandling`|Y|Y|
 |`fhirServer/core/allowClientHandlingPref`|Y|Y|
 |`fhirServer/core/checkReferenceTypes`|N|N|
+|`fhirServer/core/conditionalDeleteMaxNumber`|N|N|
 |`fhirServer/searchParameterFilter`|Y|Y|
 |`fhirServer/notifications/common/includeResourceTypes`|N|N|
 |`fhirServer/notifications/websocket/enabled`|Y|Y|

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
@@ -160,6 +160,7 @@ public class ChunkWriter extends AbstractItemWriter {
                             + "_" + chunkData.getPartNum() + ".ndjson";
                 if (isExportPublic) {
                     // Set expiration time to 2 hours(7200 seconds).
+                    // Note: IBM COS doesn't honor this but also doesn't fail on this.
                     metadata.setExpirationTime(Date.from(Instant.now().plusSeconds(7200)));
                 }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
@@ -27,6 +27,8 @@ import com.ibm.cloud.objectstorage.services.s3.model.PutObjectRequest;
 import com.ibm.fhir.bulkcommon.BulkDataUtils;
 import com.ibm.fhir.bulkcommon.Constants;
 import com.ibm.fhir.bulkexport.common.TransientUserData;
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfiguration;
 
 /**
  * Bulk export Chunk implementation - the Writer.
@@ -35,6 +37,8 @@ import com.ibm.fhir.bulkexport.common.TransientUserData;
 public class ChunkWriter extends AbstractItemWriter {
     private static final Logger logger = Logger.getLogger(ChunkWriter.class.getName());
     private AmazonS3 cosClient = null;
+    private final boolean isExportPublic = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC, true);
+
     /**
      * The IBM COS API key or S3 access key.
      */
@@ -154,11 +158,18 @@ public class ChunkWriter extends AbstractItemWriter {
             if (cosBucketPathPrefix != null && cosBucketPathPrefix.trim().length() > 0) {
                 itemName = cosBucketPathPrefix + "/" + ResourceTypes.get(chunkData.getIndexOfCurrentResourceType())
                             + "_" + chunkData.getPartNum() + ".ndjson";
+                if (isExportPublic) {
+                    // Set expiration time to 2 hours(7200 seconds).
+                    metadata.setExpirationTime(Date.from(Instant.now().plusSeconds(7200)));
+                }
+
                 req = new PutObjectRequest(cosBucketName, itemName, in, metadata);
-                // Allow public read only if cosBucketPathPrefix is used.
-                req.setCannedAcl(CannedAccessControlList.PublicRead);
-                // Set expiration time to 2 hours(7200 seconds).
-                metadata.setExpirationTime(Date.from(Instant.now().plusSeconds(7200)));
+
+                if (isExportPublic) {
+                    // Give public read only access.
+                    req.setCannedAcl(CannedAccessControlList.PublicRead);
+                }
+
             } else {
                 itemName = "job" + jobContext.getExecutionId() + "/" + ResourceTypes.get(chunkData.getIndexOfCurrentResourceType())
                             + "_" + chunkData.getPartNum() + ".ndjson";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -32,6 +32,7 @@ public class FHIRConfiguration {
     public static final String PROPERTY_DEFAULT_HANDLING = "fhirServer/core/defaultHandling";
     public static final String PROPERTY_ALLOW_CLIENT_HANDLING_PREF = "fhirServer/core/allowClientHandlingPref";
     public static final String PROPERTY_CHECK_REFERENCE_TYPES = "fhirServer/core/checkReferenceTypes";
+    public static final String PROPERTY_CONDITIONAL_DELETE_MAX_NUMBER = "fhirServer/core/conditionalDeleteMaxNumber";
 
     public static final String PROPERTY_SEARCH_PARAMETER_FILTER = "fhirServer/searchParameterFilter";
 

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -86,6 +86,7 @@ public class FHIRConfiguration {
     public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHUSERPWD = "fhirServer/bulkdata/batch-user-password";
     public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTORE = "fhirServer/bulkdata/batch-truststore";
     public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTOREPWD = "fhirServer/bulkdata/batch-truststore-password";
+    public static final String PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC = "fhirServer/bulkdata/isExportPublic";
 
     // Custom header names
     public static final String DEFAULT_TENANT_ID_HEADER_NAME = "X-FHIR-TENANT-ID";

--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRConstants.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRConstants.java
@@ -11,4 +11,5 @@ package com.ibm.fhir.core;
  */
 public class FHIRConstants {
     public static final String FHIR_LOGGING_GROUP = "FHIRServer";
+    public static final int FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT = 10;
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -105,11 +105,11 @@ public class BundleTest extends FHIRServerTestBase {
 
     private static final String PREFER_HEADER_RETURN_REPRESENTATION = "return=representation";
     private static final String PREFER_HEADER_NAME = "Prefer";
-    
+
     /**
      * Retrieve the server's conformance statement to determine the status of
      * certain runtime options.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -128,7 +128,7 @@ public class BundleTest extends FHIRServerTestBase {
     }
 
     /**
-     * wraps very common pattern read, print, check the basics into one method. 
+     * wraps very common pattern read, print, check the basics into one method.
      * @param response
      * @param method
      * @return
@@ -139,9 +139,9 @@ public class BundleTest extends FHIRServerTestBase {
         commonWork(responseBundle,method);
         return responseBundle;
     }
-    
+
     /**
-     * wraps very common pattern read, print, check the basics into one method. 
+     * wraps very common pattern read, print, check the basics into one method.
      * @param response
      * @param method
      * @return
@@ -152,13 +152,13 @@ public class BundleTest extends FHIRServerTestBase {
         commonWork(responseBundle,method);
         return responseBundle;
     }
-    
+
     public void commonWork(Bundle responseBundle, String method) throws Exception{
         assertNotNull(responseBundle);
         printBundle(method, "response", responseBundle);
         checkForIssuesWithValidation(responseBundle, true, false);
     }
-        
+
     @Test(groups = { "batch" })
     public void testEmptyBundle() throws Exception {
         WebTarget target = getWebTarget();
@@ -178,7 +178,7 @@ public class BundleTest extends FHIRServerTestBase {
     @Test(groups = { "batch" })
     public void testMissingBundleType() throws Exception {
         WebTarget target = getWebTarget();
-        
+
         JsonObjectBuilder bundleObject = Json.createBuilderFactory(null).createObjectBuilder();
         bundleObject.add("resourceType", "Bundle");
 
@@ -192,7 +192,7 @@ public class BundleTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         Bundle bundle = Bundle.builder().type(BundleType.BATCH_RESPONSE).build();
-        
+
         // Add one non-empty entry to allow the entry pass the build validation.
         String patientLocalRef = "urn:Patient_testIncorrectBundleType";
 
@@ -224,7 +224,7 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<JsonObject> entity = Entity.entity(bundleWithEntry, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertEquals(200, response.getStatus());
-        
+
         Bundle responseBundle = response.readEntity(Bundle.class);
         assertEquals("400", responseBundle.getEntry().get(0).getResponse().getStatus().getValue());
     }
@@ -232,15 +232,15 @@ public class BundleTest extends FHIRServerTestBase {
     @Test(groups = { "batch" })
     public void testMissingMethod() throws Exception {
         WebTarget target = getWebTarget();
-        
+
         JsonObjectBuilder bundleObject = TestUtil.getEmptyBundleJsonObjectBuilder();
         JsonObject PatientJsonObject = TestUtil.readJsonObject("Patient_JohnDoe.json");
         JsonObject requestJsonObject = TestUtil.getRequestJsonObject("", "Patient");
         JsonObjectBuilder resourceObject = Json.createBuilderFactory(null).createObjectBuilder();
         resourceObject.add( "resource", PatientJsonObject).add("request", requestJsonObject);
-        
+
         bundleObject.add("Entry", Json.createBuilderFactory(null).createArrayBuilder().add(resourceObject));
-        
+
         Entity<JsonObject> entity = Entity.entity(bundleObject.build(), FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertTrue(response.getStatus() >= 400);
@@ -276,14 +276,14 @@ public class BundleTest extends FHIRServerTestBase {
     @Test(groups = { "batch" })
     public void testMissingResource() throws Exception {
         WebTarget target = getWebTarget();
-        
+
         JsonObjectBuilder bundleObject = TestUtil.getEmptyBundleJsonObjectBuilder();
         JsonObject requestJsonObject = TestUtil.getRequestJsonObject("POST", "Patient");
         JsonObjectBuilder resourceObject = Json.createBuilderFactory(null).createObjectBuilder();
-        resourceObject.add("request", requestJsonObject);   
-        
+        resourceObject.add("request", requestJsonObject);
+
         bundleObject.add("Entry", Json.createBuilderFactory(null).createArrayBuilder().add(resourceObject));
-        
+
         Entity<JsonObject> entity = Entity.entity(bundleObject.build(), FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertTrue(response.getStatus() >= 400);
@@ -318,10 +318,10 @@ public class BundleTest extends FHIRServerTestBase {
         JsonObject PatientJsonObject = TestUtil.readJsonObject("Patient_JohnDoe.json");
         JsonObject requestJsonObject = TestUtil.getRequestJsonObject("POST", "Patient");
         JsonObjectBuilder resourceObject = Json.createBuilderFactory(null).createObjectBuilder();
-        resourceObject.add( "resource", PatientJsonObject).add("request", requestJsonObject);   
-        
+        resourceObject.add( "resource", PatientJsonObject).add("request", requestJsonObject);
+
         bundleObject.add("Entry", Json.createBuilderFactory(null).createArrayBuilder().add(resourceObject));
-        
+
         Entity<JsonObject> entity = Entity.entity(bundleObject.build(), FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertTrue(response.getStatus() >= 400);
@@ -346,21 +346,21 @@ public class BundleTest extends FHIRServerTestBase {
         assertBadResponse(responseBundle.getEntry().get(0), Status.NOT_FOUND.getStatusCode(),
                 "Unrecognized path in request URL");
     }
-    
-    
+
+
 
     @Test(groups = { "batch" })
     public void testInvalidResource() throws Exception {
         WebTarget target = getWebTarget();
-        
+
         JsonObjectBuilder bundleObject = TestUtil.getEmptyBundleJsonObjectBuilder();
         JsonObject PatientJsonObject = TestUtil.readJsonObject("InvalidPatient.json");
         JsonObject requestJsonObject = TestUtil.getRequestJsonObject("POST", "Patient");
         JsonObjectBuilder resourceObject = Json.createBuilderFactory(null).createObjectBuilder();
         resourceObject.add( "resource", PatientJsonObject).add("request", requestJsonObject);
-        
+
         bundleObject.add("Entry", Json.createBuilderFactory(null).createArrayBuilder().add(resourceObject));
-        
+
         Entity<JsonObject> entity = Entity.entity(bundleObject.build(), FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertTrue(response.getStatus() >= 400);
@@ -402,27 +402,27 @@ public class BundleTest extends FHIRServerTestBase {
     @Test(groups = { "batch" })
     public void testInvalidSecondResource() throws Exception {
         WebTarget target = getWebTarget();
-        
-        
+
+
         JsonObjectBuilder bundleObject = TestUtil.getEmptyBundleJsonObjectBuilder();
-        
+
         JsonObject PatientJsonObject1 = TestUtil.readJsonObject("Patient_DavidOrtiz.json");
         JsonObject PatientJsonObject2 = TestUtil.readJsonObject("InvalidPatient.json");
         JsonObject PatientJsonObject3 = TestUtil.readJsonObject("Patient_JohnDoe.json");
         JsonObject requestJsonObject = TestUtil.getRequestJsonObject("POST", "Patient");
-        
+
         JsonObjectBuilder resourceObject1 = Json.createBuilderFactory(null).createObjectBuilder();
         resourceObject1.add( "resource", PatientJsonObject1).add("request", requestJsonObject);
-        
+
         JsonObjectBuilder resourceObject2 = Json.createBuilderFactory(null).createObjectBuilder();
         resourceObject2.add( "resource", PatientJsonObject2).add("request", requestJsonObject);
-        
+
         JsonObjectBuilder resourceObject3 = Json.createBuilderFactory(null).createObjectBuilder();
         resourceObject3.add( "resource", PatientJsonObject3).add("request", requestJsonObject);
-        
+
         bundleObject.add("Entry", Json.createBuilderFactory(null).createArrayBuilder()
                 .add(resourceObject1).add(resourceObject2).add(resourceObject3));
-        
+
         Entity<JsonObject> entity = Entity.entity(bundleObject.build(), FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertTrue(response.getStatus() >= 400);
@@ -448,7 +448,7 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 3);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
@@ -480,7 +480,7 @@ public class BundleTest extends FHIRServerTestBase {
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -512,9 +512,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -546,9 +546,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -589,9 +589,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertBadResponse(responseBundle.getEntry().get(1), Status.PRECONDITION_FAILED.getStatusCode(),
@@ -634,9 +634,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertBadResponse(responseBundle.getEntry().get(0), Status.PRECONDITION_FAILED.getStatusCode(),
                 "If-Match version '1' does not match current latest version of resource: 3");
@@ -679,9 +679,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertBadResponse(responseBundle.getEntry().get(0), Status.PRECONDITION_FAILED.getStatusCode(),
                 "If-Match version '2' does not match current latest version of resource: 3");
@@ -712,9 +712,9 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response = getFHIRClient().batch(bundle);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -747,7 +747,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
 
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -768,9 +768,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
@@ -778,7 +778,7 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle resultSet = (Bundle) responseBundle.getEntry().get(0).getResource();
         assertNotNull(resultSet);
         assertTrue(resultSet.getEntry().size() > 1);
-        
+
         boolean result = false;
         for(Bundle.Entry entry : resultSet.getEntry()) {
             if(entry.getResponse() != null){
@@ -804,9 +804,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
@@ -831,9 +831,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
 
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
@@ -865,9 +865,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
@@ -892,9 +892,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
@@ -928,9 +928,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 1);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
@@ -970,9 +970,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 6);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -1030,9 +1030,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -1078,9 +1078,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -1118,9 +1118,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -1159,9 +1159,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -1191,7 +1191,7 @@ public class BundleTest extends FHIRServerTestBase {
         Patient patientVA2 = res1.readEntity(Patient.class);
         assertNotNull(patientVA2);
         checkForIssuesWithValidation(patientVA2, true, false);
-                
+
         assertNotNull(patientTVA1);
         Response res2 = target.path("Patient/" + patientTVA1.getId())
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
@@ -1199,7 +1199,7 @@ public class BundleTest extends FHIRServerTestBase {
         Patient patientVA1 = res2.readEntity(Patient.class);
         assertNotNull(patientVA1);
         checkForIssuesWithValidation(patientVA1, true, false);
-        
+
         // Retrieve the family names of the resources to be updated.
         String family1 = patientVA1.getName().get(0).getFamily().getValue();
         String family2 = patientVA2.getName().get(0).getFamily().getValue();
@@ -1218,12 +1218,12 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
-        
+
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.CONFLICT);
-        
+
         assertSearchResults(target, family1, 1);
         assertSearchResults(target, family2, 1);
 
@@ -1259,10 +1259,10 @@ public class BundleTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
 
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.CONFLICT);
-        
+
         assertSearchResults(target, family1, 1);
         assertSearchResults(target, family2, 1);
 
@@ -1383,7 +1383,7 @@ public class BundleTest extends FHIRServerTestBase {
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.INVALID);
     }
@@ -1522,7 +1522,7 @@ public class BundleTest extends FHIRServerTestBase {
         Response response = target.request().header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION).post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         // Verify that each resource was created as expected.
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 6);
         for (int i = 0; i < 6; i++) {
@@ -1579,7 +1579,7 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
         // Verify that each resource was created as expected.
@@ -1657,7 +1657,7 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
         // Verify that each of the Observations was updated,
@@ -1721,7 +1721,7 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = response.readEntity(Bundle.class);
         printBundle(method, "response", responseBundle);
         checkForIssuesWithValidation(responseBundle, true, false);
@@ -1845,9 +1845,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -1877,9 +1877,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 3);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
@@ -1910,9 +1910,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 4);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.GONE.getStatusCode());
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -1938,9 +1938,9 @@ public class BundleTest extends FHIRServerTestBase {
                                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                                 .post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.CREATED.getStatusCode());
@@ -1969,9 +1969,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
@@ -2000,9 +2000,9 @@ public class BundleTest extends FHIRServerTestBase {
         Entity<Bundle> entity = Entity.entity(bundle, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
-        
+
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.DELETED);
     }
@@ -2029,11 +2029,11 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response = client.batch(bundle);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = response.getResource(Bundle.class);
         printBundle(method, "response", responseBundle);
         checkForIssuesWithValidation(responseBundle, true, false);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 4);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -2060,11 +2060,11 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response = client.transaction(bundle);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
-        
+
         Bundle responseBundle = response.getResource(Bundle.class);
         printBundle(method, "response", responseBundle);
         checkForIssuesWithValidation(responseBundle, true, false);
-        
+
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
         assertGoodPostPutResponse(responseBundle.getEntry().get(0), Status.CREATED.getStatusCode());
         assertGoodPostPutResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
@@ -2087,7 +2087,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertResponse(response.getResponse(), Response.Status.BAD_REQUEST.getStatusCode());
 
         OperationOutcome oo = response.getResource(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.MULTIPLE_MATCHES);
     }
@@ -2107,9 +2107,9 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response = client.transaction(bundle);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.BAD_REQUEST.getStatusCode());
-        
+
         OperationOutcome oo = response.getResource(OperationOutcome.class);
-        
+
         assertNotNull(oo);
         assertEquals(oo.getIssue().get(0).getCode().getValueAsEnumConstant(), IssueType.ValueSet.INVALID);
     }
@@ -2209,8 +2209,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 4);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertBadResponse(responseBundle.getEntry().get(2), Status.PRECONDITION_FAILED.getStatusCode(),
-                "returned multiple matches");
+        assertGoodGetResponse(responseBundle.getEntry().get(2), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertBadResponse(responseBundle.getEntry().get(3), Status.BAD_REQUEST.getStatusCode(),
                 "Search parameter 'NOTASEARCH' for resource type 'Patient' was not found.");
 
@@ -2256,7 +2255,7 @@ public class BundleTest extends FHIRServerTestBase {
         Response response = target.request().post(entity, Response.class);
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle responseBundle = getEntityWithExtraWork(response,method);
-        
+
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
         // Commented out because $hello operation isn't installed by default
 //        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
@@ -2378,7 +2377,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertEquals(expectedResults, bundle.getEntry().size());
     }
-    
+
     private void assertGoodGetResponse(Bundle.Entry entry, int expectedStatusCode) throws Exception {
         assertGoodGetResponse(entry, expectedStatusCode, HTTPReturnPreference.REPRESENTATION);
     }
@@ -2400,7 +2399,7 @@ public class BundleTest extends FHIRServerTestBase {
     private void assertGoodPostPutResponse(Bundle.Entry entry, int expectedStatusCode) throws Exception {
         assertGoodPostPutResponse(entry, expectedStatusCode, HTTPReturnPreference.MINIMAL);
     }
-    
+
     private void assertGoodPostPutResponse(Bundle.Entry entry, int expectedStatusCode, HTTPReturnPreference returnPref) throws Exception {
         assertGoodGetResponse(entry, expectedStatusCode, returnPref);
         Bundle.Entry.Response response = entry.getResponse();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -2211,7 +2211,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
 
         // A search that results in multiple matches:
-        // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 400 status code.
+        // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 412 status code.
         // (2) if matches <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 204 status code.
         WebTarget target = getWebTarget();
         Response response2 =
@@ -2221,7 +2221,7 @@ public class BundleTest extends FHIRServerTestBase {
         if (searchResultBundle.getTotal().getValue() <= 10 ) {
             assertGoodGetResponse(responseBundle.getEntry().get(2), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
         } else {
-            assertBadResponse(responseBundle.getEntry().get(2), Status.BAD_REQUEST.getStatusCode(),
+            assertBadResponse(responseBundle.getEntry().get(2), Status.PRECONDITION_FAILED.getStatusCode(),
                     "The search criteria specified for a conditional delete operation returned too many matches");
         }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -14,16 +14,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.FHIRParameters;
 import com.ibm.fhir.client.FHIRResponse;
+import com.ibm.fhir.core.FHIRConstants;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.MedicationAdministration;
 import com.ibm.fhir.model.resource.Observation;
+import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
@@ -45,7 +50,7 @@ public class DeleteTest extends FHIRServerTestBase {
 
     /**
      * Retrieve the server's conformance statement to determine the status of certain runtime options.
-     * 
+     *
      * @throws Exception
      */
     @BeforeClass
@@ -321,7 +326,7 @@ public class DeleteTest extends FHIRServerTestBase {
             // Read in the resource template.
             Patient patient = TestUtil.readLocalResource("Patient_MookieBetts.json");
 
-            // Add the uniqueFamily name         
+            // Add the uniqueFamily name
             patient = setUniqueFamilyName(patient, uniqueFamilyName);
 
             response = client.create(patient);
@@ -397,14 +402,14 @@ public class DeleteTest extends FHIRServerTestBase {
         if (!deleteSupported) {
             return;
         }
-        
+
         String fakePatientRef = "Patient/" + UUID.randomUUID().toString();
         String obsId = UUID.randomUUID().toString();
         Observation obs = TestUtil.readLocalResource("Observation1.json");
-        
+
         obs = obs.toBuilder().id(obsId).subject(Reference.builder().reference(string(fakePatientRef)).build()).build();
 
-        
+
         // First conditional delete should find no matches, so we should get back a 200 OK.
         FHIRParameters query = new FHIRParameters().searchParam("_id", obsId);
         FHIRResponse response = client.conditionalDelete("Observation", query);
@@ -414,12 +419,12 @@ public class DeleteTest extends FHIRServerTestBase {
         } else {
             assertResponse(response.getResponse(), Response.Status.METHOD_NOT_ALLOWED.getStatusCode());
         }
-        
+
         // Next, create an Observation (using update for create) so that we can test conditional delete.
         response = client.update(obs);
         assertNotNull(response);
         assertResponse(response.getResponse(), Response.Status.CREATED.getStatusCode());
-        
+
         // Second conditional delete should find 1 match, so we should get back a 200.
         response = client.conditionalDelete("Observation", query);
         assertNotNull(response);
@@ -430,17 +435,31 @@ public class DeleteTest extends FHIRServerTestBase {
         } else {
             assertResponse(response.getResponse(), Response.Status.METHOD_NOT_ALLOWED.getStatusCode());
         }
-        
-        // A search that results in multiple matches should result in a 412 status code.
+
+        // A search that results in multiple matches:
+        // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 400 status code.
+        // (2) if matches <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 204 status code.
+        WebTarget target = getWebTarget();
+        Response response2 =
+                target.path("Observation").queryParam("status", "final").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response2, Response.Status.OK.getStatusCode());
+        Bundle searchResultBundle = response2.readEntity(Bundle.class);
+
         FHIRParameters multipleMatches = new FHIRParameters().searchParam("status", "final");
-        response = client.conditionalUpdate(obs, multipleMatches);
+        response = client.conditionalDelete("Observation", multipleMatches);
         assertNotNull(response);
         if (deleteSupported) {
-            assertResponse(response.getResponse(), Response.Status.PRECONDITION_FAILED.getStatusCode());
+            if (searchResultBundle.getTotal().getValue() <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT ) {
+                assertResponse(response.getResponse(), Status.NO_CONTENT.getStatusCode());
+            } else {
+                assertResponse(response, Status.BAD_REQUEST.getStatusCode());
+                assertExceptionOperationOutcome(response.getResponse().readEntity(OperationOutcome.class),
+                        "The search criteria specified for a conditional delete operation returned too many matches");
+            }
         } else {
             assertResponse(response.getResponse(), Response.Status.METHOD_NOT_ALLOWED.getStatusCode());
         }
-        
+
         // Finally, an invalid search should result in a 400 status code.
         FHIRParameters badSearch = new FHIRParameters().searchParam("invalid:search", "foo");
         response = client.conditionalUpdate(obs, badSearch);
@@ -450,5 +469,5 @@ public class DeleteTest extends FHIRServerTestBase {
         } else {
             assertResponse(response.getResponse(), Response.Status.METHOD_NOT_ALLOWED.getStatusCode());
         }
-    }    
+    }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -437,7 +437,7 @@ public class DeleteTest extends FHIRServerTestBase {
         }
 
         // A search that results in multiple matches:
-        // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 400 status code.
+        // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 412 status code.
         // (2) if matches <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 204 status code.
         WebTarget target = getWebTarget();
         Response response2 =
@@ -452,7 +452,7 @@ public class DeleteTest extends FHIRServerTestBase {
             if (searchResultBundle.getTotal().getValue() <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT ) {
                 assertResponse(response.getResponse(), Status.NO_CONTENT.getStatusCode());
             } else {
-                assertResponse(response, Status.BAD_REQUEST.getStatusCode());
+                assertResponse(response, Status.PRECONDITION_FAILED.getStatusCode());
                 assertExceptionOperationOutcome(response.getResponse().readEntity(OperationOutcome.class),
                         "The search criteria specified for a conditional delete operation returned too many matches");
             }

--- a/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
@@ -40,7 +40,26 @@
                         "driverType": 4
                     }
                 }
-            }
+            },
+        	"bulkdata": {
+            "bulkDataBatchJobIdEncryptionKey": "change-password",
+            "applicationName": "fhir-bulkimportexport-webapp",
+            "moduleName": "fhir-bulkimportexport.war",
+            "jobParameters": {
+                "cos.bucket.name": "fhir-r4-connectathon",
+                "cos.location": "us",
+                "cos.endpointurl": "fake",
+                "cos.credential.ibm": "Y",
+                "cos.api.key": "fake",
+                "cos.srvinst.id": "fake"
+            },
+            "implementation_type": "cos",
+            "batch-uri": "https://localhost:9443/ibm/api/batch/jobinstances",
+            "batch-user": "fhiradmin",
+            "batch-user-password": "change-password",
+            "batch-truststore": "resources/security/fhirTruststore.jks",
+            "batch-truststore-password": "change-password",
+            "isExportPublic": true
         }
     }
 }

--- a/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
@@ -40,8 +40,9 @@
                         "driverType": 4
                     }
                 }
-            },
-        	"bulkdata": {
+            }
+        },
+        "bulkdata": {
             "bulkDataBatchJobIdEncryptionKey": "change-password",
             "applicationName": "fhir-bulkimportexport-webapp",
             "moduleName": "fhir-bulkimportexport.war",

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -109,7 +109,6 @@
                 "cos.bucket.name": "fhir-r4-connectathon",
                 "cos.location": "us",
                 "cos.endpointurl": "fake",
-                "fhir.tenant": "default",
                 "cos.credential.ibm": "Y",
                 "cos.api.key": "fake",
                 "cos.srvinst.id": "fake"
@@ -119,7 +118,8 @@
             "batch-user": "fhiradmin",
             "batch-user-password": "change-password",
             "batch-truststore": "resources/security/fhirTruststore.jks",
-            "batch-truststore-password": "change-password"
+            "batch-truststore-password": "change-password",
+            "isExportPublic": true
         }
     }
 }

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -6,7 +6,8 @@
             "truststorePassword": "change-password",
             "tenantIdHeaderName": "X-FHIR-TENANT-ID",
             "datastoreIdHeaderName": "X-FHIR-DSID",
-            "checkReferenceTypes": true
+            "checkReferenceTypes": true,
+            "conditionalDeleteMaxNumber": 10
         },
         "authFilter": {
             "enabled": false,

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -168,7 +168,7 @@ public class Capabilities extends FHIRResource {
                     .conditionalCreate(com.ibm.fhir.model.type.Boolean.of(true))
                     .conditionalUpdate(com.ibm.fhir.model.type.Boolean.of(true))
                     .updateCreate(com.ibm.fhir.model.type.Boolean.of(isUpdateCreateEnabled()))
-                    .conditionalDelete(ConditionalDeleteStatus.SINGLE)
+                    .conditionalDelete(ConditionalDeleteStatus.MULTIPLE)
                     .conditionalRead(ConditionalReadStatus.FULL_SUPPORT)
                     .searchParam(conformanceSearchParams)
                     .build();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -542,7 +542,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     return ior;
                 } else if (responseBundle.getTotal().getValue() > searchPageSize) {
                     String msg = "The search criteria specified for a conditional delete operation returned too many matches ( > " + searchPageSize + " ).";
-                    throw buildRestException(msg, IssueType.TOO_COSTLY);
+                    throw buildRestException(msg, IssueType.MULTIPLE_MATCHES);
                 }
             } else {
                 // Make sure an id value was passed in.


### PR DESCRIPTION
(1)This PR enabled fhir server to support conditional delete with multiple matches.
passed all tests including the 2 touchstone fhir-api-r4-patient-delete-03-conditional-multiple test cases which failed before.

https://touchstone.aegis.net/touchstone/scriptexecution?exec=202003301558230438592632&qn=/FHIR4-0-1-Advanced/Patient/05-delete/fhir-api-r4-patient-delete-03-conditional-multiple#WAITING_OPER
(2) This PR also added server configure "fhirserver.bulkdata.isExportPublic" to allow user to disable public access to the exported files in COS/S3.
 