### PR TITLE
Replace /config to /userlib for sharedLib Section 4.3.2

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -624,7 +624,7 @@ To implement a persistence interceptor, complete the following steps:
 
     `com.ibm.mysolution.MyInterceptor`
 
-3.  Copy your jar to the `<WLP_HOME>/usr/servers/fhir-server/config` directory so that it is accessible to the FHIR server via the classpath (the `server.xml` file contains a library element that defines this directory as a shared library).
+3.  Copy your jar to the `<WLP_HOME>/usr/servers/fhir-server/userlib` directory so that it is accessible to the FHIR server via the classpath (the `server.xml` file contains a library element that defines this directory as a shared library).
 
 4.  Re-start the FHIR server.
 


### PR DESCRIPTION
Fhir User Guide has incorrect jar location mentioned to keep custom interceptors jar for Persistence interceptors.

Steps to reproduce the behavior:
1. Go to 'https://ibm.github.io/FHIR/guides/FHIRServerUsersGuide/#432-implementing-a-persistence-interceptor'
2. Under 4.3.2 Implementing a persistence interceptor step 3, Copy your jar to the <WLP_HOME>/usr/servers/fhir-server/config. This path should be <WLP_HOME>/usr/servers/fhir-server/userlib