### PR TITLE
issue #1187 fix for DB connection timeout issue of patient export

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1488,6 +1488,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/maxInputPerRequest`|integer|The maximum inputs per bulk import|
 |`fhirServer/bulkdata/cosFileMaxResources`|int|The maximum number of FHIR resources per COS file, "-1" means no limit, the default value is 500000 |
 |`fhirServer/bulkdata/cosFileMaxSize`|int|The maximum COS file size in bytes, "-1" means no limit, the default value is 209715200 (200M) |
+|`fhirServer/bulkdata/patientExportPageSize`|int| The search page size for patient/group export, the default value is 200 |
 
 
 ### 5.1.2 Default property values
@@ -1536,6 +1537,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/validBaseUrlsDisabled`|false|
 |`fhirServer/bulkdata/cosFileMaxResources`|500000|
 |`fhirServer/bulkdata/cosFileMaxSize`|209715200|
+|`fhirServer/bulkdata/patientExportPageSize`|200|
 
 
 ### 5.1.3 Property attributes
@@ -1602,6 +1604,7 @@ must restart the server for that change to take effect.
 |`fhirServer/bulkdata/validBaseUrlsDisabled`|Y|Y|
 |`fhirServer/bulkdata/cosFileMaxResources`|Y|Y|
 |`fhirServer/bulkdata/cosFileMaxSize`|Y|Y|
+|`fhirServer/bulkdata/patientExportPageSize`|Y|Y|
 
 ## 5.2 Keystores, truststores, and the FHIR server
 

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
@@ -4,7 +4,7 @@
         <listener ref="com.ibm.fhir.bulkexport.system.ExportJobListener"/>
     </listeners>
     <step id="step1">
-        <chunk checkpoint-policy="custom">
+        <chunk checkpoint-policy="item" item-count="1">
             <reader ref="com.ibm.fhir.bulkexport.group.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
@@ -4,7 +4,7 @@
         <listener ref="com.ibm.fhir.bulkexport.system.ExportJobListener"/>
     </listeners>
     <step id="step1">
-        <chunk checkpoint-policy="custom">
+        <chunk checkpoint-policy="item" item-count="1">
             <reader ref="com.ibm.fhir.bulkexport.patient.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkcommon/Constants.java
