### PR TITLE
Issue #1168 - default term service provider enhancements / refinements

### DIFF
--- a/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
+++ b/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
@@ -50,12 +50,12 @@ public class USCoreEthnicityExtensionTest {
                     .value(Coding.builder()
                         .system(Uri.of("urn:oid:2.16.840.1.113883.6.238"))
                         .code(Code.of("2169-1"))
-                        .display(string("Columbian"))
+                        .display(string("Colombian"))
                         .build())
                     .build())
                 .extension(Extension.builder()
                     .url("text")
-                    .value(string("Hispanic or Latino - Columbian"))
+                    .value(string("Hispanic or Latino - Colombian"))
                     .build())
                 .url("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")
                 .build();
@@ -66,11 +66,10 @@ public class USCoreEthnicityExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')");
         System.out.println("result: " + result);
 
-        Assert.assertEquals(result, SINGLETON_TRUE);
-
         List<Issue> issues = evaluator.getEvaluationContext().getIssues();
         issues.forEach(System.out::println);
 
+        Assert.assertEquals(result, SINGLETON_TRUE);
         Assert.assertEquals(issues.size(), 0);
     }
 
@@ -93,12 +92,12 @@ public class USCoreEthnicityExtensionTest {
                     .value(Coding.builder()
                         .system(Uri.of("urn:oid:2.16.840.1.113883.6.238"))
                         .code(Code.of("xxx"))
-                        .display(string("Columbian"))
+                        .display(string("Colombian"))
                         .build())
                     .build())
                 .extension(Extension.builder()
                     .url("text")
-                    .value(string("Hispanic or Latino - Columbian"))
+                    .value(string("Hispanic or Latino - Colombian"))
                     .build())
                 .url("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")
                 .build();
@@ -109,12 +108,11 @@ public class USCoreEthnicityExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')");
         System.out.println("result: " + result);
 
-        Assert.assertEquals(result, SINGLETON_FALSE);
-
         List<Issue> issues = evaluator.getEvaluationContext().getIssues();
         issues.forEach(System.out::println);
 
-        Assert.assertEquals(issues.size(), 1);
+        Assert.assertEquals(result, SINGLETON_FALSE);
+        Assert.assertEquals(issues.size(), 2);
     }
 
     /**
@@ -137,12 +135,12 @@ public class USCoreEthnicityExtensionTest {
                         .value(Coding.builder()
                             .system(Uri.of("urn:oid:2.16.840.1.113883.6.238"))
                             .code(Code.of("2169-1"))
-                            .display(string("Columbian"))
+                            .display(string("Colombian"))
                             .build())
                         .build())
                     .extension(Extension.builder()
                         .url("text")
-                        .value(string("Hispanic or Latino - Columbian"))
+                        .value(string("Hispanic or Latino - Colombian"))
                         .build())
                     .url("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")
                     .build())
@@ -182,12 +180,12 @@ public class USCoreEthnicityExtensionTest {
                         .value(Coding.builder()
                             .system(Uri.of("urn:oid:2.16.840.1.113883.6.238"))
                             .code(Code.of("xxx"))
-                            .display(string("Columbian"))
+                            .display(string("Colombian"))
                             .build())
                         .build())
                     .extension(Extension.builder()
                         .url("text")
-                        .value(string("Hispanic or Latino - Columbian"))
+                        .value(string("Hispanic or Latino - Colombian"))
                         .build())
                     .url("http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity")
                     .build())
@@ -204,6 +202,6 @@ public class USCoreEthnicityExtensionTest {
         issues.forEach(System.out::println);
 
         Assert.assertEquals(countWarnings(issues), 1);
-        Assert.assertEquals(countErrors(issues), 2);
+        Assert.assertEquals(countErrors(issues), 3);
     }
 }

--- a/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
+++ b/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
@@ -66,11 +66,10 @@ public class USCoreRaceExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')");
         System.out.println("result: " + result);
 
-        Assert.assertEquals(result, SINGLETON_TRUE);
-
         List<Issue> issues = evaluator.getEvaluationContext().getIssues();
         issues.forEach(System.out::println);
 
+        Assert.assertEquals(result, SINGLETON_TRUE);
         Assert.assertEquals(issues.size(), 0);
     }
 
@@ -109,12 +108,11 @@ public class USCoreRaceExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')");
         System.out.println("result: " + result);
 
-        Assert.assertEquals(result, SINGLETON_FALSE);
-
         List<Issue> issues = evaluator.getEvaluationContext().getIssues();
         issues.forEach(System.out::println);
 
-        Assert.assertEquals(issues.size(), 1);
+        Assert.assertEquals(result, SINGLETON_FALSE);
+        Assert.assertEquals(issues.size(), 2);
     }
 
     /**
@@ -204,6 +202,6 @@ public class USCoreRaceExtensionTest {
         issues.forEach(System.out::println);
 
         Assert.assertEquals(countWarnings(issues), 1);
-        Assert.assertEquals(countErrors(issues), 2);
+        Assert.assertEquals(countErrors(issues), 3);
     }
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DataAbsentReason.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DataAbsentReason.java
@@ -1,0 +1,383 @@
+/*
+ * (C) Copyright IBM Corp. 2019, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.model.type.code;
+
+import com.ibm.fhir.model.annotation.System;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.String;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+@System("http://terminology.hl7.org/CodeSystem/data-absent-reason")
+@Generated("com.ibm.fhir.tools.CodeGenerator")
+public class DataAbsentReason extends Code {
+    /**
+     * Unknown
+     * 
+     * <p>The value is expected to exist but is not known.
+     */
+    public static final DataAbsentReason UNKNOWN = DataAbsentReason.builder().value(ValueSet.UNKNOWN).build();
+
+    /**
+     * Asked But Unknown
+     * 
+     * <p>The source was asked but does not know the value.
+     */
+    public static final DataAbsentReason ASKED_UNKNOWN = DataAbsentReason.builder().value(ValueSet.ASKED_UNKNOWN).build();
+
+    /**
+     * Temporarily Unknown
+     * 
+     * <p>There is reason to expect (from the workflow) that the value may become known.
+     */
+    public static final DataAbsentReason TEMP_UNKNOWN = DataAbsentReason.builder().value(ValueSet.TEMP_UNKNOWN).build();
+
+    /**
+     * Not Asked
+     * 
+     * <p>The workflow didn't lead to this value being known.
+     */
+    public static final DataAbsentReason NOT_ASKED = DataAbsentReason.builder().value(ValueSet.NOT_ASKED).build();
+
+    /**
+     * Asked But Declined
+     * 
+     * <p>The source was asked but declined to answer.
+     */
+    public static final DataAbsentReason ASKED_DECLINED = DataAbsentReason.builder().value(ValueSet.ASKED_DECLINED).build();
+
+    /**
+     * Masked
+     * 
+     * <p>The information is not available due to security, privacy or related reasons.
+     */
+    public static final DataAbsentReason MASKED = DataAbsentReason.builder().value(ValueSet.MASKED).build();
+
+    /**
+     * Not Applicable
+     * 
+     * <p>There is no proper value for this element (e.g. last menstrual period for a male).
+     */
+    public static final DataAbsentReason NOT_APPLICABLE = DataAbsentReason.builder().value(ValueSet.NOT_APPLICABLE).build();
+
+    /**
+     * Unsupported
+     * 
+     * <p>The source system wasn't capable of supporting this element.
+     */
+    public static final DataAbsentReason UNSUPPORTED = DataAbsentReason.builder().value(ValueSet.UNSUPPORTED).build();
+
+    /**
+     * As Text
+     * 
+     * <p>The content of the data is represented in the resource narrative.
+     */
+    public static final DataAbsentReason AS_TEXT = DataAbsentReason.builder().value(ValueSet.AS_TEXT).build();
+
+    /**
+     * Error
+     * 
+     * <p>Some system or workflow process error means that the information is not available.
+     */
+    public static final DataAbsentReason ERROR = DataAbsentReason.builder().value(ValueSet.ERROR).build();
+
+    /**
+     * Not a Number (NaN)
+     * 
+     * <p>The numeric value is undefined or unrepresentable due to a floating point processing error.
+     */
+    public static final DataAbsentReason NOT_A_NUMBER = DataAbsentReason.builder().value(ValueSet.NOT_A_NUMBER).build();
+
+    /**
+     * Negative Infinity (NINF)
+     * 
+     * <p>The numeric value is excessively low and unrepresentable due to a floating point processing error.
+     */
+    public static final DataAbsentReason NEGATIVE_INFINITY = DataAbsentReason.builder().value(ValueSet.NEGATIVE_INFINITY).build();
+
+    /**
+     * Positive Infinity (PINF)
+     * 
+     * <p>The numeric value is excessively high and unrepresentable due to a floating point processing error.
+     */
+    public static final DataAbsentReason POSITIVE_INFINITY = DataAbsentReason.builder().value(ValueSet.POSITIVE_INFINITY).build();
+
+    /**
+     * Not Performed
+     * 
+     * <p>The value is not available because the observation procedure (test, etc.) was not performed.
+     */
+    public static final DataAbsentReason NOT_PERFORMED = DataAbsentReason.builder().value(ValueSet.NOT_PERFORMED).build();
+
+    /**
+     * Not Permitted
+     * 
+     * <p>The value is not permitted in this context (e.g. due to profiles, or the base data types).
+     */
+    public static final DataAbsentReason NOT_PERMITTED = DataAbsentReason.builder().value(ValueSet.NOT_PERMITTED).build();
+
+    private volatile int hashCode;
+
+    private DataAbsentReason(Builder builder) {
+        super(builder);
+    }
+
+    public ValueSet getValueAsEnumConstant() {
+        return (value != null) ? ValueSet.from(value) : null;
+    }
+
+    public static DataAbsentReason of(ValueSet value) {
+        switch (value) {
+        case UNKNOWN:
+            return UNKNOWN;
+        case ASKED_UNKNOWN:
+            return ASKED_UNKNOWN;
+        case TEMP_UNKNOWN:
+            return TEMP_UNKNOWN;
+        case NOT_ASKED:
+            return NOT_ASKED;
+        case ASKED_DECLINED:
+            return ASKED_DECLINED;
+        case MASKED:
+            return MASKED;
+        case NOT_APPLICABLE:
+            return NOT_APPLICABLE;
+        case UNSUPPORTED:
+            return UNSUPPORTED;
+        case AS_TEXT:
+            return AS_TEXT;
+        case ERROR:
+            return ERROR;
+        case NOT_A_NUMBER:
+            return NOT_A_NUMBER;
+        case NEGATIVE_INFINITY:
+            return NEGATIVE_INFINITY;
+        case POSITIVE_INFINITY:
+            return POSITIVE_INFINITY;
+        case NOT_PERFORMED:
+            return NOT_PERFORMED;
+        case NOT_PERMITTED:
+            return NOT_PERMITTED;
+        default:
+            throw new IllegalStateException(value.name());
+        }
+    }
+
+    public static DataAbsentReason of(java.lang.String value) {
+        return of(ValueSet.from(value));
+    }
+
+    public static String string(java.lang.String value) {
+        return of(ValueSet.from(value));
+    }
+
+    public static Code code(java.lang.String value) {
+        return of(ValueSet.from(value));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        DataAbsentReason other = (DataAbsentReason) obj;
+        return Objects.equals(id, other.id) && Objects.equals(extension, other.extension) && Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = hashCode;
+        if (result == 0) {
+            result = Objects.hash(id, extension, value);
+            hashCode = result;
+        }
+        return result;
+    }
+
+    public Builder toBuilder() {
+        Builder builder = new Builder();
+        builder.id(id);
+        builder.extension(extension);
+        builder.value(value);
+        return builder;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends Code.Builder {
+        private Builder() {
+            super();
+        }
+
+        @Override
+        public Builder id(java.lang.String id) {
+            return (Builder) super.id(id);
+        }
+
+        @Override
+        public Builder extension(Extension... extension) {
+            return (Builder) super.extension(extension);
+        }
+
+        @Override
+        public Builder extension(Collection<Extension> extension) {
+            return (Builder) super.extension(extension);
+        }
+
+        @Override
+        public Builder value(java.lang.String value) {
+            return (value != null) ? (Builder) super.value(ValueSet.from(value).value()) : this;
+        }
+
+        public Builder value(ValueSet value) {
+            return (value != null) ? (Builder) super.value(value.value()) : this;
+        }
+
+        @Override
+        public DataAbsentReason build() {
+            return new DataAbsentReason(this);
+        }
+    }
+
+    public enum ValueSet {
+        /**
+         * Unknown
+         * 
+         * <p>The value is expected to exist but is not known.
+         */
+        UNKNOWN("unknown"),
+
+        /**
+         * Asked But Unknown
+         * 
+         * <p>The source was asked but does not know the value.
+         */
+        ASKED_UNKNOWN("asked-unknown"),
+
+        /**
+         * Temporarily Unknown
+         * 
+         * <p>There is reason to expect (from the workflow) that the value may become known.
+         */
+        TEMP_UNKNOWN("temp-unknown"),
+
+        /**
+         * Not Asked
+         * 
+         * <p>The workflow didn't lead to this value being known.
+         */
+        NOT_ASKED("not-asked"),
+
+        /**
+         * Asked But Declined
+         * 
+         * <p>The source was asked but declined to answer.
+         */
+        ASKED_DECLINED("asked-declined"),
+
+        /**
+         * Masked
+         * 
+         * <p>The information is not available due to security, privacy or related reasons.
+         */
+        MASKED("masked"),
+
+        /**
+         * Not Applicable
+         * 
+         * <p>There is no proper value for this element (e.g. last menstrual period for a male).
+         */
+        NOT_APPLICABLE("not-applicable"),
+
+        /**
+         * Unsupported
+         * 
+         * <p>The source system wasn't capable of supporting this element.
+         */
+        UNSUPPORTED("unsupported"),
+
+        /**
+         * As Text
+         * 
+         * <p>The content of the data is represented in the resource narrative.
+         */
+        AS_TEXT("as-text"),
+
+        /**
+         * Error
+         * 
+         * <p>Some system or workflow process error means that the information is not available.
+         */
+        ERROR("error"),
+
+        /**
+         * Not a Number (NaN)
+         * 
+         * <p>The numeric value is undefined or unrepresentable due to a floating point processing error.
+         */
+        NOT_A_NUMBER("not-a-number"),
+
+        /**
+         * Negative Infinity (NINF)
+         * 
+         * <p>The numeric value is excessively low and unrepresentable due to a floating point processing error.
+         */
+        NEGATIVE_INFINITY("negative-infinity"),
+
+        /**
+         * Positive Infinity (PINF)
+         * 
+         * <p>The numeric value is excessively high and unrepresentable due to a floating point processing error.
+         */
+        POSITIVE_INFINITY("positive-infinity"),
+
+        /**
+         * Not Performed
+         * 
+         * <p>The value is not available because the observation procedure (test, etc.) was not performed.
+         */
+        NOT_PERFORMED("not-performed"),
+
+        /**
+         * Not Permitted
+         * 
+         * <p>The value is not permitted in this context (e.g. due to profiles, or the base data types).
+         */
+        NOT_PERMITTED("not-permitted");
+
+        private final java.lang.String value;
+
+        ValueSet(java.lang.String value) {
+            this.value = value;
+        }
+
+        public java.lang.String value() {
+            return value;
+        }
+
+        public static ValueSet from(java.lang.String value) {
+            for (ValueSet c : ValueSet.values()) {
+                if (c.value.equals(value)) {
+                    return c;
+                }
+            }
+            throw new IllegalArgumentException(value);
+        }
+    }
+}

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -61,6 +61,7 @@ import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.Uuid;
 import com.ibm.fhir.model.type.code.BundleType;
