### PR TITLE
issue #1247 Enable CADFlog for all requests in addition to operations

### DIFF
--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
@@ -157,10 +157,10 @@ public class WhcAuditCadfLogService implements AuditLogService {
         final String METHODNAME = "logEntry";
         logger.entering(CLASSNAME, METHODNAME);
 
-        // skip healthcheck and other bad operations
+        // skip healthcheck operation
         if (logEntry == null || logEntry.getContext() == null
-                || logEntry.getContext().getOperationName() == null
-                || logEntry.getContext().getOperationName().compareToIgnoreCase(HEALTHCHECKOP) == 0) {
+                || (logEntry.getContext().getOperationName() != null
+                && logEntry.getContext().getOperationName().compareToIgnoreCase(HEALTHCHECKOP) == 0)) {
             return;
         }
 

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/logging/impl/WhcAuditCadfLogService.java
@@ -160,7 +160,7 @@ public class WhcAuditCadfLogService implements AuditLogService {
         // skip healthcheck operation
         if (logEntry == null || logEntry.getContext() == null
                 || (logEntry.getContext().getOperationName() != null
-                && logEntry.getContext().getOperationName().compareToIgnoreCase(HEALTHCHECKOP) == 0)) {
+                && logEntry.getContext().getOperationName().equalsIgnoreCase(HEALTHCHECKOP))) {
             return;
         }
 


### PR DESCRIPTION
Fixed:
   - Enabled CADF logging not only for operations, but also for all other CRUD etc requests. 
Signed-off-by: Albert Wang <xuwang@us.ibm.com>