### PR TITLE
issue #944 add import counts to job exit status

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
@@ -4,7 +4,11 @@
         <property name="fhir.cosreadsperdbbatch" value="#{jobParameters['fhir.cosreadsperdbbatch']}?:1;" />
     </properties>
     <listeners>
-        <listener ref="com.ibm.fhir.bulkimport.ImportJobListener" />
+        <listener ref="com.ibm.fhir.bulkimport.ImportJobListener">
+            <properties>
+                <property name="fhir.dataSourcesInfo" value="#{jobParameters['fhir.dataSourcesInfo']}"/>
+            </properties>
+        </listener>
     </listeners>
     <step id="step1">
         <chunk checkpoint-policy="item" item-count="#{jobProperties['fhir.cosreadsperdbbatch']}">

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/BulkDataUtils.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,9 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonReader;
 import javax.net.ssl.HttpsURLConnection;
 
 import com.ibm.cloud.objectstorage.ClientConfiguration;
@@ -415,5 +419,14 @@ public class BulkDataUtils {
             }
         }
         return searchParametersForResoureTypes;
+    }
+    
+    public static JsonArray getDataSourcesFromJobInput(String dataSourcesInfo) {
+        try (JsonReader reader =
+                Json.createReader(new StringReader(
+                        new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)))) {
+            JsonArray dataSourceArray = reader.readArray();
+            return dataSourceArray;
+        }
     }
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -40,16 +40,20 @@ public class Constants {
     public static final String COS_LOCATION = "cos.location";
     public static final String COS_BUCKET_NAME = "cos.bucket.name";
     public static final String COS_IS_IBM_CREDENTIAL = "cos.credential.ibm";
+    // COS bucket for import OperationOutcomes
     public static final String COS_OPERATIONOUTCOMES_BUCKET_NAME = "cos.operationoutcomes.bucket.name";
     public static final String FHIR_TENANT = "fhir.tenant";
     public static final String FHIR_DATASTORE_ID = "fhir.datastoreid";
-    public static final String IMPORT_PARTITTION_WORKITEM = "import.partiton.workitem";
-    public static final String IMPORT_PARTITTION_RESOURCE_TYPE = "import.partiton.resourcetype";
     public static final String IMPORT_FHIR_STORAGE_TYPE = "import.fhir.storagetype";
     public static final String IMPORT_FHIR_IS_VALIDATION_ON = "import.fhir.validation";
+    public static final String IMPORT_FHIR_DATASOURCES = "fhir.dataSourcesInfo";
+    
+    // Partition work item info generated in ImportPartitionMapper.
+    public static final String IMPORT_PARTITTION_WORKITEM = "import.partiton.workitem";
+    public static final String IMPORT_PARTITTION_RESOURCE_TYPE = "import.partiton.resourcetype";   
 
     // Control if push OperationOutcomes to COS/S3.
-    public static final boolean IMPORT_IS_COLLECT_OPERATIONOUTCOMES = false;
+    public static final boolean IMPORT_IS_COLLECT_OPERATIONOUTCOMES = true;
     // Retry times when https or amazon s3 client timeout or other error happens, e.g, timeout can happen if the batch write to DB takes
     // longer than the socket timeout, set to retry once for now.
     public static final int IMPORT_RETRY_TIMES = 1;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ChunkWriter.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -64,7 +64,7 @@ public class ImportCheckPointData implements Serializable {
 
         // This naming pattern is used in bulkdata operation to generate file links for import OperationOutcomes.
         // e.g, for input file test1.ndjson, if there is any error during the importing, then the errors are in 
-        // test1.ndjson_errors.ndjson
+        // test1.ndjson_oo_errors.ndjson
         // Note: for those good imports, we don't really generate any meaningful OperationOutcome, so only error import 
         //       OperationOutcomes are supported for now.
         this.setUniqueIDForImportOperationOutcomes(importPartitionWorkitem + "_oo_success.ndjson");

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -68,7 +68,7 @@ public class ImportCheckPointData implements Serializable {
         // test1.ndjson_errors.ndjson
         // Note: for those good imports, we don't really generate any meaningful OperationOutcome, so only error import 
         //       OperationOutcomes are supported for now.
-        this.setUniqueIDForImportOperationOutcomes(importPartitionWorkitem + "_ok_file.ndjson");
+        this.setUniqueIDForImportOperationOutcomes(importPartitionWorkitem + "_oo_success.ndjson");
         this.setUniqueIDForImportFailureOperationOutcomes(importPartitionWorkitem + "_errors.ndjson");
     }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
-import com.ibm.fhir.model.util.FHIRUtil;
 
 // Class for tracking the partition import progress and for Batch job check points.
 // Also used as data carrier for collecting and aggregation of import metrics.

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -62,9 +62,14 @@ public class ImportCheckPointData implements Serializable {
         this.importPartitionWorkitem = importPartitionWorkitem;
         this.numOfProcessedResources = numOfProcessedResources;
         this.importPartitionResourceType = importPartitionResourceType;
-        String ramdomID = FHIRUtil.getRandomKey("AES");
-        this.setUniqueIDForImportOperationOutcomes(ramdomID + "_ok_file.ndjson");
-        this.setUniqueIDForImportFailureOperationOutcomes(ramdomID + "_error_file.ndjson");
+
+        // This naming pattern is used in bulkdata operation to generate file links for import OperationOutcomes.
+        // e.g, for input file test1.ndjson, if there is any error during the importing, then the errors are in 
+        // test1.ndjson_errors.ndjson
+        // Note: for those good imports, we don't really generate any meaningful OperationOutcome, so only error import 
+        //       OperationOutcomes are supported for now.
+        this.setUniqueIDForImportOperationOutcomes(importPartitionWorkitem + "_ok_file.ndjson");
+        this.setUniqueIDForImportFailureOperationOutcomes(importPartitionWorkitem + "_errors.ndjson");
     }
 
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportCheckPointData.java
@@ -69,7 +69,7 @@ public class ImportCheckPointData implements Serializable {
         // Note: for those good imports, we don't really generate any meaningful OperationOutcome, so only error import 
         //       OperationOutcomes are supported for now.
         this.setUniqueIDForImportOperationOutcomes(importPartitionWorkitem + "_oo_success.ndjson");
-        this.setUniqueIDForImportFailureOperationOutcomes(importPartitionWorkitem + "_errors.ndjson");
+        this.setUniqueIDForImportFailureOperationOutcomes(importPartitionWorkitem + "_oo_errors.ndjson");
     }
 
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
@@ -6,11 +6,8 @@
 
 package com.ibm.fhir.bulkimport;
 
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,12 +21,11 @@ import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
-import javax.json.JsonReader;
 import javax.json.JsonValue;
 
+import com.ibm.fhir.bulkcommon.BulkDataUtils;
 import com.ibm.fhir.bulkcommon.Constants;
 
 public class ImportJobListener implements JobListener {
@@ -79,10 +75,7 @@ public class ImportJobListener implements JobListener {
 
         // Generate import summary and pass it into ExitStatus of the job execution.
         // e.g, [3:0, 4:1] means 3 resources imported and 0 failures for the 1st file, and 4 imported and 1 failure for the 2nd file.
-        JsonReader reader = Json.createReader(new StringReader(
-                new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)));
-        JsonArray dataSourceArray = reader.readArray();
-        reader.close();
+        JsonArray dataSourceArray = BulkDataUtils.getDataSourcesFromJobInput(dataSourcesInfo);
 
         Map<String, Integer> inputUrlSequenceMap = new HashMap<>();
         int sequnceNum = 0;

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportJobListener.java
@@ -6,18 +6,31 @@
 
 package com.ibm.fhir.bulkimport;
 
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import javax.batch.api.BatchProperty;
 import javax.batch.api.listener.JobListener;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.context.JobContext;
 import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import com.ibm.fhir.bulkcommon.Constants;
 
 public class ImportJobListener implements JobListener {
     private static final Logger logger = Logger.getLogger(ImportJobListener.class.getName());
@@ -26,6 +39,10 @@ public class ImportJobListener implements JobListener {
 
     @Inject
     JobContext jobContext;
+    
+    @Inject
+    @BatchProperty(name = Constants.IMPORT_FHIR_DATASOURCES)
+    String dataSourcesInfo;
 
     public ImportJobListener() {
 
@@ -60,6 +77,30 @@ public class ImportJobListener implements JobListener {
             return;
         }
 
+        // Generate import summary and pass it into ExitStatus of the job execution.
+        // e.g, [3:0, 4:1] means 3 resources imported and 0 failures for the 1st file, and 4 imported and 1 failure for the 2nd file.
+        JsonReader reader = Json.createReader(new StringReader(
+                new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)));
+        JsonArray dataSourceArray = reader.readArray();
+        reader.close();
+
+        Map<String, Integer> inputUrlSequenceMap = new HashMap<>();
+        int sequnceNum = 0;
+        for (JsonValue jsonValue : dataSourceArray) {
+            JsonObject dataSourceInfo = jsonValue.asJsonObject();
+            String DSTypeInfo = dataSourceInfo.getString(Constants.IMPORT_INPUT_RESOURCE_TYPE);
+            String DSDataLocationInfo = dataSourceInfo.getString(Constants.IMPORT_INPUT_RESOURCE_URL);
+            inputUrlSequenceMap.put(DSTypeInfo + ":" + DSDataLocationInfo, sequnceNum++);
+        }
+
+        String resultInExitStatus[] = new String[sequnceNum];
+        for (ImportCheckPointData partitionSummary : partitionSummaries) {
+            int index = inputUrlSequenceMap.get(partitionSummary.getImportPartitionResourceType() + ":" + partitionSummary.getImportPartitionWorkitem());
+            resultInExitStatus[index] = partitionSummary.getNumOfImportedResources() + ":" + partitionSummary.getNumOfImportFailures();
+        }
+
+        jobContext.setExitStatus(Arrays.toString(resultInExitStatus));
+        
         for (ImportCheckPointData partitionSummary : partitionSummaries) {
             ImportCheckPointData partitionSummaryInMap = importedResourceTypeSummaries.get(partitionSummary.getImportPartitionResourceType());
             if (partitionSummaryInMap == null) {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
@@ -6,10 +6,7 @@
 
 package com.ibm.fhir.bulkimport;
 
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -20,10 +17,8 @@ import javax.batch.api.partition.PartitionPlan;
 import javax.batch.api.partition.PartitionPlanImpl;
 import javax.batch.runtime.context.StepContext;
 import javax.inject.Inject;
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
-import javax.json.JsonReader;
 import javax.json.JsonValue;
 
 import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
@@ -260,11 +255,7 @@ public class ImportPartitionMapper implements PartitionMapper {
 
     @Override
     public PartitionPlan mapPartitions() throws Exception {
-        JsonReader reader =
-                Json.createReader(new StringReader(
-                        new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)));
-        JsonArray dataSourceArray = reader.readArray();
-        reader.close();
+        JsonArray dataSourceArray = BulkDataUtils.getDataSourcesFromJobInput(dataSourcesInfo);
 
         List<FhirDataSource> fhirDataSources =
                 getFhirDataSources(dataSourceArray, BulkImportDataSourceStorageType.from(dataSourceStorageType));

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkimport/ImportPartitionMapper.java
@@ -91,7 +91,7 @@ public class ImportPartitionMapper implements PartitionMapper {
      * </pre>
      */
     @Inject
-    @BatchProperty(name = "fhir.dataSourcesInfo")
+    @BatchProperty(name = Constants.IMPORT_FHIR_DATASOURCES)
     String dataSourcesInfo;
 
     /**


### PR DESCRIPTION
Added import counts (succeeded and failures) to import javabatch job exit status.
Signed-off-by: Albert Wang <xuwang@us.ibm.com>