### PR TITLE
issue #1341 use larger cache for identity sequences in Db2

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
@@ -507,4 +507,13 @@ public interface IDatabaseAdapter {
      * @param tableName
      */
     public void setIntegrityUnchecked(String schemaName, String tableName);
+
+    /**
+     * Change the CACHE value of the named identity generated always column
+     * @param schemaName
+     * @param objectName
+     * @param columnName
+     * @param cache
+     */
+    public void alterTableColumnIdentityCache(String schemaName, String objectName, String columnName, int cache);
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -549,6 +549,21 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         runStatement(ddl);
     }
 
+    @Override
+    public void alterTableColumnIdentityCache(String schemaName, String tableName, String columnName, int cache) {
+        // Check input strings are clean
+        final String qname = DataDefinitionUtil.getQualifiedName(schemaName, tableName);
+        DataDefinitionUtil.assertValidName(columnName);
+        
+        // modify the CACHE property of the identity column
+        final String ddl = "ALTER TABLE " + qname + " ALTER COLUMN " + columnName + " SET CACHE " + cache;
+        
+        // so important, we log it
+        logger.info(ddl);
+        
+        runStatement(ddl);
+    }
+
 
     @Override
     public int findTenantId(String adminSchemaName, String tenantName) {

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -564,7 +564,6 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         runStatement(ddl);
     }
 
-
     @Override
     public int findTenantId(String adminSchemaName, String tenantName) {
         FindTenantIdDAO dao = new FindTenantIdDAO(adminSchemaName, tenantName);
@@ -641,5 +640,4 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         DeleteTenantDAO dao = new DeleteTenantDAO(adminSchemaName, tenantId);
         runStatement(dao);
     }
-
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -39,7 +39,7 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
     // Different warning messages we track so that we only have to report them once
     private enum MessageKey {
         MULTITENANCY, CREATE_VAR, CREATE_PERM, ENABLE_ROW_ACCESS, DISABLE_ROW_ACCESS, PARTITIONING,
-        ROW_TYPE, ROW_ARR_TYPE, DROP_TYPE, CREATE_PROC, DROP_PROC, TABLESPACE
+        ROW_TYPE, ROW_ARR_TYPE, DROP_TYPE, CREATE_PROC, DROP_PROC, TABLESPACE, ALTER_TABLE_SEQ_CACHE
     }
 
     // Just warn once for each unique message key. This cleans up build logs a lot
@@ -228,6 +228,20 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
         dropSequence(schemaName, sequenceName);
         createSequence(schemaName, sequenceName, restartWith, cache);
     }
+    
+    @Override
+    public void alterTableColumnIdentityCache(String schemaName, String tableName, String columnName, int cache) {
+        // Not supported by Derby
+        
+        final String qname = DataDefinitionUtil.getQualifiedName(schemaName, tableName);
+        DataDefinitionUtil.assertValidName(columnName);
+        
+        // modify the CACHE property of the identity column
+        final String ddl = "ALTER TABLE " + qname + " ALTER COLUMN " + columnName + " SET CACHE " + cache;
+
+        warnOnce(MessageKey.ALTER_TABLE_SEQ_CACHE, "Not supported in Derby: " + ddl);
+    }
+
 
 
     @Override

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -350,4 +350,4 @@ public class DerbyAdapter extends CommonDatabaseAdapter {
         // not expecting this to be called for this adapter
         throw new UnsupportedOperationException("Set integrity unchecked not supported for this adapter.");
     }
