### PR TITLE
Add id to webApplication/application-bnd/security-role/group

### DIFF
--- a/fhir-server/liberty-config/configDropins/defaults/bulkdata.xml
+++ b/fhir-server/liberty-config/configDropins/defaults/bulkdata.xml
@@ -9,15 +9,15 @@
     </featureManager>
 
     <authorization-roles id="com.ibm.ws.batch">
-        <security-role name="batchAdmin">
-            <user name="fhiradmin"/>
+        <security-role id="batchAdmin" name="batchAdmin">
+            <user id="batchAdminUser" name="fhiradmin"/>
         </security-role>
-        <security-role name="batchSubmitter">
-            <user name="fhiruser"/>
+        <security-role id="batchSubmitter" name="batchSubmitter">
+            <user id="batchSubmitterUser" name="fhiruser"/>
         </security-role>
-        <security-role name="batchMonitor">
-            <user name="fhiradmin"/>
-            <user name="fhiruser"/>
+        <security-role id="batchMonitor" name="batchMonitor">
+            <user id="batchMonitorUser1" name="fhiradmin"/>
+            <user id="batchMonitorUser2" name="fhiruser"/>
         </security-role>
     </authorization-roles>
 
@@ -25,7 +25,7 @@
         <classloader commonLibraryRef="fhirSharedLib" privateLibraryRef="configResources,fhirUserLib"/>
         <application-bnd>
             <security-role id="users" name="FHIRUsers">
-                <group name="FHIRUsers"/>
+                <group id="bulkUsersGroup" name="FHIRUsers"/>
             </security-role>
         </application-bnd>
     </webApplication>

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -59,7 +59,7 @@
         <!-- Include id attributes to make it easier to override this via dropinConfig -->
         <application-bnd>
             <security-role id="users" name="FHIRUsers">
-                <group name="FHIRUsers"/>
+                <group id="usersGroup" name="FHIRUsers"/>
             </security-role>
         </application-bnd>
     </webApplication>


### PR DESCRIPTION
By giving this element an id, we make it much simpler to override the default.
Without this, I was seeing intermittent behavior where sometimes it would use the group defined in server.xml and sometimes it would use the group defined in my override (seemingly at random).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>