### PR TITLE
Increase Poolsize to speed up automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
         cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: integration-test-results-${{ matrix.java }}
         path: SIT/integration-test-results
@@ -218,7 +218,7 @@ jobs:
         Copy-Item -Path $SRC_ST -Destination $DST_ST_F -Recurse -Force
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: integration-test-results-windows-${{ matrix.java }}
         path: SIT/integration-test-results
@@ -278,7 +278,7 @@ jobs:
         cp -pr ${GITHUB_WORKSPACE}/fhir-server-test/target/surefire-reports/* ${it_results}/fhir-server-test
     - name: Upload logs
       if: always()
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: integration-test-results-db2-${{ matrix.java }}
         path: integration-test-results

--- a/build/docker/updateSchema.sh
+++ b/build/docker/updateSchema.sh
@@ -11,4 +11,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${DIR}
 
 java -jar schema/fhir-persistence-schema-*-cli.jar \
-  --prop-file db2.properties --schema-name FHIRDATA --update-schema
+  --prop-file db2.properties --schema-name FHIRDATA --update-schema \
+  --pool-size 20

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -291,6 +291,13 @@ If you want to log the connection, you can add `loggerLevel=TRACE` to the proper
 
 Note, this was run with AdoptOpenJDK. 
 
+## Advanced Client Execution Argument
+The following are advanced execution arguments
+
+|Property|Description|Example|
+|--------|-----------|-----------|
+|`--pool-size NUM` | The number of connections used to connect to the database|`--pool-size 20`|
+
 ## Alternative: Manually apply the schema
 
 To manually apply the DDL to a Db2 instance:


### PR DESCRIPTION
Db2 automation is timing out frequently.  I found that the alter statements were taking a long time with a small default poolsize.  Increasing to 5 limited the time spent, and moving to 10 and then 20 really sped it up. (30 min to 15 min and then 15 seconds)

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>