### PR TITLE
issue #910 - test create warnings and add PL-generated warnings

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -96,9 +96,9 @@ public class FHIRUtil {
 
     /**
      * Converts a Visitable (Element or Resource) instance to a string using a FHIRGenerator.
-     * 
+     *
      * <p>The toString format (JSON or XML) can be specified through {@link FHIRModelConfig#setToStringFormat(Format)}.
-     * 
+     *
      * @param visitable
      *     the Element or Resource instance to be converted
      * @return
@@ -147,7 +147,7 @@ public class FHIRUtil {
     public static OperationOutcome.Issue buildOperationOutcomeIssue(IssueSeverity severity, IssueType code, String details) {
         return buildOperationOutcomeIssue(severity, code, details, null);
     }
-    
+
     public static OperationOutcome.Issue buildOperationOutcomeIssue(IssueSeverity severity, IssueType code, String details,
             String expression) {
         if (expression == null || expression.isEmpty()) {
@@ -467,7 +467,7 @@ public class FHIRUtil {
     private static String getExtensionStringValue(String extensionUrl, List<Extension> extensions) {
         String value = null;
         for (Extension ext : extensions) {
-            if (ext.getValue() != null && ext.getUrl().equals(extensionUrl) && 
+            if (ext.getValue() != null && ext.getUrl().equals(extensionUrl) &&
                     ext.getValue().is(com.ibm.fhir.model.type.String.class)) {
                 value = ext.getValue().as(com.ibm.fhir.model.type.String.class).getValue();
                 break;
@@ -552,7 +552,7 @@ public class FHIRUtil {
      * @return
      */
     public static boolean isFailure(IssueSeverity severity) {
-        switch (IssueSeverity.ValueSet.from(severity.getValue())) {
+        switch (severity.getValueAsEnumConstant()) {
         case INFORMATION:
         case WARNING:
             return false;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -23,6 +23,7 @@ import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -114,6 +116,9 @@ import com.ibm.fhir.search.util.SearchUtil;
 /**
  * The JDBC implementation of the FHIRPersistence interface,
  * providing implementations for CRUD APIs and search.
+ *
+ * @implNote This class is request-scoped;
+ *           it must be initialized for each request to reset the supplementalIssues list
  */
 public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistenceTransaction {
     private static final String CLASSNAME = FHIRPersistenceJDBCImpl.class.getName();
@@ -126,6 +131,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
     private ResourceDAO resourceDao;
     private ParameterDAO parameterDao;
     private TransactionSynchronizationRegistry trxSynchRegistry;
+    private List<OperationOutcome.Issue> supplementalIssues = new ArrayList<>();
 
     protected Connection sharedConnection = null;
     protected UserTransaction userTransaction = null;
@@ -207,8 +213,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         String logicalId;
 
         // We need to update the meta in the resource, so we need a modifiable version
-        Resource.Builder resultBuilder = resource.toBuilder();
-
+        Resource.Builder resultResourceBuilder = resource.toBuilder();
 
         try {
             // This create() operation is only called by a REST create. If the given resource
@@ -223,16 +228,16 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
 
             // Set the resource id and meta fields.
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-            resultBuilder.id(logicalId);
+            resultResourceBuilder.id(logicalId);
             Meta meta = resource.getMeta();
             Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
             metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
             metaBuilder.lastUpdated(lastUpdated);
-            resultBuilder.meta(metaBuilder.build());
+            resultResourceBuilder.meta(metaBuilder.build());
 
             // rebuild the resource with updated meta
             @SuppressWarnings("unchecked")
-            T updatedResource = (T) resultBuilder.build();
+            T updatedResource = (T) resultResourceBuilder.build();
 
             // Create the new Resource DTO instance.
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
@@ -257,12 +262,18 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                             + ", version=" + resourceDTO.getVersionId());
             }
 
-            SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
+            SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                     .success(true)
-                    .resource(updatedResource)
-                    .build();
+                    .resource(updatedResource);
 
-            return result;
+            // Add supplemental issues to the OperationOutcome
+            if (!supplementalIssues.isEmpty()) {
+                resultBuilder.outcome(OperationOutcome.builder()
+                    .issue(supplementalIssues)
+                    .build());
+            }
+
+            return resultBuilder.build();
         }
         catch(FHIRPersistenceFKVException e) {
             log.log(Level.SEVERE, "FK violation", e);
@@ -293,7 +304,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
         // Resources are immutable, so we need a new builder to update it (since R4)
-        Resource.Builder resultBuilder = resource.toBuilder();
+        Resource.Builder resultResourceBuilder = resource.toBuilder();
 
         try {
             // Assume we have no existing resource.
@@ -348,10 +359,10 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
             Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
             metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
             metaBuilder.lastUpdated(lastUpdated);
-            resultBuilder.meta(metaBuilder.build());
+            resultResourceBuilder.meta(metaBuilder.build());
 
             @SuppressWarnings("unchecked")
-            T updatedResource = (T) resultBuilder.build();
+            T updatedResource = (T) resultResourceBuilder.build();
 
             // Create the new Resource DTO instance.
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
@@ -376,12 +387,18 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                             + ", version=" + resourceDTO.getVersionId());
             }
 
-            SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
+            SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                     .success(true)
-                    .resource(updatedResource)
-                    .build();
+                    .resource(updatedResource);
 
-            return result;
+            // Add supplemental issues to an OperationOutcome
+            if (!supplementalIssues.isEmpty()) {
+                resultBuilder.outcome(OperationOutcome.builder()
+                    .issue(supplementalIssues)
+                    .build());
+            }
+
+            return resultBuilder.build();
         }
         catch(FHIRPersistenceFKVException e) {
             log.log(Level.SEVERE, this.performCacheDiagnostics());
@@ -619,7 +636,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
             }
         }
         catch(FHIRPersistenceFKVException e) {
-            log.log(Level.SEVERE, this.performCacheDiagnostics());
+            log.log(Level.INFO, this.performCacheDiagnostics());
             throw e;
         }
         catch(FHIRPersistenceException e) {
@@ -1127,24 +1144,27 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                                     p.addComponent(primitiveParam);
                                 } else {
                                     // log and continue
+                                    String msg = "Unable to extract value from '" + value.path() +
+                                            "'; search parameter value extraction can only be performed on Elements and primitive values.";
                                     if (log.isLoggable(Level.FINE)) {
-                                        log.fine("Unable to extract value from '" + value.path() +
-                                                "'; search parameter value extraction can only be performed on Elements and primitive values.");
+                                        log.fine(msg);
                                     }
-                                    // TODO: return this as a OperationOutcomeIssue with severity of WARNING
+                                    addWarning(IssueType.INVALID, msg);
                                     continue;
                                 }
                             } catch (IllegalArgumentException e) {
                                 // log and continue with the other parameters
-                                StringBuilder msg = new StringBuilder("Skipping search parameter '" + code + "'");
+                                StringBuilder msg = new StringBuilder("Skipped search parameter '" + code + "'");
                                 if (sp.getId() != null) {
                                     msg.append(" with id '" + sp.getId() + "'");
                                 }
                                 msg.append(" for resource type " + fhirResource.getClass().getSimpleName());
                                 // just use the message...no need for the whole stack trace
                                 msg.append(" due to \n" + e.getMessage());
-                                log.log(Level.INFO, msg.toString());
-                                // TODO: add an issue to the OperationOutcome in the return object
+                                if (log.isLoggable(Level.FINE)) {
+                                    log.fine(msg.toString());
+                                }
+                                addWarning(IssueType.INVALID, msg.toString());
                             }
                         }
                         if (components.size() == p.getComponent().size()) {
@@ -1152,7 +1172,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                             allParameters.add(p);
                         }
                     }
