### PR TITLE
Update dependencies

### DIFF
--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-FROM openliberty/open-liberty:20.0.0.3-full-java8-openj9-ubi as base
+FROM openliberty/open-liberty:20.0.0.6-full-java8-openj9-ubi as base
 
 ENV LICENSE accept
 
@@ -20,7 +20,7 @@ RUN unzip -qq /tmp/fhir-server-distribution.zip -d /tmp && \
 
 # ----------------------------------------------------------------------------
 
-FROM openliberty/open-liberty:20.0.0.3-full-java8-openj9-ubi
+FROM openliberty/open-liberty:20.0.0.6-full-java8-openj9-ubi
 COPY --chown=1001:0 --from=base /opt/ol/wlp /opt/ol/wlp
 
 MAINTAINER Lee Surprenant <lmsurpre@us.ibm.com>

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -7,7 +7,7 @@
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-set LIBERTY_VERSION=20.0.0.3
+set LIBERTY_VERSION=20.0.0.6
 
 echo Executing %0 to deploy the fhir-server web application...
 

--- a/fhir-install/src/main/resources/scripts/install.sh
+++ b/fhir-install/src/main/resources/scripts/install.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 
-export LIBERTY_VERSION="20.0.0.3"
+export LIBERTY_VERSION="20.0.0.6"
 
 echo "
 Executing $0 to deploy the fhir-server web application...

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -10,11 +10,11 @@
     <name>IBM FHIR Server</name>
 
     <properties>
-        <liberty.version>20.0.0.3</liberty.version>
+        <liberty.version>20.0.0.6</liberty.version>
         <derby.version>10.14.2.0</derby.version>
         <db2.version>11.5.0.0</db2.version>
         <postgresql.version>42.2.12</postgresql.version>
-        <cxf.version>3.3.3</cxf.version>
+        <cxf.version>3.3.6</cxf.version>
         <surefire.plugin.version>3.0.0-M3</surefire.plugin.version>
         <!-- needed for generating jacoco aggregate report in fhir-coverage-reports -->
         <maven.surefire.report.plugin>${surefire.plugin.version}</maven.surefire.report.plugin>
@@ -30,7 +30,6 @@
         <fhir-server-test.index>MINIMAL_JSON</fhir-server-test.index>
         <java.version>1.8</java.version>
         <fhir-examples.version>4.2.2-SNAPSHOT</fhir-examples.version>
-        <fhir-tools.version>4.2.2-SNAPSHOT</fhir-tools.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     </properties>
 
@@ -151,7 +150,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20090211</version>
+                <version>20200518</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -216,7 +215,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.3</version>
+                <version>1.9.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
@@ -226,7 +225,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.14</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
@@ -268,16 +267,6 @@
                 <groupId>javax.mail</groupId>
                 <artifactId>mail</artifactId>
                 <version>1.4.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>4.5.9</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.10</version>
             </dependency>
             <dependency>
                 <groupId>org.owasp.encoder</groupId>

--- a/fhir-server-webapp/pom.xml
+++ b/fhir-server-webapp/pom.xml
@@ -110,14 +110,6 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -1,9 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- THIS PRODUCT CONTAINS RESTRICTED MATERIALS OF IBM 5724-H88, 5724-J08,
-    5724-I63, 5655-W65, COPYRIGHT International Business Machines Corp., 2014
-    All Rights Reserved * Licensed Materials - Property of IBM US Government
-    Users Restricted Rights - Use, duplication or disclosure restricted by GSA
-    ADP Schedule Contract with IBM Corp. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -146,7 +140,6 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>2.0.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update to liberty 20.0.0.6, remove unused httpcomponents libs, and
update apache commons libs.

Also removed a "RESTRICTED MATERIALS" warning in fhir-server/pom.xml
which we must have missed when we move the project external last
summer/fall.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>