### PR TITLE
issue #1032 - set FHIRRequestContext threadlocal before using ConfigHelper

### DIFF
--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/util/PackageRegistryResourceProvider.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/util/PackageRegistryResourceProvider.java
@@ -25,7 +25,8 @@ import com.ibm.fhir.registry.resource.FHIRRegistryResource.Version;
 import com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider;
 
 /**
- * A static registry resource provider that is loaded from an NPM package as specified here: <a href="https://wiki.hl7.org/FHIR_NPM_Package_Spec">https://wiki.hl7.org/FHIR_NPM_Package_Spec</a>
+ * A static registry resource provider that is loaded from an NPM package as specified at
+ * <a href="https://confluence.hl7.org/pages/viewpage.action?pageId=35718629">https://confluence.hl7.org/pages/viewpage.action?pageId=35718629</a>
  *
  * <p>This implementation caches registry resources by resource type and url
  */

--- a/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/filter/rest/FHIRRestServletFilter.java
@@ -119,9 +119,11 @@ public class FHIRRestServletFilter extends HttpFilter {
         try {
             // Create a new FHIRRequestContext and set it on the current thread.
             FHIRRequestContext context = new FHIRRequestContext(tenantId, dsId);
+            // Don't try using FHIRConfigHelper before setting the context!
+            FHIRRequestContext.set(context);
 
             // Retrieve the property group pertaining to the specified datastore.
-            // Find and set the tenantKey for the request, otherwise subsequent pulls from the pool 
+            // Find and set the tenantKey for the request, otherwise subsequent pulls from the pool
             // miss the tenantKey.
             String dsPropertyName = FHIRConfiguration.PROPERTY_DATASOURCES + "/" + dsId;
             PropertyGroup dsPG = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
@@ -144,7 +146,6 @@ public class FHIRRestServletFilter extends HttpFilter {
                     context.setDataStoreMultiTenant(enabled);
                 }
             }
-            FHIRRequestContext.set(context);
 
             context.setOriginalRequestUri(originalRequestUri);
 


### PR DESCRIPTION
ConfigHelper pulls the tenantId and dsId from the threadlocal, so we
can't use that to lookup tenant-specific config until after its set.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>