-                } else {
+                } else { // ! SearchParamType.COMPOSITE.equals(sp.getType())
                     JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(sp);
 
                     for (FHIRPathNode value : values) {
@@ -1171,11 +1191,12 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                                 }
                             } else {
                                 // log and continue
+                                String msg = "Unable to extract value from '" + value.path() +
+                                        "'; search parameter value extraction can only be performed on Elements and primitive values.";
                                 if (log.isLoggable(Level.FINE)) {
-                                    log.fine("Unable to extract value from '" + value.path() +
-                                            "'; search parameter value extraction can only be performed on Elements and primitive values.");
+                                    log.fine(msg);
                                 }
-                                // TODO: return this as a OperationOutcomeIssue with severity of WARNING
+                                addWarning(IssueType.INVALID, msg);
                                 continue;
                             }
                         } catch (IllegalArgumentException e) {
@@ -1187,8 +1208,10 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
                             msg.append(" for resource type " + fhirResource.getClass().getSimpleName());
                             // just use the message...no need for the whole stack trace
                             msg.append(" due to \n" + e.getMessage());
-                            log.log(Level.INFO, msg.toString());
-                            // TODO: add an issue to the OperationOutcome in the return object
+                            if (log.isLoggable(Level.FINE)) {
+                                log.fine(msg.toString());
+                            }
+                            addWarning(IssueType.INVALID, msg.toString());
                         }
                     }
                     // retrieve the list of parameters built from all the FHIRPathElementNode values
