### PR TITLE
Skip index entries that are missing required fields instead of throwing

### DIFF
--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/util/FHIRRegistryUtil.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/util/FHIRRegistryUtil.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.format.Format;
@@ -160,12 +161,13 @@ public final class FHIRRegistryUtil {
     }
 
     public static List<Entry> readIndex(String indexPath) {
+        log.info("Loading index: " + indexPath);
         try (InputStream in = FHIRRegistryUtil.class.getClassLoader().getResourceAsStream(indexPath)) {
             Index index = new Index();
             index.load(in);
             return index.getEntries();
         } catch (Exception e) {
-            log.warning("Unable to read index: " + indexPath + " due to the following exception: " + e.getMessage());
+            log.log(Level.WARNING, "Unexpected error while loading index '" + indexPath + "'", e);
         }
         return Collections.emptyList();
     }

--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/util/Index.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/util/Index.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.json.spi.JsonProvider;
 import javax.json.stream.JsonGenerator;
@@ -33,6 +35,8 @@ import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.resource.StructureDefinition;
 
 public class Index {
+    private static final Logger log = Logger.getLogger(Index.class.getName());
+
     private static final JsonProvider PROVIDER = JsonProvider.provider();
     private static final JsonParserFactory PARSER_FACTORY = PROVIDER.createParserFactory(null);
     private static final JsonGeneratorFactory GENERATOR_FACTORY = PROVIDER.createGeneratorFactory(Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true));
@@ -93,11 +97,18 @@ public class Index {
     }
 
     private void parseFiles(JsonParser parser) {
+        int i = 0;
         while (parser.hasNext()) {
             Event event = parser.next();
             switch (event) {
             case START_OBJECT:
-                parseFile(parser);
+                try {
+                    parseFile(parser);
+                } catch (NullPointerException e) {
+                    log.log(Level.WARNING, "Skipping index entry " + i + " due to " +
+                        "one or more missing required fields, beginning with: " + e.getMessage());
+                }
+                i++;
                 break;
             case END_ARRAY:
                 return;
@@ -222,11 +233,11 @@ public class Index {
                 String version,
                 String kind,
                 String type) {
-            this.fileName = Objects.requireNonNull(fileName);
-            this.resourceType = Objects.requireNonNull(resourceType);
-            this.id = Objects.requireNonNull(id);
-            this.url = Objects.requireNonNull(url);
-            this.version = Objects.requireNonNull(version);
+            this.fileName = Objects.requireNonNull(fileName, "fileName");
+            this.resourceType = Objects.requireNonNull(resourceType, "resourceType");
+            this.id = Objects.requireNonNull(id, "id");
+            this.url = Objects.requireNonNull(url, "url");
+            this.version = Objects.requireNonNull(version, "version");
             this.kind = kind;
             this.type = type;
         }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ValidationProcessor.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ValidationProcessor.java
@@ -21,15 +21,10 @@ import com.ibm.fhir.validation.FHIRValidator;
 
 /**
  * Strategy to process resources using the {@link FHIRValidator}
-
- *
  */
 public class ValidationProcessor implements IExampleProcessor {
     private static final Logger logger = Logger.getLogger(ValidationProcessor.class.getName());
-    
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.model.spec.test.IExampleProcessor#process(java.lang.String, com.ibm.fhir.model.resource.Resource)
-     */
+
     @Override
     public void process(String jsonFile, Resource resource) throws Exception {
         List<OperationOutcome.Issue> issues = FHIRValidator.validator().validate(resource);
@@ -45,7 +40,7 @@ public class ValidationProcessor implements IExampleProcessor {
                     .collect(Collectors.joining(","));
                 issueStrings.add(details + " (" + locations + ")");
             }
-            
+
             // Only errors or worse should result in a failure.
             boolean includesFailure = false;
             for (OperationOutcome.Issue issue: issues) {
@@ -60,7 +55,7 @@ public class ValidationProcessor implements IExampleProcessor {
                 throw new Exception("Input resource failed validation: \n\t" + String.join("\n\t", issueStrings));
             }
             else {
-                logger.fine("Validation issues on '" + jsonFile + "' [INFO]: \n\t" + String.join("\n\t", issueStrings));
+                logger.info("Validation issues on '" + jsonFile + "' [INFO]: \n\t" + String.join("\n\t", issueStrings));
             }
         }
     }


### PR DESCRIPTION
Also, this PR updates the NullPointerExceptions to include the name of
the field that is missing.  I think we should consider doing that for
all uses of Objects.nonNull across the model.


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>