### PR TITLE
issue #930 - ensure status is never null from delete AND return 200 OK on success

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -567,75 +567,77 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         try {
             existingResourceDTO = this.getResourceDao().read(logicalId, resourceType.getSimpleName());
 
-            if (existingResourceDTO != null) {
-                if (existingResourceDTO.isDeleted()) {
-                    existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
-                    resourceBuilder = existingResource.toBuilder();
-
-                    SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
-                            .success(true)
-                            .resource(existingResource)
-                            .build();
-
-                    return result;
-                }
-                else {
-                    existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
-
-                    // Resources are immutable, so we need a new builder to update it (since R4)
-                    resourceBuilder = existingResource.toBuilder();
-
-                    int newVersionNumber = existingResourceDTO.getVersionId() + 1;
-                    Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-
-                    // Update the soft-delete resource to reflect the new version and lastUpdated values.
-                    Meta meta = existingResource.getMeta();
-                    Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
-                    metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
-                    metaBuilder.lastUpdated(lastUpdated);
-                    resourceBuilder.meta(metaBuilder.build());
-
-
-                    @SuppressWarnings("unchecked")
-                    T updatedResource = (T) resourceBuilder.build();
-
-                    // Create a new Resource DTO instance to represent the deleted version.
-                    com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
-                    resourceDTO.setLogicalId(logicalId);
-                    resourceDTO.setVersionId(newVersionNumber);
-
-                    // Serialize and compress the Resource
-                    GZIPOutputStream zipStream = new GZIPOutputStream(stream);
-                    FHIRGenerator.generator(Format.JSON, false).generate(updatedResource, zipStream);
-                    zipStream.finish();
-                    resourceDTO.setData(stream.toByteArray());
-                    zipStream.close();
-
-                    Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
-                    resourceDTO.setLastUpdated(timestamp);
-                    resourceDTO.setResourceType(resourceType.getSimpleName());
-                    resourceDTO.setDeleted(true);
-
-                    // Persist the logically deleted Resource DTO.
-                    this.getResourceDao().setPersistenceContext(context);
-                    this.getResourceDao().insert(resourceDTO, null, null);
-
-                    if (log.isLoggable(Level.FINE)) {
-                        log.fine("Persisted FHIR Resource '" + resourceDTO.getResourceType() + "/" + resourceDTO.getLogicalId() + "' id=" + resourceDTO.getId()
-                                    + ", version=" + resourceDTO.getVersionId());
-                    }
-
-                    SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
-                            .success(true)
-                            .resource(updatedResource)
-                            .build();
-
-                    return result;
-                }
+            if (existingResourceDTO == null) {
+                throw new FHIRPersistenceResourceNotFoundException("resource does not exist: " + 
+                        resourceType.getSimpleName() + ":" + logicalId);
             }
-            else {
-                throw new FHIRPersistenceResourceNotFoundException("resource does not exist: " + resourceType.getSimpleName() + ":" + logicalId);
+
+            if (existingResourceDTO.isDeleted()) {
+                existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
+                resourceBuilder = existingResource.toBuilder();
+
+                addWarning(IssueType.DELETED, "Resource of type'" + resourceType.getSimpleName() + 
+                        "' with id '" + logicalId + "' is already deleted.");
+                        
+                SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
+                        .success(true)
+                        .resource(existingResource)
+                        .build();
+
+                return result;
             }
+            
+            existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
+
+            // Resources are immutable, so we need a new builder to update it (since R4)
+            resourceBuilder = existingResource.toBuilder();
+
+            int newVersionNumber = existingResourceDTO.getVersionId() + 1;
+            Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+
+            // Update the soft-delete resource to reflect the new version and lastUpdated values.
+            Meta meta = existingResource.getMeta();
+            Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
+            metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
+            metaBuilder.lastUpdated(lastUpdated);
+            resourceBuilder.meta(metaBuilder.build());
+
+
+            @SuppressWarnings("unchecked")
+            T updatedResource = (T) resourceBuilder.build();
+
+            // Create a new Resource DTO instance to represent the deleted version.
+            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
+            resourceDTO.setLogicalId(logicalId);
+            resourceDTO.setVersionId(newVersionNumber);
+
+            // Serialize and compress the Resource
+            GZIPOutputStream zipStream = new GZIPOutputStream(stream);
+            FHIRGenerator.generator(Format.JSON, false).generate(updatedResource, zipStream);
+            zipStream.finish();
+            resourceDTO.setData(stream.toByteArray());
+            zipStream.close();
+
+            Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
+            resourceDTO.setLastUpdated(timestamp);
+            resourceDTO.setResourceType(resourceType.getSimpleName());
+            resourceDTO.setDeleted(true);
+
+            // Persist the logically deleted Resource DTO.
+            this.getResourceDao().setPersistenceContext(context);
+            this.getResourceDao().insert(resourceDTO, null, null);
+
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("Persisted FHIR Resource '" + resourceDTO.getResourceType() + "/" + resourceDTO.getLogicalId() + "' id=" + resourceDTO.getId()
+                            + ", version=" + resourceDTO.getVersionId());
+            }
+
+            SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
+                    .success(true)
+                    .resource(updatedResource)
+                    .build();
+
+            return result;
         }
         catch(FHIRPersistenceFKVException e) {
             log.log(Level.INFO, this.performCacheDiagnostics());
@@ -654,9 +656,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         }
     }
 
