### PR TITLE
issue 1362 Use timestamp prefix for identity strings to reduce random reads during ingestion

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -113,9 +113,11 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceFKVException;
 import com.ibm.fhir.persistence.jdbc.util.CodeSystemsCache;
 import com.ibm.fhir.persistence.jdbc.util.JDBCParameterBuildingVisitor;
 import com.ibm.fhir.persistence.jdbc.util.JDBCQueryBuilder;
+import com.ibm.fhir.persistence.jdbc.util.LogicalIdentityProvider;
 import com.ibm.fhir.persistence.jdbc.util.ParameterNamesCache;
 import com.ibm.fhir.persistence.jdbc.util.ResourceTypesCache;
 import com.ibm.fhir.persistence.jdbc.util.SqlQueryData;
+import com.ibm.fhir.persistence.jdbc.util.TimestampPrefixedUUID;
 import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.SummaryValueSet;
@@ -155,6 +157,9 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
     // Strategy for accessing FHIR configuration data
     private final FHIRConfigProvider configProvider;
+    
+    // Logical identity string provider
+    private final LogicalIdentityProvider logicalIdentityProvider = new TimestampPrefixedUUID();
 
     /**
      * Constructor for use when running as web application in WLP.
@@ -278,7 +283,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             // system-generated value. For the update-or-create scenario, see update().
             // Default version is 1 for a brand new FHIR Resource.
             int newVersionNumber = 1;
-            logicalId = UUID.randomUUID().toString();
+            logicalId = logicalIdentityProvider.createNewIdentityValue();
             if (log.isLoggable(Level.FINE)) {
                 log.fine("Creating new FHIR Resource of type '" + resource.getClass().getSimpleName() + "'");
             }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/LogicalIdentityProvider.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/LogicalIdentityProvider.java
@@ -1,0 +1,20 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.util;
+
+/**
+ * Supports different strategies for creating identity strings
+ */
+public interface LogicalIdentityProvider {
+
+    /**
+     * Create a new identity string. The max length of the string will never
+     * be greater than 100 (ASCII) characters
+     * @return
+     */
+    String createNewIdentityValue();
+}

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/TimestampPrefixedUUID.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/TimestampPrefixedUUID.java
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.util;
+
+import java.util.UUID;
+
+/**
+ * Provides identity strings using random UUID for uniqueness but
+ * prefixed with an encoded time string to improve database locality
+ * when used in b-tree indexes.
+ */
+public class TimestampPrefixedUUID implements LogicalIdentityProvider {
+
+    @Override
+    public String createNewIdentityValue() {
+        // It's OK to use milli-time here. It doesn't matter too much if the time changes
+        // because we're not using the timestamp to determine uniqueness in any way. The
+        // timestamp prefix is purely to help push index writes to the right hand side
+        // of the btree, minimizing the number of physical reads likely required 
+        // during ingestion when an index is too large to be fully cached.
+        long millis = System.currentTimeMillis();
+        
+        // String encoding. Needs to collate correctly, so don't use any
+        // byte-based encoding which would be sensitive to endian issues. For simplicity,
+        // hex is sufficient, although a custom encoding using the full character set
+        // supported by FHIR identifiers would be a little more compact (== smaller indexes).
+        // Do not use Base64.
+        String prefix = Long.toHexString(millis);
+        
+        UUID uuid = UUID.randomUUID();
+        
+        StringBuilder result = new StringBuilder();
+        result.append(prefix);
+        result.append("-"); // redundant, but more visually appealing.
+        result.append(uuid.toString());
+        return result.toString();
+    }
+}

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/TimestampPrefixedUUIDTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/TimestampPrefixedUUIDTest.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.persistence.jdbc.test.util;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.persistence.jdbc.util.TimestampPrefixedUUID;
+
+/**
+ * Unit test for {@link TimestampPrefixedUUID}
+ */
+public class TimestampPrefixedUUIDTest {
+
+    @Test
+    public void testCollation() {
+        TimestampPrefixedUUID provider = new TimestampPrefixedUUID();
+
+        // Sample this 10 times, to be sure. That's 100ms, which isn't too disruptive
+        for (int i=0; i<10; i++) {
+            // We need a time gap between the two strings
+            String s1 = provider.createNewIdentityValue();
+            try {
+                // It's only 10ms, which is sufficient. We don't want to make it any longer
+                // for the sake of slowing down the build.
+                Thread.sleep(10);
+            } catch (InterruptedException x) {
+                // NOP. Not gonna happen
+            }
+            String s2 = provider.createNewIdentityValue();
+            assertTrue(s1.compareTo(s2) < 0); // s1 < s2
+        }
+    }
+}


### PR DESCRIPTION
Closes 1362.