@@ -1429,8 +1452,8 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      */
     // This variant uses generics and is used in history.
     // TODO: this method needs to either get merged or better differentiated with the old one used for search
-    protected <T extends Resource> List<T> convertResourceDTOList(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList, Class<T> resourceType)
-                                throws FHIRException, IOException {
+    protected <T extends Resource> List<T> convertResourceDTOList(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList,
+            Class<T> resourceType) throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO List";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -1457,8 +1480,8 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
     // This variant doesn't use generics and is used in search.
     // TODO: this method needs to either get merged or better differentiated with the new one that supports history operation via generics.
     // Start by better understanding what happens for `_include` and `_revinclude` search results that contain multiple different types
-    protected List<Resource> convertResourceDTOListOld(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList, Class<? extends Resource> resourceType)
-                                throws FHIRException, IOException {
+    protected List<Resource> convertResourceDTOListOld(List<com.ibm.fhir.persistence.jdbc.dto.Resource> resourceDTOList,
+            Class<? extends Resource> resourceType) throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO List";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -1484,8 +1507,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @throws IOException
      */
     private <T extends Resource> T convertResourceDTO(com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO,
-            Class<T> resourceType,
-            List<String> elements) throws FHIRException, IOException {
+            Class<T> resourceType, List<String> elements) throws FHIRException, IOException {
         final String METHODNAME = "convertResourceDTO";
         log.entering(CLASSNAME, METHODNAME);
         T resource = null;
@@ -1619,6 +1641,19 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         finally {
             log.exiting(CLASSNAME, METHODNAME);
         }
+    }
 
+    /**
+     * Associate a supplemental warning with the current request
+     */
+    private void addWarning(IssueType issueType, String message, String... expression) {
+        supplementalIssues.add(OperationOutcome.Issue.builder()
+                .severity(IssueSeverity.WARNING)
+                .code(issueType)
+                .details(CodeableConcept.builder()
+                    .text(string(message))
+                    .build())
+                .expression(Arrays.stream(expression).map(com.ibm.fhir.model.type.String::string).collect(Collectors.toList()))
+                .build());
     }
 }

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
@@ -81,7 +81,8 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
             Format format = getFormat(mediaType);
             FHIRParser parser = FHIRParser.parser(format);
             if (parser.isPropertySupported(FHIRParser.PROPERTY_IGNORE_UNRECOGNIZED_ELEMENTS)) {
-                parser.setProperty(FHIRParser.PROPERTY_IGNORE_UNRECOGNIZED_ELEMENTS, HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+                parser.setProperty(FHIRParser.PROPERTY_IGNORE_UNRECOGNIZED_ELEMENTS,
+                        HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
             }
             return parser.parse(entityStream);
         } catch (FHIRParserException e) {
@@ -135,7 +136,7 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
         // Header evaluation
         String value = httpHeaders.getHeaderString(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME);
 
-        // IFF not Header set, then grab the Query Parameter. 
+        // IFF not Header set, then grab the Query Parameter.
         // and use the FIRST value for _pretty.
         if (value == null) {
             value = uriInfo.getQueryParameters().getFirst("_pretty");

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -629,12 +629,14 @@ public class SearchUtil {
                         if (ModelSupport.isResourceType(resType)) {
                             resourceTypes.add(resType);
                         } else {
+                            String msg = "_type search parameter has invalid resource type:" + resType;
                             if (lenient) {
-                                log.log(Level.FINE, resType + " is not valid resource type!");
+                                // TODO add this to the list of supplemental warnings?
+                                log.log(Level.FINE, resType + " is not a valid resource type");
                                 continue;
                             } else {
                                 throw SearchExceptionUtil.buildNewInvalidSearchException(
-                                        "_type search parameter has invilid resource type:" + resType);
+                                        "_type search parameter has invalid resource type:" + resType);
                             }
                         }
                     }
@@ -754,6 +756,7 @@ public class SearchUtil {
                         "Error while parsing search parameter '" + name + "' for resource type "
                                 + resourceType.getSimpleName();
                 if (lenient) {
+                    // TODO add this to the list of supplemental warnings?
                     log.log(Level.FINE, msg, se);
                 } else {
                     throw se;
@@ -1431,6 +1434,7 @@ public class SearchUtil {
             if (searchParm == null) {
                 String msg = "Undefined Inclusion Parameter: " + inclusionValue;
                 if (lenient) {
+                    // TODO add this to the list of supplemental warnings?
                     log.fine(msg);
                     continue;
                 } else {
@@ -1570,6 +1574,7 @@ public class SearchUtil {
                 }
                 if (!resourceFieldNames.contains(elementName)) {
                     if (lenient) {
+                        // TODO add this to the list of supplemental warnings?
                         log.fine("Skipping unknown element name: " + elementName);
                         continue;
                     } else {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
@@ -28,13 +28,18 @@ import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.resource.Immunization;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.ContactPoint;
+import com.ibm.fhir.model.type.Narrative;
+import com.ibm.fhir.model.type.Xhtml;
 import com.ibm.fhir.model.type.code.ContactPointSystem;
 import com.ibm.fhir.model.type.code.ContactPointUse;
+import com.ibm.fhir.model.type.code.NarrativeStatus;
 
 /**
  * Basic sniff test of the FHIR Server.
@@ -127,7 +132,7 @@ public class BasicServerTest extends FHIRServerTestBase {
 
         TestUtil.assertResourceEquals(patient, responsePatient);
     }
-    
+
     /**
      * Create a minimal Patient, then make sure we can retrieve it with varying format
      */
@@ -202,18 +207,18 @@ public class BasicServerTest extends FHIRServerTestBase {
 
         TestUtil.assertResourceEquals(observation, responseObs);
     }
-    
+
     @Test( groups = { "server-basic" })
-    public void testCreateObservationWithUnrecognizedElements1() throws Exception {
+    public void testCreateObservationWithUnrecognizedElements_strict() throws Exception {
         WebTarget target = getWebTarget();
         JsonObject jsonObject = TestUtil.readJsonObject("testdata/observation-unrecognized-elements.json");
         Entity<JsonObject> entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Observation").request().post(entity, Response.class);
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
     }
-    
+
     @Test( groups = { "server-basic" })
-    public void testCreateObservationWithUnrecognizedElements2() throws Exception {
+    public void testCreateObservationWithUnrecognizedElements_lenient_minimal() throws Exception {
         WebTarget target = getWebTarget();
         JsonObject jsonObject = TestUtil.readJsonObject("testdata/observation-unrecognized-elements.json");
         Entity<JsonObject> entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
@@ -221,6 +226,58 @@ public class BasicServerTest extends FHIRServerTestBase {
                     .header("Prefer", "handling=lenient")
                     .post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
+    }
+
+    @Test( groups = { "server-basic" })
+    public void testCreateObservationWithUnrecognizedElements_lenient_representation() throws Exception {
+        WebTarget target = getWebTarget();
+        JsonObject jsonObject = TestUtil.readJsonObject("testdata/observation-unrecognized-elements.json");
+        Entity<JsonObject> entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Observation").request()
+                    .header("Prefer", "handling=lenient;return=representation")
+                    .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+        assertNotNull(response.readEntity(Observation.class));
+    }
+
+    @Test( groups = { "server-basic" })
+    public void testCreateObservationWithUnrecognizedElements_lenient_OperationOutcome() throws Exception {
+        WebTarget target = getWebTarget();
+        JsonObject jsonObject = TestUtil.readJsonObject("testdata/observation-unrecognized-elements.json");
+        Entity<JsonObject> entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Observation").request()
+                    .header("Prefer", "handling=lenient; return=OperationOutcome")
+                    .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+        OperationOutcome outcome = response.readEntity(OperationOutcome.class);
+        assertNotNull(outcome);
+        assertTrue(outcome.getIssue().size() > 0);
+    }
+
+    @Test( groups = { "server-basic" })
+    public void testCreateImmunizationWithInvalidSearchParameter() throws Exception {
+        // This test takes advantage of a issue with the 4.0.1 spec (https://jira.hl7.org/browse/FHIR-25173)
+        // to verify that supplemental warnings that are added by the persistence layer will make it to the response
+        WebTarget target = getWebTarget();
+        Immunization resource = TestUtil.readExampleResource("json/ibm/minimal/Immunization-1.json");
+        // 1. Add narrative text to avoid dom-6 (A resource should have narrative for robust management)
+        // 2. Set occurrence to a String to get the searchparameter warning added by the persistence layer
+        resource = resource.toBuilder()
+                .text(Narrative.builder()
+                    .status(NarrativeStatus.EMPTY)
+                    .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">test</div>"))
+                    .build())
+                .occurrence(string("now"))
+                .build();
+        Entity<Resource> entity = Entity.entity(resource, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Immunization").request()
+                    .header("Prefer", "return=OperationOutcome")
+                    .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+        OperationOutcome outcome = response.readEntity(OperationOutcome.class);
+        assertNotNull(outcome);
+        assertTrue(outcome.getIssue().size() > 0);
+        assertTrue(outcome.getIssue().get(0).getDetails().getText().getValue().startsWith("Skipping search parameter 'date'"));
     }
 
     /**
@@ -309,7 +366,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         assertEquals(originalPatient.getId(), updatedPatient.getId());
         assertTrue(!updatedPatient.getMeta().getVersionId().getValue()
                 .contentEquals(originalPatient.getMeta().getVersionId().getValue()));
-        // Patient create time should be earlier than Patient update time.       
+        // Patient create time should be earlier than Patient update time.
         assertTrue(originalPatient.getMeta().getLastUpdated().getValue()
                 .compareTo(updatedPatient.getMeta().getLastUpdated().getValue()) < 0);
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -308,7 +308,7 @@ public class FHIRResource {
         if (persistence == null) {
             persistence = getPersistenceHelper().getFHIRPersistenceImplementation();
             if (log.isLoggable(Level.FINE)) {
-                log.fine("Obtained new  FHIRPersistence instance: " + persistence);
+                log.fine("Obtained new FHIRPersistence instance: " + persistence);
             }
         }
         return persistence;

--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -58,7 +58,7 @@ public class FHIRValidator {
      * @param profiles
      *     specific profile references to validate the resource against
      * @return
-     *     list of issues generated during validation
+     *     a non-null, possibly empty list of issues generated during validation
      * @throws FHIRValidationException
      *     for errors that occur during validation
      */
@@ -83,7 +83,7 @@ public class FHIRValidator {
      * @param profiles
      *     specific profile references to validate the resource against
      * @return
-     *     list of issues generated during validation
+     *     a non-null, possibly empty list of issues generated during validation
      * @throws FHIRValidationException
      *     for errors that occur during validation
      */
@@ -134,7 +134,7 @@ public class FHIRValidator {
      * @param profiles
      *     specific profile references to validate the evaluation context against
      * @return
-     *     list of issues generated during validation
+     *     a non-null, possibly empty list of issues generated during validation
      * @throws FHIRValidationException
      *     for errors that occur during validation
      * @see {@link FHIRPathEvaluator.EvaluationContext}


### PR DESCRIPTION
subsumes #915

1. Verified the support for return preference in create and update and
added corresponding tests under the BasicServerTest class

2. Collect and return supplemental warnings from the persistence layer
(e.g. search parameters that will be skipped)

3. Update doCreate/doUpdate to check the persistence-layer-generated supplemental
warnings and add them to the validation warnings

4. Added comments to various places in FHIRUtil where we may want to do
something similar in the future; basically wherever we throw in strict
mode but continue on in lenient mode

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>