### PR TITLE
Issue 1122 remove tenantKey from request context and support tenantKey without requiring fhir-server-config files

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/DefaultFHIRConfigProvider.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/DefaultFHIRConfigProvider.java
@@ -6,7 +6,6 @@
 
 package com.ibm.fhir.config;
 
-
 /**
  * Obtain configuration properties from the standard (file-based) 
  * FHIRConfiguration implementation.
@@ -17,6 +16,4 @@ public class DefaultFHIRConfigProvider implements FHIRConfigProvider {
     public PropertyGroup getPropertyGroup(String pgName) {
         return FHIRConfigHelper.getPropertyGroup(pgName);
     }
-
-    
 }

--- a/fhir-config/src/main/java/com/ibm/fhir/config/DefaultFHIRConfigProvider.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/DefaultFHIRConfigProvider.java
@@ -1,0 +1,22 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.config;
+
+
+/**
+ * Obtain configuration properties from the standard (file-based) 
+ * FHIRConfiguration implementation.
+ */
+public class DefaultFHIRConfigProvider implements FHIRConfigProvider {
+
+    @Override
+    public PropertyGroup getPropertyGroup(String pgName) {
+        return FHIRConfigHelper.getPropertyGroup(pgName);
+    }
+
+    
+}

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigProvider.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigProvider.java
@@ -6,7 +6,6 @@
 
 package com.ibm.fhir.config;
 
-
 /**
  * Allows access to the FHIR server configuration to be hidden behind an adapter,
  * decoupling the consumer from file-based FHIRConfiguration stuff.
@@ -19,6 +18,4 @@ public interface FHIRConfigProvider {
      * @return
      */
     PropertyGroup getPropertyGroup(String pgName);
