### PR TITLE
issue #1237 - stop adding duplicate SearchParameters with base Resource

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.search.parameters;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -227,9 +226,9 @@ public final class ParametersUtil {
     /**
      * Add the search parameters associated with "parent" types like Resource or DomainResource to the ParameterMaps
      * for each child resource type that extend from these.
-     * 
+     *
      * @param allTypesParametersMaps a mutable map from type names to ParametersMaps
-     * @return a modified allTypesParametersMaps with abstract search parameters applied to all children in the 
+     * @return a modified allTypesParametersMaps with abstract search parameters applied to all children in the
      *         type hierarchy
      */
     private static Map<String, ParametersMap> assignInheritedToAll(Map<String, ParametersMap> allTypesParametersMaps) {
@@ -241,15 +240,21 @@ public final class ParametersUtil {
         ParametersMap resourceMap = allTypesParametersMaps.get(SearchConstants.RESOURCE_RESOURCE);
         ParametersMap domainResourceMap = allTypesParametersMaps.get(SearchConstants.DOMAIN_RESOURCE_RESOURCE);
 
+        if (resourceMap == null && domainResourceMap == null) {
+            // nothing to do, so exit early
+            return allTypesParametersMaps;
+        }
+
         for (Class<? extends Resource> resourceType : ModelSupport.getResourceTypes()) {
             String resourceName = resourceType.getSimpleName();
             ParametersMap typeSpecificMap = allTypesParametersMaps.computeIfAbsent(resourceName, k -> new ParametersMap());
-            if (resourceMap != null && Resource.class != resourceType) {
-                typeSpecificMap.insertAll(resourceMap);
-            }
 
             if (domainResourceMap != null && DomainResource.class != resourceType && DomainResource.class.isAssignableFrom(resourceType)) {
                 typeSpecificMap.insertAll(domainResourceMap);
+            }
+
+            if (resourceMap != null && Resource.class != resourceType) {
+                typeSpecificMap.insertAll(resourceMap);
             }
         }
 

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -29,8 +29,6 @@ import com.ibm.fhir.search.util.SearchUtil;
 
 /**
  * This class tests various multi-tenant enabled search parameter-related methods of the SearchUtil class.
- *
- *
  */
 public class MultiTenantSearchParameterTest extends BaseSearchTest {
 
@@ -51,7 +49,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Medication");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters2", result);
-        assertEquals(21, result.size());
+        assertEquals(15, result.size());
     }
 
     @Test
@@ -61,7 +59,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters1", result);
-        assertEquals(50, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -74,12 +72,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Patient", result);
-        assertEquals(41, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Observation", result);
-        assertEquals(50, result.size());
+        assertEquals(44, result.size());
     }
 
     @Test
@@ -93,10 +91,10 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters4/Observation", result);
-        assertEquals(8, result.size());
+        assertEquals(2, result.size());
         List<String> codes = getSearchParameterCodes(result);
         assertTrue(codes.contains("code"));
-        assertTrue(codes.contains("_id"));
+        assertTrue(codes.contains("value-range"));
     }
 
     @Test
@@ -107,7 +105,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters5/Device", result);
-        assertEquals(8, result.size());
+        assertEquals(2, result.size());
         List<String> codes = getSearchParameterCodes(result);
         assertTrue(codes.contains("patient"));
         assertTrue(codes.contains("organization"));
@@ -121,7 +119,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters6/Patient", result);
-        assertEquals(10, result.size());
+        assertEquals(4, result.size());
         List<String> codes = getSearchParameterCodes(result);
         assertTrue(codes.contains("active"));
         assertTrue(codes.contains("address"));
@@ -133,7 +131,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("MedicationAdministration");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters6/MedicationAdministration", result);
-        assertEquals(25, result.size());
+        assertEquals(19, result.size());
     }
 
     @Test
@@ -144,12 +142,12 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Patient", result);
-        assertEquals(41, result.size());
+        assertEquals(35, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Device", result);
-        assertEquals(24, result.size());
+        assertEquals(18, result.size());
     }
 
     @Test
@@ -244,14 +242,14 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     public void testGetSearchParameter7() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
         SearchParameter result = SearchUtil.getSearchParameter("Observation", "_lastUpdated");
-        assertNotNull(result);
+        assertNull(result);
     }
 
     @Test
     public void testGetSearchParameter8() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
         SearchParameter result = SearchUtil.getSearchParameter(Observation.class, "_lastUpdated");
-        assertNotNull(result);
+        assertNull(result);
     }
 
     @Test

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -51,12 +51,12 @@ public class ParametersUtilTest extends BaseSearchTest {
         // Tests JSON
         Map<String, ParametersMap> params = ParametersUtil.getBuiltInSearchParametersMap();
         assertNotNull(params);
-        // Intentionally the data is caputred in the bytearray output stream.
+        // Intentionally the data is captured in the bytearray output stream.
         try (ByteArrayOutputStream outBA = new ByteArrayOutputStream(); PrintStream out = new PrintStream(outBA, true);) {
             ParametersUtil.print(out);
             Assert.assertNotNull(outBA);
         }
-        assertEquals(params.size(), 134);
+        assertEquals(params.size(), 148);
     }
 
     @Test(expectedExceptions = {})

--- a/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
+++ b/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
@@ -2,11 +2,13 @@
 	"__comment": "FHIR Server configuration for mythical tenant id 'tenant1'",
 	"fhirServer": {
 		"searchParameterFilter": {
-			"Observation": ["subject",
-			"patient",
-			"value-quantity",
-			"component-value-quantity"],
-			"Resource": ["_id"],
+			"Observation": [
+				"_id",
+				"subject",
+				"patient",
+				"value-quantity",
+				"component-value-quantity"
+			],
 			"*": ["*"]
 		},
 		"persistence": {


### PR DESCRIPTION
I found that we were adding the Resource-level SearchParameters in two
different places and this was causing some inconsistent behavior.
In this option, I stop adding the Resource search-parameters at the end
of getFilteredBuiltinSearchParameters.

This effectively reverts us to the searchfilter behavior we had in our
DSTU2 implementation; if a filter is present for a given type, then the
common parameters must be explicitly listed as allowed search parameters
as well.

Also: removes redundant getSearchParameterByCodeIfPresent in favor of
`getApplicableSearchParametersMap(resourceType).get(code)`

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>