### PR TITLE
issue #1237 - stop double-adding inhereted searchparameters

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.resource.SearchParameter;
@@ -35,6 +36,9 @@ public class ParametersMap {
      * @implSpec package-private to prevent insertion from outside the package
      */
     void insert(String code, SearchParameter parameter) {
+        Objects.requireNonNull(code, "cannot insert a null code");
+        Objects.requireNonNull(parameter, "cannot insert a null parameter");
+
         if (codeMap.containsKey(code)) {
             SearchParameter previous = codeMap.get(code);
             if (previous.getExpression() == null || previous.getExpression().equals(parameter.getExpression())) {
@@ -45,13 +49,12 @@ public class ParametersMap {
                         + "replacing search parameter of id '" + previous.getId()
                         + "' with search parameter of id '" + parameter.getId() + "'");
             }
-
         }
         codeMap.put(code, parameter);
 
         String url = parameter.getUrl().getValue();
         if (urlMap.containsKey(url)) {
-            SearchParameter previous = codeMap.get(url);
+            SearchParameter previous = urlMap.get(url);
             if (previous.getExpression() == null || previous.getExpression().equals(parameter.getExpression())) {
                 log.info("SearchParameter with url '" + url + "' already exists with the same expression; "
                         + "adding additional code '" + previous.getCode() + "'");

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.search.parameters;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -18,12 +17,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.resource.Bundle;
-import com.ibm.fhir.model.resource.DomainResource;
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.type.code.SearchParamType;
-import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.search.SearchConstants;
 
@@ -132,7 +128,7 @@ public final class ParametersUtil {
         }
 
         // Return an unmodifiable copy, lest there be side effects.
-        return Collections.unmodifiableMap(assignInheritedToAll(typeToParamMap));
+        return Collections.unmodifiableMap(typeToParamMap);
     }
 
     private static List<SearchParameter> getSearchParameters() {
@@ -192,7 +188,7 @@ public final class ParametersUtil {
         }
 
         // Return an unmodifiable copy, lest there be side effects.
-        return Collections.unmodifiableMap(assignInheritedToAll(typeToParamMap));
+        return Collections.unmodifiableMap(typeToParamMap);
     }
 
     /**
@@ -222,38 +218,6 @@ public final class ParametersUtil {
      */
     public static Map<String, ParametersMap> getBuiltInSearchParametersMap() {
         return builtInSearchParameters;
-    }
-
-    /**
-     * Add the search parameters associated with "parent" types like Resource or DomainResource to the ParameterMaps
-     * for each child resource type that extend from these.
-     * 
-     * @param allTypesParametersMaps a mutable map from type names to ParametersMaps
-     * @return a modified allTypesParametersMaps with abstract search parameters applied to all children in the 
-     *         type hierarchy
-     */
-    private static Map<String, ParametersMap> assignInheritedToAll(Map<String, ParametersMap> allTypesParametersMaps) {
-
-        // The hierarchy of resources drives the search parameters assigned in the map.
-        // Resource > DomainResource > Instance (e.g. Claim or CarePlan).
-        // As such all resources receive the Resource parameters and some receive DomainResource parameters.
-
-        ParametersMap resourceMap = allTypesParametersMaps.get(SearchConstants.RESOURCE_RESOURCE);
-        ParametersMap domainResourceMap = allTypesParametersMaps.get(SearchConstants.DOMAIN_RESOURCE_RESOURCE);
-
-        for (Class<? extends Resource> resourceType : ModelSupport.getResourceTypes()) {
-            String resourceName = resourceType.getSimpleName();
-            ParametersMap typeSpecificMap = allTypesParametersMaps.computeIfAbsent(resourceName, k -> new ParametersMap());
-            if (resourceMap != null && Resource.class != resourceType) {
-                typeSpecificMap.insertAll(resourceMap);
-            }
-
-            if (domainResourceMap != null && DomainResource.class != resourceType && DomainResource.class.isAssignableFrom(resourceType)) {
-                typeSpecificMap.insertAll(domainResourceMap);
-            }
-        }
-
-        return allTypesParametersMaps;
     }
 
     /**

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -29,8 +29,6 @@ import com.ibm.fhir.search.util.SearchUtil;
 
 /**
  * This class tests various multi-tenant enabled search parameter-related methods of the SearchUtil class.
- *
- *
  */
 public class MultiTenantSearchParameterTest extends BaseSearchTest {
 
@@ -51,7 +49,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Medication");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters2", result);
-        assertEquals(21, result.size());
+        assertEquals(15, result.size());
     }
 
     @Test
@@ -61,7 +59,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters1", result);
-        assertEquals(50, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -74,12 +72,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Patient", result);
-        assertEquals(41, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Observation", result);
-        assertEquals(50, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -133,7 +131,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("MedicationAdministration");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters6/MedicationAdministration", result);
-        assertEquals(25, result.size());
+        assertEquals(19, result.size());
     }
 
     @Test
@@ -144,12 +142,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Patient", result);
-        assertEquals(41, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Device", result);
-        assertEquals(24, result.size());
+        assertEquals(18, result.size());
     }
 
     @Test

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
@@ -87,14 +87,10 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
             System.out.println("As Follows: ");
             System.out.println(result.stream().map(in -> in.getCode().getValue()).collect(Collectors.toList()));
         }
-        assertEquals(2, result.size());
+        assertEquals(8, result.size());
         SearchParameter sp = result.get(0);
         assertNotNull(sp);
         assertEquals("code", sp.getCode().getValue());
-
-        sp = result.get(1);
-        assertNotNull(sp);
-        assertEquals("value-range", sp.getCode().getValue());
 
         result = SearchUtil.getApplicableSearchParameters("Immunization");
         assertNotNull(result);
@@ -110,7 +106,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters4/Device", result);
-        assertEquals(2, result.size());
+        assertEquals(8, result.size());
         List<String> codes = getSearchParameterCodes(result);
         assertTrue(codes.contains("patient"));
         assertTrue(codes.contains("organization"));
@@ -124,7 +120,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters5/Patient", result);
-        assertEquals(4, result.size());
+        assertEquals(10, result.size());
         List<String> codes = getSearchParameterCodes(result);
         assertTrue(codes.contains("active"));
         assertTrue(codes.contains("address"));

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -22,7 +22,6 @@ import java.io.PrintStream;
 import java.io.Reader;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -51,7 +50,7 @@ public class ParametersUtilTest extends BaseSearchTest {
         // Tests JSON
         Map<String, ParametersMap> params = ParametersUtil.getBuiltInSearchParametersMap();
         assertNotNull(params);
-        // Intentionally the data is caputred in the bytearray output stream.
+        // Intentionally the data is captured in the bytearray output stream.
         try (ByteArrayOutputStream outBA = new ByteArrayOutputStream(); PrintStream out = new PrintStream(outBA, true);) {
             ParametersUtil.print(out);
             Assert.assertNotNull(outBA);
@@ -102,29 +101,6 @@ public class ParametersUtilTest extends BaseSearchTest {
         assertNotNull(result);
         assertNull(result.get("Junk"));
         assertFalse(result.get("Observation").isEmpty());
-    }
-
-    @Test
-    public void testResourceDefaults() throws IOException {
-        Map<String, ParametersMap> result = ParametersUtil.getBuiltInSearchParametersMap();
-        ParametersMap params1 = result.get("Observation");
-        ParametersMap params2 = result.get("Resource");
-
-        // Check that each returned "Resource" is included in the first set returned.
-        assertNotNull(params1);
-        assertNotNull(params2);
-        assertEquals(params2.size(), 6);
-        params2.values().stream().forEach(new Consumer<SearchParameter>() {
-
-            @Override
-            public void accept(SearchParameter resourceParam) {
-                if (DEBUG) {
-                    System.out.println("Checking Resource Param -> " + resourceParam.getId());
-                }
-                assertTrue(params1.values().contains(resourceParam));
-            }
-
-        });
     }
 
     @Test


### PR DESCRIPTION
I found that we were adding the Resource-level SearchParameters in two
different places and this was causing some inconsistent behavior.
In this option, I stop adding the Resource search parameters in
ParametersUtil and instead update the methods in SearchUtil to ensure
that these parameters are handled properly.

Also: removes redundant `getApplicableSearchParametersMap(resourceType)`
in favor of `getSearchParameter()` calls which eventually reach
`getSearchParameterByCodeIfPresent()`.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>