### PR TITLE
Improve handling of cross-resource-type searchparam code conflicts

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ValidationSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ValidationSupport.java
@@ -467,14 +467,14 @@ public final class ValidationSupport {
     }
 
     private static String getReferenceReference(Reference reference) {
-        if (reference.getReference() != null && reference.getReference().getValue() != null) {
+        if (reference.getReference() != null) {
             return reference.getReference().getValue();
         }
         return null;
     }
 
     private static String getReferenceType(Reference reference) {
-        if (reference.getType() != null && reference.getType().getValue() != null) {
+        if (reference.getType() != null) {
             return reference.getType().getValue();
         }
         return null;

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -196,20 +196,23 @@ public class SearchUtil {
             result.addAll(filterSearchParameters(filterRules, resourceType, spMap.values()));
         }
 
-        // Retrieve the SPs associated with the "Resource" resource type and filter per the filter rules.
-        spMap = spBuiltin.get(SearchConstants.RESOURCE_RESOURCE);
-        if (spMap != null && !spMap.isEmpty()) {
-            Collection<SearchParameter> superParams = filterSearchParameters(filterRules, SearchConstants.RESOURCE_RESOURCE, spMap.values());
-            Set<String> resultCodes = result.stream()
-                    .map(sp -> sp.getCode().getValue())
-                    .collect(Collectors.toSet());
+        if (!SearchConstants.RESOURCE_RESOURCE.equals(resourceType)) {
+            // Retrieve the SPs associated with the "Resource" resource type and filter per the filter rules.
+            spMap = spBuiltin.get(SearchConstants.RESOURCE_RESOURCE);
+            if (spMap != null && !spMap.isEmpty()) {
+                Collection<SearchParameter> superParams =
+                        filterSearchParameters(filterRules, SearchConstants.RESOURCE_RESOURCE, spMap.values());
+                Set<String> resultCodes = result.stream()
+                        .map(sp -> sp.getCode().getValue())
+                        .collect(Collectors.toSet());
 
-            for (SearchParameter sp : superParams) {
-                if (resultCodes.contains(sp.getCode().getValue())) {
-                    log.warning("Detected conflict for code '" + sp.getCode() + "'; code is defined for both " +
-                            SearchConstants.RESOURCE_RESOURCE + " and " + resourceType + "; using " + resourceType);
-                } else {
-                    result.add(sp);
+                for (SearchParameter sp : superParams) {
+                    if (resultCodes.contains(sp.getCode().getValue())) {
+                        log.warning("Detected conflict for code '" + sp.getCode().getValue() + "'; code is defined for both " +
+                                SearchConstants.RESOURCE_RESOURCE + " and " + resourceType + "; using " + resourceType);
+                    } else {
+                        result.add(sp);
+                    }
                 }
             }
         }


### PR DESCRIPTION
1. Use the code value instead of the code object in the warning message;
this should be safe because code is a required element on
SearchParameter

2. Stop adding Resource parameters to the Resource datatype, which was
leading to invalid warnings like this:
```
Detected conflict for code ... code is defined for both Resource and
Resource; using Resource
```

Also included a random cleanup item in ValidationSupport that I had lying around.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>