@@ -18,6 +18,7 @@ public class Constants {
     // The minimal size (10M bytes) for COS multiple-parts upload.
     public static final int COS_PART_MINIMALSIZE = 10485760;
     public static final int DEFAULT_SEARCH_PAGE_SIZE = 1000;
+    public static final int DEFAULT_PATIENT_EXPORT_SEARCH_PAGE_SIZE = 200;
     public static final int DEFAULT_COSFILE_MAX_SIZE = 209715200;
     public static final int DEFAULT_COSFILE_MAX_RESOURCESNUMBER = 500000;
     public static final String FHIR_SEARCH_LASTUPDATED = "_lastUpdated";

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/CheckPointUserData.java
@@ -32,10 +32,11 @@ public class CheckPointUserData implements java.io.Serializable {
     private String resourceTypeSummary = null;
     // Used to mark the complete of the partition.
     private boolean isMoreToExport = true;
+    private int lastWritePageNum;
 
     public CheckPointUserData(int pageNum, String uploadId, List<PartETag> cosDataPacks, int partNum,
             int indexOfCurrentTypeFilter, String resourceTypeSummary, int totalResourcesNum, int currentUploadResourceNum,
-            int currentUploadSize, int uploadCount, int lastPageNum) {
+            int currentUploadSize, int uploadCount, int lastPageNum, int lastWritePageNum) {
         super();
         this.pageNum = pageNum;
         this.uploadId = uploadId;
@@ -48,13 +49,14 @@ public class CheckPointUserData implements java.io.Serializable {
         this.currentUploadSize = currentUploadSize;
         this.uploadCount = uploadCount;
         this.lastPageNum = lastPageNum;
+        this.lastWritePageNum = lastWritePageNum;
     }
 
     public static CheckPointUserData fromTransientUserData(TransientUserData userData) {
         return new CheckPointUserData(userData.getPageNum(), userData.getUploadId(), userData.getCosDataPacks(),
                 userData.getPartNum(), userData.getIndexOfCurrentTypeFilter(), userData.getResourceTypeSummary(),
                 userData.getTotalResourcesNum(), userData.getCurrentUploadResourceNum(), userData.getCurrentUploadSize(),
-                userData.getUploadCount(), userData.getLastPageNum());
+                userData.getUploadCount(), userData.getLastPageNum(), userData.getLastWritePageNum());
     }
 
     public int getPageNum() {
@@ -159,6 +161,14 @@ public class CheckPointUserData implements java.io.Serializable {
 
     public void setUploadCount(int uploadCount) {
         this.uploadCount = uploadCount;
+    }
+
+    public int getLastWritePageNum() {
+        return lastWritePageNum;
+    }
+
+    public void setLastWritePageNum(int lastWritePageNum) {
+        this.lastWritePageNum = lastWritePageNum;
     }
 
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/TransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/common/TransientUserData.java
@@ -21,9 +21,9 @@ public class TransientUserData extends CheckPointUserData {
 
     public TransientUserData(int pageNum, String uploadId, List<PartETag> cosDataPacks, int partNum,
             int indexOfCurrentTypeFilter, String resourceTypeSummary, int totalResourcesNum, int currentPartResourceNum,
-            int currentPartSize, int uploadCount, int lastPageNum) {
+            int currentPartSize, int uploadCount, int lastPageNum, int lastWritePageNum) {
         super(pageNum, uploadId, cosDataPacks, partNum, indexOfCurrentTypeFilter, resourceTypeSummary,
-                totalResourcesNum, currentPartResourceNum, currentPartSize, uploadCount, lastPageNum);
+                totalResourcesNum, currentPartResourceNum, currentPartSize, uploadCount, lastPageNum, lastWritePageNum);
     }
 
     public static TransientUserData fromCheckPointUserData(CheckPointUserData checkPointData) {
@@ -31,7 +31,7 @@ public class TransientUserData extends CheckPointUserData {
                 checkPointData.getCosDataPacks(), checkPointData.getPartNum(), checkPointData.getIndexOfCurrentTypeFilter(),
                 checkPointData.getResourceTypeSummary(), checkPointData.getTotalResourcesNum(),
                 checkPointData.getCurrentUploadResourceNum(), checkPointData.getCurrentUploadSize(),
-                checkPointData.getUploadCount(), checkPointData.getLastPageNum());
+                checkPointData.getUploadCount(), checkPointData.getLastPageNum(), checkPointData.getLastWritePageNum());
     }
 
     public ByteArrayOutputStream getBufferStream() {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/group/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/group/ChunkReader.java
@@ -140,7 +140,7 @@ public class ChunkReader extends com.ibm.fhir.bulkexport.patient.ChunkReader {
         pageNum++;
 
         if (chunkData == null) {
-            chunkData = new TransientUserData(pageNum, null, new ArrayList<PartETag>(), 1, 0, null, 0, 0, 0, 1, 0);
+            chunkData = new TransientUserData(pageNum, null, new ArrayList<PartETag>(), 1, 0, null, 0, 0, 0, 1, 0, 1);
             stepCtx.setTransientUserData(chunkData);
         } else {
             chunkData.setPageNum(pageNum);

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkReader.java
@@ -217,7 +217,7 @@ public class ChunkReader extends AbstractItemReader {
         pageNum++;
 
         if (chunkData == null) {
-            chunkData = new TransientUserData(pageNum, null, new ArrayList<PartETag>(), 1, 0, null, 0, 0, 0, 1, 0);
+            chunkData = new TransientUserData(pageNum, null, new ArrayList<PartETag>(), 1, 0, null, 0, 0, 0, 1, 0, 1);
             chunkData.setLastPageNum(searchContext.getLastPageNumber());
             stepCtx.setTransientUserData(chunkData);
         } else {
@@ -242,7 +242,7 @@ public class ChunkReader extends AbstractItemReader {
     public void open(Serializable checkpoint) throws Exception {
         if (checkpoint != null) {
             CheckPointUserData checkPointData = (CheckPointUserData) checkpoint;
-            pageNum = checkPointData.getPageNum();
+            pageNum = checkPointData.getLastWritePageNum();
             indexOfCurrentTypeFilter = checkPointData.getIndexOfCurrentTypeFilter();
             stepCtx.setTransientUserData(TransientUserData.fromCheckPointUserData(checkPointData));
         }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/system/ChunkWriter.java
@@ -195,9 +195,13 @@ public class ChunkWriter extends AbstractItemWriter {
             logger.warning("writeItems: chunkData is null, this should never happen!");
             throw new Exception("writeItems: chunkData is null, this should never happen!");
         } else {
-            if (chunkData.getBufferStream().size() > 0) {
+            boolean isTimeToWrite = chunkData.getPageNum() > chunkData.getLastPageNum()
+            || chunkData.getBufferStream().size() > Constants.COS_PART_MINIMALSIZE
+            || chunkData.isFinishCurrentUpload();
+            if (chunkData.getBufferStream().size() > 0 && isTimeToWrite) {
                 pushFhirJsonsToCos(new ByteArrayInputStream(chunkData.getBufferStream().toByteArray()),
                         chunkData.getBufferStream().size());
+                chunkData.setLastWritePageNum(chunkData.getPageNum());
             }
         }
     }

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -102,6 +102,7 @@ public class FHIRConfiguration {
             "fhirServer/bulkdata/maxInputPerRequest";
     public static final String PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE = "fhirServer/bulkdata/cosFileMaxSize";
     public static final String PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXRESOURCES = "fhirServer/bulkdata/cosFileMaxResources";
+    public static final String PROPERTY_BULKDATA_PATIENTEXPORT_PAGESIZE = "fhirServer/bulkdata/patientExportPageSize";
 
     // Custom header names
     public static final String DEFAULT_TENANT_ID_HEADER_NAME = "X-FHIR-TENANT-ID";


### PR DESCRIPTION
Changes for patient/group export:
(1) Added config fhirServer/bulkdata/patientExportPageSize to control search page size.
(2) Changed the checkpoint algorithm from custom to 1 item (one search page).
(3) Added lastWritePageNum to checkpointdata to allow the job to restart from the last written page if the job is stopped and restarted.  

Signed-off-by: Albert Wang <xuwang@us.ibm.com>