- }
+}

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/AlterTableIdentityCache.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/AlterTableIdentityCache.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.database.utils.model;
+
+import java.util.Set;
+
+import com.ibm.fhir.database.utils.api.IDatabaseAdapter;
+
+/**
+ * Modify an existing sequence to start with a higher value
+ */
+public class AlterTableIdentityCache extends BaseObject {
+    private final String columnName;
+    
+    // caching sequence values for tuning
+    private final int cache;
+
+    /**
+     * Public constructor
+     * 
+     * @param schemaName
+     * @param sequenceName
+     * @param version
+     * @param startWith
+     * @param cache
+     */
+    public AlterTableIdentityCache(String schemaName, String tableName, String columnName, int cache, int version) {
+        super(schemaName, tableName, DatabaseObjectType.SEQUENCE, version);
+        this.columnName = columnName;
+        this.cache = cache;
+    }
+
+    @Override
+    public String getTypeNameVersion() {
+        // There's typically only one identity column on a table, but we still
+        // want to qualify the name with the column just to make sure it's unique
+        return getObjectType().name() + ":" + getQualifiedName() + "." + this.columnName + ":" + this.version;
+        
+    }
+
+    @Override
+    public void apply(IDatabaseAdapter target) {
+        target.alterTableColumnIdentityCache(getSchemaName(), getObjectName(), this.columnName, this.cache);
+    }
+
+    @Override
+    public void apply(Integer priorVersion, IDatabaseAdapter target) {
+        apply(target);
+    }
+
+    @Override
+    public void drop(IDatabaseAdapter target) {
+        target.dropSequence(getSchemaName(), getObjectName());
+    }
+
+    @Override
+    protected void grantGroupPrivileges(IDatabaseAdapter target, Set<Privilege> group, String toUser) {
+        target.grantSequencePrivileges(getSchemaName(), getObjectName(), group, toUser);
+    }
+
+    @Override
+    public void visit(DataModelVisitor v) {
+        v.visited(this);
+    }
+
+    @Override
+    public void visitReverse(DataModelVisitor v) {
+        v.visited(this);
+    }
+}

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/AlterTableIdentityCache.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/AlterTableIdentityCache.java
@@ -11,7 +11,8 @@ import java.util.Set;
 import com.ibm.fhir.database.utils.api.IDatabaseAdapter;
 
 /**
- * Modify an existing sequence to start with a higher value
+ * Modify the CACHE property of an AS IDENTITY column (changes
+ * the CACHE property of the underlying SEQUENCE).
  */
 public class AlterTableIdentityCache extends BaseObject {
     private final String columnName;
@@ -38,7 +39,7 @@ public class AlterTableIdentityCache extends BaseObject {
     public String getTypeNameVersion() {
         // There's typically only one identity column on a table, but we still
         // want to qualify the name with the column just to make sure it's unique
-        return getObjectType().name() + ":" + getQualifiedName() + "." + this.columnName + ":" + this.version;
+        return getObjectType().name() + ":" + getQualifiedName() + ":" + this.columnName + ":" + this.version;
         
     }
 
@@ -54,12 +55,12 @@ public class AlterTableIdentityCache extends BaseObject {
 
     @Override
     public void drop(IDatabaseAdapter target) {
-        target.dropSequence(getSchemaName(), getObjectName());
+        // NOP
     }
 
     @Override
     protected void grantGroupPrivileges(IDatabaseAdapter target, Set<Privilege> group, String toUser) {
-        target.grantSequencePrivileges(getSchemaName(), getObjectName(), group, toUser);
+        // NOP
     }
 
     @Override

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/DataModelVisitor.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/DataModelVisitor.java
@@ -68,4 +68,9 @@ public interface DataModelVisitor {
      * @param alterSequence
      */
     public void visited(AlterSequenceStartWith alterSequence);
+    
+    /**
+     * @param alterTable
+     */
+    public void visited(AlterTableIdentityCache alterTable);
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/DataModelVisitorBase.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/DataModelVisitorBase.java
@@ -68,4 +68,9 @@ public class DataModelVisitorBase implements DataModelVisitor {
     public void visited(AlterSequenceStartWith alterSequence) {
         // NOP
     }
+    
+    @Override
+    public void visited(AlterTableIdentityCache alterTable) {
+        // NOP
+    }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
@@ -51,7 +51,8 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
         DROP_TYPE,
         CREATE_PROC,
         DROP_PROC,
-        TABLESPACE
+        TABLESPACE,
+        ALTER_TABLE_SEQ_CACHE
     }
 
     // Just warn once for each unique message key. This cleans up build logs a lot
@@ -366,5 +367,18 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
     public void setIntegrityUnchecked(String schemaName, String tableName) {
         // not expecting this to be called for this adapter
         throw new UnsupportedOperationException("Set integrity unchecked not supported for this adapter.");
+    }
+    
+    @Override
+    public void alterTableColumnIdentityCache(String schemaName, String tableName, String columnName, int cache) {
+        // Not supported by PostgreSQL
+        
+        final String qname = DataDefinitionUtil.getQualifiedName(schemaName, tableName);
+        DataDefinitionUtil.assertValidName(columnName);
+        
+        // modify the CACHE property of the identity column
+        final String ddl = "ALTER TABLE " + qname + " ALTER COLUMN " + columnName + " SET CACHE " + cache;
+
+        warnOnce(MessageKey.ALTER_TABLE_SEQ_CACHE, "Not supported in PostgreSQL: " + ddl);
     }
 }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -64,6 +64,7 @@ import com.ibm.fhir.database.utils.common.AddForeignKeyConstraint;
 import com.ibm.fhir.database.utils.common.DropColumn;
 import com.ibm.fhir.database.utils.common.DropForeignKeyConstraint;
 import com.ibm.fhir.database.utils.common.DropIndex;
+import com.ibm.fhir.database.utils.model.AlterTableIdentityCache;
 import com.ibm.fhir.database.utils.model.ColumnBase;
 import com.ibm.fhir.database.utils.model.ColumnDefBuilder;
 import com.ibm.fhir.database.utils.model.ForeignKeyConstraint;
@@ -309,6 +310,11 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**
@@ -357,6 +363,11 @@ ALTER TABLE device_token_values ADD CONSTRAINT fk_device_token_values_r  FOREIGN
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**
@@ -416,6 +427,11 @@ ALTER TABLE device_date_values ADD CONSTRAINT fk_device_date_values_r  FOREIGN K
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**
@@ -479,6 +495,11 @@ ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_r  FOREI
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**
@@ -528,6 +549,11 @@ ALTER TABLE device_latlng_values ADD CONSTRAINT fk_device_latlng_values_r  FOREI
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**
@@ -591,6 +617,11 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
 
         group.add(tbl);
         model.addTable(tbl);
+        
+        // issue-1341. Default sequence cache for generated identity columns is too small
+        AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
+        alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
+        group.add(alterTable);
     }
 
     /**

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaConstants.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaConstants.java
@@ -33,6 +33,7 @@ public class FhirSchemaConstants {
     public static final String TENANT_SEQUENCE = "TENANT_SEQUENCE";
     public static final long FHIR_REF_SEQUENCE_START = 20000;
     public static final int FHIR_REF_SEQUENCE_CACHE = 1000;
+    public static final int FHIR_IDENTITY_SEQUENCE_CACHE = 1000;
     
     // Tenant constants
     public static final String MT_ID = "MT_ID";

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
@@ -18,6 +18,7 @@ public enum FhirSchemaVersion {
      V0001(1, "Initial version")
     ,V0002(2, "Composite search value support")
     ,V0003(3, "issue-1263 fhir_ref_sequence start with 20000")
+    ,V0004(4, "row_id sequence cache 20 to 1000")
     ;
     
     // The version number recorded in the VERSION_HISTORY

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbyMigrationTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbyMigrationTest.java
@@ -144,7 +144,7 @@ public class DerbyMigrationTest {
         // 4. Assert they match
         List<String> migrated_ddl = inferDDL(dbPath);
         System.out.println(FhirSchemaVersion.V0001.name() + " migrated: " + migrated_ddl);
-        System.out.println(FhirSchemaVersion.V0002.name() + "   latest: " + latest_ddl);
+        System.out.println(FhirSchemaVersion.V0004.name() + "   latest: " + latest_ddl);
         assertEquals(latest_ddl, migrated_ddl);
     }
 


### PR DESCRIPTION
Addresses Db2 performance concerns with high concurrency causing contention on sequences used to support parameter table row_id identity columns.

Closing #1341.