### PR TITLE
issue #1005 - move ig jars to userlib dir

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1,4 +1,4 @@
-<WLP_HOME>---
+---
 layout: post
 title:  IBM FHIR Server User's Guide
 description: IBM FHIR Server User's Guide

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1,4 +1,4 @@
----
+<WLP_HOME>---
 layout: post
 title:  IBM FHIR Server User's Guide
 description: IBM FHIR Server User's Guide
@@ -159,11 +159,11 @@ Throughout this document, we use a path notation to refer to property names. For
 ## 3.3 Tenant-specific configuration properties
 The FHIR server supports certain multi-tenant features. One such feature is the ability to set certain configuration properties on a per-tenant basis.
 
-In general, the configuration properties for a particular tenant are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/fhir-server-config.json` file, where `<tenant-id>` refers to the tenant's “short name” or tenant id.
+In general, the configuration properties for a particular tenant are stored in the `<WLP_HOME>/usr/servers/fhir-server/config/<tenant-id>/fhir-server-config.json` file, where `<tenant-id>` refers to the tenant's “short name” or tenant id.
 
-The global configuration is considered to be associated with a tenant named `default`, so those properties are stored in the `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/fhir-server-config.json` file.
+The global configuration is considered to be associated with a tenant named `default`, so those properties are stored in the `<WLP_HOME>/usr/servers/fhir-server/config/default/fhir-server-config.json` file.
 
-Similarly, tenant-specific search parameters are found at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/<tenant-id>/extension-search-parameters.json`, whereas the global/default extension search parameters are at `<WLP_HOME>/wlp/usr/servers/fhir-server/config/default/extension-search-parameters.json`.
+Similarly, tenant-specific search parameters are found at `<WLP_HOME>/usr/servers/fhir-server/config/<tenant-id>/extension-search-parameters.json`, whereas the global/default extension search parameters are at `<WLP_HOME>/usr/servers/fhir-server/config/default/extension-search-parameters.json`.
 
 Search parameters are handled like a single configuration properly; providing a tenant-specific file will override the global/default extension search parameters as defined at [FHIRSearchConfiguration](https://ibm.github.io/FHIR/guides/FHIRSearchConfiguration).
 
@@ -337,7 +337,7 @@ Here is a simple example of a single (default) datastore:
     }
 }
 ```
-In this example, we define an embedded Derby database named `derby/fhirDB` (a location relative to the `<WLP_HOME>/wlp/usr/servers/fhir-server` directory. The datastore-id associated with this datastore is `default`, which is the value that is used if no `X-FHIR-DSID` request header is found in the incoming request. So, when only a single database is being used, it's wise to leverage the `default` datastore-id value to allow REST API consumers to avoid having to set the `X-FHIR-DSID` request header on each request.
+In this example, we define an embedded Derby database named `derby/fhirDB` (a location relative to the `<WLP_HOME>/usr/servers/fhir-server` directory. The datastore-id associated with this datastore is `default`, which is the value that is used if no `X-FHIR-DSID` request header is found in the incoming request. So, when only a single database is being used, it's wise to leverage the `default` datastore-id value to allow REST API consumers to avoid having to set the `X-FHIR-DSID` request header on each request.
 
 ##### 3.4.2.2.2 Example 2
 This example shows a slightly more complex scenario. In this scenario, the `acme` tenant would like to store data in one of two study-specific Db2 databases with datastore-id values `study1` and `study2`. All resource types pertaining to a given study will be stored in that study's database so there's no need for a proxy persistence layer or routing rules, and so forth.
@@ -453,7 +453,7 @@ To contribute an operation:
 
 2. Create a file named `com.ibm.fhir.operation.FHIROperation` with one or more fully qualified `FHIROperation` classnames and package it in your jar under `META-INF/services/`.
 
-3. Include your jar file under the `<WLP_HOME>/wlp/usr/servers/fhir-server/userlib/` directory of your installation.
+3. Include your jar file under the `<WLP_HOME>/usr/servers/fhir-server/userlib/` directory of your installation.
 
 4. Restart the FHIR server. Changes to custom operations require a server restart, because the server discovers and instantiates operations during server startup only.
 
@@ -1619,7 +1619,7 @@ Here are some notes related to these authentication schemes:
 To properly configure the FHIR server's keystore and truststore files, perform the following steps.
 
 ### 5.2.3.1 Configure the keyStores
-1.  Create a new self-signed server certificate<sup id="a8">[8](#f8)</sup> and store it in a new keystore file located in the `$WLP_HOME/usr/servers/fhir-server/resources/security` directory.
+1.  Create a new self-signed server certificate<sup id="a8">[8](#f8)</sup> and store it in a new keystore file located in the `<WLP_HOME>/usr/servers/fhir-server/resources/security` directory.
 
     In these instructions, we'll call this file `serverKeystore.jks`, although you can name your server keystore file anything you choose. We'll use the `keytool`<sup id="a9">[9](#f9)</sup> command for all keystore- and truststore-related steps, although there are several ways to perform these actions.
 
@@ -1667,7 +1667,7 @@ To properly configure the FHIR server's keystore and truststore files, perform t
 At this point, you should have a client keystore that contains a client certificate whose Distinguished Name's Common Name component is set to the username. You should also have a client truststore which contains the server's public key certificate. Essentially, the server and client both have a keystore that contains their own private and public key certificate and they both have a truststore which contains the public key certificate of their counterpart.
 
 ### 5.2.3.1 Configure the server
-Copy the server keystore (`serverKeystore.jks`) and truststore (`serverTruststore.jks`) files to the appropriate directory (`$WLP_HOME/usr/servers/fhir-server/resources/security`). Then configure the `server.xml` file correctly to reference your new keystore and truststore files.
+Copy the server keystore (`serverKeystore.jks`) and truststore (`serverTruststore.jks`) files to the appropriate directory (`<WLP_HOME>/usr/servers/fhir-server/resources/security`). Then configure the `server.xml` file correctly to reference your new keystore and truststore files.
 
 ### 5.2.3.2 Configure the client
 The precise steps required to configure certificate-based authentication for a client application depend on the specific REST API client framework, but these are the general rules:
@@ -1683,7 +1683,7 @@ The IBM FHIR Server supports these via Liberty's OpenID Connect support.
 The following sections are adapted from the [WebSphere Liberty Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSD28V_liberty/com.ibm.websphere.wlp.core.doc/ae/twlp_config_oidc_pc_examp_beginner.html), but the steps apply to OpenLiberty as well.
 
 ### 5.3.1 Configure Liberty as the OpenID Connect Provider
-Liberty can be configured to act as an OpenID Connect Provider via the [openidConnectServer-1.0 feature](https://openliberty.io/docs/ref/feature/#openidConnectServer-1.0.html). To enable this feature without modifying the default `server.xml`, move the `oidcProvider.xml` config snippet on the installed FHIR Server from `$WLP_HOME/usr/servers/fhir-server/configDropins/disabled/` to `$WLP_HOME/usr/servers/fhir-server/configDropins/defaults/` and modify as desired.
+Liberty can be configured to act as an OpenID Connect Provider via the [openidConnectServer-1.0 feature](https://openliberty.io/docs/ref/feature/#openidConnectServer-1.0.html). To enable this feature without modifying the default `server.xml`, move the `oidcProvider.xml` config snippet on the installed FHIR Server from `<WLP_HOME>/usr/servers/fhir-server/configDropins/disabled/` to `<WLP_HOME>/usr/servers/fhir-server/configDropins/defaults/` and modify as desired.
 
 A copy of this snippet is provided here for illustrative purposes:
 ```xml
