### PR TITLE
issue #1052 - ignore non-return parameter "general parameters" in search

### DIFF
--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRConstants.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRConstants.java
@@ -1,15 +1,36 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.core;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * This class contains constants that are used through the fhir-* projects.
  */
 public class FHIRConstants {
     public static final String FHIR_LOGGING_GROUP = "FHIRServer";
+
     public static final int FHIR_CONDITIONAL_DELETE_MAX_NUMBER_DEFAULT = 10;
+
+    public static final String FORMAT = "_format";
+
+    public static final String PRETTY = "_pretty";
+
+    public static final String SUMMARY = "_summary";
+
+    public static final String ELEMENTS = "_elements";
+
+    /**
+     * General parameter names that can be used with any FHIR interaction.
+     *
+     * @see <a href="https://www.hl7.org/fhir/r4/http.html#parameters">https://www.hl7.org/fhir/r4/http.html#parameters</a>
+     */
+    public static final List<String> GENERAL_PARAMETER_NAMES =
+            Collections.unmodifiableList(Arrays.asList(FORMAT, PRETTY, SUMMARY, ELEMENTS));
 }

--- a/fhir-core/src/main/java/com/ibm/fhir/core/context/FHIRPagingContext.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/context/FHIRPagingContext.java
@@ -1,20 +1,75 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.core.context;
 
+/**
+ * The paging context for given request
+ */
 public interface FHIRPagingContext {
+    /**
+     * @return the last page number
+     */
     int getLastPageNumber();
+
+    /**
+     * @return the current page number
+     */
     int getPageNumber();
+
+    /**
+     * @return the number of resources in a single page
+     * @see <a href="https://www.hl7.org/fhir/r4/search.html#count">https://www.hl7.org/fhir/r4/search.html#count</a>
+     * @implSpec this number only applies to resources with {@code entry.search.mode = search}
+     *           and does not include included resources or operation outcomes
+     */
     int getPageSize();
+
+    /**
+     * @return the total number of matching resources for the corresponding query
+     * @see <a href="https://www.hl7.org/fhir/r4/search.html#count">https://www.hl7.org/fhir/r4/search.html#count</a>
+     * @implSpec this number only includes the total number of matching resources; it does not count extra resources
+     *           such as OperationOutcome or included resources that may also be returned
+     */
     int getTotalCount();
+
+    /**
+     * @param lastPageNumber the last page of results that can be requested for the corresponding query
+     */
     void setLastPageNumber(int lastPageNumber);
+
+    /**
+     * @param pageNumber the current page number
+     */
     void setPageNumber(int pageNumber);
+
+    /**
+     * @param pageSize the number of resources to include in a single page
+     * @see <a href="https://www.hl7.org/fhir/r4/search.html#count">https://www.hl7.org/fhir/r4/search.html#count</a>
+     * @implSpec this number only applies to resources with {@code entry.search.mode = search}
+     *           and does not include included resources or operation outcomes
+     *
+     */
     void setPageSize(int pageSize);
+
+    /**
+     * @param totalCount the total number of matching resources for the corresponding query
+     * @see <a href="https://www.hl7.org/fhir/r4/search.html#count">https://www.hl7.org/fhir/r4/search.html#count</a>
+     * @implSpec this number only includes the total number of matching resources; it does not count extra resources
+     *           such as OperationOutcome or included resources that may also be returned
+     */
     void setTotalCount(int totalCount);
+
+    /**
+     * @return whether the request should be handled with leniency
+     */
     boolean isLenient();
+
+    /**
+     * @param lenient whether the request should be handled with leniency
+     */
     void setLenient(boolean lenient);
 }

