### PR TITLE
issue #943 change isExportPublic etc to tenant specific

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1596,12 +1596,12 @@ must restart the server for that change to take effect.
 |`fhirServer/bulkdata/jobParameters/cos.api.key`|Y|Y|
 |`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|Y|Y|
 |`fhirServer/bulkdata/bulkDataBatchJobIdEncryptionKey`|Y|Y|
-|`fhirServer/bulkdata/isExportPublic`|N|Y|
+|`fhirServer/bulkdata/isExportPublic`|Y|Y|
 |`fhirServer/bulkdata/validBaseUrls`|Y|Y|
 |`fhirServer/bulkdata/maxInputPerRequest`|Y|Y|
 |`fhirServer/bulkdata/validBaseUrlsDisabled`|Y|Y|
-|`fhirServer/bulkdata/cosFileMaxResources`|N|Y|
-|`fhirServer/bulkdata/cosFileMaxSize`|N|Y|
+|`fhirServer/bulkdata/cosFileMaxResources`|Y|Y|
+|`fhirServer/bulkdata/cosFileMaxSize`|Y|Y|
 
 ## 5.2 Keystores, truststores, and the FHIR server
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointAlgorithm.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointAlgorithm.java
@@ -26,8 +26,6 @@ import com.ibm.fhir.config.FHIRConfiguration;
 @Dependent
 public class CheckPointAlgorithm implements CheckpointAlgorithm {
     private final static Logger logger = Logger.getLogger(CheckPointAlgorithm.class.getName());
-    private int cosFileMaxResources = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXRESOURCES, Constants.DEFAULT_COSFILE_MAX_RESOURCESNUMBER);
-    private int cosFileMaxSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE  , Constants.DEFAULT_COSFILE_MAX_SIZE);
 
     @Inject
     StepContext stepCtx;
@@ -53,38 +51,28 @@ public class CheckPointAlgorithm implements CheckpointAlgorithm {
      // Nothing to do here at present
     }
 
-    /**
-     * @see CheckpointAlgorithm#checkpointTimeout()
-     */
     @Override
     public int checkpointTimeout() {
         return 0;
     }
 
-    /**
-     * @see CheckpointAlgorithm#endCheckpoint()
-     */
     @Override
     public void endCheckpoint() {
         // Nothing to do here at present
     }
 
-    /**
-     * @see CheckpointAlgorithm#beginCheckpoint()
-     */
     @Override
     public void beginCheckpoint() {
         // Nothing to do here at present
     }
 
-    /**
-     * @see CheckpointAlgorithm#isReadyToCheckpoint()
-     */
     @Override
     public boolean isReadyToCheckpoint() {
         TransientUserData chunkData = (TransientUserData) stepCtx.getTransientUserData();
 
         if (chunkData != null) {
+            int cosFileMaxResources = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXRESOURCES, Constants.DEFAULT_COSFILE_MAX_RESOURCESNUMBER);
+            int cosFileMaxSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE  , Constants.DEFAULT_COSFILE_MAX_SIZE);
             if (cosBucketFileMaxSize != null) {
                 try {
                     cosFileMaxSize = Integer.parseInt(cosBucketFileMaxSize);

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointAlgorithm.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointAlgorithm.java
@@ -72,7 +72,7 @@ public class CheckPointAlgorithm implements CheckpointAlgorithm {
 
         if (chunkData != null) {
             int cosFileMaxResources = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXRESOURCES, Constants.DEFAULT_COSFILE_MAX_RESOURCESNUMBER);
-            int cosFileMaxSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE  , Constants.DEFAULT_COSFILE_MAX_SIZE);
+            int cosFileMaxSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE , Constants.DEFAULT_COSFILE_MAX_SIZE);
             if (cosBucketFileMaxSize != null) {
                 try {
                     cosFileMaxSize = Integer.parseInt(cosBucketFileMaxSize);

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
@@ -203,8 +203,7 @@ public class ChunkWriter extends AbstractItemWriter {
     }
 
     @Override
-    public void open(Serializable checkpoint) throws Exception
-    {
+    public void open(Serializable checkpoint) throws Exception  {
         isExportPublic = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC, true);
 
     }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.bulkexport.system;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -34,7 +35,7 @@ import com.ibm.fhir.config.FHIRConfiguration;
 public class ChunkWriter extends AbstractItemWriter {
     private static final Logger logger = Logger.getLogger(ChunkWriter.class.getName());
     private AmazonS3 cosClient = null;
-    private final boolean isExportPublic = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC, true);
+    private boolean isExportPublic = true;
 
     /**
      * The IBM COS API key or S3 access key.
@@ -199,5 +200,12 @@ public class ChunkWriter extends AbstractItemWriter {
                         chunkData.getBufferStream().size());
             }
         }
+    }
+
+    @Override
+    public void open(Serializable checkpoint) throws Exception
+    {
+        isExportPublic = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC, true);
+
     }
 }


### PR DESCRIPTION
Changed these following bulkdata configurations to tenant specific:
    - fhirServer/bulkdata/isExportPublic
    - fhirServer/bulkdata/cosFileMaxResources
    - fhirServer/bulkdata/cosFileMaxSize

Signed-off-by: Albert Wang <xuwang@us.ibm.com>