### PR TITLE
issue #1198 performance enhancement for patient/group export

### DIFF
--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/patient/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/bulkexport/patient/ChunkReader.java
@@ -134,6 +134,7 @@ public class ChunkReader extends AbstractItemReader {
         FHIRSearchContext searchContext;
 
         if (chunkData != null) {
+            // TODO the following replaceAll can be dropped after issue(https://github.com/IBM/FHIR/issues/300) is fixed.
             patientIds.replaceAll(x -> "Patient/" + x);
             do {
                 Map<String, List<String>> queryParameters = new HashMap<>();


### PR DESCRIPTION
Performance enhancement:
    changed to get resources for the whole page of patients in one query for each compartment search criteria instead of do compartment search for the resource type patient by patient.
    According to the test results, this has improved the export performance by more than 10 times.

Signed-off-by: Albert Wang <xuwang@us.ibm.com>