### PR TITLE
issue #1061 fixes for improving postgresql update performance

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -227,9 +227,9 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
         String targetSchema, String targetTable, String tenantColumnName,
         List<String> columns, boolean enforced) {
 
-        // If enforced=false, skip the constraint because derby doesn't support unenforced constraints
+        // If enforced=false, skip the constraint because Derby doesn't support unenforced constraints
         if (enforced) {
-            // Make the call, but without the tenantColumnName because PostgreSQL doesn't support our multi-tenant implementation
+            // Make the call, but without the tenantColumnName because Derby doesn't support our multi-tenant implementation
             super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
         }
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -224,13 +224,14 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
 
     @Override
     public void createForeignKeyConstraint(String constraintName, String schemaName, String name,
-            String targetSchema, String targetTable, String tenantColumnName,
-            List<String> columns, boolean enforced) {
+        String targetSchema, String targetTable, String tenantColumnName,
+        List<String> columns, boolean enforced) {
 
-        // Make the call, but
-        // 1. without the tenantColumnName because Derby doesn't support our multi-tenant implementation; and
-        // 2. with enforced=true because Derby doesn't support non-default constraint characteristics
-        super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
+        // If enforced=false, skip the constraint because derby doesn't support unenforced constraints
+        if (enforced) {
+            // Make the call, but without the tenantColumnName because PostgreSQL doesn't support our multi-tenant implementation
+            super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
+        }
     }
 
     @Override

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
@@ -247,10 +247,9 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
             String targetSchema, String targetTable, String tenantColumnName,
             List<String> columns, boolean enforced) {
 
-        // Make the call, but
-        // 1. without the tenantColumnName because PostgreSql doesn't support our multi-tenant implementation; and
-        // 2. with enforced=true because PostgreSql doesn't support non-default constraint characteristics
+        // If enforced=false, skip the constraint because PostgreSQL doesn't support unenforced constraints
         if (enforced) {
+            // Make the call, but without the tenantColumnName because PostgreSQL doesn't support our multi-tenant implementation
             super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
         }
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
@@ -250,7 +250,9 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
         // Make the call, but
         // 1. without the tenantColumnName because PostgreSql doesn't support our multi-tenant implementation; and
         // 2. with enforced=true because PostgreSql doesn't support non-default constraint characteristics
-        super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
+        if (enforced) {
+            super.createForeignKeyConstraint(constraintName, schemaName, name, targetSchema, targetTable, null, columns, true);
+        }
     }
 
     @Override

--- a/fhir-persistence-schema/src/main/resources/add_any_resource_postgresql.sql
+++ b/fhir-persistence-schema/src/main/resources/add_any_resource_postgresql.sql
@@ -37,7 +37,8 @@
   v_duplicate               INT := 0;
   v_version                 INT := 0;
   v_insert_version          INT := 0;
-  lock_cur CURSOR (t_resource_type_id INT, t_logical_id VARCHAR(255)) FOR SELECT logical_resource_id FROM {{SCHEMA_NAME}}.logical_resources WHERE resource_type_id = t_resource_type_id AND logical_id = t_logical_id FOR UPDATE;
+  -- Because we don't really update any existing key, so use NO KEY UPDATE to achieve better concurrence performance. 
+  lock_cur CURSOR (t_resource_type_id INT, t_logical_id VARCHAR(255)) FOR SELECT logical_resource_id FROM {{SCHEMA_NAME}}.logical_resources WHERE resource_type_id = t_resource_type_id AND logical_id = t_logical_id FOR NO KEY UPDATE;
 
 BEGIN
   v_schema_name := '{{SCHEMA_NAME}}';
@@ -45,8 +46,6 @@ BEGIN
     FROM {{SCHEMA_NAME}}.resource_types WHERE resource_type = p_resource_type;
 
   -- Get a lock at the system-wide logical resource level
-  -- we need to use a cursor in this context because we need the FOR UPDATE WITH RS support
-  -- and this does not work with the SET (?,?) = (select ...) construct
   OPEN lock_cur(t_resource_type_id := v_resource_type_id, t_logical_id := p_logical_id);
   FETCH lock_cur INTO v_logical_resource_id;
   CLOSE lock_cur;


### PR DESCRIPTION
To achieve better update performance:
-Updated add_any_resource function for postgresql to use "no key update";
-Updated postgresqladapter to disable the constrains for composites.

Per tests, the first change improved the updates of observations from only about 3/second to more than 33/second; and the second change further improved the performance to about 60/second, almost the same as importing new resources.




Signed-off-by: Albert Wang <xuwang@us.ibm.com>