--- a/fhir-core/src/main/java/com/ibm/fhir/core/context/impl/FHIRPagingContextImpl.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/context/impl/FHIRPagingContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,19 +12,27 @@ public class FHIRPagingContextImpl implements FHIRPagingContext {
     protected static final int DEFAULT_PAGE_SIZE = 10;
     protected static final int DEFAULT_PAGE_NUMBER = 1;
     protected static final int DEFAULT_LAST_PAGE_NUMBER = Integer.MAX_VALUE;
-    
+
     protected int lastPageNumber;
     protected int pageNumber;
     protected int pageSize;
     protected int totalCount;
     protected boolean lenient = true;
-    
+
+    /**
+     * Create a FHIRPagingContextImpl with the default values:
+     * <pre>
+     * page number: 1
+     * page size: 10
+     * last page: 214748364
+     * </pre>
+     */
     public FHIRPagingContextImpl() {
         this.pageNumber = DEFAULT_PAGE_NUMBER;
         this.pageSize = DEFAULT_PAGE_SIZE;
         this.lastPageNumber = DEFAULT_LAST_PAGE_NUMBER;
     }
-    
+
     @Override
     public int getLastPageNumber() {
         return lastPageNumber;
@@ -39,7 +47,7 @@ public class FHIRPagingContextImpl implements FHIRPagingContext {
     public int getPageSize() {
         return pageSize;
     }
-    
+
     @Override
     public int getTotalCount() {
         return totalCount;
@@ -64,7 +72,7 @@ public class FHIRPagingContextImpl implements FHIRPagingContext {
     public void setTotalCount(int totalCount) {
         this.totalCount = totalCount;
     }
-    
+
     @Override
     public boolean isLenient() {
         return lenient;

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -56,7 +56,7 @@ public abstract class AbstractPersistenceTest {
 
     // A hook for subclasses to override and provide specific test database setup functionality if required.
     protected void bootstrapDatabase() throws Exception {}
-    
+
     // A hook for subclasses to override and provide specific test database shutdown functionality if required.
     protected void shutdownDatabase() throws Exception {}
 
@@ -101,7 +101,7 @@ public abstract class AbstractPersistenceTest {
             persistence.getTransaction().commit();
         }
     }
-    
+
     @AfterSuite(alwaysRun = true)
     public void tearDown() throws Exception {
         shutdownDatabase();
@@ -137,10 +137,10 @@ public abstract class AbstractPersistenceTest {
         for (String key : queryParms.keySet()) {
 
             expectedCount++;
-            if (!SearchUtil.isSearchResultParameter(key)) {
+            if (!SearchUtil.isSearchResultParameter(key) && !SearchUtil.isGeneralParameter(key)) {
                 String paramName = key;
                 if (SearchUtil.isChainedParameter(key)) {
-                    // ignore the chained part and just very the reference param is there
+                    // ignore the chained part and just verify the reference param is there
                     paramName = key.split("\\.")[0];
                 }
                 // strip any modifiers

--- a/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,7 +27,7 @@ public class SearchConstants {
     private SearchConstants() {
         // No Op
     }
-    
+
     private static final String SUBSETTED_TAG_SYSTEM = "http://terminology.hl7.org/CodeSystem/v3-ObservationValue";
     private static final String SUBSETTED_TAG_CODE = "SUBSETTED";
     private static final String SUBSETTED_TAG_DISPLAY = "subsetted";
@@ -38,7 +38,7 @@ public class SearchConstants {
             .build();
 
     public static final String LOG_BOUNDARY = "---------------------------------------------------------";
-    
+
     // XML Processing.
     public static final String DTM_MANAGER = "com.sun.org.apache.xml.internal.dtm.DTMManager";
 
@@ -52,8 +52,8 @@ public class SearchConstants {
     public static final String BACKSLASH_NEGATIVE_LOOKBEHIND = "(?<!\\\\)";
 
     public static final String COMPARTMENTS_JSON = "compartments.json";
-    
-    // Value Types Regex. 
+
+    // Value Types Regex.
     public static final String PARAMETER_DELIMITER_REGEX = "\\|";
     public static final String COMPONENT_PATH_REGEX = "\\.";
     public static final char START_WHERE = '(';
@@ -62,9 +62,6 @@ public class SearchConstants {
     // If the user specifies a value greater than this, we'll just use this value instead.
     // In the future, we might want to make this value configurable.
     public static final int MAX_PAGE_SIZE = 1000;
-
-    // _format
-    public static final String FORMAT = "_format";
 
     // _sort
     public static final String SORT = "_sort";
@@ -83,20 +80,17 @@ public class SearchConstants {
 
     // _count
     public static final String COUNT = "_count";
-    
+
     // _summary
     public static final String SUMMARY = "_summary";
-    
-    // _pretty
-    public static final String PRETTY = "_pretty";
-    
+
     // _type
     public static final String RESOURCE_TYPE = "_type";
 
     // set as unmodifiable
     public static final List<String> SEARCH_RESULT_PARAMETER_NAMES =
             Collections.unmodifiableList(Arrays.asList(SORT, COUNT, PAGE, INCLUDE, REVINCLUDE, ELEMENTS, SUMMARY));
-    
+
     // set as unmodifiable
     public static final List<String> SYSTEM_LEVEL_SORT_PARAMETER_NAMES = Collections.unmodifiableList(Arrays.asList("_id", "_lastUpdated"));
 
@@ -109,29 +103,29 @@ public class SearchConstants {
     public static final String CHAINED_PARAMETER_CHARACTER = ".";
 
     public static final String PARAMETER_DELIMITER = "|";
-    
+
     public static final char COLON_DELIMITER = ':';
 
     public static final String COLON_DELIMITER_STR = ":";
-    
+
     public static final String WILDCARD = "*";
-    
+
     public static final char AND_CHAR = '&';
-    
+
     public static final char EQUALS_CHAR = '=';
-    
+
     public static final String JOIN_STR = ",";
-    
+
     public static final String AND_CHAR_STR = "&";
-    
+
     // Filter
     public static final String WILDCARD_FILTER = "*";
-    
-    // Resource Constants to reflect a hierarchy: 
+
+    // Resource Constants to reflect a hierarchy:
     // RESOURCE -> DOMAIN_RESOURCE -> Instance (e.g. Claim);
     public static final String RESOURCE_RESOURCE = "Resource";
     public static final String DOMAIN_RESOURCE_RESOURCE = "DomainResource";
-    
+
     // The resourceTypeModifierMap is set one time on startup and is a final value.
     // Set as unmodifiable.
     public static final Map<Type, List<Modifier>> RESOURCE_TYPE_MODIFIER_MAP =
@@ -143,7 +137,7 @@ public class SearchConstants {
                     put(SearchConstants.Type.STRING, Arrays.asList(Modifier.EXACT, Modifier.CONTAINS, Modifier.MISSING));
                     put(SearchConstants.Type.REFERENCE, Arrays.asList(Modifier.TYPE, Modifier.IDENTIFIER, Modifier.MISSING));
                     put(SearchConstants.Type.URI, Arrays.asList(Modifier.BELOW, Modifier.ABOVE, Modifier.MISSING));
-                    put(SearchConstants.Type.TOKEN, Arrays.asList(Modifier.TEXT, Modifier.NOT, 
+                    put(SearchConstants.Type.TOKEN, Arrays.asList(Modifier.TEXT, Modifier.NOT,
                             Modifier.ABOVE, Modifier.BELOW, Modifier.IN, Modifier.NOT_IN, Modifier.OF_TYPE, Modifier.MISSING));
                     put(SearchConstants.Type.NUMBER, Arrays.asList(Modifier.MISSING));
                     put(SearchConstants.Type.DATE, Arrays.asList(Modifier.MISSING));
@@ -157,14 +151,14 @@ public class SearchConstants {
      * Prefixes for Search parameters
      */
     public enum Prefix {
-        EQ("eq"), 
-        NE("ne"), 
-        GT("gt"), 
-        LT("lt"), 
-        GE("ge"), 
-        LE("le"), 
-        SA("sa"), 
-        EB("eb"), 
+        EQ("eq"),
+        NE("ne"),
+        GT("gt"),
+        LT("lt"),
+        GE("ge"),
+        LE("le"),
+        SA("sa"),
+        EB("eb"),
         AP("ap");
 
         private String value = null;
@@ -189,19 +183,19 @@ public class SearchConstants {
 
     /**
      * Types
-     * 
+     *
      * @author markd
      *
      */
     public enum Type {
-        NUMBER("number"), 
-        DATE("date"), 
-        STRING("string"), 
-        TOKEN("token"), 
-        REFERENCE("reference"), 
-        COMPOSITE("composite"), 
-        QUANTITY("quantity"), 
-        URI("uri"), 
+        NUMBER("number"),
+        DATE("date"),
+        STRING("string"),
+        TOKEN("token"),
+        REFERENCE("reference"),
+        COMPOSITE("composite"),
+        QUANTITY("quantity"),
+        URI("uri"),
         SPECIAL("special");
 
         private String value = null;
@@ -237,8 +231,8 @@ public class SearchConstants {
         ABOVE("above"),
         NOT("not"),
         NOT_IN("not-in"),
-        TYPE("[type]"), 
-        OF_TYPE("of-type"), 
+        TYPE("[type]"),
+        OF_TYPE("of-type"),
         IDENTIFIER("identifier");
 
         private String value = null;

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -30,6 +30,7 @@ import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.resource.SearchParameter.Component;
@@ -632,11 +633,10 @@ public class SearchUtil {
                             String msg = "_type search parameter has invalid resource type:" + resType;
                             if (lenient) {
                                 // TODO add this to the list of supplemental warnings?
-                                log.log(Level.FINE, resType + " is not a valid resource type");
+                                log.log(Level.FINE, msg);
                                 continue;
                             } else {
-                                throw SearchExceptionUtil.buildNewInvalidSearchException(
-                                        "_type search parameter has invalid resource type:" + resType);
+                                throw SearchExceptionUtil.buildNewInvalidSearchException(msg);
                             }
                         }
                     }
@@ -656,9 +656,6 @@ public class SearchUtil {
             String name = entry.getKey();
             try {
                 List<String> params = entry.getValue();
-                if (SearchConstants.FORMAT.equals(name)) {
-                    continue;
-                }
 
                 if (isSearchResultParameter(name)) {
                     parseSearchResultParameter(resourceType, context, name, params, lenient);
@@ -669,6 +666,8 @@ public class SearchUtil {
                         context.getIncludeParameters().clear();
                         context.getRevIncludeParameters().clear();
                     }
+                } else if (isGeneralParameter(name) ) {
+                    // we'll handle it somewhere else, so just ignore it here
                 } else if (isChainedParameter(name)) {
                     List<String> chainedParemeters = params;
                     for (String chainedParameterString : chainedParemeters) {
@@ -1066,6 +1065,10 @@ public class SearchUtil {
 
     public static boolean isSearchResultParameter(String name) {
         return SearchConstants.SEARCH_RESULT_PARAMETER_NAMES.contains(name);
+    }
+
+    public static boolean isGeneralParameter(String name) {
+        return FHIRConstants.GENERAL_PARAMETER_NAMES.contains(name);
     }
 
     private static void parseSearchResultParameter(Class<?> resourceType, FHIRSearchContext context, String name,

--- a/fhir-server-test/src/test/java/testng.xml
+++ b/fhir-server-test/src/test/java/testng.xml
@@ -19,6 +19,7 @@
             <class name="com.ibm.fhir.server.test.FHIRDocumentOperationTest" />
             <class name="com.ibm.fhir.server.test.FHIRValidateOperationTest" />
             <class name="com.ibm.fhir.server.test.FHIRHealthcheckOperationTest" />
+            <class name="com.ibm.fhir.server.test.PrettyServerFormatTest" />
             <class name="com.ibm.fhir.server.test.MultiDataStoreTest" />
             <class name="com.ibm.fhir.server.test.SearchTest" />
             <class name="com.ibm.fhir.server.test.SearchAllTest" />


### PR DESCRIPTION
1. added PrettyServerFormatTest to testng.xml

2. moved "general parameter" parameter names to FHIRConstants in `fhir-core`
and update SearchUtil; this fixes #1052 

3. added javadoc to the FHIRPagingContext interface

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>