### PR TITLE
Minor swagger definition changes

### DIFF
--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -1275,7 +1275,6 @@ public class FHIROpenApiGenerator {
                 .add("valueString", "text value")
                 .build();
             example = factory.createArrayBuilder().add(obj).build();
-            property.add("example", example);
         } else if (Identifier.class.equals(modelClass) && Reference.class.equals(fieldClass)) {
             // "example": {"reference":"Organization/123","type":"Organization","display":"The Assigning Organization"}
             example = factory.createObjectBuilder()
@@ -1284,7 +1283,6 @@ public class FHIROpenApiGenerator {
                     .add("display", "The Assigning Organization")
                     // skip assigner to break the recursion
                     .build();
-            property.add("example", example);
         }
 
         if (many) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -1059,6 +1059,8 @@ public class FHIROpenApiGenerator {
                 }
             }
 
+            JsonArray requiredArray = required.build();
+
             Class<?> superClass = modelClass.getSuperclass();
             if (superClass != null && superClass.getPackage().getName().startsWith("com.ibm.fhir.model")
                     && !superClass.equals(AbstractVisitable.class)) {
@@ -1071,6 +1073,9 @@ public class FHIROpenApiGenerator {
                 JsonObjectBuilder wrapper = factory.createObjectBuilder();
                 wrapper.add("type", "object");
                 wrapper.add("properties", properties);
+                if (!requiredArray.isEmpty()) {
+                    wrapper.add("required", requiredArray);
+                }
                 allOf.add(wrapper);
 
                 definition.add("allOf", allOf);
@@ -1080,11 +1085,9 @@ public class FHIROpenApiGenerator {
                     definition.add("discriminator", "resourceType");
                 }
                 definition.add("properties", properties);
-            }
-
-            JsonArray requiredArray = required.build();
-            if (!requiredArray.isEmpty()) {
-                definition.add("required", requiredArray);
+                if (!requiredArray.isEmpty()) {
+                    definition.add("required", requiredArray);
+                }
             }
 
             if (Resource.class.isAssignableFrom(modelClass)) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -35,6 +35,7 @@ import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonReader;
+import javax.json.JsonStructure;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
@@ -1263,17 +1264,18 @@ public class FHIROpenApiGenerator {
         }
 
         // Include select examples to help tools avoid bumping into infinite recursion (if they try generate examples)
+        JsonStructure example = null;
         if (Element.class.equals(modelClass) && Extension.class.equals(fieldClass)) {
             // "example": [{"url":"http://example.com","valueString":"textValue"}]
             JsonObject obj = factory.createObjectBuilder()
                 .add("url", "http://example.com")
                 .add("valueString", "text value")
                 .build();
-            JsonArray example = factory.createArrayBuilder().add(obj).build();
+            example = factory.createArrayBuilder().add(obj).build();
             property.add("example", example);
         } else if (Identifier.class.equals(modelClass) && Reference.class.equals(fieldClass)) {
             // "example": {"reference":"Organization/123","type":"Organization","display":"The Assigning Organization"}
-            JsonObject example = factory.createObjectBuilder()
+            example = factory.createObjectBuilder()
                     .add("reference", "Organization/123")
                     .add("type", "Organization")
                     .add("display", "The Assigning Organization")
@@ -1286,8 +1288,14 @@ public class FHIROpenApiGenerator {
             JsonObjectBuilder wrapper = factory.createObjectBuilder();
             wrapper.add("type", "array");
             wrapper.add("items", property);
+            if (example != null) {
+                wrapper.add("example", example);
+            }
             properties.add(elementName, wrapper);
         } else {
+            if (example != null) {
+                property.add("example", example);
+            }
             properties.add(elementName, property);
         }
     }
@@ -1306,7 +1314,7 @@ public class FHIROpenApiGenerator {
                 .replaceAll("‑", "&#8209;"); // Non-Breaking Hyphen
 
         if (!Charset.forName("US-ASCII").newEncoder().canEncode(cleansed)) {
-            // If a new character sneaks in - it'll output here. 
+            // If a new character sneaks in - it'll output here.
             // Best place to look up entity is https://unicodelookup.com
             System.out.println("[Failure to cleanse the description] - " + cleansed);
         }

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -798,6 +798,8 @@ public class FHIRSwaggerGenerator {
                 }
             }
 
+            JsonArray requiredArray = required.build();
+
             Class<?> superClass = modelClass.getSuperclass();
             if (superClass != null
                     && superClass.getPackage().getName().startsWith("com.ibm.fhir.model")
@@ -811,6 +813,9 @@ public class FHIRSwaggerGenerator {
                 JsonObjectBuilder wrapper = factory.createObjectBuilder();
                 wrapper.add("type", "object");
                 wrapper.add("properties", properties);
+                if (!requiredArray.isEmpty()) {
+                    wrapper.add("required", requiredArray);
+                }
                 allOf.add(wrapper);
 
                 definition.add("allOf", allOf);
@@ -820,11 +825,9 @@ public class FHIRSwaggerGenerator {
                     definition.add("discriminator", "resourceType");
                 }
                 definition.add("properties", properties);
-            }
-
-            JsonArray requiredArray = required.build();
-            if (!requiredArray.isEmpty()) {
-                definition.add("required", requiredArray);
+                if (!requiredArray.isEmpty()) {
+                    definition.add("required", requiredArray);
+                }
             }
 
             if (Resource.class.isAssignableFrom(modelClass)) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -1008,7 +1008,6 @@ public class FHIRSwaggerGenerator {
                 .add("valueString", "text value")
                 .build();
             example = factory.createArrayBuilder().add(obj).build();
-            property.add("example", example);
         } else if (Identifier.class.equals(modelClass) && Reference.class.equals(fieldClass)) {
             // "example": {"reference":"Organization/123","type":"Organization","display":"The Assigning Organization"}
             example = factory.createObjectBuilder()
@@ -1017,7 +1016,6 @@ public class FHIRSwaggerGenerator {
                     .add("display", "The Assigning Organization")
                     // skip assigner to break the recursion
                     .build();
-            property.add("example", example);
         }
 
         if (many) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -29,6 +29,7 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import javax.json.JsonStructure;
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import javax.json.stream.JsonGenerator;
@@ -994,18 +995,20 @@ public class FHIRSwaggerGenerator {
             property.add("description", description);
         }
 
+
         // Include select examples to help tools avoid bumping into infinite recursion (if they try generate examples)
+        JsonStructure example = null;
         if (Element.class.equals(modelClass) && Extension.class.equals(fieldClass)) {
             // "example": [{"url":"http://example.com","valueString":"textValue"}]
             JsonObject obj = factory.createObjectBuilder()
                 .add("url", "http://example.com")
                 .add("valueString", "text value")
                 .build();
-            JsonArray example = factory.createArrayBuilder().add(obj).build();
+            example = factory.createArrayBuilder().add(obj).build();
             property.add("example", example);
         } else if (Identifier.class.equals(modelClass) && Reference.class.equals(fieldClass)) {
             // "example": {"reference":"Organization/123","type":"Organization","display":"The Assigning Organization"}
-            JsonObject example = factory.createObjectBuilder()
+            example = factory.createObjectBuilder()
                     .add("reference", "Organization/123")
                     .add("type", "Organization")
                     .add("display", "The Assigning Organization")
@@ -1018,8 +1021,14 @@ public class FHIRSwaggerGenerator {
             JsonObjectBuilder wrapper = factory.createObjectBuilder();
             wrapper.add("type", "array");
             wrapper.add("items", property);
+            if (example != null) {
+                wrapper.add("example", example);
+            }
             properties.add(elementName, wrapper);
         } else {
+            if (example != null) {
+                property.add("example", example);
+            }
             properties.add(elementName, property);
         }
     }


### PR DESCRIPTION
Bruno reported that he's still seeing a "MAX DEPTH" issue in the examples generated by IBM API Connect...this was supposed to have been fixed by https://github.com/IBM/FHIR/pull/863 but I think I know why it didn't work...

Bruno to confirm ASAP so we can possibly try squeezing this in for 4.2.2.

Additionally, I moved the list of required fields for each object down one level in the hierarchy as requested by a potential user of the tool.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>