### PR TITLE
Move to @RolesAllowed security, update server config, and introduce jwtRP.xml

### DIFF
--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -18,26 +18,6 @@
         <url-pattern>/*</url-pattern>
     </servlet-mapping>
 
-    <!-- Security definitions for the web app -->
-    <security-role>
-        <role-name>FHIRUsers</role-name>
-    </security-role>
-    <security-constraint>
-        <web-resource-collection>
-            <web-resource-name>FHIR REST API</web-resource-name>
-            <url-pattern>/*</url-pattern>
-            <http-method>GET</http-method>
-            <http-method>POST</http-method>
-            <http-method>PUT</http-method>
-            <http-method>PATCH</http-method>
-            <http-method>DELETE</http-method>
-            <http-method>HEAD</http-method>
-            <http-method>TRACE</http-method>
-        </web-resource-collection>
-        <auth-constraint>
-            <role-name>FHIRUsers</role-name>
-        </auth-constraint>
-    </security-constraint>
     <login-config>
         <auth-method>CLIENT-CERT</auth-method>
     </login-config>

--- a/fhir-server/liberty-config/configDropins/disabled/jwtRP.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/jwtRP.xml
@@ -1,0 +1,32 @@
+<server description="fhir-server">
+
+    <!-- Enable features -->
+    <featureManager>
+        <!-- mpJwt-1.1 is already enabled in the default server.xml, but it doesn't hurt to repeat it here -->
+        <feature>mpJwt-1.1</feature>
+    </featureManager>
+
+    <!-- Override the application-bnd binding of the main webapp -->
+    <webApplication contextRoot="fhir-server/api/v4" id="fhir-server-webapp" location="fhir-server.war" name="fhir-server-webapp">
+        <application-bnd>
+            <security-role id="users" name="FHIRUsers">
+                <group name="JwtUsers" access-id="group:https://localhost:9443/oauth2/endpoint/oauth2-provider/FHIRUsers"/>
+            </security-role>
+        </application-bnd>
+    </webApplication>
+
+    <!-- The MP JWT configuration that injects the caller's JWT into a
+         ResourceScoped bean for inspection. -->
+    <mpJwt id="jwtConsumer"
+           keyName="libertyop"
+           userNameAttribute="sub"
+           groupNameAttribute="groupIds"
+           issuer="https://localhost:9443/oauth2/endpoint/oauth2-provider,https://host.docker.internal:9443/oauth2/endpoint/oauth2-provider"
+           authFilterRef="filter"/>
+
+    <authFilter id="filter">
+        <requestUrl urlPattern="/fhir-server" />
+        <requestUrl matchType="notContain" urlPattern="/fhir-server/api/v4/metadata" />
+        <requestUrl matchType="notContain" urlPattern="/fhir-server/api/v4/.well-known/smart-configuration" />
+    </authFilter>
+</server>

--- a/fhir-server/liberty-config/configDropins/disabled/oauthResourceServer.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/oauthResourceServer.xml
@@ -16,5 +16,7 @@
 
     <authFilter id="filter">
         <requestUrl urlPattern="/fhir-server"/>
+        <requestUrl matchType="notContain" urlPattern="/fhir-server/api/v4/metadata" />
+        <requestUrl matchType="notContain" urlPattern="/fhir-server/api/v4/.well-known/smart-configuration" />
     </authFilter>
 </server>

--- a/fhir-server/liberty-config/configDropins/disabled/oidcProvider.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/oidcProvider.xml
@@ -5,6 +5,10 @@
         <feature>openidConnectServer-1.0</feature>
     </featureManager>
 
+    <!-- oauthProvider requires singleSignonEnabled to be set to true due to the use of form login -->
+    <!-- https://stackoverflow.com/a/53526545/161022 -->
+    <webAppSecurity singleSignonEnabled="true"/>
+
     <openidConnectProvider id="oidc-provider" 
         oauthProviderRef="oauth2-provider" 
         keyStoreRef="defaultKeyStore"

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -12,6 +12,9 @@
         <feature>websocket-1.1</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpOpenAPI-1.0</feature>
+        <!-- mpJwt-1.1 isn't used by default, 
+             but we include it here to avoid NoClassDefFound in our classes that *can* use it -->
+        <feature>mpJwt-1.1</feature>
     </featureManager>
 
     <!-- Disable welcome page so that internal server info won't be revealed in responses
@@ -54,7 +57,7 @@
     <webApplication contextRoot="fhir-server/api/v4" id="fhir-server-webapp" location="fhir-server.war" name="fhir-server-webapp">
         <classloader commonLibraryRef="fhirSharedLib" privateLibraryRef="configResources,fhirUserLib"/>
         <!-- Include id attributes to make it easier to override this via dropinConfig -->
-        <application-bnd id="binding">
+        <application-bnd>
             <security-role id="users" name="FHIRUsers">
                 <group name="FHIRUsers"/>
             </security-role>
@@ -95,7 +98,7 @@
         <connectionManager/>
     </dataSource>
 
-    <webAppSecurity allowFailOverToBasicAuth="true"/>
+    <webAppSecurity allowFailOverToBasicAuth="true" singleSignonEnabled="false"/>
 
     <!-- Define a basic user registry with a few users. -->
     <basicRegistry id="basic" realm="BasicRealm"> 

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -127,6 +127,24 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+            <version>1.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>2.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRHttpServletRequestWrapper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRHttpServletRequestWrapper.java
@@ -582,12 +582,13 @@ public class FHIRHttpServletRequestWrapper extends HttpServletRequestWrapper {
     }
 
     /**
-     * @param arg0
+     * @param headerName
      * @return
      * @see javax.servlet.http.HttpServletRequest#getDateHeader(java.lang.String)
+     * @throws IllegalArgumentException
      */