-    
-    
 }

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigProvider.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigProvider.java
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.config;
+
+
+/**
+ * Allows access to the FHIR server configuration to be hidden behind an adapter,
+ * decoupling the consumer from file-based FHIRConfiguration stuff.
+ */
+public interface FHIRConfigProvider {
+
+    /**
+     * Get the named PropertyGroup
+     * @param pgName
+     * @return
+     */
+    PropertyGroup getPropertyGroup(String pgName);
+    
+    
+}

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRRequestContext.java
@@ -30,8 +30,10 @@ import com.ibm.fhir.exception.FHIRException;
 public class FHIRRequestContext {
     private static final Logger log = Logger.getLogger(FHIRRequestContext.class.getName());
 
+    // The tenantId. Corresponding tenantKey is retrieved from the configuration on demand
     private String tenantId;
-    private String tenantKey;
+    
+    // The datastore to be used for this request. Usually "default"
     private String dataStoreId;
     private String requestUniqueId;
     private String originalRequestUri;
@@ -75,40 +77,12 @@ public class FHIRRequestContext {
         return tenantId;
     }
 
-    /** 
-     * @deprecated tenantKey should be looked up on-the-fly from the fhir server configuration (e.g. from 
-     *            FHIRDbDAOImpl.getConnection() in fhir-persistence-jdbc)
-     */
-    @Deprecated
-    public String getTenantKey() {
-        return this.tenantKey;
-    }
-
     public void setTenantId(String tenantId) throws FHIRException {
         Matcher matcher = validChars.matcher(tenantId);
         if (matcher.matches()) {
             this.tenantId = tenantId;
         } else {
             throw new FHIRException("Invalid tenantId. " + errorMsg);
-        }
-    }
-
-    /**
-     * Setter for the tenant key
-     * 
-     * @param base64
-     * @throws FHIRException if the given value is not a valid Base64 string
-     * @deprecated tenantKey should be looked up on-the-fly from the fhir server configuration (e.g. from 
-     *             FHIRDbDAOImpl.getConnection() in fhir-persistence-jdbc)
-     */
-    @Deprecated
-    public void setTenantKey(String base64) throws FHIRException {
-        try {
-            Base64.getDecoder().decode(base64);
-            this.tenantKey = base64;
-        } catch (IllegalArgumentException x) {
-            // Tenant key is a secret, so don't include it in any error message
-            throw new FHIRException("Invalid tenantKey.");
         }
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/connection/SetTenantAction.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/connection/SetTenantAction.java
@@ -14,6 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
@@ -38,20 +39,25 @@ public class SetTenantAction extends ChainedAction {
     
     // Used to indicate the default behavior of a datastore as multitenant.
     public static final List<String> DATASTORE_REQUIRES_ROW_PERMISSIONS = Arrays.asList("db2");
+    
+    // From where we get our configuration information
+    private final FHIRConfigProvider configProvider;
 
     /**
      * Default public constructor. No next action, so this will be the last action applied
      */
-    public SetTenantAction() {
+    public SetTenantAction(FHIRConfigProvider configProvider) {
         super();
+        this.configProvider = configProvider;
     }
     
     /**
      * Public constructor
      * @param next the next action in the chain
      */
-    public SetTenantAction(Action next) {
+    public SetTenantAction(FHIRConfigProvider configProvider, Action next) {
         super(next);
+        this.configProvider = configProvider;
     }
 
     @Override
@@ -86,7 +92,7 @@ public class SetTenantAction extends ChainedAction {
         // Find and set the tenantKey for the request, otherwise subsequent pulls from the pool
         // miss the tenantKey.
         String dsPropertyName = FHIRConfiguration.PROPERTY_DATASOURCES + "/" + datastoreId;
-        PropertyGroup dsPG = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
+        PropertyGroup dsPG = configProvider.getPropertyGroup(dsPropertyName);
         if (dsPG != null) {
             
             try {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/connection/SetTenantAction.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/connection/SetTenantAction.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.ibm.fhir.config.FHIRConfigHelper;
 import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
@@ -44,7 +43,8 @@ public class SetTenantAction extends ChainedAction {
     private final FHIRConfigProvider configProvider;
 
     /**
-     * Default public constructor. No next action, so this will be the last action applied
+     * Public constructor. No next action, so this will be the last action applied
+     * @param configProvider adapter for access to fhir-server-config properties
      */
     public SetTenantAction(FHIRConfigProvider configProvider) {
         super();
@@ -53,6 +53,7 @@ public class SetTenantAction extends ChainedAction {
     
     /**
      * Public constructor
+     * @param configProvider adapter for access to fhir-server-config properties
      * @param next the next action in the chain
      */
     public SetTenantAction(FHIRConfigProvider configProvider, Action next) {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
@@ -424,8 +424,6 @@ public class Main {
         // IConnectionProvider implementation used by the persistence
         // layer to obtain connections.
         try (DerbyFhirDatabase database = new DerbyFhirDatabase()) {
-            // note that Derby doesn't support multi-tenancy, so we don't need to supply
-            // a FHIRConfigProvider
             persistence = new FHIRPersistenceJDBCImpl(this.configProps, database);
 
             // create a custom list of operations to apply in order to each resource
@@ -528,7 +526,6 @@ public class Main {
         PoolConnectionProvider connectionPool = new PoolConnectionProvider(cp, this.threads);
         ITransactionProvider transactionProvider = new SimpleTransactionProvider(connectionPool);
         FHIRConfigProvider configProvider = new DefaultFHIRConfigProvider();
-
 
         // create a custom list of operations to apply in order to each resource
         DriverMetrics dm = new DriverMetrics();

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
@@ -6,9 +6,11 @@
 
 package com.ibm.fhir.persistence.jdbc.test.spec;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -17,8 +19,15 @@ import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+
 import com.ibm.fhir.config.DefaultFHIRConfigProvider;
 import com.ibm.fhir.config.FHIRConfigProvider;
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.database.utils.api.ITransactionProvider;
 import com.ibm.fhir.database.utils.common.JdbcConnectionProvider;
 import com.ibm.fhir.database.utils.common.JdbcPropertyAdapter;
@@ -76,6 +85,7 @@ public class Main {
     private static final Logger logger = Logger.getLogger(Main.class.getName());
 
     private static final int EXIT_RUNTIME_ERROR = 1;
+    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
 
     // The persistence API
     protected FHIRPersistence persistence = null;
@@ -294,6 +304,31 @@ public class Main {
             break;
         }
     }
+    
+    /**
+     * Configure the property group to inject the tenantKey, which is the only attribute
+     * required for this scenario
+     * @param configProvider
+     * @throws Exception
+     */
+    protected void configure(TestFHIRConfigProvider configProvider) throws Exception {
+
+        final String dsPropertyName = FHIRConfiguration.PROPERTY_DATASOURCES + "/default";
+
+        // The bare necessities we need to provide to the persistence layer in this case
+        final String jsonString = " {" + 
+                "    \"tenantKey\": \"" + this.tenantKey + "\"," + 
+                "    \"type\": \"db2\"," + 
+                "    \"multitenant\": true" + 
+                "}";
+        
+        try (JsonReader reader = JSON_READER_FACTORY.createReader(new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8)))) {
+            JsonObject jsonObj = reader.readObject();
+            PropertyGroup pg = new PropertyGroup(jsonObj);
+            configProvider.addPropertyGroup(dsPropertyName, pg);
+        }
+    }
+
 
     /**
      * Process the examples
@@ -308,7 +343,9 @@ public class Main {
         JdbcConnectionProvider cp = new JdbcConnectionProvider(translator, adapter);
         PoolConnectionProvider connectionPool = new PoolConnectionProvider(cp, this.threads);
         ITransactionProvider transactionProvider = new SimpleTransactionProvider(connectionPool);
-
+        TestFHIRConfigProvider configProvider = new TestFHIRConfigProvider(new DefaultFHIRConfigProvider());
+        configure(configProvider);
+        
         // Provide the credentials we need for accessing a multi-tenant schema (if enabled)
         // Must set this BEFORE we create our persistence object
         if (this.tenantName == null || tenantKey == null) {
@@ -327,7 +364,8 @@ public class Main {
                 connectionPool,
                 this.tenantName,
                 this.tenantKey,
-                transactionProvider);
+                transactionProvider,
+                configProvider);
 
         // The driver will iterate over all the JSON examples in the R4 specification, parse
         // the resource and call the processor.
@@ -379,6 +417,8 @@ public class Main {
      * @throws Exception
      */
     protected void processDerby() throws Exception {
+        // For Derby, the standard config provider is sufficient
+        FHIRConfigProvider configProvider = new DefaultFHIRConfigProvider();
 
         // The DerbyFhirDatabase encapsulates Derby and provides an
         // IConnectionProvider implementation used by the persistence
@@ -396,7 +436,7 @@ public class Main {
             R4JDBCExamplesProcessor processor = new R4JDBCExamplesProcessor(persistence,
                     () -> createPersistenceContext(),
                     () -> createHistoryPersistenceContext(),
-                    operations);
+                    operations, configProvider);
 
             // The driver will iterate over all the JSON examples in the R4 specification, parse
             // the resource and call the processor.
@@ -435,6 +475,7 @@ public class Main {
         JdbcConnectionProvider cp = new JdbcConnectionProvider(translator, adapter);
         PoolConnectionProvider connectionPool = new PoolConnectionProvider(cp, this.threads);
         ITransactionProvider transactionProvider = new SimpleTransactionProvider(connectionPool);
+        FHIRConfigProvider configProvider = new DefaultFHIRConfigProvider();
 
         // create a custom list of operations to apply in order to each resource
         DriverMetrics dm = new DriverMetrics();
@@ -447,7 +488,8 @@ public class Main {
                 connectionPool,
                 null,
                 null,
-                transactionProvider);
+                transactionProvider,
+                configProvider);
 
         // The driver will iterate over all the JSON examples in the R4 specification, parse
         // the resource and call the processor.
@@ -485,6 +527,8 @@ public class Main {
         JdbcConnectionProvider cp = new JdbcConnectionProvider(translator, adapter);
         PoolConnectionProvider connectionPool = new PoolConnectionProvider(cp, this.threads);
         ITransactionProvider transactionProvider = new SimpleTransactionProvider(connectionPool);
+        FHIRConfigProvider configProvider = new DefaultFHIRConfigProvider();
+
 
         // create a custom list of operations to apply in order to each resource
         DriverMetrics dm = new DriverMetrics();
@@ -497,7 +541,8 @@ public class Main {
                 connectionPool,
                 null,
                 null,
-                transactionProvider);
+                transactionProvider,
+                configProvider);
 
         // The driver will iterate over all the JSON examples in the R4 specification, parse
         // the resource and call the processor.

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/Main.java
@@ -17,6 +17,8 @@ import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.config.DefaultFHIRConfigProvider;
+import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.database.utils.api.ITransactionProvider;
 import com.ibm.fhir.database.utils.common.JdbcConnectionProvider;
 import com.ibm.fhir.database.utils.common.JdbcPropertyAdapter;
@@ -382,6 +384,8 @@ public class Main {
         // IConnectionProvider implementation used by the persistence
         // layer to obtain connections.
         try (DerbyFhirDatabase database = new DerbyFhirDatabase()) {
+            // note that Derby doesn't support multi-tenancy, so we don't need to supply
+            // a FHIRConfigProvider
             persistence = new FHIRPersistenceJDBCImpl(this.configProps, database);
 
             // create a custom list of operations to apply in order to each resource

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
@@ -57,6 +57,9 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
     /**
      * Public constructor. Uses a defaultlist of operations
      * @param persistence
+     * @param persistenceContextSupplier
+     * @param historyContextSupplier
+     * @param configProvider
      */
     public R4JDBCExamplesProcessor(FHIRPersistence persistence,
             Supplier<FHIRPersistenceContext> persistenceContextSupplier,
@@ -89,6 +92,7 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
      * @param persistenceContextSupplier
      * @param historyContextSupplier
      * @param operations
+     * @param configProvider
      */
     public R4JDBCExamplesProcessor(FHIRPersistence persistence, Supplier<FHIRPersistenceContext> persistenceContextSupplier,
             Supplier<FHIRPersistenceContext> historyContextSupplier, Collection<ITestResourceOperation> operations, FHIRConfigProvider configProvider) {
@@ -103,10 +107,13 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
 
     /**
      * Create a processor with a specific set of operations
-     * @param persistence
-     * @param persistenceContextSupplier
-     * @param historyContextSupplier
      * @param operations
+     * @param configProps
+     * @param cp
+     * @param tenantName
+     * @param tenantKey
+     * @param transactionProvider
+     * @param configProvider
      */
     public R4JDBCExamplesProcessor(Collection<ITestResourceOperation> operations,
             Properties configProps, IConnectionProvider cp, String tenantName, String tenantKey, ITransactionProvider transactionProvider, FHIRConfigProvider configProvider) {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesProcessor.java
@@ -6,23 +6,14 @@
 
 package com.ibm.fhir.persistence.jdbc.test.spec;
 
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Supplier;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonReaderFactory;
-
-import com.ibm.fhir.config.DefaultFHIRConfigProvider;
-import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.config.FHIRRequestContext;
-import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.api.ITransaction;
 import com.ibm.fhir.database.utils.api.ITransactionProvider;
@@ -41,7 +32,6 @@ import com.ibm.fhir.persistence.util.ResourceFingerprintVisitor;
  *
  */
 public class R4JDBCExamplesProcessor implements IExampleProcessor {
-    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
 
     // the list of operations we apply to reach resource
     private final List<ITestResourceOperation> operations = new ArrayList<>();
@@ -60,6 +50,9 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
     private String tenantName;
     private String tenantKey;
     private ITransactionProvider transactionProvider;
+    
+    // Adapter used by the persistence layer to access certain fhir-server-config properties
+    private final FHIRConfigProvider configProvider;
 
     /**
      * Public constructor. Uses a defaultlist of operations
@@ -67,10 +60,12 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
      */
     public R4JDBCExamplesProcessor(FHIRPersistence persistence,
             Supplier<FHIRPersistenceContext> persistenceContextSupplier,
-            Supplier<FHIRPersistenceContext> historyContextSupplier) {
+            Supplier<FHIRPersistenceContext> historyContextSupplier,
+            FHIRConfigProvider configProvider) {
         this.persistence = persistence;
         this.persistenceContextSupplier = persistenceContextSupplier;
         this.historyContextSupplier = historyContextSupplier;
+        this.configProvider = configProvider;
 
         // The sequence of operations we want to apply to each resource
         operations.add(new CreateOperation());
@@ -83,6 +78,9 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
         operations.add(new DeleteOperation());
         operations.add(new DeleteOperation());
         operations.add(new HistoryOperation(4)); // create+update+update+delete = 4 versions
+        
+        // Use a custom configuration provider so that we can support passing the tenant key
+        // without having to create a fhir-server-configuration.json file
     }
 
     /**
@@ -93,10 +91,11 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
      * @param operations
      */
     public R4JDBCExamplesProcessor(FHIRPersistence persistence, Supplier<FHIRPersistenceContext> persistenceContextSupplier,
-            Supplier<FHIRPersistenceContext> historyContextSupplier, Collection<ITestResourceOperation> operations) {
+            Supplier<FHIRPersistenceContext> historyContextSupplier, Collection<ITestResourceOperation> operations, FHIRConfigProvider configProvider) {
         this.persistence = persistence;
         this.persistenceContextSupplier = persistenceContextSupplier;
         this.historyContextSupplier = historyContextSupplier;
+        this.configProvider = configProvider;
 
         // The sequence of operations we want to apply to each resource
         this.operations.addAll(operations);
@@ -110,7 +109,7 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
      * @param operations
      */
     public R4JDBCExamplesProcessor(Collection<ITestResourceOperation> operations,
-            Properties configProps, IConnectionProvider cp, String tenantName, String tenantKey, ITransactionProvider transactionProvider) {
+            Properties configProps, IConnectionProvider cp, String tenantName, String tenantKey, ITransactionProvider transactionProvider, FHIRConfigProvider configProvider) {
         this.persistence = null;
         this.persistenceContextSupplier = null;
         this.historyContextSupplier = null;
@@ -119,42 +118,14 @@ public class R4JDBCExamplesProcessor implements IExampleProcessor {
         this.tenantName = tenantName;
         this.tenantKey = tenantKey;
         this.transactionProvider = transactionProvider;
+        this.configProvider = configProvider;
 
         // The sequence of operations we want to apply to each resource
         this.operations.addAll(operations);
     }
 
-    /**
-     * Configure the property group to inject the tenantKey, which is the only attribute
-     * required for this scenario
-     * @param configProvider
-     * @throws Exception
-     */
-    protected void configure(TestFHIRConfigProvider configProvider) throws Exception {
-
-        final String dsPropertyName = FHIRConfiguration.PROPERTY_DATASOURCES + "/default";
-
-        // The bare necessities we need to provide to the persistence layer in this case
-        final String jsonString = " {" + 
-                "    \"tenantKey\": \"" + this.tenantKey + "\"," + 
-                "    \"type\": \"db2\"," + 
-                "    \"multitenant\": true" + 
-                "}";
-        
-        try (JsonReader reader = JSON_READER_FACTORY.createReader(new ByteArrayInputStream(jsonString.getBytes(StandardCharsets.UTF_8)))) {
-            JsonObject jsonObj = reader.readObject();
-            PropertyGroup pg = new PropertyGroup(jsonObj);
-            configProvider.addPropertyGroup(dsPropertyName, pg);
-        }
-    }
-
     @Override
     public void process(String jsonFile, Resource resource) throws Exception {
-
-        // Use a custom configuration provider so that we can support passing the tenant key
-        // without having to create a fhir-server-configuration.json file
-        TestFHIRConfigProvider configProvider = new TestFHIRConfigProvider(new DefaultFHIRConfigProvider());
-        configure(configProvider);
 
         // Initialize the test context. As we run through the sequence of operations, each
         // one will update the context which will then be used by the next operation

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
@@ -10,9 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.config.DefaultFHIRConfigProvider;
+import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.api.ITransactionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
@@ -26,7 +27,6 @@ import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.test.common.AbstractPersistenceTest;
-import com.ibm.fhir.schema.derby.DerbyFhirDatabase;
 import com.ibm.fhir.validation.test.ValidationProcessor;
 
 public class R4JDBCExamplesTest extends AbstractPersistenceTest {
@@ -52,6 +52,7 @@ public class R4JDBCExamplesTest extends AbstractPersistenceTest {
         // testng test process the samples one by one, so set the connection pool size to 1.
         PoolConnectionProvider connectionPool = new PoolConnectionProvider(derbyConnectionProvider, 1);
         ITransactionProvider transactionProvider = new SimpleTransactionProvider(connectionPool);
+        FHIRConfigProvider configProvider = new DefaultFHIRConfigProvider();
         List<ITestResourceOperation> operations = new ArrayList<>();
         operations.add(new CreateOperation());
         operations.add(new ReadOperation());
@@ -69,7 +70,8 @@ public class R4JDBCExamplesTest extends AbstractPersistenceTest {
                 connectionPool,
                 null,
                 null,
-                transactionProvider);
+                transactionProvider,
+                configProvider);
 
         // The driver will iterate over all the examples in the index, parse
         // the resource and call the processor.

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/TestFHIRConfigProvider.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/TestFHIRConfigProvider.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import com.ibm.fhir.config.FHIRConfigProvider;
 import com.ibm.fhir.config.PropertyGroup;
 
-
 /**
  * Allow unit-tests to provide configuration information to lower layers
  * without needed to have fhir-server-config.json files

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/TestFHIRConfigProvider.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/TestFHIRConfigProvider.java
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.test.spec;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.ibm.fhir.config.FHIRConfigProvider;
+import com.ibm.fhir.config.PropertyGroup;
+
+
+/**
+ * Allow unit-tests to provide configuration information to lower layers
+ * without needed to have fhir-server-config.json files
+ */
+public class TestFHIRConfigProvider implements FHIRConfigProvider {
+    // forward requests we don't care about to this delegate
+    private final FHIRConfigProvider delegate;
+
+    // Map of custom PropertyGroups addressed by their full path name
+    private final Map<String,PropertyGroup> propertyGroupMap = new HashMap<>();
+
+    /**
+     * Public constructor
+     * @param delegate
+     */
+    public TestFHIRConfigProvider(FHIRConfigProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public PropertyGroup getPropertyGroup(String pgName) {
+        
+        // Try the map first to see if a property group has been
+        // overridden (the reason why we're here). If not, then
+        // simply delegate
+        PropertyGroup result = propertyGroupMap.get(pgName);
+        if (result == null && delegate != null) {
+            result = delegate.getPropertyGroup(pgName);
+        }
+        
+        return result;
+    }
+
+    /**
+     * Add a PropertyGroup using the given pgName as a key. This {@link PropertyGroup}
+     * will be returned by {@link #getPropertyGroup(String)} based on a perfect
+     * match of the pgName. Useful for simple injection of configuration. This does not
+     * support any hierarchical capability of the actual FHIRConfiguration
+     * implementation (by design).
+     * @param pgName the full path key used to find this PropertyGroup
+     * @param pg the PropertyGroup value
+     */
+    public void addPropertyGroup(String pgName, PropertyGroup pg) {
+        this.propertyGroupMap.put(pgName, pg);
+    }
+}


### PR DESCRIPTION
This change permits the R4 examples JDBC Main to run against DB2 databases without requiring a fhir-server-config.json file to be defined with the tenantKey (which in this case is provided as a command-line argument). This change follows on from a previous change which moved the tenantKey out of the FHIRRequestContext.

This change also now removes the tenantKey property from the FHIRRequestContext, which had previously been marked as deprecated.