+    /**
+     * @throws FHIRPersistenceResourceDeletedException if the resource being read is currently in a deleted state and
+     *         FHIRPersistenceContext.includeDeleted() is set to false
+     */
     @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
-                            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+                            throws FHIRPersistenceException {
         final String METHODNAME = "read";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -838,7 +844,10 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         return issues;
     }
 
-
+    /**
+     * @throws FHIRPersistenceResourceDeletedException if the resource being read is currently in a deleted state and
+     *         FHIRPersistenceContext.includeDeleted() is set to false
+     */
     @Override
     public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
                         throws FHIRPersistenceException {
@@ -852,7 +861,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
         try {
             version = Integer.parseInt(versionId);
             resourceDTO = this.getResourceDao().versionRead(logicalId, resourceType.getSimpleName(), version);
-            if (resourceDTO != null && resourceDTO.isDeleted()) {
+            if (resourceDTO != null && resourceDTO.isDeleted() && !context.includeDeleted()) {
                 throw new FHIRPersistenceResourceDeletedException("Resource '" +
                         resourceType.getSimpleName() + "/" + logicalId + "' version " + versionId + " is deleted.");
             }
@@ -893,8 +902,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      * @throws IOException
      */
     protected List<Resource> buildSortedFhirResources(FHIRPersistenceContext context, Class<? extends Resource> resourceType, List<Long> sortedIdList,
-                                                      List<String> elements)
-                            throws FHIRException, FHIRPersistenceException, IOException {
+            List<String> elements) throws FHIRException, FHIRPersistenceException, IOException {
         final String METHOD_NAME = "buildFhirResource";
         log.entering(this.getClass().getName(), METHOD_NAME);
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -569,7 +569,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
 
             if (existingResourceDTO == null) {
                 throw new FHIRPersistenceResourceNotFoundException("resource does not exist: " + 
-                        resourceType.getSimpleName() + ":" + logicalId);
+                        resourceType.getSimpleName() + "/" + logicalId);
             }
 
             if (existingResourceDTO.isDeleted()) {
@@ -903,7 +903,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, FHIRPersistence
      */
     protected List<Resource> buildSortedFhirResources(FHIRPersistenceContext context, Class<? extends Resource> resourceType, List<Long> sortedIdList,
             List<String> elements) throws FHIRException, FHIRPersistenceException, IOException {
-        final String METHOD_NAME = "buildFhirResource";
+        final String METHOD_NAME = "buildSortedFhirResources";
         log.entering(this.getClass().getName(), METHOD_NAME);
 
         long resourceId;

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,7 +11,6 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 
 /**
  * This interface defines the contract between the FHIR Server's REST API layer and the underlying
@@ -19,35 +18,34 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedExceptio
  * instances of FHIR Resources.
  */
 public interface FHIRPersistence {
-    
+
     /**
      * Stores a new FHIR Resource in the datastore.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resource the FHIR Resource instance to be created in the datastore
-     * @return a SingleResourceResult with a copy of resource with Meta fields updated by the persistence layer and/or 
+     * @return a SingleResourceResult with a copy of resource with Meta fields updated by the persistence layer and/or
      *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
     <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
-    
+
     /**
      * Retrieves the most recent version of a FHIR Resource from the datastore.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
      * @return a SingleResourceResult with the FHIR Resource that was retrieved from the datastore and/or
      *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
-     * @throws FHIRPersistenceResourceDeletedException
      */
-    <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) 
-                            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException;
-    
+    <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
+            throws FHIRPersistenceException;
+
     /**
      * Retrieves a specific version of a FHIR Resource from the datastore.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instance to be retrieved
      * @param logicalId the logical id of the Resource instance to be retrieved
@@ -55,14 +53,13 @@ public interface FHIRPersistence {
      * @return a SingleResourceResult with the FHIR Resource that was retrieved from the datastore and/or
      *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
-     * @throws FHIRPersistenceResourceDeletedException
      */
-    <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId) 
-                    throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException;
-    
+    <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
+            throws FHIRPersistenceException;
+
     /**
      * Updates an existing FHIR Resource by storing a new version in the datastore.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param logicalId the logical id of the FHIR Resource to be updated
      * @param resource the new contents of the FHIR Resource to be stored
@@ -71,10 +68,10 @@ public interface FHIRPersistence {
      * @throws FHIRPersistenceException
      */
     <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException;
-    
+
     /**
      * Deletes the specified FHIR Resource from the datastore.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType The type of FHIR Resource to be deleted.
      * @param logicalId the logical id of the FHIR Resource to be deleted
@@ -85,10 +82,10 @@ public interface FHIRPersistence {
     default <T extends Resource> SingleResourceResult<T> delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
         throw new FHIRPersistenceNotSupportedException("The 'delete' operation is not supported by this persistence implementation");
     }
-    
+
     /**
      * Retrieves all of the versions of the specified FHIR Resource.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type of the Resource instances to be retrieved
      * @param logicalId the logical id of the Resource instances to be retrieved
@@ -97,10 +94,10 @@ public interface FHIRPersistence {
      * @throws FHIRPersistenceException
      */
     <T extends Resource> MultiResourceResult<T> history(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException;
-    
+
     /**
      * Performs a search on the specified target resource type using the specified search parameters.
-     * 
+     *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resourceType the resource type which is the target of the search
      * @return a MultiResourceResult with the list of FHIR Resources in the search result set and/or
@@ -126,7 +123,7 @@ public interface FHIRPersistence {
      * This can then be used to control transactional boundaries.
      */
     FHIRPersistenceTransaction getTransaction();
-    
+
     /**
      * Returns true iff the persistence layer implementation supports the "delete" operation.
      */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
@@ -197,7 +197,7 @@ public class FHIRCliTest extends FHIRServerTestBase {
     }
 
     @Test(dependsOnMethods={"testConditionalDeletePatient"})
-    public void testConditionalDeletePatientError() throws Exception {
+    public void testConditionalDeletePatientTwice() throws Exception {
         if (!deleteSupported) {
             return;
         }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/cli/test/FHIRCliTest.java
@@ -147,7 +147,7 @@ public class FHIRCliTest extends FHIRServerTestBase {
         assertNotNull(patientId);
         runTest("testDeletePatient", "-p", propsFile(), "--operation", "delete", "--type", "Patient", "--resourceId", patientId);
         if (deleteSupported) {
-            verifyConsoleOutput("Status code: 204", "ETag: W/\"3\"");
+            verifyConsoleOutput("Status code: 200", "ETag: W/\"3\"");
         } else {
             verifyConsoleOutput("Status code: 405");
 
@@ -193,7 +193,7 @@ public class FHIRCliTest extends FHIRServerTestBase {
 
         assertNotNull(patientId);
         runTest("testConditionalDeletePatient", "-p", propsFile(), "--operation", "conditional-delete", "--type", "Patient", "-qp", "_id=" + patientId);
-        verifyConsoleOutput("Status code: 204", "ETag: W/\"6\"");
+        verifyConsoleOutput("Status code: 200", "ETag: W/\"6\"");
     }
 
     @Test(dependsOnMethods={"testConditionalDeletePatient"})

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1881,8 +1881,8 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 3);
-        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
         assertBadResponse(responseBundle.getEntry().get(2), Status.BAD_REQUEST.getStatusCode(),
                 "Bundle.Entry.resource not allowed for BundleEntry with DELETE method.");
     }
@@ -1973,8 +1973,8 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
-        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
     }
 
     @Test(groups = { "transaction" }, dependsOnMethods = { "testTransactionDeletes" })
@@ -2208,7 +2208,7 @@ public class BundleTest extends FHIRServerTestBase {
         printBundle(method, "response", responseBundle);
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 4);
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
 
         // A search that results in multiple matches:
         // (1) if matches > FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT, then result in a 412 status code.
@@ -2332,8 +2332,8 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = response.getResource(Bundle.class);
         printBundle(method, "response", responseBundle);
         assertResponseBundle(responseBundle, BundleType.TRANSACTION_RESPONSE, 2);
-        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
-        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.NO_CONTENT.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
+        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
     }
 
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -90,7 +90,7 @@ public class DeleteTest extends FHIRServerTestBase {
         FHIRResponse response = client.delete(deletedType, deletedId);
         assertNotNull(response);
         if (deleteSupported) {
-            assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+            assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             assertNotNull(response.getETag());
             assertEquals("W/\"2\"", response.getETag());
         } else {
@@ -286,7 +286,7 @@ public class DeleteTest extends FHIRServerTestBase {
 
         FHIRResponse response = client.delete(deletedType, deletedId);
         assertNotNull(response);
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
     }
 
     @Test(dependsOnMethods = {
@@ -357,10 +357,10 @@ public class DeleteTest extends FHIRServerTestBase {
 
         // Delete a couple of resources created by the search test, then re-invoke the search.
         response = client.delete("Patient", patientIds.get(3));
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
 
         response = client.delete("Patient", patientIds.get(7));
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
 
         FHIRParameters parameters = new FHIRParameters().searchParam("name", uniqueFamilyName);
         response = client.search("Patient", parameters);
@@ -383,13 +383,13 @@ public class DeleteTest extends FHIRServerTestBase {
 
         // Delete 3 more patients.
         response = client.delete("Patient", patientIds.get(2));
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
 
         response = client.delete("Patient", patientIds.get(8));
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
 
         response = client.delete("Patient", patientIds.get(9));
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
 
         FHIRParameters parameters = new FHIRParameters().searchParam("name", uniqueFamilyName);
         response = client.search("Patient", parameters);
@@ -430,7 +430,7 @@ public class DeleteTest extends FHIRServerTestBase {
         response = client.conditionalDelete("Observation", query);
         assertNotNull(response);
         if (deleteSupported) {
-            assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+            assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             assertNotNull(response.getETag());
             assertEquals("W/\"2\"", response.getETag());
         } else {
@@ -452,7 +452,7 @@ public class DeleteTest extends FHIRServerTestBase {
         if (deleteSupported) {
             if (searchResultBundle.getTotal().getValue() <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT ) {
                 if (searchResultBundle.getTotal().getValue() > 0) {
-                    assertResponse(response.getResponse(), Status.NO_CONTENT.getStatusCode());
+                    assertResponse(response.getResponse(), Status.OK.getStatusCode());
                 } else {
                     assertResponse(response.getResponse(), Status.OK.getStatusCode());
                     assertNotNull(response.getResource(OperationOutcome.class));

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -115,7 +115,7 @@ public class DeleteTest extends FHIRServerTestBase {
     }
 
     @Test(dependsOnMethods = {
-            "testReadDeletedResource"
+            "testDeleteNewResource"
     })
     public void testVreadDeletedResource() throws Exception {
         if (!deleteSupported) {
@@ -131,7 +131,7 @@ public class DeleteTest extends FHIRServerTestBase {
     }
 
     @Test(dependsOnMethods = {
-            "testVreadDeletedResource"
+            "testDeleteNewResource"
     })
     public void testDeleteDeletedResource() throws Exception {
         if (!deleteSupported) {
@@ -143,8 +143,9 @@ public class DeleteTest extends FHIRServerTestBase {
 
         FHIRResponse response = client.delete(deletedType, deletedId);
         assertNotNull(response);
-        assertResponse(response.getResponse(), Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         assertNotNull(response.getETag());
+        assertNotNull(response.getResource(OperationOutcome.class));
         assertEquals("W/\"2\"", response.getETag());
     }
 
@@ -450,7 +451,12 @@ public class DeleteTest extends FHIRServerTestBase {
         assertNotNull(response);
         if (deleteSupported) {
             if (searchResultBundle.getTotal().getValue() <= FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT ) {
-                assertResponse(response.getResponse(), Status.NO_CONTENT.getStatusCode());
+                if (searchResultBundle.getTotal().getValue() > 0) {
+                    assertResponse(response.getResponse(), Status.NO_CONTENT.getStatusCode());
+                } else {
+                    assertResponse(response.getResponse(), Status.OK.getStatusCode());
+                    assertNotNull(response.getResource(OperationOutcome.class));
+                }
             } else {
                 assertResponse(response, Status.PRECONDITION_FAILED.getStatusCode());
                 assertExceptionOperationOutcome(response.getResponse().readEntity(OperationOutcome.class),

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
@@ -38,21 +38,22 @@ public class SearchNearTest extends FHIRServerTestBase {
         Response response = target.path("Location").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
+        locationId = getLocationLogicalId(response);
+
         Entity<Location> entityAbs = Entity.entity(locationAbs, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response responseAbs = target.path("Location").request().post(entityAbs, Response.class);
         assertResponse(responseAbs, Response.Status.CREATED.getStatusCode());
 
-        locationId = getLocationLogicalId(response);
-        locationAbsId = getLocationLogicalId(response);
+        locationAbsId = getLocationLogicalId(responseAbs);
 
         // Next, call the 'read' API to retrieve the new Location and verify it.
         response   = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
-        
+
         response   = target.path("Location/" + locationAbsId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
     }
-    
+
     @AfterClass
     public void testDeleteLocations() {
         WebTarget target = getWebTarget();
@@ -112,13 +113,13 @@ public class SearchNearTest extends FHIRServerTestBase {
         parameters.searchParam("near", "40.256500|-80.694810|500.0|km,40.256500|-80.694810|500.0|km");
         parameters.searchParam("near", "42.256500|-83.694810|11.20|km");
         FHIRResponse response = client.search(Location.class.getSimpleName(), parameters);
-        
+
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
-    
+
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
     public void testSearchUsingLocationWithMissing() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
@@ -128,7 +129,7 @@ public class SearchNearTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
-    
+
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })
     public void testSearchUsingLocationWithMissingFalse() throws Exception {
         FHIRParameters parameters = new FHIRParameters();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchNearTest.java
@@ -58,9 +58,9 @@ public class SearchNearTest extends FHIRServerTestBase {
     public void testDeleteLocations() {
         WebTarget target = getWebTarget();
         Response response   = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response, Response.Status.OK.getStatusCode());
         response   = target.path("Location/" + locationAbsId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.NO_CONTENT.getStatusCode());
+        assertResponse(response, Response.Status.OK.getStatusCode());
     }
 
     @Test(groups = { "server-search-near" }, dependsOnMethods = { "testCreateLocation" })

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -63,8 +63,10 @@ public class Delete extends FHIRResource {
 
             // The server should return either a 200 OK if the response contains a payload, or a 204 No Content with no response payload
             if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                status = Status.OK;
                 response = Response.ok(ior.getOperationOutcome());
             } else {
+                status = Status.NO_CONTENT;
                 response = Response.noContent();
             }
 
@@ -119,10 +121,18 @@ public class Delete extends FHIRResource {
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             ior = helper.doDelete(type, null, searchQueryString, null);
             status = ior.getStatus();
-            ResponseBuilder response = Response.status(status);
-            if (ior.getOperationOutcome() != null) {
-                response.entity(ior.getOperationOutcome());
+
+            ResponseBuilder response;
+
+            // The server should return either a 200 OK if the response contains a payload, or a 204 No Content with no response payload
+            if (ior.getOperationOutcome() != null && HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
+                status = Status.OK;
+                response = Response.ok(ior.getOperationOutcome());
+            } else {
+                status = Status.NO_CONTENT;
+                response = Response.noContent();
             }
+
             if (ior.getResource() != null) {
                 response = addHeaders(response, ior.getResource());
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -493,6 +493,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
         FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
 
+        // A list of supplemental warnings to include in the response
+        List<Issue> warnings = new ArrayList<>();
+
         try {
             String resourceTypeName = type;
             if (!ModelSupport.isResourceType(type)) {
@@ -519,6 +522,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 try {
                     MultivaluedMap<String, String> searchParameters = getQueryParameterMap(searchQueryString);
                     searchParameters.putSingle(SearchConstants.COUNT, Integer.toString(searchPageSize));
+                    // TODO add support for collecting the warnings from the search
                     responseBundle = doSearch(type, null, null, searchParameters, null, requestProperties, null);
                 } catch (FHIROperationException e) {
                     throw e;
@@ -564,12 +568,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                                 .total(UnsignedInt.of(1))
                                 .build();
                     } else {
-                        throw new FHIRPersistenceResourceNotFoundException("Can not find " + type + " with id '" + id + "'.");
+                        warnings.add(buildOperationOutcomeIssue(IssueSeverity.WARNING, IssueType.NOT_FOUND, "Cannot find "
+                                + type + " with id '" + id + "'."));
                     }
                 } catch (FHIRPersistenceResourceDeletedException e) {
                     // Absorb this exception.
                     ior.setResource(doRead(type, id, false, true, requestProperties, null));
-                    return ior;
+                    warnings.add(buildOperationOutcomeIssue(IssueSeverity.WARNING, IssueType.DELETED, "Resource of type'"
+                        + type + "' with id '" + id + "' is already deleted."));
                 }
             }
 
@@ -589,7 +595,11 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     FHIRPersistenceContext persistenceContext =
                             FHIRPersistenceContextFactory.createPersistenceContext(event);
 
-                    Resource resource = persistence.delete(persistenceContext, resourceType, id).getResource();
+                    SingleResourceResult<? extends Resource> result = persistence.delete(persistenceContext, resourceType, id);
+                    if (result.getOutcome() != null) {
+                        warnings.addAll(result.getOutcome().getIssue());
+                    }
+                    Resource resource = result.getResource();
                     event.setFhirResource(resource);
 
                     if (responseBundle.getEntry().size() == 1) {
@@ -604,7 +614,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 txn.commit();
                 txn = null;
 
-                ior.setStatus(Response.Status.NO_CONTENT);
+            }
+
+            // The server should return either a 200 OK if the response contains a payload, or a 204 No Content with no response payload
+            if (!warnings.isEmpty()) {
+                ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(warnings));
+                ior.setStatus(Status.OK);
+            } else {
+                ior.setStatus(Status.NO_CONTENT);
             }
 
             return ior;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -491,8 +491,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         // Save the current request context.
         FHIRRequestContext requestContext = FHIRRequestContext.get();
         FHIRTransactionHelper txn = new FHIRTransactionHelper(getTransaction());
-        Response.Status status = null;
-
         FHIRRestOperationResponse ior = new FHIRRestOperationResponse();
 
         try {
@@ -511,7 +509,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             Bundle responseBundle = null;
 
             if (searchQueryString != null) {
-                int searchPageSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_CONDITIONAL_DELETE_MAX_NUMBER, FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT);
+                int searchPageSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_CONDITIONAL_DELETE_MAX_NUMBER,
+                        FHIRConstants.FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT);
 
                 if (log.isLoggable(Level.FINE)) {
                     log.fine("Performing conditional delete with search criteria: "
@@ -541,9 +540,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     if (log.isLoggable(Level.FINE)) {
                         log.fine(msg);
                     }
-                    status = Response.Status.OK;
                     ior.setOperationOutcome(FHIRUtil.buildOperationOutcome(msg, IssueType.NOT_FOUND, IssueSeverity.WARNING));
-                    ior.setStatus(status);
+                    ior.setStatus(Status.OK);
                     return ior;
                 } else if (responseBundle.getTotal().getValue() > searchPageSize) {
                     String msg = "The search criteria specified for a conditional delete operation returned too many matches ( > " + searchPageSize + " ).";

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -610,10 +610,19 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     getInterceptorMgr().fireAfterDeleteEvent(event);
                 }
 
+                warnings.add(Issue.builder()
+                        .severity(IssueSeverity.INFORMATION)
+                        .code(IssueType.INFORMATIONAL)
+                        .details(CodeableConcept.builder()
+                            .text(string("Deleted " + responseBundle.getEntry().size() + " " + type + " resource(s) " +
+                                " with the following id(s): " + 
+                                responseBundle.getEntry().stream().map(Bundle.Entry::getId).collect(Collectors.joining(","))))
+                            .build())
+                        .build());
+
                 // Commit our transaction if we started one before.
                 txn.commit();
                 txn = null;
-
             }
 
             // The server should return either a 200 OK if the response contains a payload, or a 204 No Content with no response payload

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
@@ -48,18 +48,18 @@ import com.ibm.fhir.model.util.FHIRUtil;
  * This class provides convenience methods for FHIR Rest services that need to write FHIR audit log entries.
  */
 public class RestAuditLogger {
-    
+
     private static final String CLASSNAME = RestAuditLogger.class.getName();
     private static final Logger log = java.util.logging.Logger.getLogger(CLASSNAME);
-    
+
     private static final String HEADER_IBM_APP_USER = "IBM-App-User";
     private static final String HEADER_CLIENT_CERT_CN = "IBM-App-cli-CN";
     private static final String HEADER_CLIENT_CERT_ISSUER_OU = "IBM-App-iss-OU";
     private static final String HEADER_CORRELATION_ID = "IBM-DP-correlationid";
-    
+
     private static final String COMPONENT_ID = "fhir-server";
-    
-    
+
+
     /**
      * Builds an audit log entry for a 'create' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -67,23 +67,23 @@ public class RestAuditLogger {
      * @param startTime - The start time of the create request execution.
      * @param endTime - The end time of the create request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logCreate(HttpServletRequest request, Resource resource, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logCreate";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_CREATE);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-        
+
         entry.getContext().setAction("C");
         entry.setDescription("FHIR Create request");
-        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for an 'update' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -92,24 +92,24 @@ public class RestAuditLogger {
      * @param startTime - The start time of the update request execution.
      * @param endTime - The end time of the update request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
-    public static void logUpdate(HttpServletRequest request, Resource oldResource, Resource updatedResource, Date startTime, Date endTime, 
+    public static void logUpdate(HttpServletRequest request, Resource oldResource, Resource updatedResource, Date startTime, Date endTime,
                                  Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logUpdate";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_UPDATE);
         populateAuditLogEntry(entry, request, updatedResource, startTime, endTime, responseStatus);
-        
+
         entry.getContext().setAction("U");
         entry.setDescription("FHIR Update request");
-                
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for an 'patch' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -118,24 +118,24 @@ public class RestAuditLogger {
      * @param startTime - The start time of the patch request execution.
      * @param endTime - The end time of the patch request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
-    public static void logPatch(HttpServletRequest request, Resource oldResource, Resource updatedResource, Date startTime, Date endTime, 
+    public static void logPatch(HttpServletRequest request, Resource oldResource, Resource updatedResource, Date startTime, Date endTime,
                                  Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logPatch";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_PATCH);
         populateAuditLogEntry(entry, request, updatedResource, startTime, endTime, responseStatus);
-        
+
         entry.getContext().setAction("P");
         entry.setDescription("FHIR Patch request");
-                
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'read' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -143,23 +143,23 @@ public class RestAuditLogger {
      * @param startTime - The start time of the read request execution.
      * @param endTime - The end time of the read request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logRead(HttpServletRequest request, Resource resource, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logRead";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_READ);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-                
+
         entry.getContext().setAction("R");
         entry.setDescription("FHIR Read request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'delete' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -167,23 +167,23 @@ public class RestAuditLogger {
      * @param startTime - The start time of the read request execution.
      * @param endTime - The end time of the read request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logDelete(HttpServletRequest request, Resource resource, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logDelete";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_DELETE);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-                
+
         entry.getContext().setAction("D");
         entry.setDescription("FHIR Delete request");
-        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'version-read' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -191,23 +191,23 @@ public class RestAuditLogger {
      * @param startTime - The start time of the read request execution.
      * @param endTime - The end time of the read request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logVersionRead(HttpServletRequest request, Resource resource, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logVersionRead";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_VREAD);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-                
+
         entry.getContext().setAction("R");
         entry.setDescription("FHIR VersionRead request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'history' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -215,16 +215,16 @@ public class RestAuditLogger {
      * @param startTime - The start time of the bundle request execution.
      * @param endTime - The end time of the bundle request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logHistory(HttpServletRequest request, Bundle bundle, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logHistory";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_HISTORY);
-        long totalHistory = 0;    
-        
+        long totalHistory = 0;
+
         populateAuditLogEntry(entry, request, null, startTime, endTime, responseStatus);
         if (bundle != null) {
             if (bundle.getTotal() != null) {
@@ -234,11 +234,11 @@ public class RestAuditLogger {
         }
         entry.getContext().setAction("R");
         entry.setDescription("FHIR History request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'validate' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -246,23 +246,23 @@ public class RestAuditLogger {
      * @param startTime - The start time of the validate request execution.
      * @param endTime - The end time of the validate request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logValidate(HttpServletRequest request, Resource resource, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logValidate";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_VALIDATE);
         populateAuditLogEntry(entry, request, resource, startTime, endTime, responseStatus);
-                
+
         entry.getContext().setAction("R");
         entry.setDescription("FHIR Validate request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'bundle' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -270,19 +270,19 @@ public class RestAuditLogger {
      * @param startTime - The start time of the bundle request execution.
      * @param endTime - The end time of the bundle request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logBundle(HttpServletRequest request, Bundle bundle, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logBundle";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_BUNDLE);
         long readCount = 0;
         long createCount = 0;
         long updateCount = 0;
         HTTPVerb requestMethod;
-                    
+
         populateAuditLogEntry(entry, request, null, startTime, endTime, responseStatus);
         if (bundle != null) {
             for (Entry bundleEntry : bundle.getEntry()) {
@@ -300,7 +300,7 @@ public class RestAuditLogger {
                         break;
                     default:
                         break;
-                    
+
                     }
                 }
             }
@@ -310,11 +310,11 @@ public class RestAuditLogger {
                 .resourcesRead(readCount)
                 .resourcesUpdated(updateCount).build());
         entry.setDescription("FHIR Bundle request");
-        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'search' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -323,17 +323,17 @@ public class RestAuditLogger {
      * @param startTime - The start time of the bundle request execution.
      * @param endTime - The end time of the bundle request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logSearch(HttpServletRequest request, MultivaluedMap<String, String> queryParms, Bundle bundle, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logSearch";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_SEARCH);
         populateAuditLogEntry(entry, request, null, startTime, endTime, responseStatus);
         long totalSearch = 0;
-        
+
         if (queryParms != null && !queryParms.isEmpty()) {
             entry.getContext().setQueryParameters(queryParms.toString());
         }
@@ -345,54 +345,54 @@ public class RestAuditLogger {
         }
         entry.getContext().setAction("R");
         entry.setDescription("FHIR Search request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Builds an audit log entry for a 'metadata' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
      * @param startTime - The start time of the metadata request execution.
      * @param endTime - The end time of the metadata request execution.
      * @param responseStatus - The response status.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logMetadata(HttpServletRequest request, Date startTime, Date endTime, Response.Status responseStatus) throws Exception {
         final String METHODNAME = "logMetadata";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_METADATA);
         populateAuditLogEntry(entry, request, null, startTime, endTime, responseStatus);
-                
+
         entry.getContext().setAction("R");
         entry.setDescription("FHIR Metadata request");
-                        
+
         auditLogSvc.logEntry(entry);
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
+
     /**
      * Logs an Audit Log Entry for FHIR server configuration data.
      * @param configData - The configuration data to be saved in the audit log.
-     * @throws Exception 
+     * @throws Exception
      */
     public static void logConfig(String configData) throws Exception {
         final String METHODNAME = "logConfig";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_CONFIGDATA);
         entry.setConfigData(ConfigData.builder().serverStartupParameters(configData).build());
         entry.setDescription("FHIR ConfigData request");
-        
+
         auditLogSvc.logEntry(entry);
-        
+
         log.exiting(METHODNAME, METHODNAME);
-        
+
     }
-    
+
     /**
      * Builds an audit log entry for an 'operation' REST service invocation.
      * @param request - The HttpServletRequest representation of the REST request.
@@ -404,16 +404,16 @@ public class RestAuditLogger {
      * @param endTime - The end time of the metadata request execution.
      * @param responseStatus - The response status.
      */
-    public static void logOperation(HttpServletRequest request, String operationName, String resourceTypeName, String logicalId, 
+    public static void logOperation(HttpServletRequest request, String operationName, String resourceTypeName, String logicalId,
                                     String versionId, Date startTime, Date endTime, Response.Status responseStatus) {
         final String METHODNAME = "logOperation";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         Basic.Builder tempResourceBuilder = null;
         Meta meta;
         AuditLogService auditLogSvc = AuditLogServiceFactory.getService();
         AuditLogEntry entry = initLogEntry(AuditLogEventType.FHIR_OPERATION);
-        
+
         try {
             if (resourceTypeName != null) {
                 tempResourceBuilder = Basic.builder().code(CodeableConcept.builder()
@@ -430,18 +430,18 @@ public class RestAuditLogger {
             entry.getContext().setAction("O");
             entry.setDescription("FHIR Operation request");
             entry.getContext().setOperationName(operationName);
-            
+
             auditLogSvc.logEntry(entry);
-             
+
         }
         catch(Throwable e) {
             log.log(Level.SEVERE, "Failure recording operation audit log entry ", e);
         }
-         
+
         log.exiting(CLASSNAME, METHODNAME);
     }
 
-    
+
     /**
      * Populates the passed audit log entry, with attributes common to all REST services.
      * @param entry - The AuditLogEntry to be populated.
@@ -452,20 +452,19 @@ public class RestAuditLogger {
      * @param responseStatus - The response status.
      * @return AuditLogEntry - an initialized audit log entry.
      */
-    private static AuditLogEntry populateAuditLogEntry(AuditLogEntry entry, HttpServletRequest request, Resource resource, 
+    private static AuditLogEntry populateAuditLogEntry(AuditLogEntry entry, HttpServletRequest request, Resource resource,
                                                  Date startTime, Date endTime, Response.Status responseStatus) {
-        
         final String METHODNAME = "populateAuditLogEntry";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         StringBuffer requestUrl;
         String patientIdExtUrl;
         List<String> userList = new ArrayList<>();
-        
+
         // Build a list of possible user names. Pick the first non-null user name to include in the audit log entry.
         userList.add(request.getHeader(HEADER_IBM_APP_USER));
         userList.add(request.getHeader(HEADER_CLIENT_CERT_CN));
-        
+
         Principal userPrincipal = request.getUserPrincipal();
         if (userPrincipal != null) {
             userList.add(userPrincipal.getName());
@@ -476,7 +475,7 @@ public class RestAuditLogger {
                 break;
             }
         }
-        
+
         entry.setLocation(new StringBuilder()
                             .append(request.getRemoteAddr())
                             .append("/")
@@ -502,19 +501,19 @@ public class RestAuditLogger {
                 entry.getContext().getData().setVersionId(resource.getMeta().getVersionId().getValue());
             }
         }
-        
+
         entry.setClientCertCn(request.getHeader(HEADER_CLIENT_CERT_CN));
         entry.setClientCertIssuerOu(request.getHeader(HEADER_CLIENT_CERT_ISSUER_OU));
         entry.setCorrelationId(request.getHeader(HEADER_CORRELATION_ID));
-        
+
         patientIdExtUrl = FHIRConfigHelper.getStringProperty(FHIRConfiguration.PROPERTY_AUDIT_PATIENT_ID_EXTURL, null);
         entry.setPatientId(FHIRUtil.getExtensionStringValue(resource, patientIdExtUrl));
         entry.getContext().setRequestUniqueId(FHIRRequestContext.get().getRequestUniqueId());
-        
+
         log.exiting(CLASSNAME, METHODNAME);
         return entry;
     }
-    
+
     /**
      * Builds and returns an AuditLogEntry with the minimum required fields populated.
      * @param eventType - A valid type of audit log event
@@ -523,12 +522,12 @@ public class RestAuditLogger {
     private static AuditLogEntry initLogEntry(AuditLogEventType eventType) {
         final String METHODNAME = "initLogEntry";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         String timestamp;
         String componentIp = null;
         AuditLogEntry logEntry;
         String tenantId;
-        
+
         tenantId = FHIRRequestContext.get().getTenantId();
         timestamp = FHIRUtilities.formatTimestamp(new Date(System.currentTimeMillis()));
         try {
@@ -537,7 +536,7 @@ public class RestAuditLogger {
         catch(UnknownHostException e) {
             log.severe("Failure acquiring host name or IP: " + e.getMessage());
         }
-        
+
         logEntry = new AuditLogEntry(COMPONENT_ID, eventType.value(), timestamp, componentIp, tenantId);
         log.exiting(CLASSNAME, METHODNAME);
         return logEntry;


### PR DESCRIPTION
While investigating the issue, I found that `delete` and `conditionalDelete` were handled subtely different.
Now the response status is set in FHIRRestHelper.doDelete() and these two variants share a common buildResponse helper.

Additionally, we were inconsistent in the response status being returned.
Previously we were returning 204 (No Content) for some deletes and 200 (OK) status for others.
Now we will always return a 200 (OK) for a successful delete and the response will always contain an OperationOutcome:
* For conditional deletes with no matches, we return a warning
* For the deletion of a previously deleted resource, we return a warning
* For the deletion of a non-existent resource, we return a warning
* For any other successful deletion (conditional or not), we return an informational message with the number of resources deleted (and their logical ids)

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>