-    public long getDateHeader(String arg0) {
-        return delegate.getDateHeader(arg0);
+    public long getDateHeader(String headerName) {
+        return delegate.getDateHeader(headerName);
     }
 
     /**

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -19,6 +22,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -34,8 +39,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Batch extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Batch.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Batch() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -22,6 +25,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRMediaType;
@@ -37,11 +42,19 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Create extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Create.class.getName());
 
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
+
     /**
-     * This HL7-defined extension header supports "conditional create", allowing a client to create a new resource only if some equivalent 
+     * This HL7-defined extension header supports "conditional create", allowing a client to create a new resource only if some equivalent
      * resource does not already exist on the server.
      * The client defines what equivalence means in this case by supplying a FHIR search query using an HL7 defined extension header "If-None-Exist" as shown:
      * <pre>

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
@@ -21,6 +24,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -35,8 +40,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Delete extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Delete.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Delete() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -142,7 +142,12 @@ public class FHIRResource {
             // e.g "Sun, 06 Nov 1994 08:49:37 GMT", "Sunday, 06-Nov-94 08:49:37 GMT", "Sunday, 06-Nov-1994 08:49:37 GMT"
             // If 2 digits year is used, then means 1940 to 2039.
             modifiedSince = httpServletRequest.getDateHeader(HttpHeaders.IF_MODIFIED_SINCE);
-        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
+            if (log.isLoggable(Level.FINE)) {
+                String headerVal = httpServletRequest.getHeader(HttpHeaders.IF_MODIFIED_SINCE);
+                log.log(Level.FINE, HttpHeaders.IF_MODIFIED_SINCE + " header value '" + headerVal + "' is not valid per rfc1123 or rfc850; "
+                        + "continuing with alternate formats.", e);
+            }
             try {
                 // Then handle ANSIC format, e.g, "Sun Nov  6 08:49:37 1994"
                 // and touchStone specific format, e.g, "Sat, 28-Sep-19 16:11:14"
@@ -150,6 +155,11 @@ public class FHIRResource {
                 modifiedSince = HTTP_DATETIME_FORMATTER.parse(httpServletRequest.getHeader(HttpHeaders.IF_MODIFIED_SINCE), LocalDateTime::from)
                         .atZone(ZoneId.of("GMT")).toInstant().toEpochMilli();
             } catch (DateTimeParseException e1) {
+                if (log.isLoggable(Level.FINE)) {
+                    String headerVal = httpServletRequest.getHeader(HttpHeaders.IF_MODIFIED_SINCE);
+                    log.log(Level.FINE, HttpHeaders.IF_MODIFIED_SINCE + " header value '" + headerVal + "' is not valid per rfc1123 or rfc850; "
+                            + "continuing without.", e);
+                }
                 modifiedSince = -1;
             }
         }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -20,6 +23,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -32,8 +37,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class History extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(History.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public History() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.json.JsonArray;
 import javax.json.JsonPatch;
 import javax.json.JsonValue;
@@ -25,6 +28,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRMediaType;
@@ -48,8 +53,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Patch extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Patch.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Patch() throws Exception {
         super();
@@ -201,7 +214,7 @@ public class Patch extends FHIRResource {
             Resource resource = ior.getResource();
             if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
                 response.entity(resource);
-            } else if (ior.getOperationOutcome() != null && 
+            } else if (ior.getOperationOutcome() != null &&
                     HTTPReturnPreference.OPERATION_OUTCOME == FHIRRequestContext.get().getReturnPreference()) {
                 response.entity(ior.getOperationOutcome());
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -13,6 +13,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -26,6 +29,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Resource;
@@ -38,8 +43,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Read extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Read.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Read() throws Exception {
         super();
@@ -47,7 +60,7 @@ public class Read extends FHIRResource {
 
     @GET
     @Path("{type}/{id}")
-    public Response read(@PathParam("type") String type, @PathParam("id") String id, 
+    public Response read(@PathParam("type") String type, @PathParam("id") String id,
             @HeaderParam(HttpHeaders.IF_NONE_MATCH) String ifNoneMatch) throws Exception {
         log.entering(this.getClass().getName(), "read(String,String)");
         Date startTime = new Date();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -22,6 +25,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -34,8 +39,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Search extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Search.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Search() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
@@ -23,6 +26,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRMediaType;
@@ -40,8 +45,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class Update extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Update.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public Update() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -12,6 +12,9 @@ import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.security.RolesAllowed;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -21,6 +24,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -34,8 +39,16 @@ import com.ibm.fhir.server.util.RestAuditLogger;
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
+@RolesAllowed("FHIRUsers")
+@RequestScoped
 public class VRead extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(VRead.class.getName());
+
+    // The JWT of the current caller. Since this is a request scoped resource, the
+    // JWT will be injected for each JAX-RS request. The injection is performed by
+    // the mpJwt feature.
+    @Inject
+    private JsonWebToken jwt;
 
     public VRead() throws Exception {
         super();


### PR DESCRIPTION
1. Move webapp security info into `RolesAllowed` annotations on a per-JAXRS-resource basis and make the `metadata` and `.well-known/smart-configuration` endpoints open by default

2. Introduce jwtRP.xml as a new configDropin alternative to oauthResourceServer which
can be used to introspect jwt tokens that are passed to the server for
introspecting scopes and making authorization decisions

3. Re-introduce `singleSignonEnabled="false"` on the
default server.xml and override this setting within the
`oidcProvider.xml` dropin

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>