### PR TITLE
BulkData $bulkdata-status DELETE API must stop first #952

### DIFF
--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -332,7 +332,7 @@ public class BulkDataClient {
         runVerificationOfTenantForJob(job);
 
         // 3 optimistic delete (empty)
-        Response.Status status = runDeleteOfTenantForJob(job);
+        Response.Status status = runDeleteJobForTenant(job);
 
         // Check 3 (B), else fall through (A).
         // Default Response is Accepted (202)
@@ -347,7 +347,7 @@ public class BulkDataClient {
         } else if (HttpStatus.SC_NO_CONTENT != status.getStatusCode()) {
             // The Delete is unsuccessful (SC_NO_CONTENT)
             // 3.B - STOP Condition and now step 4 in the flow.
-            status = runStopOfTenantForJob(job);
+            status = runStopOfTenantJob(job);
         }
         return status;
     }
@@ -355,7 +355,7 @@ public class BulkDataClient {
     /*
      * stops the job (local or remote batch processor).
      */
-    private Response.Status runStopOfTenantForJob(String job) throws Exception {
+    private Response.Status runStopOfTenantJob(String job) throws Exception {
         // 4 - Check the State of the Job (batchStatus)
         //      - batchStatus - STARTING, STARTED, STOPPING, STOPPED, FAILED, COMPLETED, ABANDONED
 
@@ -418,7 +418,7 @@ public class BulkDataClient {
     /*
      * deletes the job
      */
-    private Response.Status runDeleteOfTenantForJob(String job) throws Exception {
+    private Response.Status runDeleteJobForTenant(String job) throws Exception {
         Response.Status status = Response.Status.NO_CONTENT;
         try {
             // Example: https://localhost:9443/ibm/api/batch/jobexecutions/9

--- a/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
+++ b/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
@@ -137,11 +137,11 @@ public class CosExportImpl implements ExportImportBulkData {
             tmpProperties.putAll(properties);
             addBaseUri(operationContext, tmpProperties);
             BulkDataClient client = new BulkDataClient(tmpProperties);
-            client.delete(job);
+            Response.Status status = client.delete(job);
 
             // Set to accepted for signaling purposes, it does not OVERRIDE the above Status
             Response response = Response.status(Status.ACCEPTED).build();
-            operationContext.setProperty(FHIROperationContext.PROPNAME_STATUS_TYPE, Response.Status.ACCEPTED);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_STATUS_TYPE, status);
             operationContext.setProperty(FHIROperationContext.PROPNAME_RESPONSE, response);
             return FHIROperationUtil.getOutputParameters(null);
         } catch (FHIROperationException fe) {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ImportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ImportOperationTest.java
@@ -76,6 +76,8 @@ import com.ibm.fhir.model.type.Url;
 grab content-location
 
 curl 'https://localhost:9443/fhir-server/api/v4/$bulkdata-status?job=FvHrLGPv0oKZNyLzBnY5iA%3D%3D' -k -u "fhiruser:change-password" -v
+
+curl -X DELETE 'https://localhost:9443/fhir-server/api/v4/$bulkdata-status?job=k%2Fd8cTAU%2BUeVEwqURPZ3oA%3D%3D' -k -u "fhiruser:change-password" -v
  * </pre>
  */
 public class ImportOperationTest extends FHIRServerTestBase {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -14,6 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
@@ -104,7 +105,7 @@ public class Operation extends FHIRResource {
                     FHIROperationContext.createSystemOperationContext();
             operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST );
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
@@ -122,6 +123,49 @@ public class Operation extends FHIRResource {
             try {
                 RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null,
                         startTime, new Date(), status);
+            } catch (Exception e) {
+                log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
+            }
+
+            log.exiting(this.getClass().getName(), "invoke(String,Resource)");
+        }
+    }
+
+    @DELETE
+    @Path("${operationName}")
+    public Response invokeDelete(@PathParam("operationName") String operationName) {
+        // This operation is at a top-level, there are no extra values passed through.
+        // This feature is used by operations to execute a specific operation.
+
+        log.entering(this.getClass().getName(), "invokeDelete(String)");
+        Date startTime = new Date();
+        Response.Status status = null;
+
+        try {
+            checkInitComplete();
+
+            FHIROperationContext operationContext = FHIROperationContext.createSystemOperationContext();
+            operationContext.setProperty(FHIROperationContext.PROPNAME_URI_INFO, uriInfo);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_HEADERS, httpHeaders);
+            operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.DELETE);
+
+            FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
+            Resource result =
+                    helper.doInvoke(operationContext, null, null, null, operationName, null,
+                            uriInfo.getQueryParameters(), null);
+            Response response = buildResponse(operationContext, null, result);
+            status = Response.Status.fromStatusCode(response.getStatus());
+            return response;
+        } catch (FHIROperationException e) {
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
+        } catch (Exception e) {
+            status = Status.INTERNAL_SERVER_ERROR;
+            return exceptionResponse(e, status);
+        } finally {
+            try {
+                RestAuditLogger.logOperation(httpServletRequest, operationName, null, null, null, startTime, new Date(),
+                        status);
             } catch (Exception e) {
                 log.log(Level.SEVERE, AUDIT_LOGGING_ERR_MSG, e);
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -134,8 +134,7 @@ public class Operation extends FHIRResource {
     @DELETE
     @Path("${operationName}")
     public Response invokeDelete(@PathParam("operationName") String operationName) {
-        // This operation is at a top-level, there are no extra values passed through.
-        // This feature is used by operations to execute a specific operation.
+        // Support for calling a HTTP DELETE for a System-Level Operation calls.
 
         log.entering(this.getClass().getName(), "invokeDelete(String)");
         Date startTime = new Date();


### PR DESCRIPTION
- Update REST Operation with method DELETE (takes no content)
- Improved the ImportOperationTest
- Update CosExportImpl
- Improve error conditions of DELETE support for the Java Batch
Framework

I executed the QA using injected code into the Import operation to test the behaviors and error conditions, as this could introduce risk in the resulting code I removed before I checked in.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>