@@ -1779,7 +1779,7 @@ This will redirect you to the configured redirect uri for your client, passing i
 For a server running on localhost, the token URL is `https://localhost:9443/oidc/endpoint/oidc-provider/token`.
 
 ### 5.3.2 Configure Liberty to be an Oauth 2.0 Protected Resource Server
-Liberty can be configured to act as an OAuth 2.0 Protected Resource Server via the [openidConnectClient-1.0 feature](https://openliberty.io/docs/ref/feature/#openidConnectClient-1.0.html). To enable this feature without modifying the default `server.xml`, move the `oauthResourceServer.xml` config snippet on the installed FHIR Server from `$WLP_HOME/usr/servers/fhir-server/configDropins/disabled/` to `$WLP_HOME/usr/servers/fhir-server/configDropins/defaults/` and modify as desired.
+Liberty can be configured to act as an OAuth 2.0 Protected Resource Server via the [openidConnectClient-1.0 feature](https://openliberty.io/docs/ref/feature/#openidConnectClient-1.0.html). To enable this feature without modifying the default `server.xml`, move the `oauthResourceServer.xml` config snippet on the installed FHIR Server from `<WLP_HOME>/usr/servers/fhir-server/configDropins/disabled/` to `<WLP_HOME>/usr/servers/fhir-server/configDropins/defaults/` and modify as desired.
 
 A copy of this snippet is provided here for illustrative purposes:
 ```xml

--- a/fhir-install/pom.xml
+++ b/fhir-install/pom.xml
@@ -32,6 +32,21 @@
             <type>war</type>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-ig-us-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-ig-carin-bb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-ig-mcode</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyclient</artifactId>
         </dependency>

--- a/fhir-install/src/main/assembly/distribution.xml
+++ b/fhir-install/src/main/assembly/distribution.xml
@@ -12,7 +12,7 @@
     <fileSets>
         <fileSet>
             <directory>../fhir-server/liberty-config</directory>
-            <outputDirectory>fhir/server/usr/servers/fhir-server</outputDirectory>
+            <outputDirectory>servers/fhir-server</outputDirectory>
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
@@ -24,22 +24,22 @@
     <files>
         <file>
             <source>src/main/resources/docs/README.txt</source>
-            <outputDirectory>fhir/server/fhir/docs</outputDirectory>
+            <outputDirectory>servers/fhir-server/docs</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-server-webapp/target/fhir-server.war</source>
-            <outputDirectory>fhir/server/usr/servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-bulkimportexport-webapp/target/fhir-bulkimportexport.war</source>
-            <outputDirectory>fhir/server/usr/servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-openapi/target/fhir-openapi.war</source>
-            <outputDirectory>fhir/server/usr/servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
     </files>
@@ -57,7 +57,7 @@
             <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
-            <outputDirectory>fhir/server/usr/shared/resources/lib/fhir</outputDirectory>
+            <outputDirectory>shared/resources/lib/fhir</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -70,7 +70,16 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>fhir/server/usr/shared/resources/lib/derby</outputDirectory>
+            <outputDirectory>servers/fhir-server/userlib</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+            <includes>
+                <include>${project.groupId}:fhir-ig-*</include>
+            </includes>
+        </dependencySet>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <outputDirectory>shared/resources/lib/derby</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -80,7 +89,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>fhir/server/usr/shared/resources/lib/db2</outputDirectory>
+            <outputDirectory>shared/resources/lib/db2</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -89,7 +98,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>fhir/server/usr/shared/resources/lib/postgresql</outputDirectory>
+            <outputDirectory>shared/resources/lib/postgresql</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>

--- a/fhir-install/src/main/resources/scripts/install-fhir.sh
+++ b/fhir-install/src/main/resources/scripts/install-fhir.sh
@@ -64,7 +64,7 @@ fi
 # Copy our server assets
 echo -n "
 Deploying fhir-server assets to server runtime environment... "
-cp -pr ${basedir}/fhir/server/* ${WLP_ROOT}
+cp -pr ${basedir}/* ${WLP_ROOT}/usr
 rc=$?
 if [ $rc != 0 ]; then
     echo "Error deploying fhir-server assets to server runtime environment: $rc"

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -82,7 +82,7 @@ if errorlevel 1 (
 
 @REM Copy our server assets
 echo Deploying fhir-server assets to server runtime environment.
-xcopy /S /Y /Q %BASEDIR%\* %WLP_ROOT%\usr
+xcopy /S /Y /Q %BASEDIR%\* %WLP_ROOT%\usr\
 if errorlevel 1 (
     set rc=%ERRORLEVEL%
     echo Error deploying fhir-server assets to server runtime environment: %rc%

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -82,7 +82,7 @@ if errorlevel 1 (
 
 @REM Copy our server assets
 echo Deploying fhir-server assets to server runtime environment.
-xcopy /S /Y /Q %BASEDIR%\fhir\server\* %WLP_ROOT%
+xcopy /S /Y /Q %BASEDIR%\* %WLP_ROOT%\usr
 if errorlevel 1 (
     set rc=%ERRORLEVEL%
     echo Error deploying fhir-server assets to server runtime environment: %rc%

--- a/fhir-install/src/main/resources/scripts/install.sh
+++ b/fhir-install/src/main/resources/scripts/install.sh
@@ -77,7 +77,7 @@ fi
 # Copy our server assets
 echo -n "
 Deploying fhir-server assets to server runtime environment... "
-cp -pr ${basedir}/fhir/server/* ${LIBERTY_ROOT}
+cp -pr ${basedir}/* ${LIBERTY_ROOT}/usr
 rc=$?
 if [ $rc != 0 ]; then
     echo "Error deploying fhir-server assets to server runtime environment: $rc"

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -460,16 +460,16 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
         log.exiting(CLASSNAME, METHODNAME);
 
     }
-    
+
     protected  Integer getResourceTypeIdFromCaches(String resourceType) {
         // Get resourceTypeId from ResourceTypesCache first.
-    	Integer resourceTypeId = ResourceTypesCache.getResourceTypeId(resourceType);
+        Integer resourceTypeId = ResourceTypesCache.getResourceTypeId(resourceType);
         // If no found, then get resourceTypeId from local newResourceTypeIds in case this id is already in newResourceTypeIds
         // but has not been updated to ResourceTypesCache yet. newResourceTypeIds is updated to ResourceTypesCache only when the
         // current transaction is committed.
         if (resourceTypeId == null) {
             resourceTypeId = this.newResourceTypeIds.get(resourceType);
-        }       
+        }
         return resourceTypeId;
     }
 

--- a/fhir-server-webapp/pom.xml
+++ b/fhir-server-webapp/pom.xml
@@ -62,51 +62,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-ig-us-core</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-config</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-ig-carin-bb</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-config</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-ig-mcode</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-config</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>fhir-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>fhir-operation-document</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Instead of packaging them in the fhir-server-webapp war, now we place
them in a userlib dir and the server will discover them from there.

I also performed some path simplification on the install scripts.
We used to create the install files at `/fhir/server/usr/*` but, since
we no longer package the fhir-client or the cli utilities in the
distribution, there's really no need to have these 3 levels.

Finally, I moved the docs (which have a single README which now points
at our website) into the fhir-server directory.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>