### PR TITLE
issue #1039 - move fhir-server artifacts under subdirectory in distribution zip

### DIFF
--- a/fhir-install/src/main/assembly/distribution.xml
+++ b/fhir-install/src/main/assembly/distribution.xml
@@ -12,7 +12,7 @@
     <fileSets>
         <fileSet>
             <directory>../fhir-server/liberty-config</directory>
-            <outputDirectory>servers/fhir-server</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server</outputDirectory>
             <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
@@ -24,22 +24,22 @@
     <files>
         <file>
             <source>src/main/resources/docs/README.txt</source>
-            <outputDirectory>servers/fhir-server/docs</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server/docs</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-server-webapp/target/fhir-server.war</source>
-            <outputDirectory>servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-bulkimportexport-webapp/target/fhir-bulkimportexport.war</source>
-            <outputDirectory>servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
         <file>
             <source>../fhir-openapi/target/fhir-openapi.war</source>
-            <outputDirectory>servers/fhir-server/apps</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server/apps</outputDirectory>
             <fileMode>0755</fileMode>
         </file>
     </files>
@@ -57,7 +57,7 @@
             <useProjectArtifact>false</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <useTransitiveFiltering>true</useTransitiveFiltering>
-            <outputDirectory>shared/resources/lib/fhir</outputDirectory>
+            <outputDirectory>artifacts/shared/resources/lib/fhir</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -70,7 +70,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>servers/fhir-server/userlib</outputDirectory>
+            <outputDirectory>artifacts/servers/fhir-server/userlib</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -79,7 +79,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>shared/resources/lib/derby</outputDirectory>
+            <outputDirectory>artifacts/shared/resources/lib/derby</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -89,7 +89,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>shared/resources/lib/db2</outputDirectory>
+            <outputDirectory>artifacts/shared/resources/lib/db2</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>
@@ -98,7 +98,7 @@
         </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
-            <outputDirectory>shared/resources/lib/postgresql</outputDirectory>
+            <outputDirectory>artifacts/shared/resources/lib/postgresql</outputDirectory>
             <directoryMode>0755</directoryMode>
             <fileMode>0755</fileMode>
             <includes>

--- a/fhir-install/src/main/resources/scripts/install-fhir.sh
+++ b/fhir-install/src/main/resources/scripts/install-fhir.sh
@@ -64,7 +64,7 @@ fi
 # Copy our server assets
 echo -n "
 Deploying fhir-server assets to server runtime environment... "
-cp -pr ${basedir}/* ${WLP_ROOT}/usr
+cp -pr ${basedir}/artifacts/* ${WLP_ROOT}/usr
 rc=$?
 if [ $rc != 0 ]; then
     echo "Error deploying fhir-server assets to server runtime environment: $rc"

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -82,7 +82,7 @@ if errorlevel 1 (
 
 @REM Copy our server assets
 echo Deploying fhir-server assets to server runtime environment.
-xcopy /S /Y /Q %BASEDIR%\* %WLP_ROOT%\usr\
+xcopy /S /Y /Q %BASEDIR%\artifacts\* %WLP_ROOT%\usr\
 if errorlevel 1 (
     set rc=%ERRORLEVEL%
     echo Error deploying fhir-server assets to server runtime environment: %rc%

--- a/fhir-install/src/main/resources/scripts/install.sh
+++ b/fhir-install/src/main/resources/scripts/install.sh
@@ -77,7 +77,7 @@ fi
 # Copy our server assets
 echo -n "
 Deploying fhir-server assets to server runtime environment... "
-cp -pr ${basedir}/* ${LIBERTY_ROOT}/usr
+cp -pr ${basedir}/artifacts/* ${LIBERTY_ROOT}/usr/
 rc=$?
 if [ $rc != 0 ]; then
     echo "Error deploying fhir-server assets to server runtime environment: $rc"

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceFactory.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,9 +16,6 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
  */
 public class MockPersistenceFactory implements FHIRPersistenceFactory {
 
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.persistence.FHIRPersistenceFactory#getInstance()
-     */
     @Override
     public FHIRPersistence getInstance() throws FHIRPersistenceException {
         return new MockPersistenceImpl();

--- a/fhir-server/liberty-config/configDropins/disabled/cloud.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/cloud.xml
@@ -1,0 +1,30 @@
+<server>
+    <!-- webApp security is MUST be provided via a gateway -->
+    <webAppSecurity singleSignonEnabled="false" useAuthenticationDataForUnprotectedResource="false"/>
+    <webApplication id="fhir-server-webapp">
+        <application-bnd id="binding">
+            <security-role id="users" name="FHIRUsers">
+                <special-subject type="EVERYONE"/>
+            </security-role>
+        </application-bnd>
+    </webApplication>
+
+    <logging traceSpecification="${env.TRACE_SPEC}" traceFileName="stdout" isoDateFormat="true"/>
+
+    <!-- set statementCacheSize, syncQueryTimeoutWithTransactionTimeout, pool size, and timeouts -->
+    <dataSource id="fhirProxyDataSource" jndiName="jdbc/fhirProxyDataSource" type="javax.sql.XADataSource" statementCacheSize="100" syncQueryTimeoutWithTransactionTimeout="true">
+        <jdbcDriver libraryRef="fhirSharedLib" javax.sql.XADataSource="com.ibm.fhir.persistence.proxy.FHIRProxyXADataSource"/>
+        <connectionManager maxPoolSize="400" minPoolSize="20" connectionTimeout="60s" maxIdleTime="2m"/>
+    </dataSource>
+
+    <!-- temporary test for performance -->
+    <executor name="LargeThreadPool" id="default" coreThreads="40" maxThreads="40" />
+
+    <!-- temporary test for performance -->
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="-1" httpsPort="9443" onError="FAIL">
+        <httpOptions maxKeepAliveRequests="-1" persistTimeout="120s" purgeDataDuringClose="true"/>
+        <accessLogging logFormat='%h %i %u %t "%r" %s %b'/>
+    </httpEndpoint>
+
+    <remoteIp useRemoteIpInAccessLog="true"/>
+</server>


### PR DESCRIPTION
to avoid the need for writing logic to prevent the installer from
recusively copying its files to itself in perpetuum

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>