### PR TITLE
issue #1257 - handle codes which conflict across resource types

### DIFF
--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
@@ -12,6 +12,7 @@ import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeClass;
@@ -88,9 +89,11 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
             System.out.println(result.stream().map(in -> in.getCode().getValue()).collect(Collectors.toList()));
         }
         assertEquals(8, result.size());
-        SearchParameter sp = result.get(0);
-        assertNotNull(sp);
-        assertEquals("code", sp.getCode().getValue());
+        Set<String> codes = result.stream().map(sp -> sp.getCode().getValue()).collect(Collectors.toSet());
+        assertTrue(codes.contains("code"));
+        assertTrue(codes.contains("value-range"));
+        assertTrue(codes.contains("_lastUpdated"));
+        assertTrue(codes.contains("_id"));
 
         result = SearchUtil.getApplicableSearchParameters("Immunization");
         assertNotNull(result);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -215,7 +215,6 @@ public class Capabilities extends FHIRResource {
             List<SearchParameter> searchParameters = SearchUtil.getApplicableSearchParameters(resourceTypeName);
             if (searchParameters != null) {
                 for (SearchParameter searchParameter : searchParameters) {
-                    // The name here is a natural language name, and intentionally not replaced with code.
                     Rest.Resource.SearchParam.Builder conformanceSearchParamBuilder =
                             Rest.Resource.SearchParam.builder()
                                 .name(searchParameter.getCode())


### PR DESCRIPTION
In https://github.com/IBM/FHIR/pull/1238 I introduced a conflict check
for the ParametersMap, but this is only constructed on a
per-resource-type basis.
With this change, we will now detect conflicts where the same code is
defined for both a specific resource type and the more generic
"Resource" type as well.


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>