### PR TITLE
Sequence Lock Contention on Apache Derby #1038

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyMaster.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyMaster.java
@@ -59,12 +59,16 @@ public class DerbyMaster implements AutoCloseable {
         // However, any driver prior to JDBC 4.0 has to be loaded with the method Class.forName.
         try {
             Class.forName(DERBY_TRANSLATOR.getDriverClassName());
-        }
-        catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);
         }
 
-        DerbyServerPropertiesMgr.setServerProperties(DEBUG);
+        // Derby Server Properties are now set using the System Stored procedures.
+        try {
+            DerbyServerPropertiesMgr.setServerProperties(DEBUG, getConnection());
+        } catch (SQLException e) {
+            logger.warning("Derby Server Properties not set");
+        }
     }
 
     /**
@@ -136,7 +140,6 @@ public class DerbyMaster implements AutoCloseable {
         if (connection == null) {
             try {
                 // Make sure the Derby driver is loaded
-
                 Properties properties = new Properties();
                 DerbyPropertyAdapter adapter = new DerbyPropertyAdapter(properties);
                 adapter.setDatabase(database);

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyServerPropertiesMgr.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyServerPropertiesMgr.java
@@ -6,14 +6,29 @@
 
 package com.ibm.fhir.database.utils.derby;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Properties;
-
+import java.util.logging.Logger;
 
 /**
  * Server properties for embedded derby which is used in unit tests and server integration tests,
  * equal to setting in derby.properties.
  */
 public class DerbyServerPropertiesMgr {
+    private static final Logger logger = Logger.getLogger(DerbyServerPropertiesMgr.class.getName());
+
+    private DerbyServerPropertiesMgr() {
+        // No Operation
+    }
+
+    /**
+     * sets the properties in the system properties.
+     * 
+     * @param isDebug
+     */
     public static void setServerProperties(boolean isDebug) {
         Properties sysProperties = System.getProperties();
         // This speeds up sequence fetching by pre-creating 1000 instead of the default 100.
@@ -26,4 +41,40 @@ public class DerbyServerPropertiesMgr {
         }
     }
 
+    /**
+     * sets the server properties in
+     * 
+     * @param isDebug
+     * @param conn
+     * @throws SQLException
+     */
+    public static void setServerProperties(boolean isDebug, Connection conn) throws SQLException {
+        // Link https://db.apache.org/derby/docs/10.9/ref/crefproper22250.html
+        try (Statement s = conn.createStatement();) {
+            // Preallocation - https://db.apache.org/derby/docs/10.9/ref/rrefproperpreallocator.html
+            // Since we're driving contention with 1000, we're jumping to 5000.
+            setProperty(s, "derby.language.sequence.preallocator", "5000");
+            if (isDebug) {
+                setProperty(s, "derby.language.logQueryPlan", "true");
+                setProperty(s, "derby.language.logStatementText", "true");
+                setProperty(s, "derby.locks.deadlockTrace", "true");
+                setProperty(s, "derby.infolog.append", "true");
+            }
+        }
+    }
+
+    public static void setProperty(Statement s, String name, String value) throws SQLException {
+        // Check the value
+        s.execute("VALUES SYSCS_UTIL.SYSCS_GET_DATABASE_PROPERTY('" + name + "')");
+        ResultSet r = s.getResultSet();
+        r.next();
+        logger.info(
+                "Database Property [" + name + "] is desired [" + value + "] and is current [" + r.getString(1) + "]");
+        s.executeUpdate("CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY('" + name + "', '" + value + "')");
+        s.execute("VALUES SYSCS_UTIL.SYSCS_GET_DATABASE_PROPERTY('" + name + "')");
+        r = s.getResultSet();
+        r.next();
+        logger.info(
+                "Database Property [" + name + "] is desired [" + value + "] and is current [" + r.getString(1) + "]");
+    }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyServerPropertiesMgr.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyServerPropertiesMgr.java
@@ -52,8 +52,8 @@ public class DerbyServerPropertiesMgr {
         // Link https://db.apache.org/derby/docs/10.9/ref/crefproper22250.html
         try (Statement s = conn.createStatement();) {
             // Preallocation - https://db.apache.org/derby/docs/10.9/ref/rrefproperpreallocator.html
-            // Since we're driving contention with 1000, we're jumping to 5000.
-            setProperty(s, "derby.language.sequence.preallocator", "5000");
+            // Since we're driving contention with 1000, we're jumping to 10000.
+            setProperty(s, "derby.language.sequence.preallocator", "10000");
             if (isDebug) {
                 setProperty(s, "derby.language.logQueryPlan", "true");
                 setProperty(s, "derby.language.logStatementText", "true");

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/DerbyBootstrapper.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/DerbyBootstrapper.java
@@ -17,6 +17,7 @@ import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.database.utils.api.IDatabaseAdapter;
 import com.ibm.fhir.database.utils.common.JdbcTarget;
 import com.ibm.fhir.database.utils.derby.DerbyAdapter;
+import com.ibm.fhir.database.utils.derby.DerbyServerPropertiesMgr;
 import com.ibm.fhir.database.utils.derby.DerbyTranslator;
 import com.ibm.fhir.database.utils.model.DatabaseObjectType;
 import com.ibm.fhir.database.utils.model.PhysicalDataModel;
@@ -62,6 +63,9 @@ public class DerbyBootstrapper {
             log.finer("Obtaining connection for tenantId/dsId: " + tenantId + "/" + dsId);
             connection = fhirDb.getConnection(tenantId, dsId);
             log.finer("Connection: " + connection.toString());
+
+            // Sets the sequence properties on teh database.
+            DerbyServerPropertiesMgr.setServerProperties(false, connection);
 
             dbDriverName = connection.getMetaData().getDriverName();
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
@@ -44,7 +44,6 @@ import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
-import com.ibm.fhir.database.utils.derby.DerbyServerPropertiesMgr;
 import com.ibm.fhir.model.config.FHIRModelConfig;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.notification.websocket.impl.FHIRNotificationServiceEndpointConfig;
@@ -204,9 +203,6 @@ public class FHIRServletContextListener implements ServletContextListener {
         Boolean performDbBootstrap = fhirConfig.getBooleanProperty(PROPERTY_JDBC_BOOTSTRAP_DB, Boolean.FALSE);
         if (performDbBootstrap) {
             log.info("Performing Derby database bootstrapping...");
-
-            // Start derby with debug off by default.
-            DerbyServerPropertiesMgr.setServerProperties(false);
 
             String datasourceJndiName = fhirConfig.getStringProperty(FHIRConfiguration.PROPERTY_JDBC_DATASOURCE_JNDINAME, "jdbc/fhirDB");
             InitialContext ctxt = new InitialContext();


### PR DESCRIPTION
Addresses lock contention with verification of the number of sequence numbers preallocated for each database instance using a callable system stored procedure for derby only.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>