### PR TITLE
When searchparameter expression resolves to extension element, use value

### DIFF
--- a/fhir-ig-davinci-pdex-plan-net/pom.xml
+++ b/fhir-ig-davinci-pdex-plan-net/pom.xml
@@ -21,6 +21,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-ig-us-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
@@ -76,6 +76,11 @@ public abstract class Element extends AbstractVisitable {
         return elementType.cast(this);
     }
 
+    /**
+     * @return
+     *     true if the element is a FHIR primitive type and has a primitive value (as opposed to not having a value and just 
+     *     having extensions), otherwise false
+     */
     public boolean hasValue() {
         return false;
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -33,6 +33,7 @@ import com.ibm.fhir.model.type.ContactPoint;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
+import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Identifier;
 import com.ibm.fhir.model.type.Money;
@@ -643,6 +644,16 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
         }
 
         return false;
+    }
+
+    @Override
+    public boolean visit(java.lang.String elementName, int elementIndex, Extension extension) {
+        if (extension.getValue() != null) {
+            extension.getValue().accept(this);
+            return false;
+        } else {
+            return true;
+        }
     }
 
     /*

--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/util/PackageRegistryResourceProvider.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/util/PackageRegistryResourceProvider.java
@@ -57,7 +57,8 @@ public abstract class PackageRegistryResourceProvider implements FHIRRegistryRes
     public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
         Objects.requireNonNull(resourceType);
         Objects.requireNonNull(url);
-        List<FHIRRegistryResource> registryResources = registryResourceMap.getOrDefault(resourceType, Collections.emptyMap()).getOrDefault(url, Collections.emptyList());
+        List<FHIRRegistryResource> registryResources = registryResourceMap.getOrDefault(resourceType, Collections.emptyMap())
+                .getOrDefault(url, Collections.emptyList());
         if (!registryResources.isEmpty()) {
             if (version != null) {
                 Version v = Version.from(version);

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -1873,7 +1873,12 @@ public class CodeGenerator {
             return;
         }
 
-        if (!"Element".equals(name)) {
+        if ("Element".equals(name)) {
+            cb.javadocStart()
+                .javadocReturn("true if the element is a FHIR primitive type and has a primitive value "
+                        + "(as opposed to not having a value and just having extensions), otherwise false")
+                .javadocEnd();
+        } else {
             cb.override();
         }
 


### PR DESCRIPTION
While testing with the DaVinci PDEX Plan-Net we noticed that some of the
search parameters weren't getting indexed.
Upon further inspection, it was because the expression led to an
Extension element and not the value of that extension.
I'm still not sure what is "best practice" but I found that the
`mothersMaidenName` search parameter from the base spec has the same
issue and so I think its good for us to handle this.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>