+import com.ibm.fhir.model.type.code.DataAbsentReason;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.ResourceType;
@@ -70,9 +71,16 @@ import com.ibm.fhir.model.visitor.Visitable;
  * Utility methods for working with the FHIR object model.
  */
 public class FHIRUtil {
+    public static final Pattern REFERENCE_PATTERN = buildReferencePattern();
+    public static final Extension DATA_ABSENT_REASON_UNKNOWN = Extension.builder()
+            .url("http://hl7.org/fhir/StructureDefinition/data-absent-reason")
+            .value(DataAbsentReason.UNKNOWN)
+            .build();
+    public static final com.ibm.fhir.model.type.String STRING_DATA_ABSENT_REASON_UNKNOWN = com.ibm.fhir.model.type.String.builder()
+            .extension(DATA_ABSENT_REASON_UNKNOWN)
+            .build();
     private static final SecureRandom RANDOM = new SecureRandom();
     private static final JsonBuilderFactory BUILDER_FACTORY = Json.createBuilderFactory(null);
-    public static final Pattern REFERENCE_PATTERN = buildReferencePattern();
     private static final Logger log = Logger.getLogger(FHIRUtil.class.getName());
     private static final OperationOutcome ALL_OK = OperationOutcome.builder()
         .issue(Issue.builder()

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
@@ -125,7 +125,7 @@ public class MemberOfFunctionTest {
         EvaluationContext evaluationContext = new EvaluationContext(Code.of("x"));
         Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, "$this.memberOf('http://ibm.com/fhir/ValueSet/vs1', 'extensible')");
 
-        Assert.assertEquals(evaluationContext.getIssues().size(), 1);
+        Assert.assertEquals(evaluationContext.getIssues().size(), 2);
         Issue issue = evaluationContext.getIssues().get(0);
         Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);
@@ -139,7 +139,7 @@ public class MemberOfFunctionTest {
         EvaluationContext evaluationContext = new EvaluationContext(Code.of("x"));
         Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, "$this.memberOf('http://ibm.com/fhir/ValueSet/vs1', 'preferred')");
 
-        Assert.assertEquals(evaluationContext.getIssues().size(), 1);
+        Assert.assertEquals(evaluationContext.getIssues().size(), 2);
         Issue issue = evaluationContext.getIssues().get(0);
         Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
@@ -13,12 +13,21 @@ import java.util.Set;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;
 import com.ibm.fhir.model.resource.ConceptMap;
 import com.ibm.fhir.model.resource.ValueSet;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.String;
+import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
 import com.ibm.fhir.term.service.provider.DefaultTermServiceProvider;
+import com.ibm.fhir.term.spi.ExpansionParameters;
 import com.ibm.fhir.term.spi.FHIRTermServiceProvider;
+import com.ibm.fhir.term.spi.LookupOutcome;
+import com.ibm.fhir.term.spi.LookupParameters;
 import com.ibm.fhir.term.spi.TranslationOutcome;
+import com.ibm.fhir.term.spi.TranslationParameters;
+import com.ibm.fhir.term.spi.ValidationOutcome;
+import com.ibm.fhir.term.spi.ValidationParameters;
 
 public class FHIRTermService implements FHIRTermServiceProvider {
     private static final FHIRTermService INSTANCE = new FHIRTermService();
@@ -43,10 +52,25 @@ public class FHIRTermService implements FHIRTermServiceProvider {
     }
 
     /**
-     * Expand the given value set per the algorithm here: http://hl7.org/fhir/valueset.html#expansion
+     * Expand the given value set and expansion parameters
      *
      * @param valueSet
-     *     the value set to be expanded
+     *     the value set to expand
+     * @param parameters
+     *     the expansion parameters
+     * @return
+     *     the expanded value set, or the original value set if already expanded or unable to expand
+     */
+    @Override
+    public ValueSet expand(ValueSet valueSet, ExpansionParameters parameters) {
+        return provider.expand(valueSet, parameters);
+    }
+
+    /**
+     * Expand the given value set
+     *
+     * @param valueSet
+     *     the value set to expand
      * @return
      *     the expanded value set, or the original value set if already expanded or unable to expand
      */
@@ -56,15 +80,30 @@ public class FHIRTermService implements FHIRTermServiceProvider {
     }
 
     /**
+     * Lookup the code system concept for the given coding and lookup parameters
+     *
+     * @param coding
+     *     the coding to lookup
+     * @param parameters
+     *     the lookup parameters
+     * @return
+     *     the outcome of the lookup
+     */
+    @Override
+    public LookupOutcome lookup(Coding coding, LookupParameters parameters) {
+        return provider.lookup(coding, parameters);
+    }
+
+    /**
      * Lookup the code system concept for the given coding
      *
      * @param coding
      *     the coding to lookup
      * @return
-     *     the code system concept that matches the given coding, or null if no such concept exists
+     *     the outcome of the lookup
      */
     @Override
-    public Concept lookup(Coding coding) {
+    public LookupOutcome lookup(Coding coding) {
         return provider.lookup(coding);
     }
 
@@ -98,22 +137,105 @@ public class FHIRTermService implements FHIRTermServiceProvider {
     }
 
     /**
-     * Indicates whether a code system concept matches the given coding
+     * Validate a code and display against its system and version using the provided validation parameters
+     *
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(Uri system, String version, Code code, String display, ValidationParameters parameters) {
+        return provider.validateCode(system, version, code, display, parameters);
+    }
+
+    /**
+     * Validate a code and display against its system and version
+     *
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(Uri system, String version, Code code, String display) {
+        return provider.validateCode(system, version, code, display);
+    }
+
+    /**
+     * Validate a coding against its system and version using the provided validation parameters
+     *
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(Coding coding, ValidationParameters parameters) {
+        return provider.validateCode(coding, parameters);
+    }
+
+    /**
+     * Validate a coding against its system and version
      *
      * @param coding
      *     the coding
      * @return
-     *     true if a code system concept matches the given coding, false otherwise
+     *     the outcome of validation
      */
     @Override
-    public boolean validateCode(Coding coding) {
+    public ValidationOutcome validateCode(Coding coding) {
         return provider.validateCode(coding);
     }
 
     /**
-     * Indicates whether the given code is a member of the provided value set
+     * Validate a codeable concept against its system and version using the provided validation parameters
      *
-     * @implSpec
+     * @param codeableConcept
+     *     the codeable concept
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(CodeableConcept codeableConcept, ValidationParameters parameters) {
+        return provider.validateCode(codeableConcept, parameters);
+    }
+
+    /**
+     * Validate a codeable concept against its system and version
+     *
+     * @param codeableConcept
+     *     the codeable concept
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(CodeableConcept codeableConcept) {
+        return provider.validateCode(codeableConcept);
+    }
+
+    /**
+     * Validate a code and display using the provided value set and validation parameters
+     *
+     * @apiNote
      *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
@@ -123,46 +245,130 @@ public class FHIRTermService implements FHIRTermServiceProvider {
      *     the version
      * @param code
      *     the code
+     * @param display
+     *     the display
+     * @param parameters
+     *     the validation parameters
      * @return
-     *     true if the given code is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
     @Override
-    public boolean validateCode(ValueSet valueSet, String system, String version, String code) {
-        return provider.validateCode(valueSet, system, version, code);
+    public ValidationOutcome validateCode(ValueSet valueSet, Uri system, String version, Code code, String display, ValidationParameters parameters) {
+        return provider.validateCode(valueSet, system, version, code, display, parameters);
     }
 
     /**
-     * Indicates whether the given coding is a member of the provided value set
+     * Validate a code and display using the provided value set
      *
-     * @implSpec
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(ValueSet valueSet, Uri system, String version, Code code, String display) {
+        return provider.validateCode(valueSet, system, version, code, display);
+    }
+
+    /**
+     * Validate a coding using the provided value set using the provided validation parameters
+     *
+     * @apiNote
      *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
      * @param coding
      *     the coding
+     * @param parameters
+     *     the validation parameters
      * @return
-     *     true if the given coding is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
     @Override
-    public boolean validateCode(ValueSet valueSet, Coding coding) {
+    public ValidationOutcome validateCode(ValueSet valueSet, Coding coding, ValidationParameters parameters) {
+        return provider.validateCode(valueSet, coding, parameters);
+    }
+
+    /**
+     * Validate a coding using the provided value set using the provided validation parameters
+     *
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(ValueSet valueSet, Coding coding) {
         return provider.validateCode(valueSet, coding);
     }
 
     /**
-     * Indicates whether the given codeable concept contains a coding that is a member of the provided value set
+     * Validate a codeable concept using the provided value set using the provided validation parameters
      *
-     * @implSpec
+     * @apiNote
      *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
-     * @param codeableConcept
+     * @param codeable concept
      *     the codeable concept
+     * @param parameters
+     *     the validation parameters
      * @return
-     *     true if the given codeable concept contains a coding that is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
     @Override
-    public boolean validateCode(ValueSet valueSet, CodeableConcept codeableConcept) {
+    public ValidationOutcome validateCode(ValueSet valueSet, CodeableConcept codeableConcept, ValidationParameters parameters) {
+        return provider.validateCode(valueSet, codeableConcept, parameters);
+    }
+
+    /**
+     * Validate a codeable concept using the provided value set
+     *
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param codeable concept
+     *     the codeable concept
+     * @return
+     *     the outcome of validation
+     */
+    @Override
+    public ValidationOutcome validateCode(ValueSet valueSet, CodeableConcept codeableConcept) {
         return provider.validateCode(valueSet, codeableConcept);
+    }
+
+    /**
+     * Translate the given coding using the provided concept map and translation parameters
+     *
+     * @param conceptMap
+     *     the concept map
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the translation parameters
+     * @return
+     *     the outcome of translation
+     */
+    @Override
+    public TranslationOutcome translate(ConceptMap conceptMap, Coding coding, TranslationParameters parameters) {
+        return provider.translate(conceptMap, coding, parameters);
     }
 
     /**

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/DefaultTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/DefaultTermServiceProvider.java
@@ -7,6 +7,8 @@
 package com.ibm.fhir.term.service.provider;
 
 import static com.ibm.fhir.core.util.LRUCache.createLRUCache;
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.model.util.FHIRUtil.STRING_DATA_ABSENT_REASON_UNKNOWN;
 import static com.ibm.fhir.term.util.CodeSystemSupport.findConcept;
 import static com.ibm.fhir.term.util.CodeSystemSupport.getCodeSystem;
 import static com.ibm.fhir.term.util.CodeSystemSupport.getConcepts;
@@ -19,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.ibm.fhir.model.resource.CodeSystem;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;
@@ -26,16 +29,29 @@ import com.ibm.fhir.model.resource.ConceptMap;
 import com.ibm.fhir.model.resource.ValueSet;
 import com.ibm.fhir.model.resource.ValueSet.Expansion;
 import com.ibm.fhir.model.resource.ValueSet.Expansion.Contains;
+import com.ibm.fhir.model.type.Boolean;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.CodeSystemHierarchyMeaning;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
+import com.ibm.fhir.term.spi.ExpansionParameters;
 import com.ibm.fhir.term.spi.FHIRTermServiceProvider;
+import com.ibm.fhir.term.spi.LookupOutcome;
+import com.ibm.fhir.term.spi.LookupOutcome.Designation;
+import com.ibm.fhir.term.spi.LookupOutcome.Property;
+import com.ibm.fhir.term.spi.LookupParameters;
 import com.ibm.fhir.term.spi.TranslationOutcome;
+import com.ibm.fhir.term.spi.TranslationParameters;
+import com.ibm.fhir.term.spi.ValidationOutcome;
+import com.ibm.fhir.term.spi.ValidationParameters;
 import com.ibm.fhir.term.util.ConceptMapSupport;
 import com.ibm.fhir.term.util.ValueSetSupport;
 
+/**
+ * Default implementation of the FHIRTermServiceProvider interface using CodeSystemSupport, ConceptMapSupport, and ValueSetSupport
+ */
 public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
     private static final Logger log = Logger.getLogger(DefaultTermServiceProvider.class.getName());
 
@@ -48,39 +64,57 @@ public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public ValueSet expand(ValueSet valueSet) {
+    public ValueSet expand(ValueSet valueSet, ExpansionParameters parameters) {
         return ValueSetSupport.expand(valueSet);
     }
 
     @Override
-    public Concept lookup(Coding coding) {
-        String system = (coding.getSystem() != null) ? coding.getSystem().getValue() : null;
-        String version = (coding.getVersion() != null) ? coding.getVersion().getValue() : null;
-        String code = (coding.getCode() != null) ? coding.getCode().getValue() : null;
-
+    public LookupOutcome lookup(Coding coding, LookupParameters parameters) {
+        Uri system = coding.getSystem();
+        Code code = coding.getCode();
         if (system != null && code != null) {
-            String url = (version != null) ? system + "|" + version : system;
+            String version = (coding.getVersion() != null) ? coding.getVersion().getValue() : null;
+            String url = (version != null) ? system.getValue() + "|" + version : system.getValue();
             CodeSystem codeSystem = getCodeSystem(url);
             if (codeSystem != null) {
-                return findConcept(codeSystem, Code.of(code));
+                Concept concept = findConcept(codeSystem, code);
+                if (concept != null) {
+                    return LookupOutcome.builder()
+                            .name((codeSystem.getName() != null) ? codeSystem.getName() : STRING_DATA_ABSENT_REASON_UNKNOWN)
+                            .version(codeSystem.getVersion())
+                            .display((concept.getDisplay() != null) ? concept.getDisplay() : STRING_DATA_ABSENT_REASON_UNKNOWN)
+                            .property(concept.getProperty().stream()
+                                .map(property -> Property.builder()
+                                    .code(property.getCode())
+                                    .value(property.getValue())
+                                    .build())
+                                .collect(Collectors.toList()))
+                            .designation(concept.getDesignation().stream()
+                                .map(designation -> Designation.builder()
+                                    .language(designation.getLanguage())
+                                    .use(designation.getUse())
+                                    .value(designation.getValue())
+                                    .build())
+                                .collect(Collectors.toList()))
+                            .build();
+                }
             }
         }
-
         return null;
     }
 
     @Override
     public ConceptSubsumptionOutcome subsumes(Coding codingA, Coding codingB) {
-        String systemA = (codingA.getSystem() != null) ? codingA.getSystem().getValue() : null;
+        Uri systemA = codingA.getSystem();
         String versionA = (codingA.getVersion() != null) ? codingA.getVersion().getValue() : null;
-        String codeA = (codingA.getCode() != null) ? codingA.getCode().getValue() : null;
+        Code codeA = codingA.getCode();
 
-        String systemB = (codingB.getSystem() != null) ? codingB.getSystem().getValue() : null;
+        Uri systemB = codingB.getSystem();
         String versionB = (codingB.getVersion() != null) ? codingB.getVersion().getValue() : null;
-        String codeB = (codingB.getCode() != null) ? codingB.getCode().getValue() : null;
+        Code codeB = codingB.getCode();
 
         if (systemA != null && systemB != null && codeA != null && codeB != null && systemA.equals(systemB)) {
-            String url = systemA;
+            String url = systemA.getValue();
 
             if (versionA != null || versionB != null) {
                 if (versionA != null && versionB != null && !versionA.equals(versionB)) {
@@ -91,15 +125,15 @@ public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
 
             CodeSystem codeSystem = getCodeSystem(url);
             if (codeSystem != null && CodeSystemHierarchyMeaning.IS_A.equals(codeSystem.getHierarchyMeaning())) {
-                Concept conceptA = findConcept(codeSystem, Code.of(codeA));
+                Concept conceptA = findConcept(codeSystem, codeA);
                 if (conceptA != null) {
-                    Concept conceptB = findConcept(conceptA, Code.of(codeB));
+                    Concept conceptB = findConcept(conceptA, codeB);
                     if (conceptB != null) {
                         return conceptA.equals(conceptB) ? ConceptSubsumptionOutcome.EQUIVALENT : ConceptSubsumptionOutcome.SUBSUMES;
                     }
-                    conceptB = findConcept(codeSystem, Code.of(codeB));
+                    conceptB = findConcept(codeSystem, codeB);
                     if (conceptB != null) {
-                        conceptA = findConcept(conceptB, Code.of(codeA));
+                        conceptA = findConcept(conceptB, codeA);
                         return (conceptA != null) ? ConceptSubsumptionOutcome.SUBSUMED_BY : ConceptSubsumptionOutcome.NOT_SUBSUMED;
                     }
                 }
@@ -111,15 +145,15 @@ public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
 
     @Override
     public Set<Concept> closure(Coding coding) {
-        String system = (coding.getSystem() != null) ? coding.getSystem().getValue() : null;
+        Uri system = coding.getSystem();
         String version = (coding.getVersion() != null) ? coding.getVersion().getValue() : null;
-        String code = (coding.getCode() != null) ? coding.getCode().getValue() : null;
+        Code code = coding.getCode();
 
         if (system != null && code != null) {
-            String url = (version != null) ? system + "|" + version : system;
+            String url = (version != null) ? system.getValue() + "|" + version : system.getValue();
             CodeSystem codeSystem = getCodeSystem(url);
             if (codeSystem != null && CodeSystemHierarchyMeaning.IS_A.equals(codeSystem.getHierarchyMeaning())) {
-                Concept concept = findConcept(codeSystem, Code.of(code));
+                Concept concept = findConcept(codeSystem, code);
                 if (concept != null) {
                     return getConcepts(concept);
                 }
@@ -130,41 +164,68 @@ public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public boolean validateCode(Coding coding) {
-        return lookup(coding) != null;
+    public ValidationOutcome validateCode(Coding coding, ValidationParameters parameters) {
+        LookupOutcome outcome = lookup(coding);
+        return buildValidationOutcome(coding, (outcome != null), outcome);
     }
 
     @Override
-    public boolean validateCode(ValueSet valueSet, String system, String version, String code) {
-        return contains(getCodeSetMap(valueSet), system, version, code);
-    }
-
-    @Override
-    public boolean validateCode(ValueSet valueSet, Coding coding) {
-        return contains(getCodeSetMap(valueSet), coding);
-    }
-
-    @Override
-    public boolean validateCode(ValueSet valueSet, CodeableConcept codeableConcept) {
-        Map<String, Set<String>> codeSetMap = getCodeSetMap(valueSet);
+    public ValidationOutcome validateCode(CodeableConcept codeableConcept, ValidationParameters parameters) {
         for (Coding coding : codeableConcept.getCoding()) {
-            if (contains(codeSetMap, coding)) {
-                return true;
+            ValidationOutcome outcome = validateCode(coding);
+            if (Boolean.FALSE.equals(outcome.getResult())) {
+                return outcome;
             }
         }
-        return false;
+        return buildValidationOutcome(null, true, null);
     }
 
     @Override
-    public TranslationOutcome translate(ConceptMap conceptMap, Coding coding) {
+    public ValidationOutcome validateCode(ValueSet valueSet, Coding coding, ValidationParameters parameters) {
+        boolean result = validateCode(getCodeSetMap(valueSet), coding);
+        LookupOutcome outcome = result ? lookup(coding) : null;
+        return buildValidationOutcome(coding, result, outcome);
+    }
+
+    @Override
+    public ValidationOutcome validateCode(ValueSet valueSet, CodeableConcept codeableConcept, ValidationParameters parameters) {
+        Map<String, Set<String>> codeSetMap = getCodeSetMap(valueSet);
+        for (Coding coding : codeableConcept.getCoding()) {
+            boolean result = validateCode(codeSetMap, coding);
+            if (result) {
+                LookupOutcome outcome = lookup(coding);
+                return buildValidationOutcome(coding, result, outcome);
+            }
+        }
+        return buildValidationOutcome(null, false, null);
+    }
+
+    @Override
+    public TranslationOutcome translate(ConceptMap conceptMap, Coding coding, TranslationParameters parameters) {
         return ConceptMapSupport.translate(conceptMap, coding);
     }
 
-    private boolean contains(Map<String, Set<String>> codeSetMap, Coding coding) {
+    private ValidationOutcome buildValidationOutcome(Coding coding, boolean result, LookupOutcome outcome) {
+        String message = null;
+        if (!result && coding != null && coding.getCode() != null) {
+            message = String.format("Code '%s' is invalid", coding.getCode().getValue());
+        }
+        if (result && outcome != null && coding != null && outcome.getDisplay() != null && coding.getDisplay() != null && !outcome.getDisplay().equals(coding.getDisplay())) {
+            message = String.format("The display '%s' is incorrect for code '%s' from code system '%s'", coding.getDisplay().getValue(), coding.getCode().getValue(), coding.getSystem().getValue());
+            result = false;
+        }
+        return ValidationOutcome.builder()
+                .result(result ? Boolean.TRUE : Boolean.FALSE)
+                .message((message != null) ? string(message) : null)
+                .display((outcome != null) ? outcome.getDisplay() : null)
+                .build();
+    }
+
+    private boolean validateCode(Map<String, Set<String>> codeSetMap, Coding coding) {
         String system = (coding.getSystem() != null) ? coding.getSystem().getValue() : null;
         String version = (coding.getVersion() != null) ? coding.getVersion().getValue() : null;
         String code = (coding.getCode() != null) ? coding.getCode().getValue() : null;
-        return contains(codeSetMap, system, version, code);
+        return validateCode(codeSetMap, system, version, code);
     }
 
     /**
@@ -187,7 +248,7 @@ public class DefaultTermServiceProvider implements FHIRTermServiceProvider {
      * @return
      *     true if a codeSet is found and the provided code is a member of that codeSet, false otherwise
      */
-    private boolean contains(Map<String, Set<String>> codeSetMap, String system, String version, String code) {
+    private boolean validateCode(Map<String, Set<String>> codeSetMap, String system, String version, String code) {
         if (system != null && version != null) {
             Set<String> codeSet = codeSetMap.get(system + "|" + version);
             if (codeSet != null) {

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/util/FHIRTermServiceUtil.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/util/FHIRTermServiceUtil.java
@@ -1,0 +1,69 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.service.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Element;
+
+public final class FHIRTermServiceUtil {
+    private FHIRTermServiceUtil() { }
+
+    public static Parameter getParameter(Parameters parameters, String name) {
+        return parameters.getParameter().stream()
+                .filter(parameter -> parameter.getName() != null)
+                .filter(parameter -> parameter.getName().getValue().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static <T extends Element> T getParameterValue(Parameters parameters, String name, Class<T> elementType) {
+        return elementType.cast(getParameter(parameters, name));
+    }
+
+    public static List<Parameter> getParameters(Parameters parameters, String name) {
+        return parameters.getParameter().stream()
+                .filter(parameter -> parameter.getName() != null)
+                .filter(parameter -> parameter.getName().getValue().equals(name))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+
+    public static <T extends Element> List<T> getParameterValues(Parameters parameters, String name, Class<T> elementType) {
+        return getParameters(parameters, name).stream()
+                .map(parameter -> elementType.cast(parameter.getValue()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+
+    public static Parameter getPart(Parameter parameter, String name) {
+        return parameter.getPart().stream()
+                .filter(part -> part.getName() != null)
+                .filter(part -> part.getName().getValue().equals(name))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static <T extends Element> T getPartValue(Parameter parameter, String name, Class<T> elementType) {
+        return elementType.cast(getPart(parameter, name));
+    }
+
+    public static List<Parameter> getParts(Parameter parameter, String name) {
+        return parameter.getPart().stream()
+                .filter(part -> part.getName() != null)
+                .filter(part -> part.getName().getValue().equals(name))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+
+    public static <T extends Element> List<T> getPartValues(Parameter parameter, String name, Class<T> elementType) {
+        return getParts(parameter, name).stream()
+                .map(part -> elementType.cast(part.getValue()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/ExpansionParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/ExpansionParameters.java
@@ -1,0 +1,387 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Boolean;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.DateTime;
+import com.ibm.fhir.model.type.Integer;
+import com.ibm.fhir.model.type.String;
+import com.ibm.fhir.model.type.Uri;
+
+/**
+ * This class is used to represent the optional input parameters of the expand operation:
+ * <a href="http://hl7.org/fhir/valueset-operation-expand.html">http://hl7.org/fhir/valueset-operation-expand.html</a>
+ */
+public class ExpansionParameters {
+    public static final ExpansionParameters EMPTY = ExpansionParameters.builder().build();
+
+    private final Uri context;
+    private final Code contextDirection;
+    private final String filter;
+    private final DateTime date;
+    private final Integer offset;
+    private final Integer count;
+    private final Boolean includeDesignations;
+    private final Boolean activeOnly;
+    private final Boolean excludeNested;
+    private final Boolean excludeNotForUI;
+    private final Boolean excludePostCoordinated;
+    private final Code displayLanguage;
+    private final List<Canonical> excludeSystem;
+    private final List<Canonical> systemVersion;
+    private final List<Canonical> checkSystemVersion;
+    private final List<Canonical> forceSystemVersion;
+
+    private ExpansionParameters(Builder builder) {
+        context = builder.context;
+        contextDirection = builder.contextDirection;
+        filter = builder.filter;
+        date = builder.date;
+        offset = builder.offset;
+        count = builder.count;
+        includeDesignations = builder.includeDesignations;
+        activeOnly = builder.activeOnly;
+        excludeNested = builder.excludeNested;
+        excludeNotForUI = builder.excludeNotForUI;
+        excludePostCoordinated = builder.excludePostCoordinated;
+        displayLanguage = builder.displayLanguage;
+        excludeSystem = Collections.unmodifiableList(builder.excludeSystem);
+        systemVersion = Collections.unmodifiableList(builder.systemVersion);
+        checkSystemVersion = Collections.unmodifiableList(builder.checkSystemVersion);
+        forceSystemVersion = Collections.unmodifiableList(builder.forceSystemVersion);
+    }
+
+    public Uri getContext() {
+        return context;
+    }
+
+    public Code getContextDirection() {
+        return contextDirection;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public DateTime getDate() {
+        return date;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public Boolean getIncludeDesignations() {
+        return includeDesignations;
+    }
+
+    public Boolean getActiveOnly() {
+        return activeOnly;
+    }
+
+    public Boolean getExcludeNested() {
+        return excludeNested;
+    }
+
+    public Boolean getExcludeNotForUI() {
+        return excludeNotForUI;
+    }
+
+    public Boolean getExcludePostCoordinated() {
+        return excludePostCoordinated;
+    }
+
+    public Code getDisplayLanguage() {
+        return displayLanguage;
+    }
+
+    public List<Canonical> getExcludeSystem() {
+        return excludeSystem;
+    }
+
+    public List<Canonical> getSystemVersion() {
+        return systemVersion;
+    }
+
+    public List<Canonical> getCheckSystemVersion() {
+        return checkSystemVersion;
+    }
+
+    public List<Canonical> getForceSystemVersion() {
+        return forceSystemVersion;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ExpansionParameters other = (ExpansionParameters) obj;
+        return Objects.equals(context, other.context) &&
+                Objects.equals(contextDirection, other.contextDirection) &&
+                Objects.equals(filter, other.filter) &&
+                Objects.equals(date, other.date) &&
+                Objects.equals(offset, other.offset) &&
+                Objects.equals(count, other.count) &&
+                Objects.equals(includeDesignations, other.includeDesignations) &&
+                Objects.equals(activeOnly, other.activeOnly) &&
+                Objects.equals(excludeNested, other.excludeNested) &&
+                Objects.equals(excludeNotForUI, other.excludeNotForUI) &&
+                Objects.equals(excludePostCoordinated, other.excludePostCoordinated) &&
+                Objects.equals(displayLanguage, other.displayLanguage) &&
+                Objects.equals(excludeSystem, other.excludeSystem) &&
+                Objects.equals(systemVersion, other.systemVersion) &&
+                Objects.equals(checkSystemVersion, other.checkSystemVersion) &&
+                Objects.equals(forceSystemVersion, other.forceSystemVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context,
+            contextDirection,
+            filter,
+            date,
+            offset,
+            count,
+            includeDesignations,
+            activeOnly,
+            excludeNested,
+            excludeNotForUI,
+            excludePostCoordinated,
+            displayLanguage,
+            excludeSystem,
+            systemVersion,
+            checkSystemVersion,
+            forceSystemVersion);
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ExpansionParameters from(Parameters parameters) {
+        Parameter context = getParameter(parameters, "context");
+        Parameter contextDirection = getParameter(parameters, "contextDirection");
+        Parameter filter = getParameter(parameters, "filter");
+        Parameter date = getParameter(parameters, "date");
+        Parameter offset = getParameter(parameters, "offset");
+        Parameter count = getParameter(parameters, "count");
+        Parameter includeDesignations = getParameter(parameters, "includeDesignations");
+        Parameter activeOnly = getParameter(parameters, "activeOnly");
+        Parameter excludeNested = getParameter(parameters, "excludeNested");
+        Parameter excludeNotForUI = getParameter(parameters, "excludeNotForUI");
+        Parameter excludePostCoordinated = getParameter(parameters, "excludePostCoordinated");
+        Parameter displayLanguage = getParameter(parameters, "displayLanguage");
+        return ExpansionParameters.builder()
+                .context((context != null) ? context.getValue().as(Uri.class) : null)
+                .contextDirection((contextDirection != null) ? contextDirection.getValue().as(Code.class) : null)
+                .filter((filter != null) ? filter.getValue().as(String.class) : null)
+                .date((date != null) ? date.getValue().as(DateTime.class) : null)
+                .offset((offset != null) ? offset.getValue().as(Integer.class) : null)
+                .count((count != null) ? count.getValue().as(Integer.class) : null)
+                .includeDesignations((includeDesignations != null) ? includeDesignations.getValue().as(Boolean.class) : null)
+                .activeOnly((activeOnly != null) ? activeOnly.getValue().as(Boolean.class) : null)
+                .excludeNested((excludeNested != null) ? excludeNested.getValue().as(Boolean.class) : null)
+                .excludeNotForUI((excludeNotForUI != null) ? excludeNotForUI.getValue().as(Boolean.class) : null)
+                .excludePostCoordinated((excludePostCoordinated != null) ? excludePostCoordinated.getValue().as(Boolean.class) : null)
+                .displayLanguage((displayLanguage != null) ? displayLanguage.getValue().as(Code.class) : null)
+                .excludeSystem(getParameters(parameters, "excludeSystem").stream()
+                        .map(parameter -> parameter.getValue().as(Canonical.class))
+                        .collect(Collectors.toList()))
+                .systemVersion(getParameters(parameters, "systemVersion").stream()
+                        .map(parameter -> parameter.getValue().as(Canonical.class))
+                        .collect(Collectors.toList()))
+                .checkSystemVersion(getParameters(parameters, "checkSystemVersion").stream()
+                        .map(parameter -> parameter.getValue().as(Canonical.class))
+                        .collect(Collectors.toList()))
+                .forceSystemVersion(getParameters(parameters, "forceSystemVersion").stream()
+                        .map(parameter -> parameter.getValue().as(Canonical.class))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static class Builder {
+        private Uri context;
+        private Code contextDirection;
+        private String filter;
+        private DateTime date;
+        private Integer offset;
+        private Integer count;
+        private Boolean includeDesignations;
+        private Boolean activeOnly;
+        private Boolean excludeNested;
+        private Boolean excludeNotForUI;
+        private Boolean excludePostCoordinated;
+        private Code displayLanguage;
+        private List<Canonical> excludeSystem = new ArrayList<>();
+        private List<Canonical> systemVersion = new ArrayList<>();
+        private List<Canonical> checkSystemVersion = new ArrayList<>();
+        private List<Canonical> forceSystemVersion = new ArrayList<>();
+
+        private Builder() { }
+
+        public Builder context(Uri context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder contextDirection(Code contextDirection) {
+            this.contextDirection = contextDirection;
+            return this;
+        }
+
+        public Builder filter(String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder date(DateTime date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder offset(Integer offset) {
+            this.offset = offset;
+            return this;
+        }
+
+        public Builder count(Integer count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder includeDesignations(Boolean includeDesignations) {
+            this.includeDesignations = includeDesignations;
+            return this;
+        }
+
+        public Builder activeOnly(Boolean activeOnly) {
+            this.activeOnly = activeOnly;
+            return this;
+        }
+
+        public Builder excludeNested(Boolean excludeNested) {
+            this.excludeNested = excludeNested;
+            return this;
+        }
+
+        public Builder excludeNotForUI(Boolean excludeNotForUI) {
+            this.excludeNotForUI = excludeNotForUI;
+            return this;
+        }
+
+        public Builder excludePostCoordinated(Boolean excludePostCoordinated) {
+            this.excludePostCoordinated = excludePostCoordinated;
+            return this;
+        }
+
+        public Builder displayLanguage(Code displayLanguage) {
+            this.displayLanguage = displayLanguage;
+            return this;
+        }
+
+        public Builder excludeSystem(Canonical... excludeSystem) {
+            for (Canonical value : excludeSystem) {
+                this.excludeSystem.add(value);
+            }
+            return this;
+        }
+
+        public Builder excludeSystem(Collection<Canonical> excludeSystem) {
+            this.excludeSystem = new ArrayList<>(excludeSystem);
+            return this;
+        }
+
+        public Builder systemVersion(Canonical... systemVersion) {
+            for (Canonical value : systemVersion) {
+                this.systemVersion.add(value);
+            }
+            return this;
+        }
+
+        public Builder systemVersion(Collection<Canonical> systemVersion) {
+            this.systemVersion = new ArrayList<>(systemVersion);
+            return this;
+        }
+
+        public Builder checkSystemVersion(Canonical... checkSystemVersion) {
+            for (Canonical value : checkSystemVersion) {
+                this.checkSystemVersion.add(value);
+            }
+            return this;
+        }
+
+        public Builder checkSystemVersion(Collection<Canonical> checkSystemVersion) {
+            this.checkSystemVersion = new ArrayList<>(checkSystemVersion);
+            return this;
+        }
+
+        public Builder forceSystemVersion(Canonical... forceSystemVersion) {
+            for (Canonical value : forceSystemVersion) {
+                this.forceSystemVersion.add(value);
+            }
+            return this;
+        }
+
+        public Builder forceSystemVersion(Collection<Canonical> forceSystemVersion) {
+            this.forceSystemVersion = new ArrayList<>(excludeSystem);
+            return this;
+        }
+
+        public ExpansionParameters build() {
+            return new ExpansionParameters(this);
+        }
+
+        protected Builder from(ExpansionParameters expansionParameters) {
+            context = expansionParameters.context;
+            contextDirection = expansionParameters.contextDirection;
+            filter = expansionParameters.filter;
+            date = expansionParameters.date;
+            offset = expansionParameters.offset;
+            count = expansionParameters.count;
+            includeDesignations = expansionParameters.includeDesignations;
+            activeOnly = expansionParameters.activeOnly;
+            excludeNested = expansionParameters.excludeNested;
+            excludeNotForUI = expansionParameters.excludeNotForUI;
+            excludePostCoordinated = expansionParameters.excludePostCoordinated;
+            displayLanguage = expansionParameters.displayLanguage;
+            excludeSystem.addAll(expansionParameters.excludeSystem);
+            systemVersion.addAll(expansionParameters.systemVersion);
+            checkSystemVersion.addAll(expansionParameters.checkSystemVersion);
+            forceSystemVersion.addAll(expansionParameters.forceSystemVersion);
+            return this;
+        }
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
@@ -11,8 +11,11 @@ import java.util.Set;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;
 import com.ibm.fhir.model.resource.ConceptMap;
 import com.ibm.fhir.model.resource.ValueSet;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.String;
+import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
 
 public interface FHIRTermServiceProvider {
@@ -26,16 +29,41 @@ public interface FHIRTermServiceProvider {
      */
     boolean isExpandable(ValueSet valueSet);
 
-
     /**
-     * Expand the given value set per the algorithm here: http://hl7.org/fhir/valueset.html#expansion
+     * Expand the given value set and expansion parameters
      *
      * @param valueSet
-     *     the value set to be expanded
+     *     the value set to expand
+     * @param parameters
+     *     the expansion parameters
      * @return
      *     the expanded value set, or the original value set if already expanded or unable to expand
      */
-    ValueSet expand(ValueSet valueSet);
+    ValueSet expand(ValueSet valueSet, ExpansionParameters parameters);
+
+    /**
+     * Expand the given value set
+     *
+     * @param valueSet
+     *     the value set to expand
+     * @return
+     *     the expanded value set, or the original value set if already expanded or unable to expand
+     */
+    default ValueSet expand(ValueSet valueSet) {
+        return expand(valueSet, ExpansionParameters.EMPTY);
+    }
+
+    /**
+     * Lookup the code system concept for the given coding and lookup parameters
+     *
+     * @param coding
+     *     the coding to lookup
+     * @param parameters
+     *     the lookup parameters
+     * @return
+     *     the outcome of the lookup
+     */
+    LookupOutcome lookup(Coding coding, LookupParameters parameters);
 
     /**
      * Lookup the code system concept for the given coding
@@ -43,9 +71,11 @@ public interface FHIRTermServiceProvider {
      * @param coding
      *     the coding to lookup
      * @return
-     *     the code system concept that matches the given coding, or null if no such concept exists
+     *     the outcome of the lookup
      */
-    Concept lookup(Coding coding);
+    default LookupOutcome lookup(Coding coding) {
+        return lookup(coding, LookupParameters.EMPTY);
+    }
 
     /**
      * Perform a subsumption test to determine if the code system concept represented by the given coding "A" subsumes
@@ -71,20 +101,102 @@ public interface FHIRTermServiceProvider {
     Set<Concept> closure(Coding coding);
 
     /**
-     * Indicates whether a code system concept matches the given coding
+     * Validate a code and display against its system and version using the provided validation parameters
+     *
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    default ValidationOutcome validateCode(Uri system, String version, Code code, String display, ValidationParameters parameters) {
+        Coding coding = Coding.builder()
+                .system(system)
+                .version(version)
+                .code(code)
+                .display(display)
+                .build();
+        return validateCode(coding, parameters);
+    }
+
+    /**
+     * Validate a code and display against its system and version
+     *
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @return
+     *     the outcome of validation
+     */
+    default ValidationOutcome validateCode(Uri system, String version, Code code, String display) {
+        return validateCode(system, version, code, display, ValidationParameters.EMPTY);
+    }
+
+    /**
+     * Validate a coding against its system and version using the provided validation parameters
+     *
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    ValidationOutcome validateCode(Coding coding, ValidationParameters parameters);
+
+    /**
+     * Validate a coding against its system and version
      *
      * @param coding
      *     the coding
      * @return
-     *     true if a code system concept matches the given coding, false otherwise
+     *     the outcome of validation
      */
-    boolean validateCode(Coding coding);
+    default ValidationOutcome validateCode(Coding coding) {
+        return validateCode(coding, ValidationParameters.EMPTY);
+    }
 
     /**
-     * Indicates whether the given code is a member of the provided value set
+     * Validate a codeable concept against its system and version using the provided validation parameters
+     *
+     * @param codeableConcept
+     *     the codeable concept
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    ValidationOutcome validateCode(CodeableConcept codeableConcept, ValidationParameters parameters);
+
+    /**
+     * Validate a codeable concept against its system and version
+     *
+     * @param codeableConcept
+     *     the codeable concept
+     * @return
+     *     the outcome of validation
+     */
+    default ValidationOutcome validateCode(CodeableConcept codeableConcept) {
+        return validateCode(codeableConcept, ValidationParameters.EMPTY);
+    }
+
+    /**
+     * Validate a code and display using the provided value set and validation parameters
      *
      * @apiNote
-     *     the implementation should expand the provided value set if needed
+     *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
      * @param system
@@ -93,38 +205,124 @@ public interface FHIRTermServiceProvider {
      *     the version
      * @param code
      *     the code
+     * @param display
+     *     the display
+     * @param parameters
+     *     the validation parameters
      * @return
-     *     true if the given code is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
-    boolean validateCode(ValueSet valueSet, String system, String version, String code);
+    default ValidationOutcome validateCode(ValueSet valueSet, Uri system, String version, Code code, String display, ValidationParameters parameters) {
+        Coding coding = Coding.builder()
+                .system(system)
+                .version(version)
+                .code(code)
+                .display(display)
+                .build();
+        return validateCode(valueSet, coding, parameters);
+    }
 
     /**
-     * Indicates whether the given coding is a member of the provided value set
+     * Validate a code and display using the provided value set
      *
      * @apiNote
-     *     the implementation should expand the provided value set if needed
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param system
+     *     the system
+     * @param version
+     *     the version
+     * @param code
+     *     the code
+     * @param display
+     *     the display
+     * @return
+     *     the outcome of validation
+     */
+    default ValidationOutcome validateCode(ValueSet valueSet, Uri system, String version, Code code, String display) {
+        return validateCode(valueSet, system, version, code, display, ValidationParameters.EMPTY);
+    }
+
+    /**
+     * Validate a coding using the provided value set using the provided validation parameters
+     *
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
      * @param coding
      *     the coding
+     * @param parameters
+     *     the validation parameters
      * @return
-     *     true if the given coding is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
-    boolean validateCode(ValueSet valueSet, Coding coding);
+    ValidationOutcome validateCode(ValueSet valueSet, Coding coding, ValidationParameters parameters);
 
     /**
-     * Indicates whether the given codeable concept contains a coding that is a member of the provided value set
+     * Validate a coding using the provided value set using the provided validation parameters
      *
      * @apiNote
-     *     the implementation should expand the provided value set if needed
+     *     the implementation will expand the provided value set if needed
      * @param valueSet
      *     the value set
-     * @param codeableConcept
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    default ValidationOutcome validateCode(ValueSet valueSet, Coding coding) {
+        return validateCode(valueSet, coding, ValidationParameters.EMPTY);
+    }
+
+    /**
+     * Validate a codeable concept using the provided value set using the provided validation parameters
+     *
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param codeable concept
+     *     the codeable concept
+     * @param parameters
+     *     the validation parameters
+     * @return
+     *     the outcome of validation
+     */
+    ValidationOutcome validateCode(ValueSet valueSet, CodeableConcept codeableConcept, ValidationParameters parameters);
+
+    /**
+     * Validate a codeable concept using the provided value set
+     *
+     * @apiNote
+     *     the implementation will expand the provided value set if needed
+     * @param valueSet
+     *     the value set
+     * @param codeable concept
      *     the codeable concept
      * @return
-     *     true if the given codeable concept contains a coding that is a member of the provided value set, false otherwise
+     *     the outcome of validation
      */
-    boolean validateCode(ValueSet valueSet, CodeableConcept codeableConcept);
+    default ValidationOutcome validateCode(ValueSet valueSet, CodeableConcept codeableConcept) {
+        return validateCode(valueSet, codeableConcept, ValidationParameters.EMPTY);
+    }
+
+    /**
+     * Translate the given coding using the provided concept map and translation parameters
+     *
+     * @param conceptMap
+     *     the concept map
+     * @param coding
+     *     the coding
+     * @param parameters
+     *     the translation parameters
+     * @return
+     *     the outcome of translation
+     */
+    TranslationOutcome translate(ConceptMap conceptMap, Coding coding, TranslationParameters parameters);
 
     /**
      * Translate the given coding using the provided concept map
@@ -136,5 +334,7 @@ public interface FHIRTermServiceProvider {
      * @return
      *     the outcome of translation
      */
-    TranslationOutcome translate(ConceptMap conceptMap, Coding coding);
+    default TranslationOutcome translate(ConceptMap conceptMap, Coding coding) {
+        return translate(conceptMap, coding, TranslationParameters.EMPTY);
+    }
 }

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/LookupOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/LookupOutcome.java
@@ -1,0 +1,453 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.model.type.String.string;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.Element;
+import com.ibm.fhir.model.type.String;
+
+/**
+ * This class is used to represent the outcome of the lookup operation:
+ * <a href="http://hl7.org/fhir/codesystem-operation-lookup.html">http://hl7.org/fhir/codesystem-operation-lookup.html</a>
+ */
+public class LookupOutcome {
+    private final String name;
+    private final String version;
+    private final String display;
+    private final List<Designation> designation;
+    private final List<Property> property;
+
+    private LookupOutcome(Builder builder) {
+        name = Objects.requireNonNull(builder.name);
+        version = builder.version;
+        display = Objects.requireNonNull(builder.display);
+        designation = Collections.unmodifiableList(builder.designation);
+        property = Collections.unmodifiableList(builder.property);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    public List<Designation> getDesignation() {
+        return designation;
+    }
+
+    public List<Property> getProperty() {
+        return property;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        LookupOutcome other = (LookupOutcome) obj;
+        return Objects.equals(name, other.name) &&
+                Objects.equals(version, other.version) &&
+                Objects.equals(display, other.display) &&
+                Objects.equals(designation, other.designation) &&
+                Objects.equals(property, other.property);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, version, display, designation, property);
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Parameters toParameters() {
+        Parameters.Builder parametersBuilder = Parameters.builder();
+
+        parametersBuilder.parameter(Parameter.builder()
+            .name(string("name"))
+            .value(name)
+            .build());
+
+        if (version != null) {
+            parametersBuilder.parameter(Parameter.builder()
+                .name(string("name"))
+                .value(version)
+                .build());
+
+            parametersBuilder.parameter(Parameter.builder()
+                .name(string("name"))
+                .value(display)
+                .build());
+        }
+
+        for (Designation designation : this.designation) {
+            Parameter.Builder designationParameterBuilder = Parameter.builder();
+
+            designationParameterBuilder.name(string("designation"));
+
+            if (designation.language != null) {
+                designationParameterBuilder.part(Parameter.builder()
+                    .name(string("language"))
+                    .value(designation.language)
+                    .build());
+            }
+
+            if (designation.use != null) {
+                designationParameterBuilder.part(Parameter.builder()
+                    .name(string("use"))
+                    .value(designation.use)
+                    .build());
+            }
+
+            designationParameterBuilder.part(Parameter.builder()
+                .name(string("value"))
+                .value(designation.value)
+                .build());
+
+            parametersBuilder.parameter(designationParameterBuilder.build());
+        }
+
+        for (Property property : this.property) {
+            Parameter.Builder propertyParameterBuilder = Parameter.builder();
+
+            propertyParameterBuilder.name(string("property"));
+
+            propertyParameterBuilder.part(Parameter.builder()
+                .name(string("code"))
+                .value(property.code)
+                .build());
+
+            propertyParameterBuilder.part(Parameter.builder()
+                .name(string("value"))
+                .value(property.value)
+                .build());
+
+            if (property.description != null) {
+                propertyParameterBuilder.part(Parameter.builder()
+                    .name(string("description"))
+                    .value(property.description)
+                    .build());
+            }
+
+            for (Property subproperty : property.subproperty) {
+                Parameter.Builder subpropertyParameterBuilder = Parameter.builder();
+
+                subpropertyParameterBuilder.name(string("subproperty"));
+
+                subpropertyParameterBuilder.part(Parameter.builder()
+                    .name(string("code"))
+                    .value(subproperty.code)
+                    .build());
+
+                subpropertyParameterBuilder.part(Parameter.builder()
+                    .name(string("value"))
+                    .value(subproperty.value)
+                    .build());
+
+                if (subproperty.description != null) {
+                    subpropertyParameterBuilder.part(Parameter.builder()
+                        .name(string("description"))
+                        .value(subproperty.description)
+                        .build());
+                }
+
+                propertyParameterBuilder.part(subpropertyParameterBuilder.build());
+            }
+
+            parametersBuilder.parameter(propertyParameterBuilder.build());
+        }
+
+        return parametersBuilder.build();
+    }
+
+    public static class Builder {
+        private String name;
+        private String version;
+        private String display;
+        private List<Designation> designation = new ArrayList<>();
+        private List<Property> property = new ArrayList<>();
+
+        private Builder() { }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder display(String display) {
+            this.display = display;
+            return this;
+        }
+
+        public Builder designation(Designation... designation) {
+            for (Designation value : designation) {
+                this.designation.add(value);
+            }
+            return this;
+        }
+
+        public Builder designation(Collection<Designation> designation) {
+            this.designation = new ArrayList<>(designation);
+            return this;
+        }
+
+        public Builder property(Property... property) {
+            for (Property value : property) {
+                this.property.add(value);
+            }
+            return this;
+        }
+
+        public Builder property(Collection<Property> property) {
+            this.property = new ArrayList<>(property);
+            return this;
+        }
+
+        public LookupOutcome build() {
+            return new LookupOutcome(this);
+        }
+
+        public Builder from(LookupOutcome lookupOutcome) {
+            name = lookupOutcome.name;
+            version = lookupOutcome.version;
+            display = lookupOutcome.display;
+            designation.addAll(lookupOutcome.designation);
+            property.addAll(lookupOutcome.property);
+            return this;
+        }
+    }
+
+    public static class Designation {
+        private final Code language;
+        private final Coding use;
+        private final String value;
+
+        public Designation(Builder builder) {
+            language = builder.language;
+            use = builder.use;
+            value = Objects.requireNonNull(builder.value);
+        }
+
+        public Code getLanguage() {
+            return language;
+        }
+
+        public Coding getUse() {
+            return use;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Designation other = (Designation) obj;
+            return Objects.equals(language, other.language) &&
+                    Objects.equals(use, other.use) &&
+                    Objects.equals(value, other.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(language, use, value);
+        }
+
+        public Builder toBuilder() {
+            return new Builder().from(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private Code language;
+            private Coding use;
+            private String value;
+
+            private Builder() { }
+
+            public Builder language(Code language) {
+                this.language = language;
+                return this;
+            }
+
+            public Builder use(Coding use) {
+                this.use = use;
+                return this;
+            }
+
+            public Builder value(String value) {
+                this.value = value;
+                return this;
+            }
+
+            public Designation build() {
+                return new Designation(this);
+            }
+
+            public Builder from(Designation designation) {
+                language = designation.language;
+                use = designation.use;
+                value = designation.value;
+                return this;
+            }
+        }
+    }
+
+    public static class Property {
+        private final Code code;
+        private final Element value;
+        private final String description;
+        private final List<Property> subproperty;
+
+        public Property(Builder builder) {
+            code = Objects.requireNonNull(builder.code);
+            value = Objects.requireNonNull(builder.value);
+            description = builder.description;
+            subproperty = Collections.unmodifiableList(builder.subproperty);
+        }
+
+        public Code getCode() {
+            return code;
+        }
+
+        public Element getValue() {
+            return value;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public List<Property> getSubproperty() {
+            return subproperty;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Property other = (Property) obj;
+            return Objects.equals(code, other.code) &&
+                    Objects.equals(value, other.value) &&
+                    Objects.equals(description, other.description) &&
+                    Objects.equals(subproperty, other.subproperty);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(code, value, description, subproperty);
+        }
+
+        public Builder toBuilder() {
+            return new Builder().from(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            private Code code;
+            private Element value;
+            private String description;
+            private List<Property> subproperty = new ArrayList<>();
+
+            private Builder() { }
+
+            public Builder code(Code code) {
+                this.code = code;
+                return this;
+            }
+
+            public Builder value(Element value) {
+                this.value = value;
+                return this;
+            }
+
+            public Builder description(String description) {
+                this.description = description;
+                return this;
+            }
+
+            public Builder subproperty(Property... subproperty) {
+                for (Property value : subproperty) {
+                    this.subproperty.add(value);
+                }
+                return this;
+            }
+
+            public Builder subproperty(Collection<Property> subproperty) {
+                this.subproperty = new ArrayList<>(subproperty);
+                return this;
+            }
+
+            public Property build() {
+                return new Property(this);
+            }
+
+            protected Builder from(Property property) {
+                code = property.code;
+                value = property.value;
+                description = property.description;
+                subproperty.addAll(property.subproperty);
+                return this;
+            }
+        }
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/LookupParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/LookupParameters.java
@@ -1,0 +1,135 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.DateTime;
+
+/**
+ * This class is used to represent the optional input parameters of the lookup operation:
+ * <a href="http://hl7.org/fhir/codesystem-operation-lookup.html">http://hl7.org/fhir/codesystem-operation-lookup.html</a>
+ */
+public class LookupParameters {
+    public static final LookupParameters EMPTY = LookupParameters.builder().build();
+
+    private final DateTime date;
+    private final Code displayLanguage;
+    private final List<Code> property;
+
+    private LookupParameters(Builder builder) {
+        date = builder.date;
+        displayLanguage = builder.displayLanguage;
+        property = Collections.unmodifiableList(builder.property);
+    }
+
+    public DateTime getDate() {
+        return date;
+    }
+
+    public Code getDisplayLanguage() {
+        return displayLanguage;
+    }
+
+    public List<Code> getProperty() {
+        return property;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        LookupParameters other = (LookupParameters) obj;
+        return Objects.equals(date, other.date) &&
+                Objects.equals(displayLanguage, other.displayLanguage) &&
+                Objects.equals(property, other.property);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date, displayLanguage, property);
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static LookupParameters from(Parameters parameters) {
+        Parameter date = getParameter(parameters, "date");
+        Parameter displayLanguage = getParameter(parameters, "displayLanguage");
+        return LookupParameters.builder()
+                .date((date != null) ? date.getValue().as(DateTime.class): null)
+                .displayLanguage((displayLanguage != null) ? displayLanguage.getValue().as(Code.class) : null)
+                .property(getParameters(parameters, "property").stream()
+                    .map(parameter -> parameter.getValue().as(Code.class))
+                    .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static class Builder {
+        private DateTime date;
+        private Code displayLanguage;
+        private List<Code> property = new ArrayList<>();
+
+        private Builder() { }
+
+        public Builder date(DateTime date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder displayLanguage(Code displayLanguage) {
+            this.displayLanguage = displayLanguage;
+            return this;
+        }
+
+        public Builder property(Code...property) {
+            for (Code value : property) {
+                this.property.add(value);
+            }
+            return this;
+        }
+
+        public Builder property(Collection<Code> property) {
+            this.property = new ArrayList<>(property);
+            return this;
+        }
+
+        public LookupParameters build() {
+            return new LookupParameters(this);
+        }
+
+        protected Builder from(LookupParameters lookupParameters) {
+            date = lookupParameters.date;
+            displayLanguage = lookupParameters.displayLanguage;
+            property.addAll(lookupParameters.property);
+            return this;
+        }
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/TranslationOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/TranslationOutcome.java
@@ -24,7 +24,8 @@ import com.ibm.fhir.model.type.code.ConceptMapEquivalence;
 import com.ibm.fhir.term.spi.TranslationOutcome.Match.Product;
 
 /**
- * This class represents the outcome of translation per: <a href="http://hl7.org/fhir/conceptmap-operation-translate.html">http://hl7.org/fhir/conceptmap-operation-translate.html</a>
+ * This class is used to represent the outcome of the translate operation:
+ * <a href="http://hl7.org/fhir/conceptmap-operation-translate.html">http://hl7.org/fhir/conceptmap-operation-translate.html</a>
  */
 public class TranslationOutcome {
     private final Boolean result;

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/TranslationParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/TranslationParameters.java
@@ -1,0 +1,204 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getPart;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Boolean;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Uri;
+
+/**
+ * This class is used to represent the optional input parameters of the translate operation:
+ * <a href="http://hl7.org/fhir/conceptmap-operation-translate.html">http://hl7.org/fhir/conceptmap-operation-translate.html</a>
+ */
+public class TranslationParameters {
+    public static final TranslationParameters EMPTY = TranslationParameters.builder().build();
+
+    private final List<Dependency> dependency;
+    private final Boolean reverse;
+
+    private TranslationParameters(Builder builder) {
+        dependency = Collections.unmodifiableList(builder.dependency);
+        reverse = builder.reverse;
+    }
+
+    public List<Dependency> getDependency() {
+        return dependency;
+    }
+
+    public Boolean getReverse() {
+        return reverse;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        TranslationParameters other = (TranslationParameters) obj;
+        return Objects.equals(dependency, other.dependency) &&
+                Objects.equals(reverse, other.reverse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dependency, reverse);
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static TranslationParameters from(Parameters parameters) {
+        Parameter reverse = getParameter(parameters, "reverse");
+        return TranslationParameters.builder()
+                .dependency(getParameters(parameters, "dependency").stream()
+                    .map(Dependency::from)
+                    .collect(Collectors.toList()))
+                .reverse((reverse != null) ? reverse.getValue().as(Boolean.class) : null)
+                .build();
+    }
+
+    public static class Builder {
+        private List<Dependency> dependency = new ArrayList<>();
+        private Boolean reverse;
+
+        private Builder() { }
+
+        public Builder dependency(Dependency...dependency) {
+            for (Dependency value : dependency) {
+                this.dependency.add(value);
+            }
+            return this;
+        }
+
+        public Builder dependency(Collection<Dependency> dependency) {
+            this.dependency = new ArrayList<>(dependency);
+            return this;
+        }
+
+        public Builder reverse(Boolean reverse) {
+            this.reverse = reverse;
+            return this;
+        }
+
+        public TranslationParameters build() {
+            return new TranslationParameters(this);
+        }
+
+        protected Builder from(TranslationParameters translationParameters) {
+            dependency.addAll(translationParameters.dependency);
+            reverse = translationParameters.reverse;
+            return this;
+        }
+    }
+
+    public static class Dependency {
+        private final Uri element;
+        private final CodeableConcept concept;
+
+        private Dependency(Builder builder) {
+            this.element = builder.element;
+            this.concept = builder.concept;
+        }
+
+        public Uri getElement() {
+            return element;
+        }
+
+        public CodeableConcept getConcept() {
+            return concept;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Dependency other = (Dependency) obj;
+            return Objects.equals(element, other.element) &&
+                    Objects.equals(concept, other.concept);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(element, concept);
+        }
+
+        public Builder toBuilder() {
+            return new Builder().from(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Dependency from(Parameter parameter) {
+            Parameter element = getPart(parameter, "element");
+            Parameter concept = getPart(parameter, "concept");
+            return Dependency.builder()
+                    .element((element != null) ? element.getValue().as(Uri.class) : null)
+                    .concept((concept != null) ? concept.getValue().as(CodeableConcept.class) : null)
+                    .build();
+        }
+
+        public static class Builder {
+            private Uri element;
+            private CodeableConcept concept;
+
+            private Builder() { }
+
+            public Builder element(Uri element) {
+                this.element = element;
+                return this;
+            }
+
+            public Builder concept(CodeableConcept concept) {
+                this.concept = concept;
+                return this;
+            }
+
+            public Dependency build() {
+                return new Dependency(this);
+            }
+
+            protected Builder from(Dependency dependency) {
+                element = dependency.element;
+                concept = dependency.concept;
+                return this;
+            }
+        }
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/ValidationOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/ValidationOutcome.java
@@ -1,0 +1,134 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.model.type.String.string;
+
+import java.util.Objects;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Boolean;
+import com.ibm.fhir.model.type.String;
+
+/**
+ * This class is used to represent the outcome of the validate-code operations:
+ * <a href="http://hl7.org/fhir/codesystem-operation-validate-code.html">http://hl7.org/fhir/codesystem-operation-validate-code.html</a>
+ * and <a href="http://hl7.org/fhir/valueset-operation-validate-code.html">http://hl7.org/fhir/valueset-operation-validate-code.html</a>
+ */
+public class ValidationOutcome {
+    private final Boolean result;
+    private final String message;
+    private final String display;
+
+    private ValidationOutcome(Builder builder) {
+        result = Objects.requireNonNull(builder.result);
+        message = builder.message;
+        display = builder.display;
+    }
+
+    public Boolean getResult() {
+        return result;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ValidationOutcome other = (ValidationOutcome) obj;
+        return Objects.equals(result, other.result) &&
+                Objects.equals(message, other.message) &&
+                Objects.equals(display, other.display);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(result, message, display);
+    }
+
+    public Parameters toParameters() {
+        Parameters.Builder parametersBuilder = Parameters.builder();
+
+        parametersBuilder.parameter(Parameter.builder()
+            .name(string("result"))
+            .value(result)
+            .build());
+
+        if (message != null) {
+            parametersBuilder.parameter(Parameter.builder()
+                .name(string("message"))
+                .value(message)
+                .build());
+        }
+
+        if (display != null) {
+            parametersBuilder.parameter(Parameter.builder()
+                .name(string("display"))
+                .value(display)
+                .build());
+        }
+
+        return parametersBuilder.build();
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Boolean result;
+        private String message;
+        private String display;
+
+        private Builder() { }
+
+        public Builder result(Boolean result) {
+            this.result = result;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder display(String display) {
+            this.display = display;
+            return this;
+        }
+
+        public ValidationOutcome build() {
+            return new ValidationOutcome(this);
+        }
+
+        protected Builder from(ValidationOutcome validationOutcome) {
+            result = validationOutcome.result;
+            message = validationOutcome.message;
+            display = validationOutcome.display;
+            return this;
+        }
+    }
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/ValidationParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/ValidationParameters.java
@@ -1,0 +1,123 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.spi;
+
+import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
+
+import java.util.Objects;
+
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Parameters.Parameter;
+import com.ibm.fhir.model.type.Boolean;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.DateTime;
+
+/**
+ * This class is used to represent the optional input parameters of the validate-code operations:
+ * <a href="http://hl7.org/fhir/codesystem-operation-validate-code.html">http://hl7.org/fhir/codesystem-operation-validate-code.html</a>
+ * and <a href="http://hl7.org/fhir/valueset-operation-validate-code.html">http://hl7.org/fhir/valueset-operation-validate-code.html</a>
+ */
+public class ValidationParameters {
+    public static final ValidationParameters EMPTY = ValidationParameters.builder().build();
+
+    private final DateTime date;
+    private final Boolean _abstract;
+    private final Code displayLanguage;
+
+    private ValidationParameters(Builder builder) {
+        this.date = builder.date;
+        this._abstract = builder._abstract;
+        this.displayLanguage = builder.displayLanguage;
+    }
+
+    public DateTime getDate() {
+        return date;
+    }
+
+    public Boolean getAbstract() {
+        return _abstract;
+    }
+
+    public Code getDisplayLanguage() {
+        return displayLanguage;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ValidationParameters other = (ValidationParameters) obj;
+        return Objects.equals(date, other.date) &&
+                Objects.equals(_abstract, other._abstract) &&
+                Objects.equals(displayLanguage, other.displayLanguage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date, _abstract, displayLanguage);
+    }
+
+    public Builder toBuilder() {
+        return new Builder().from(this);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ValidationParameters from(Parameters parameters) {
+        Parameter date = getParameter(parameters, "date");
+        Parameter _abstract = getParameter(parameters, "abstract");
+        Parameter displayLanguage = getParameter(parameters, "displayLanguage");
+        return ValidationParameters.builder()
+                .date((date != null) ? date.getValue().as(DateTime.class) : null)
+                ._abstract((_abstract != null) ? _abstract.getValue().as(Boolean.class) : null)
+                .displayLanguage((displayLanguage != null) ? displayLanguage.getValue().as(Code.class) : null)
+                .build();
+    }
+
+    public static class Builder {
+        private DateTime date;
+        private Boolean _abstract;
+        private Code displayLanguage;
+
+        private Builder() { }
+
+        public Builder date(DateTime date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder _abstract(Boolean _abstract) {
+            this._abstract = _abstract;
+            return this;
+        }
+
+        public Builder displayLanguage(Code displayLanguage) {
+            this.displayLanguage = displayLanguage;
+            return this;
+        }
+
+        public ValidationParameters build() {
+            return new ValidationParameters(this);
+        }
+
+        protected Builder from(ValidationParameters validationParameters) {
+            date = validationParameters.date;
+            _abstract = validationParameters._abstract;
+            displayLanguage = validationParameters.displayLanguage;
+            return this;
+        }
+    }
+}

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -260,6 +260,7 @@ public class CodeGenerator {
         generateXMLParser(basePath);
         generateModelClassesFile(basePath);
         generateCodeSubtypeClass("ConceptSubsumptionOutcome", "http://hl7.org/fhir/ValueSet/concept-subsumption-outcome", basePath);
+        generateCodeSubtypeClass("DataAbsentReason", "http://hl7.org/fhir/ValueSet/data-absent-reason", basePath);
     }
 
     private void generateModelClassesFile(String basePath) {

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/BodyWeightProfileTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/BodyWeightProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -99,7 +99,7 @@ public class BodyWeightProfileTest {
             issues.forEach(System.out::println);
         }
 
-        Assert.assertEquals(issues.size(), 4);
+        Assert.assertEquals(issues.size(), 5);
         Assert.assertTrue(issues.stream().filter(issue -> issue.getDetails().getText().getValue().startsWith("dom-6")).count() == 1);
         Assert.assertTrue(issues.stream().filter(issue -> issue.getDetails().getText().getValue().startsWith("vs-1")).count() == 1);
         Assert.assertTrue(issues.stream().filter(issue -> issue.getDetails().getText().getValue().startsWith("generated-bodyweight-3")).count() == 1);


### PR DESCRIPTION
This PR contains changes to the `FHIRTermServiceProvider` interface including the introduction of various `Parameters` and `Outcome` classes that can be converted to/from a Parameters resource for compatibility with the operations framework.


Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>