### PR TITLE
WIP: issue #1340 - support bulk export to parquet format

### DIFF
--- a/build/docker/minio/.gitignore
+++ b/build/docker/minio/.gitignore
@@ -1,0 +1,1 @@
+miniodata/

--- a/fhir-bulkimportexport-webapp/pom.xml
+++ b/fhir-bulkimportexport-webapp/pom.xml
@@ -131,6 +131,7 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
             <version>3.0.0</version>
+            <scope>provided</scope>
             <exclusions>
                 <!-- <exclusion>
                     <groupId>xerces</groupId>
@@ -190,6 +191,7 @@
             <groupId>com.ibm.stocator</groupId>
             <artifactId>stocator</artifactId>
             <version>1.1.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.wnameless</groupId>

--- a/fhir-bulkimportexport-webapp/pom.xml
+++ b/fhir-bulkimportexport-webapp/pom.xml
@@ -132,9 +132,57 @@
             <artifactId>spark-sql_2.12</artifactId>
             <version>3.0.0</version>
             <exclusions>
-                <exclusion>
+                <!-- <exclusion>
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
+                </exclusion> -->
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro-mapred</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.inject</groupId>
+                    <artifactId>jersey-hk2</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-storage-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.orc</groupId>
+                    <artifactId>orc-mapreduce</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-vector</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/fhir-bulkimportexport-webapp/pom.xml
+++ b/fhir-bulkimportexport-webapp/pom.xml
@@ -136,18 +136,6 @@
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
                 </exclusion>
-                <!-- <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-server</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.containers</groupId>
-                    <artifactId>jersey-container-servlet-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.containers</groupId>
-                    <artifactId>jersey-container-servlet</artifactId>
-                </exclusion> -->
             </exclusions>
         </dependency>
         <dependency>

--- a/fhir-bulkimportexport-webapp/pom.xml
+++ b/fhir-bulkimportexport-webapp/pom.xml
@@ -128,6 +128,39 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>3.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <!-- <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet</artifactId>
+                </exclusion> -->
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.stocator</groupId>
+            <artifactId>stocator</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.wnameless</groupId>
+            <artifactId>json-flattener</artifactId>
+            <version>0.6.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportChunkJob.xml
@@ -9,11 +9,12 @@
                 <properties >
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>
-                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>                   
+                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>
                     <property name="fhir.search.fromdate" value="#{jobParameters['fhir.search.fromdate']}"/>
                     <property name="fhir.search.todate" value="#{jobParameters['fhir.search.todate']}"/>
                     <property name="fhir.search.pagesize" value="#{jobParameters['fhir.search.pagesize']}"/>
-                    <property name="fhir.typeFilters" value="#{jobParameters['fhir.typeFilters']}"/>                   
+                    <property name="fhir.typeFilters" value="#{jobParameters['fhir.typeFilters']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </reader>
             <writer ref="com.ibm.fhir.jbatch.bulkdata.export.system.ChunkWriter">
@@ -26,6 +27,7 @@
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>
                     <property name="cos.bucket.pathprefix" value="#{jobParameters['cos.bucket.pathprefix']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </writer>
             <checkpoint-algorithm ref="com.ibm.fhir.jbatch.bulkdata.export.common.CheckPointAlgorithm">

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
@@ -8,13 +8,14 @@
             <reader ref="com.ibm.fhir.jbatch.bulkdata.export.group.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>
-                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>                   
+                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
                     <property name="fhir.search.fromdate" value="#{jobParameters['fhir.search.fromdate']}"/>
                     <property name="fhir.search.todate" value="#{jobParameters['fhir.search.todate']}"/>
                     <property name="fhir.search.pagesize" value="#{jobParameters['fhir.search.pagesize']}"/>
                     <property name="fhir.search.patientgroupid" value="#{jobParameters['fhir.search.patientgroupid']}"/>
                     <property name="fhir.typeFilters" value="#{jobParameters['fhir.typeFilters']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </reader>
             <writer ref="com.ibm.fhir.jbatch.bulkdata.export.system.ChunkWriter">
@@ -27,6 +28,7 @@
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>
                     <property name="cos.bucket.pathprefix" value="#{jobParameters['cos.bucket.pathprefix']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </writer>
             <checkpoint-algorithm ref="com.ibm.fhir.jbatch.bulkdata.export.common.CheckPointAlgorithm">

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
@@ -8,12 +8,13 @@
             <reader ref="com.ibm.fhir.jbatch.bulkdata.export.patient.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>
-                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>                   
+                    <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
                     <property name="fhir.search.fromdate" value="#{jobParameters['fhir.search.fromdate']}"/>
                     <property name="fhir.search.todate" value="#{jobParameters['fhir.search.todate']}"/>
                     <property name="fhir.search.pagesize" value="#{jobParameters['fhir.search.pagesize']}"/>
                     <property name="fhir.typeFilters" value="#{jobParameters['fhir.typeFilters']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </reader>
             <writer ref="com.ibm.fhir.jbatch.bulkdata.export.system.ChunkWriter">
@@ -26,6 +27,7 @@
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>
                     <property name="cos.bucket.pathprefix" value="#{jobParameters['cos.bucket.pathprefix']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
+                    <property name="fhir.exportFormat" value="#{jobParameters['fhir.exportFormat']}"/>
                 </properties>
             </writer>
             <checkpoint-algorithm ref="com.ibm.fhir.jbatch.bulkdata.export.common.CheckPointAlgorithm">

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
@@ -11,14 +11,22 @@ package com.ibm.fhir.jbatch.bulkdata.common;
  *
  */
 public class Constants {
+    public static final String MEDIA_TYPE_ND_JSON = "application/fhir+ndjson";
+    public static final String MEDIA_TYPE_PARQUET = "application/fhir+parquet";
 
     public static final String DEFAULT_FHIR_TENANT = "default";
     public static final String DEFAULT_COS_BUCKETNAME = "fhir-bulkImExport-Connectathon";
 
-    // The minimal size (10M bytes) for COS multiple-parts upload.
+    /**
+     * The minimal size (10MiB) for COS multiple-parts upload (NDJSON-only)
+     */
     public static final int COS_PART_MINIMALSIZE = 10485760;
     public static final int DEFAULT_SEARCH_PAGE_SIZE = 1000;
     public static final int DEFAULT_PATIENT_EXPORT_SEARCH_PAGE_SIZE = 200;
+
+    /**
+     * The threshold size (200MiB) for when to start writing to a new file (NDJSON-only)
+     */
     public static final int DEFAULT_COSFILE_MAX_SIZE = 209715200;
     public static final int DEFAULT_COSFILE_MAX_RESOURCESNUMBER = 500000;
     public static final String FHIR_SEARCH_LASTUPDATED = "_lastUpdated";
@@ -55,6 +63,7 @@ public class Constants {
     public static final String EXPORT_FHIR_SEARCH_TODATE = "fhir.search.todate";
     public static final String EXPORT_FHIR_SEARCH_PAGESIZE = "fhir.search.pagesize";
     public static final String EXPORT_FHIR_SEARCH_TYPEFILTERS = "fhir.typeFilters";
+    public static final String EXPORT_FHIR_FORMAT = "fhir.exportFormat";
     public static final String EXPORT_FHIR_SEARCH_PATIENTGROUPID = "fhir.search.patientgroupid";
     public static final String EXPORT_COS_OBJECT_PATHPREFIX = "cos.bucket.pathprefix";
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
@@ -11,9 +11,6 @@ package com.ibm.fhir.jbatch.bulkdata.common;
  *
  */
 public class Constants {
-    public static final String MEDIA_TYPE_ND_JSON = "application/fhir+ndjson";
-    public static final String MEDIA_TYPE_PARQUET = "application/fhir+parquet";
-
     public static final String DEFAULT_FHIR_TENANT = "default";
     public static final String DEFAULT_COS_BUCKETNAME = "fhir-bulkImExport-Connectathon";
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/CheckPointUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/CheckPointUserData.java
@@ -261,6 +261,9 @@ public class CheckPointUserData implements java.io.Serializable {
         return lastWritePageNum;
     }
 
+    /**
+     * @param lastWritePageNum the last page of search results that was exported
+     */
     public void setLastWritePageNum(int lastWritePageNum) {
         this.lastWritePageNum = lastWritePageNum;
     }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
@@ -58,13 +58,15 @@ public class SparkParquetWriter implements AutoCloseable {
                 .config("fs.stocator.cos.scheme", "cos");
 
         if (useIAM) {
-            sessionBuilder.config("fs.cos.fhir.endpoint", cosEndpoint)
-            .config("fs.cos.fhir.iam.api.key", apiKeyOrAccessKey)
-            .config("fs.cos.fhir.iam.service.id", serviceInstanceIdOrSecretKey);
+            sessionBuilder
+                .config("fs.cos.fhir.endpoint", cosEndpoint)
+                .config("fs.cos.fhir.iam.api.key", apiKeyOrAccessKey)
+                .config("fs.cos.fhir.iam.service.id", serviceInstanceIdOrSecretKey);
         } else {
-            sessionBuilder.config("fs.cos.fhir.endpoint", cosEndpoint)
-            .config("fs.cos.fhir.access.key", apiKeyOrAccessKey)
-            .config("fs.cos.fhir.secret.key", serviceInstanceIdOrSecretKey);
+            sessionBuilder
+                .config("fs.cos.fhir.endpoint", cosEndpoint)
+                .config("fs.cos.fhir.access.key", apiKeyOrAccessKey)
+                .config("fs.cos.fhir.secret.key", serviceInstanceIdOrSecretKey);
         }
 
         spark = sessionBuilder.getOrCreate();

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.jbatch.bulkdata.export.system;
+package com.ibm.fhir.jbatch.bulkdata.export.common;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -34,9 +34,7 @@ public class SparkParquetWriter implements AutoCloseable {
     public SparkParquetWriter() {
         spark = SparkSession.builder()
             .appName("parquetWriter")
-            // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
-            // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
-            .master("local[*]") //
+            .master("local[*]")
             .getOrCreate();
     }
 
@@ -109,7 +107,9 @@ public class SparkParquetWriter implements AutoCloseable {
         String flatJson = JsonFlattener.flatten(jInput);
         String flattenJson1 = flatJson.replaceAll("\\[", "").replaceAll("\\]", "");
         String flattenJson = flattenJson1.replace('.', '_');
-        System.out.println("flattenAndClean: Flattened string = " + flattenJson);
+        if (logger.isLoggable(Level.FINER)) {
+            logger.finer("flattenAndClean: Flattened string = " + flattenJson);
+        }
         return (flattenJson);
     }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/SparkParquetWriter.java
@@ -35,6 +35,7 @@ public class SparkParquetWriter implements AutoCloseable {
         spark = SparkSession.builder()
             .appName("parquetWriter")
             .master("local[*]")
+            .config("spark.ui.enabled", false)
             .getOrCreate();
     }
 
@@ -50,6 +51,7 @@ public class SparkParquetWriter implements AutoCloseable {
         Builder sessionBuilder = SparkSession.builder()
                 .appName("parquetWriter")
                 .master("local[*]")
+                .config("spark.ui.enabled", false)
                 .config("fs.cos.impl", "com.ibm.stocator.fs.ObjectStoreFileSystem")
                 .config("fs.stocator.scheme.list", "cos")
                 .config("fs.stocator.cos.impl", "com.ibm.stocator.fs.cos.COSAPIClient")

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/TransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/TransientUserData.java
@@ -7,17 +7,31 @@
 package com.ibm.fhir.jbatch.bulkdata.export.common;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Bulk export Chunk implementation - job cache data.
  *
  */
 public class TransientUserData extends CheckPointUserData {
+    private final static Logger logger = Logger.getLogger(TransientUserData.class.getName());
     private static final long serialVersionUID = -5892726731783560418L;
-    private ByteArrayOutputStream bufferStream = new ByteArrayOutputStream();
+
+    private ByteArrayOutputStream bufferStream = new ByteArrayOutputStream(2 ^ 16); // 2 ^ 20 = 1 MiB
+    private Path tmpFile;
 
     protected TransientUserData() {
         super();
+        try {
+            tmpFile = Files.createTempDirectory("fhir");
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Unable to create temporary file", e);
+            throw new RuntimeException(e);
+        }
     }
 
     public static TransientUserData fromCheckPointUserData(CheckPointUserData checkPointData) {
@@ -40,6 +54,11 @@ public class TransientUserData extends CheckPointUserData {
     public ByteArrayOutputStream getBufferStream() {
         return bufferStream;
     }
+
+    public Path getTempFile() {
+        return tmpFile;
+    }
+
     public static class Builder extends CheckPointUserData.Builder {
 
         public static Builder builder() {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/TransientUserData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/common/TransientUserData.java
@@ -7,31 +7,18 @@
 package com.ibm.fhir.jbatch.bulkdata.export.common;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Bulk export Chunk implementation - job cache data.
  *
  */
 public class TransientUserData extends CheckPointUserData {
-    private final static Logger logger = Logger.getLogger(TransientUserData.class.getName());
     private static final long serialVersionUID = -5892726731783560418L;
 
     private ByteArrayOutputStream bufferStream = new ByteArrayOutputStream(2 ^ 16); // 2 ^ 20 = 1 MiB
-    private Path tmpFile;
 
     protected TransientUserData() {
         super();
-        try {
-            tmpFile = Files.createTempDirectory("fhir");
-        } catch (IOException e) {
-            logger.log(Level.SEVERE, "Unable to create temporary file", e);
-            throw new RuntimeException(e);
-        }
     }
 
     public static TransientUserData fromCheckPointUserData(CheckPointUserData checkPointData) {
@@ -53,10 +40,6 @@ public class TransientUserData extends CheckPointUserData {
 
     public ByteArrayOutputStream getBufferStream() {
         return bufferStream;
-    }
-
-    public Path getTempFile() {
-        return tmpFile;
     }
 
     public static class Builder extends CheckPointUserData.Builder {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/patient/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/patient/ChunkReader.java
@@ -92,6 +92,13 @@ public class ChunkReader extends AbstractItemReader {
     protected String fhirResourceType;
 
     /**
+     * Fhir export format.
+     */
+    @Inject
+    @BatchProperty(name = Constants.EXPORT_FHIR_FORMAT)
+    protected String fhirExportFormat;
+
+    /**
      * Fhir Search from date.
      */
     @Inject
@@ -303,7 +310,7 @@ public class ChunkReader extends AbstractItemReader {
         List<Resource> resources = null;
         FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
         txn.begin();
-        
+
         try {
             persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
             resources = fhirPersistence.search(persistenceContext, Patient.class).getResource();
@@ -336,7 +343,7 @@ public class ChunkReader extends AbstractItemReader {
 
         if (resources != null) {
             if (logger.isLoggable(Level.FINE)) {
-                logger.fine("readItem(" + fhirResourceType + "): loaded patients number - " + resources.size());
+                logger.fine("readItem(" + fhirResourceType + "): loaded " + resources.size() + " patients");
             }
 
             List<String> patientIds = resources.stream().filter(item -> item.getId() != null).map(item -> item.getId()).collect(Collectors.toList());

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
@@ -144,10 +144,9 @@ public class ChunkReader extends AbstractItemReader {
             }
 
             try {
-                if (FHIRMediaType.APPLICATION_PARQUET.equals(fhirExportFormat)) {
-                    // No need to write here because we're letting spark write to COS...we don't need to
-                    // control the Multi-part upload like in the NDJSON case
-                } else {
+                // No need to fill buffer for parquet because we're letting spark write to COS;
+                // we don't need to control the Multi-part upload like in the NDJSON case
+                if (!FHIRMediaType.APPLICATION_PARQUET.equals(fhirExportFormat)) {
                     FHIRGenerator.generator(Format.JSON).generate(res, chunkData.getBufferStream());
                     chunkData.getBufferStream().write(Constants.NDJSON_LINESEPERATOR);
                 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
@@ -45,7 +45,6 @@ import com.ibm.fhir.search.util.SearchUtil;
 
 /**
  * Bulk system export Chunk implementation - the Reader.
- *
  */
 @Dependent
 public class ChunkReader extends AbstractItemReader {
@@ -89,6 +88,13 @@ public class ChunkReader extends AbstractItemReader {
     String fhirResourceType;
 
     /**
+     * Fhir export format.
+     */
+    @Inject
+    @BatchProperty(name = Constants.EXPORT_FHIR_FORMAT)
+    protected String fhirExportFormat;
+
+    /**
      * Fhir Search from date.
      */
     @Inject
@@ -126,42 +132,47 @@ public class ChunkReader extends AbstractItemReader {
     private void fillChunkDataBuffer(List<Resource> resources) throws Exception {
         TransientUserData chunkData = (TransientUserData) stepCtx.getTransientUserData();
         int resSubTotal = 0;
-        if (chunkData != null) {
-            for (Resource res : resources) {
-                if (res == null || (isDoDuplicationCheck && loadedResourceIds.contains(res.getId()))) {
-                    continue;
-                }
-
-                try {
-                    FHIRGenerator.generator(Format.JSON).generate(res, chunkData.getBufferStream());
-                    chunkData.getBufferStream().write(Constants.NDJSON_LINESEPERATOR);
-                    resSubTotal++;
-                    if (isDoDuplicationCheck) {
-                        loadedResourceIds.add(res.getId());
-                    }
-                } catch (FHIRGeneratorException e) {
-                    if (res.getId() != null) {
-                        logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with id '"
-                                + res.getId() + "'", e);
-                    } else {
-                        logger.log(Level.WARNING,
-                                "fillChunkDataBuffer: Error while writing resources with unknown id", e);
-                    }
-                } catch (IOException e) {
-                    logger.warning("fillChunkDataBuffer: chunkDataBuffer written error!");
-                    throw e;
-                }
-            }
-            chunkData.setCurrentUploadResourceNum(chunkData.getCurrentUploadResourceNum() + resSubTotal);
-            chunkData.setCurrentUploadSize(chunkData.getCurrentUploadSize() + chunkData.getBufferStream().size());
-            chunkData.setTotalResourcesNum(chunkData.getTotalResourcesNum() + resSubTotal);
-            logger.fine("fillChunkDataBuffer: Processed resources - " + resSubTotal + "; Bufferred data size - "
-                    + chunkData.getBufferStream().size());
-        } else {
+        if (chunkData == null) {
             logger.warning("fillChunkDataBuffer: chunkData is null, this should never happen!");
             throw new Exception("fillChunkDataBuffer: chunkData is null, this should never happen!");
         }
 
+        for (Resource res : resources) {
+            if (res == null || (isDoDuplicationCheck && loadedResourceIds.contains(res.getId()))) {
+                continue;
+            }
+
+            try {
+                if (Constants.MEDIA_TYPE_PARQUET.equals(fhirExportFormat)) {
+                    // No need to write here because we're letting spark write to COS...we don't need to
+                    // control the Multi-part upload like in the NDJSON case
+                } else {
+                    FHIRGenerator.generator(Format.JSON).generate(res, chunkData.getBufferStream());
+                    chunkData.getBufferStream().write(Constants.NDJSON_LINESEPERATOR);
+                }
+                resSubTotal++;
+                if (isDoDuplicationCheck && res.getId() != null) {
+                    loadedResourceIds.add(res.getId());
+                }
+            } catch (FHIRGeneratorException e) {
+                // TODO write OperationOutcome to COS for these errors
+                if (res.getId() != null) {
+                    logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with id '"
+                            + res.getId() + "'", e);
+                } else {
+                    logger.log(Level.WARNING,
+                            "fillChunkDataBuffer: Error while writing resources with no id", e);
+                }
+            } catch (IOException e) {
+                logger.warning("fillChunkDataBuffer: chunkDataBuffer written error!");
+                throw e;
+            }
+        }
+        chunkData.setCurrentUploadResourceNum(chunkData.getCurrentUploadResourceNum() + resSubTotal);
+        chunkData.setCurrentUploadSize(chunkData.getCurrentUploadSize() + chunkData.getBufferStream().size());
+        chunkData.setTotalResourcesNum(chunkData.getTotalResourcesNum() + resSubTotal);
+        logger.fine("fillChunkDataBuffer: Processed resources - " + resSubTotal + "; Bufferred data size - "
+                + chunkData.getBufferStream().size());
     }
 
     @Override
@@ -173,7 +184,7 @@ public class ChunkReader extends AbstractItemReader {
                 chunkData.setMoreToExport(false);
                 return null;
             } else {
-             // If there is more typeFilter to process for current resource type, then reset pageNum only and move to the next typeFilter.
+                // If there is more typeFilter to process for current resource type, then reset pageNum only and move to the next typeFilter.
                 pageNum = 1;
                 indexOfCurrentTypeFilter++;
             }
@@ -244,7 +255,7 @@ public class ChunkReader extends AbstractItemReader {
 
         if (resources != null) {
             if (logger.isLoggable(Level.FINE)) {
-                logger.fine("readItem: loaded resources number - " + resources.size());
+                logger.fine("readItem: loaded " + resources.size() + " resources");
             }
             fillChunkDataBuffer(resources);
         } else {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkReader.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.jbatch.bulkdata.common.BulkDataUtils;
 import com.ibm.fhir.jbatch.bulkdata.common.Constants;
 import com.ibm.fhir.jbatch.bulkdata.export.common.CheckPointUserData;
@@ -143,7 +144,7 @@ public class ChunkReader extends AbstractItemReader {
             }
 
             try {
-                if (Constants.MEDIA_TYPE_PARQUET.equals(fhirExportFormat)) {
+                if (FHIRMediaType.APPLICATION_PARQUET.equals(fhirExportFormat)) {
                     // No need to write here because we're letting spark write to COS...we don't need to
                     // control the Multi-part upload like in the NDJSON case
                 } else {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ChunkWriter.java
@@ -287,7 +287,12 @@ public class ChunkWriter extends AbstractItemWriter {
         cosClient = BulkDataUtils.getCosClient(cosCredentialIbm, cosApiKeyProperty, cosSrvinstId, cosEndpointUrl,
                 cosLocation, isCosClientUseFhirServerTrustStore);
 
-        parquetWriter = new SparkParquetWriter("Y".equalsIgnoreCase(cosCredentialIbm), cosEndpointUrl, cosApiKeyProperty, cosSrvinstId);
+        try {
+            Class.forName("org.apache.spark.sql.SparkSession");
+            parquetWriter = new SparkParquetWriter("Y".equalsIgnoreCase(cosCredentialIbm), cosEndpointUrl, cosApiKeyProperty, cosSrvinstId);
+        } catch (ClassNotFoundException e) {
+            logger.info("No SparkSession in classpath; skipping SparkParquetWriter initialization");
+        }
 
         if (cosClient == null) {
             logger.warning("open: Failed to get CosClient!");
@@ -300,6 +305,8 @@ public class ChunkWriter extends AbstractItemWriter {
     @Override
     public void close() throws Exception {
         logger.fine("closing the ChunkWriter");
-        parquetWriter.close();
+        if (parquetWriter != null) {
+            parquetWriter.close();
+        }
     }
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
@@ -21,6 +21,8 @@ import javax.batch.runtime.context.JobContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import org.apache.spark.sql.SparkSession;
+
 import com.ibm.fhir.jbatch.bulkdata.common.Constants;
 import com.ibm.fhir.jbatch.bulkdata.export.common.CheckPointUserData;
 
@@ -38,7 +40,13 @@ public class ExportJobListener implements JobListener {
     String dataSourcesInfo;
 
     public ExportJobListener() {
-        // do nothing
+        // Create the global spark session
+        SparkSession.builder()
+            .appName("parquetWriter")
+            // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
+            // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
+            .master("local[*]") //
+            .getOrCreate();
     }
 
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
@@ -40,16 +40,22 @@ public class ExportJobListener implements JobListener {
     String dataSourcesInfo;
 
     public ExportJobListener() {
-        // Create the global spark session
-        SparkSession.builder()
-            .appName("parquetWriter")
-            // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
-            // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
-            .master("local[*]")
-            // this undocumented feature allows us to avoid a bunch of unneccessary dependencies and avoid
-            // launching the unnecessary SparkUI stuff, but there is some risk in using it as its undocumented.
-            .config("spark.ui.enabled", false)
-            .getOrCreate();
+        try {
+            Class.forName("org.apache.spark.sql.SparkSession");
+
+            // Create the global spark session
+            SparkSession.builder()
+                .appName("parquetWriter")
+                // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
+                // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
+                .master("local[*]")
+                // this undocumented feature allows us to avoid a bunch of unneccessary dependencies and avoid
+                // launching the unnecessary SparkUI stuff, but there is some risk in using it as its undocumented.
+                .config("spark.ui.enabled", false)
+                .getOrCreate();
+        } catch (ClassNotFoundException e) {
+            logger.info("No SparkSession in classpath; skipping spark session initialization");
+        }
     }
 
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/ExportJobListener.java
@@ -45,7 +45,10 @@ public class ExportJobListener implements JobListener {
             .appName("parquetWriter")
             // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
             // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
-            .master("local[*]") //
+            .master("local[*]")
+            // this undocumented feature allows us to avoid a bunch of unneccessary dependencies and avoid
+            // launching the unnecessary SparkUI stuff, but there is some risk in using it as its undocumented.
+            .config("spark.ui.enabled", false)
             .getOrCreate();
     }
 

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/SparkParquetWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/export/system/SparkParquetWriter.java
@@ -1,0 +1,120 @@
+/*
+ * (C) Copyright IBM Corp. 2019, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.jbatch.bulkdata.export.system;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.SparkSession.Builder;
+
+import com.github.wnameless.json.flattener.JsonFlattener;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
+import com.ibm.fhir.model.resource.Resource;
+
+public class SparkParquetWriter implements AutoCloseable {
+    private static final Logger logger = Logger.getLogger(SparkParquetWriter.class.getName());
+
+    private SparkSession spark;
+
+    /**
+     * Create a SparkParquetWriter that can only write to file URIs
+     */
+    public SparkParquetWriter() {
+        spark = SparkSession.builder()
+            .appName("parquetWriter")
+            // local : Run Spark locally with one worker thread (i.e. no parallelism at all).
+            // local[*] : Run Spark locally with as many worker threads as logical cores on your machine.
+            .master("local[*]") //
+            .getOrCreate();
+    }
+
+    /**
+     * Create a SparkParquetWriter that can write to either file or cos URIs
+     *
+     * @param isCOS whether to use IBM Cloud Identity and Access Management; if false we use "HMAC" auth
+     * @param cosEndpoint the S3 endpoint to connect to; include the scheme, typically "https://")
+     * @param apiKeyOrAccessKey a valid ServiceCredential ApiKey (for IAM) or AccessKey (for HMAC)
+     * @param serviceInstanceIdOrSecretKey a valid ServiceInstanceId (for IAM) or SecretKey (for HMAC)
+     */
+    public SparkParquetWriter(boolean useIAM, String cosEndpoint, String apiKeyOrAccessKey, String serviceInstanceIdOrSecretKey) {
+        Builder sessionBuilder = SparkSession.builder()
+                .appName("parquetWriter")
+                .master("local[*]")
+                .config("fs.cos.impl", "com.ibm.stocator.fs.ObjectStoreFileSystem")
+                .config("fs.stocator.scheme.list", "cos")
+                .config("fs.stocator.cos.impl", "com.ibm.stocator.fs.cos.COSAPIClient")
+                .config("fs.stocator.cos.scheme", "cos");
+
+        if (useIAM) {
+            sessionBuilder.config("fs.cos.fhir.endpoint", cosEndpoint)
+            .config("fs.cos.fhir.iam.api.key", apiKeyOrAccessKey)
+            .config("fs.cos.fhir.iam.service.id", serviceInstanceIdOrSecretKey);
+        } else {
+            sessionBuilder.config("fs.cos.fhir.endpoint", cosEndpoint)
+            .config("fs.cos.fhir.access.key", apiKeyOrAccessKey)
+            .config("fs.cos.fhir.secret.key", serviceInstanceIdOrSecretKey);
+        }
+
+        spark = sessionBuilder.getOrCreate();
+    }
+
+    /**
+     * Write a list of resources to a parquet file under a single logical file that is actually a directory.
+     *
+     * @param resources the list of resources to write
+     * @param outDirName the target directory, using either a file URI or a cos URI like "cos://bucket.service/object-key"
+     * @throws FHIRGeneratorException
+     * @implnote If a cos URI is passed, the file will be created if needed. For a file URI
+     */
+    public void writeParquet(List<Resource> resources, String outDirName)
+            throws FHIRGeneratorException {
+        ArrayList<String> flatJsonResources = new ArrayList<String>();
+
+        FHIRGenerator generator = FHIRGenerator.generator(Format.JSON);
+        for (Resource singleResource : resources) {
+            StringWriter stringWriter = new StringWriter();
+            generator.generate(singleResource, stringWriter);
+            flatJsonResources.add(flattenAndClean(stringWriter.toString()));
+        }
+
+        Dataset<String> jDataset = spark.createDataset(flatJsonResources, Encoders.STRING());
+        Dataset<?> jsonDF = spark.read().json(jDataset);
+
+        if (logger.isLoggable(Level.FINEST)) {
+            // Show prints to system.out
+            // We'd need to temporarily redirect that to our own OutputStream to properly log this
+            // but its really just for debug, so I chose to print it to System.out for now.
+            jsonDF.show(false);
+        }
+
+        jsonDF.coalesce(1).write().mode("append").parquet(outDirName);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.fine("Parquet file written under " + outDirName);
+        }
+    }
+
+    public static String flattenAndClean(String jInput) {
+        String flatJson = JsonFlattener.flatten(jInput);
+        String flattenJson1 = flatJson.replaceAll("\\[", "").replaceAll("\\]", "");
+        String flattenJson = flattenJson1.replace('.', '_');
+        System.out.println("flattenAndClean: Flattened string = " + flattenJson);
+        return (flattenJson);
+    }
+
+    @Override
+    public void close() throws Exception {
+        // TODO: anything to clean up?
+    }
+}

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ChunkWriter.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ChunkWriter.java
@@ -177,7 +177,7 @@ public class ChunkWriter extends AbstractItemWriter {
             for (Object objResJsonList : arg0) {
                 @SuppressWarnings("unchecked")
                 List<Resource> fhirResourceList = (List<Resource>) objResJsonList;
-    
+
                 for (Resource fhirResource : fhirResourceList) {
                     try {
                         String id = fhirResource.getId();
@@ -186,8 +186,15 @@ public class ChunkWriter extends AbstractItemWriter {
                         if (failValidationIds.contains(id)) {
                             continue;
                         }
-                        OperationOutcome operationOutcome =
-                                fhirPersistence.update(persistenceContext, id, fhirResource).getOutcome();
+                        OperationOutcome operationOutcome;
+                        if (id == null) {
+                            operationOutcome =
+                                    fhirPersistence.create(persistenceContext, fhirResource).getOutcome();
+                        } else {
+                            operationOutcome =
+                                    fhirPersistence.update(persistenceContext, id, fhirResource).getOutcome();
+                        }
+
                         succeededNum++;
                         if (Constants.IMPORT_IS_COLLECT_OPERATIONOUTCOMES && operationOutcome != null) {
                             FHIRGenerator.generator(Format.JSON).generate(operationOutcome, chunkData.getBufferStreamForImport());
@@ -266,7 +273,7 @@ public class ChunkWriter extends AbstractItemWriter {
             chunkData.getBufferStreamForImportError().reset();
         }
     }
-    
+
     @Override
     public void open(Serializable checkpoint) throws Exception {
         if (fhirValidation != null) {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportCheckPointData.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportCheckPointData.java
@@ -362,4 +362,20 @@ public class ImportCheckPointData implements Serializable {
     public void setInFlyRateBeginMilliSeconds(long inFlyRateBeginMilliSeconds) {
         this.inFlyRateBeginMilliSeconds = inFlyRateBeginMilliSeconds;
     }
+
+    @Override
+    public String toString() {
+        return "ImportCheckPointData [importPartitionWorkitem=" + importPartitionWorkitem + ", numOfProcessedResources=" + numOfProcessedResources
+                + ", numOfImportedResources=" + numOfImportedResources + ", numOfImportFailures=" + numOfImportFailures + ", totalReadMilliSeconds="
+                + totalReadMilliSeconds + ", totalWriteMilliSeconds=" + totalWriteMilliSeconds + ", totalValidationMilliSeconds=" + totalValidationMilliSeconds
+                + ", importFileSize=" + importFileSize + ", inFlyRateBeginMilliSeconds=" + inFlyRateBeginMilliSeconds + ", numOfToBeImported="
+                + numOfToBeImported + ", numOfParseFailures=" + numOfParseFailures + ", importPartitionResourceType=" + importPartitionResourceType
+                + ", uniqueIDForImportOperationOutcomes=" + uniqueIDForImportOperationOutcomes + ", partNumForOperationOutcomes=" + partNumForOperationOutcomes
+                + ", uploadIdForOperationOutcomes=" + uploadIdForOperationOutcomes + ", dataPacksForOperationOutcomes=" + dataPacksForOperationOutcomes
+                + ", uniqueIDForImportFailureOperationOutcomes=" + uniqueIDForImportFailureOperationOutcomes + ", partNumForFailureOperationOutcomes="
+                + partNumForFailureOperationOutcomes + ", uploadIdForFailureOperationOutcomes=" + uploadIdForFailureOperationOutcomes
+                + ", dataPacksForFailureOperationOutcomes=" + dataPacksForFailureOperationOutcomes + "]";
+    }
+
+
 }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportJobListener.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportJobListener.java
@@ -90,6 +90,10 @@ public class ImportJobListener implements JobListener {
 
         String resultInExitStatus[] = new String[sequnceNum];
         for (ImportCheckPointData partitionSummary : partitionSummaries) {
+            if (partitionSummary == null) {
+                logger.warning("One or more partitionSummaries are null; results may be incomplete");
+                continue;
+            }
             int index = inputUrlSequenceMap.get(partitionSummary.getImportPartitionResourceType() + ":" + partitionSummary.getImportPartitionWorkitem());
             resultInExitStatus[index] = partitionSummary.getNumOfImportedResources() + ":" + partitionSummary.getNumOfImportFailures();
         }

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportPartitionAnalyzer.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportPartitionAnalyzer.java
@@ -55,6 +55,7 @@ public class ImportPartitionAnalyzer implements PartitionAnalyzer {
         // Aggregate the processed resource numbers from different partitions for the same resource types.
         ImportCheckPointData importedResourceTypeInFlySummary = importedResourceTypeInFlySummaries.get(partitionSummaryForMetrics.getImportPartitionResourceType());
         if (importedResourceTypeInFlySummary == null) {
+            // Instantiate a partition summary for this resourceType and add it to the list
             importedResourceTypeInFlySummary = ImportCheckPointData.Builder.builder()
                     .importPartitionResourceType(partitionSummaryForMetrics.getImportPartitionResourceType())
                     .numOfProcessedResources(Constants.IMPORT_NUMOFFHIRRESOURCES_PERREAD)
@@ -63,6 +64,7 @@ public class ImportPartitionAnalyzer implements PartitionAnalyzer {
             importedResourceTypeInFlySummaries.put(partitionSummaryForMetrics.getImportPartitionResourceType(),
                     importedResourceTypeInFlySummary);
         } else {
+            // Add info to the object thats already in the list
             importedResourceTypeInFlySummary.setNumOfProcessedResources(importedResourceTypeInFlySummary.getNumOfProcessedResources() + Constants.IMPORT_NUMOFFHIRRESOURCES_PERREAD);
 
             if (importedResourceTypeInFlySummary.getNumOfProcessedResources() % Constants.IMPORT_INFLY_RATE_NUMOFFHIRRESOURCES == 0) {

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportPartitionCollector.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/load/ImportPartitionCollector.java
@@ -106,7 +106,7 @@ public class ImportPartitionCollector implements PartitionCollector {
 
         // This function is called at partition chunk check points and also at the end of partition processing.
         // So, check the NumOfToBeImported to make sure at the end of partition processing:
-        // (1) upload the remaining OperationComes to COS/S3.
+        // (1) upload the remaining OperationOutcomes to COS/S3.
         // (2) finish the multiple-parts uploads.
         // (3) release the resources hold by this partition.
         if (partitionSummaryData.getNumOfToBeImported() == 0) {
@@ -166,6 +166,10 @@ public class ImportPartitionCollector implements PartitionCollector {
 
         ImportCheckPointData partitionSummaryForMetrics = ImportCheckPointData.fromImportTransientUserData(partitionSummaryData);
         partitionSummaryForMetrics.setNumOfToBeImported(partitionSummaryData.getNumOfToBeImported());
+
+        if (logger.isLoggable(Level.FINE)) {
+            logger.info("collected partition data: " + partitionSummaryForMetrics);
+        }
         return partitionSummaryForMetrics;
     }
 

--- a/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
+++ b/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.testng.annotations.Test;
 
-import com.ibm.fhir.jbatch.bulkdata.export.system.SparkParquetWriter;
+import com.ibm.fhir.jbatch.bulkdata.export.common.SparkParquetWriter;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.HumanName;

--- a/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
+++ b/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
@@ -60,7 +60,7 @@ public class SparkParquetWriterTest {
      */
     private static final String API_KEY = "REPLACEME";
 
-    @Test
+    @Test(enabled = true)
     public void testWriteFile() throws Exception {
         try (SparkParquetWriter sparkParquetWriter = new SparkParquetWriter()) {
             Patient patient = buildPatient();

--- a/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
+++ b/fhir-bulkimportexport-webapp/src/test/java/com/ibm/fhir/bulkcommon/SparkParquetWriterTest.java
@@ -1,0 +1,136 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.bulkcommon;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.jbatch.bulkdata.export.system.SparkParquetWriter;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.type.Date;
+import com.ibm.fhir.model.type.HumanName;
+import com.ibm.fhir.model.type.Id;
+import com.ibm.fhir.model.type.Instant;
+import com.ibm.fhir.model.type.Meta;
+import com.ibm.fhir.model.type.Narrative;
+import com.ibm.fhir.model.type.Xhtml;
+import com.ibm.fhir.model.type.code.NarrativeStatus;
+
+/**
+ * Only the file-system based path is tested by default;
+ * manually set the constants and enable testWriteCOSviaHMAC to test the write to Cloug Object Storage
+ */
+public class SparkParquetWriterTest {
+    /**
+     * The S3 endpoint for regional buckets in us-south
+     */
+    private static final String ENDPOINT = "https://s3.us-south.cloud-object-storage.appdomain.cloud";
+
+    /**
+     * The name of the bucket to use for the test
+     */
+    private static final String BUCKET_NAME = "fhir-bulkimexport-connectathon";
+
+    /**
+     * Access Key for HMAC Authentication
+     */
+    private static final String ACCESS_KEY = "REPLACEME";
+    /**
+     * Secret Key for HMAC Authentication
+     */
+    private static final String SECRET_KEY = "REPLACEME";
+
+    /**
+     * IBM Cloud Object Storage Service Id for IAM-based authentication
+     */
+    private static final String SERVICE_ID = "REPLACEME";
+    /**
+     * IAM API Key
+     */
+    private static final String API_KEY = "REPLACEME";
+
+    @Test
+    public void testWriteFile() throws Exception {
+        try (SparkParquetWriter sparkParquetWriter = new SparkParquetWriter()) {
+            Patient patient = buildPatient();
+
+            Path tmpDir = Files.createTempDirectory("SparkParquetWriterTest");
+            sparkParquetWriter.writeParquet(Collections.singletonList(patient), tmpDir.toString());
+            assertTrue(Files.exists(tmpDir));
+            FileUtils.deleteDirectory(tmpDir.toFile());
+        }
+    }
+
+    /**
+     * Enter valid values for ENDPOINT, BUCKET_NAME, ACCESS_KEY, and SECRET_KEY and manually enable this test
+     * to perform a write to IBM Cloud Object Storage
+     */
+    @Test(enabled = false)
+    public void testWriteCOSviaHMAC() throws Exception {
+        try (SparkParquetWriter sparkParquetWriter = new SparkParquetWriter(false, ENDPOINT, ACCESS_KEY, SECRET_KEY)) {
+            Patient patient = buildPatient();
+
+            String itemName = "cos://" + BUCKET_NAME + ".fhir/Patient_2.parquet";
+            sparkParquetWriter.writeParquet(Collections.singletonList(patient), itemName);
+        }
+    }
+
+    /**
+     * Disabled until we get a version of Stocator that will work with IAM creds
+     */
+    @Test(enabled = false)
+    public void testWriteCOSviaIAM() throws Exception {
+        try (SparkParquetWriter sparkParquetWriter = new SparkParquetWriter(true, ENDPOINT, API_KEY, SERVICE_ID)) {
+            Patient patient = buildPatient();
+
+            String itemName = "cos://" + BUCKET_NAME + ".fhir/Patient_1.parquet";
+            sparkParquetWriter.writeParquet(Collections.singletonList(patient), itemName);
+        }
+    }
+
+    private static Patient buildPatient() {
+        java.lang.String div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p></div>";
+
+        java.lang.String id = "9aac1d9c-ea5f-4513-af9c-897ab21dd11d";
+
+        Meta meta = Meta.builder().versionId(Id.of("1"))
+                .lastUpdated(Instant.of("2019-01-01T12:00:00Z"))
+                .build();
+
+        HumanName name = HumanName.builder()
+                .id("someId")
+                .given(string("John"))
+                .given(string("Jingle"))
+                .given(string("value no extension"))
+                .family(string("Doe"))
+                .build();
+
+        Narrative text = Narrative.builder()
+                .status(NarrativeStatus.GENERATED)
+                .div(Xhtml.xhtml(div))
+                .build();
+
+        Patient patient = Patient.builder()
+                .id(id)
+                .text(text)
+                .active(com.ibm.fhir.model.type.Boolean.TRUE)
+                .multipleBirth(com.ibm.fhir.model.type.Integer.of(2))
+                .meta(meta)
+                .name(name)
+                .birthDate(Date.of("1970-01-01"))
+                .build();
+
+        return patient;
+    }
+}

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -97,7 +97,7 @@ public class FHIRConfiguration {
     public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTOREPWD = "fhirServer/bulkdata/batch-truststore-password";
     public static final String PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC = "fhirServer/bulkdata/isExportPublic";
     public static final String PROPERTY_BULKDATA_BATCHJOB_USEFHIRSERVERTRUSTSTORE = "fhirServer/bulkdata/useFhirServerTrustStore";
-    
+
     public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_BASE_URLS = "fhirServer/bulkdata/validBaseUrls";
     public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_URLS_DISABLED = "fhirServer/bulkdata/validBaseUrlsDisabled";
     public static final String PROPERTY_BULKDATA_BATCHJOB_MAX_INPUT_PER_TENANT =

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -97,6 +97,7 @@ public class FHIRConfiguration {
     public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTOREPWD = "fhirServer/bulkdata/batch-truststore-password";
     public static final String PROPERTY_BULKDATA_BATCHJOB_ISEXPORTPUBLIC = "fhirServer/bulkdata/isExportPublic";
     public static final String PROPERTY_BULKDATA_BATCHJOB_USEFHIRSERVERTRUSTSTORE = "fhirServer/bulkdata/useFhirServerTrustStore";
+    public static final String PROPERTY_BULKDATA_BATCHJOB_ENABLEPARQUET = "fhirServer/bulkdata/enableParquet";
 
     public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_BASE_URLS = "fhirServer/bulkdata/validBaseUrls";
     public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_URLS_DISABLED = "fhirServer/bulkdata/validBaseUrlsDisabled";

--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRMediaType.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRMediaType.java
@@ -15,12 +15,20 @@ public class FHIRMediaType extends MediaType {
     public final static String SUBTYPE_FHIR_JSON = "fhir+json";
     public final static String APPLICATION_FHIR_JSON = "application/" + SUBTYPE_FHIR_JSON;
     public final static MediaType APPLICATION_FHIR_JSON_TYPE = new MediaType("application", SUBTYPE_FHIR_JSON);
-   
+
     public final static String SUBTYPE_FHIR_XML = "fhir+xml";
     public final static String APPLICATION_FHIR_XML = "application/" + SUBTYPE_FHIR_XML;
     public final static MediaType APPLICATION_FHIR_XML_TYPE = new MediaType("application", SUBTYPE_FHIR_XML);
-    
+
     public final static String SUBTYPE_JSON_PATCH = "json-patch+json";
     public final static String APPLICATION_JSON_PATCH = "application/" + SUBTYPE_JSON_PATCH;
     public final static MediaType APPLICATION_JSON_PATCH_TYPE = new MediaType("application", SUBTYPE_JSON_PATCH);
+
+    public final static String SUBTYPE_FHIR_NDJSON = "fhir+ndjson";
+    public static final String APPLICATION_NDJSON = "application/" + SUBTYPE_FHIR_NDJSON;
+    public final static MediaType APPLICATION_FHIR_NDJSON_TYPE = new MediaType("application", SUBTYPE_FHIR_NDJSON);
+
+    public final static String SUBTYPE_FHIR_PARQUET = "fhir+parquet";
+    public static final String APPLICATION_PARQUET = "application/"  + SUBTYPE_FHIR_PARQUET;
+    public final static MediaType APPLICATION_FHIR_PARQUET_TYPE = new MediaType("application", SUBTYPE_FHIR_PARQUET);
 }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -570,17 +570,19 @@ public class FHIRUtil {
     }
 
     /**
-     * Generate a random AES key or 32 byte value encoded as a Base64 string.
+     * Generate a random key using the passed algorithm or, if that algorithm isn't supported, a random 32 byte value.
+     * In either case, the resulting value is encoded as a Base64 string before returning.
      *
-     * @return
+     * @return a base64-encoded random key string
      */
-    public static String getRandomKey(String key) {
+    public static String getRandomKey(String algorithm) {
         KeyGenerator keyGen;
         try {
-            keyGen = KeyGenerator.getInstance(key);
+            keyGen = KeyGenerator.getInstance(algorithm);
             keyGen.init(256);
             return Base64.getEncoder().encodeToString(keyGen.generateKey().getEncoded());
         } catch (NoSuchAlgorithmException e) {
+            log.warning("Algorithm '" + algorithm + "' is not supported; using SecureRandom instead");
             byte[] buffer = new byte[32];
             RANDOM.setSeed(System.currentTimeMillis());
             RANDOM.nextBytes(buffer);

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/FHIRParserTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/FHIRParserTest.java
@@ -23,12 +23,12 @@ public class FHIRParserTest {
     public void testUnrecognizedElements1() throws Exception {
         String value = "handling=strict";
         if (value.startsWith("handling=")) {
-            
+
             value = value.substring("handling=".length());
             System.out.println(value);
         }
-        
-        
+
+
         try (InputStream in = FHIRParserTest.class.getClassLoader().getResourceAsStream("JSON/observation-unrecognized-elements.json")) {
             FHIRParser.parser(Format.JSON).parse(in);
             fail();
@@ -36,7 +36,7 @@ public class FHIRParserTest {
             assertTrue(e.getMessage().startsWith("Unrecognized element"));
         }
     }
-    
+
     @Test
     public void testUnrecognizedElements2() throws Exception {
         try (InputStream in = FHIRParserTest.class.getClassLoader().getResourceAsStream("JSON/observation-unrecognized-elements.json")) {

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -310,7 +310,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
@@ -363,7 +363,7 @@ ALTER TABLE device_token_values ADD CONSTRAINT fk_device_token_values_r  FOREIGN
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
@@ -427,7 +427,7 @@ ALTER TABLE device_date_values ADD CONSTRAINT fk_device_date_values_r  FOREIGN K
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
@@ -495,7 +495,7 @@ ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_r  FOREI
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
@@ -549,7 +549,7 @@ ALTER TABLE device_latlng_values ADD CONSTRAINT fk_device_latlng_values_r  FOREI
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first
@@ -617,7 +617,7 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
 
         group.add(tbl);
         model.addTable(tbl);
-        
+
         // issue-1341. Default sequence cache for generated identity columns is too small
         AlterTableIdentityCache alterTable = new AlterTableIdentityCache(schemaName, tableName, ROW_ID, FhirSchemaConstants.FHIR_IDENTITY_SEQUENCE_CACHE, FhirSchemaVersion.V0004.vid());
         alterTable.addDependency(tbl); // Depends on the CREATE TABLE, which obviously must be executed first

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
@@ -459,6 +459,20 @@ public class ExportOperationTest extends FHIRServerTestBase {
     }
 
     /**
+     * Ensure that export to parquet returns a reasonable error when its disabled on the server
+     */
+    @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = true)
+    public void testExportToParquetResponse() throws Exception {
+        if (ON) {
+            Response response =
+                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null);
+            assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode(), "Response status");
+        } else {
+            System.out.println("Base Export Test Disabled, Skipping");
+        }
+    }
+
+    /**
      * Disabled due to limitations with writing parquet to minio
      * https://stackoverflow.com/questions/63174444/how-to-write-parquet-to-minio-from-spark
      */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
@@ -26,6 +26,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -55,7 +56,8 @@ public class ExportOperationTest extends FHIRServerTestBase {
     public static final String GROUP_VALID_URL = "Group/?/$export";
     public static final String BASE_VALID_URL = "/$export";
     public static final String BASE_VALID_STATUS_URL = "/$bulkdata-status";
-    public static final String FORMAT = "application/fhir+ndjson";
+    public static final String FORMAT_NDJSON = "application/fhir+ndjson";
+    public static final String FORMAT_PARQUET = "application/fhir+parquet";
     private final String tenantName = "default";
     private final String dataStoreId = "default";
 
@@ -64,13 +66,13 @@ public class ExportOperationTest extends FHIRServerTestBase {
     private static boolean isUseMinio = false;
     private static boolean isUseMinioInBuildPipeline = false;
 
-    public static final boolean DEBUG = false;
+    public static final boolean DEBUG = true;
     private String exportStatusUrl;
     private String savedPatientId, savedPatientId2;
     private String savedGroupId, savedGroupId2;
     private String minioUserName;
     private String minioPassword;
-  
+
     @BeforeClass
     public void setup() throws Exception {
         Properties testProperties = TestUtil.readTestProperties("test.properties");
@@ -98,10 +100,9 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 .header("X-FHIR-TENANT-ID", tenantName)
                 .header("X-FHIR-DSID", dataStoreId)
                 .post(entity, Response.class);
-
     }
 
-    /*
+    /**
      * @param outputFormat
      * @param since
      * @param types
@@ -111,7 +112,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
      * @throws IOException
      */
     private Parameters generateParameters(String outputFormat, Instant since, List<String> types, List<String> typeFilters)
-        throws FHIRGeneratorException, IOException {
+            throws FHIRGeneratorException, IOException {
         List<Parameter> parameters = new ArrayList<>();
 
         if (outputFormat != null) {
@@ -172,15 +173,15 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 .header("X-FHIR-DSID", dataStoreId)
                 .get(Response.class);
     }
-    
+
     private void verifyDownloadUrl(String downloadUrl) {
-        // Minio doesn't support file level ACL using which we make can make the published file public, so we have to 
-        // get the token first, and then use the token to download the file. 
+        // Minio doesn't support file level ACL using which we make can make the published file public, so we have to
+        // get the token first, and then use the token to download the file.
         if (isUseMinio) {
             downloadUrl = downloadUrl.substring(8);
             String minioHost = downloadUrl.substring(0, downloadUrl.indexOf("/"));
             String minioFilePath = downloadUrl.substring(minioHost.length());
-            
+
             // If using minio in build pipeline, then we have to change the host name to "localhost" to all the
             // build machine to access the minio server via it.
             if (isUseMinioInBuildPipeline) {
@@ -188,21 +189,21 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 minioHostArray[0] = "localhost";
                 minioHost = String.join(":", minioHostArray);
             }
-            
+
             String minioAuthUrl = "https://" + minioHost + "/minio/webrpc";
-            String minioAuthRequestBody = "{\"id\":1,\"jsonrpc\":\"2.0\",\"params\":{\"username\":\"" 
+            String minioAuthRequestBody = "{\"id\":1,\"jsonrpc\":\"2.0\",\"params\":{\"username\":\""
                 + minioUserName  + "\",\"password\":\"" + minioPassword + "\"},\"method\":\"Web.Login\"}";
-            
+
             WebTarget client2 = ClientBuilder.newBuilder().trustStore(client.getTrustStore()).build().target(minioAuthUrl);
             Response response = client2.request()
                     .header("Content-Type", MediaType.APPLICATION_JSON)
                     .header("User-Agent", "Mozilla")
                     .post(Entity.json(minioAuthRequestBody));
-            
+
             String strToken = response.readEntity(String.class);
             strToken = strToken.substring(strToken.indexOf("token\":") + 8);
             strToken = strToken.substring(0, strToken.indexOf(",") - 1);
-            
+
             downloadUrl = "https://" + minioHost + "/minio/download" + minioFilePath + "?token=" + strToken;
             client2 = ClientBuilder.newBuilder().trustStore(client.getTrustStore()).build().target(downloadUrl);
             response = client2.request()
@@ -222,7 +223,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
             response = doGet(exportStatusUrl, FHIRMediaType.APPLICATION_FHIR_JSON);
             // 202 accept means the request is still under processing
             // 200 mean export is finished
-            assertTrue(response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.ACCEPTED.getStatusCode());
+            assertEquals(Status.Family.familyOf(response.getStatus()), Status.Family.SUCCESSFUL);
             Thread.sleep(5000);
         } while (response.getStatus() == Response.Status.ACCEPTED.getStatusCode());
 
@@ -440,7 +441,32 @@ public class ExportOperationTest extends FHIRServerTestBase {
     public void testBaseExport() throws Exception {
         if (ON) {
             Response response =
-                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null);
+                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null);
+            assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+            // check the content-location that's returned.
+            String contentLocation = response.getHeaderString("Content-Location");
+            if (DEBUG) {
+                System.out.println("Content Location: " + contentLocation);
+            }
+
+            assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
+            exportStatusUrl = contentLocation;
+            checkExportStatus(false);
+        } else {
+            System.out.println("Base Export Test Disabled, Skipping");
+        }
+    }
+
+    /**
+     * Disabled due to limitations with writing parquet to minio
+     * https://stackoverflow.com/questions/63174444/how-to-write-parquet-to-minio-from-spark
+     */
+    @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
+    public void testBaseExportToParquet() throws Exception {
+        if (ON) {
+            Response response =
+                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null);
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -461,7 +487,32 @@ public class ExportOperationTest extends FHIRServerTestBase {
     public void testPatientExport() throws Exception {
         if (ON) {
             Response response =
-                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null);
+                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null);
+            assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+            // check the content-location that's returned.
+            String contentLocation = response.getHeaderString("Content-Location");
+            if (DEBUG) {
+                System.out.println("Content Location: " + contentLocation);
+            }
+
+            assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
+            exportStatusUrl = contentLocation;
+            checkExportStatus(true);
+        } else {
+            System.out.println("Patient Export Test Disabled, Skipping");
+        }
+    }
+
+    /**
+     * Disabled due to limitations with writing parquet to minio
+     * https://stackoverflow.com/questions/63174444/how-to-write-parquet-to-minio-from-spark
+     */
+    @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
+    public void testPatientExportToParquet() throws Exception {
+        if (ON) {
+            Response response =
+                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null);
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -482,7 +533,32 @@ public class ExportOperationTest extends FHIRServerTestBase {
     public void testGroupExport() throws Exception {
         if (ON) {
             Response response =
-                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT, Instant.of("2019-01-01T08:21:26.94-04:00"), null, null);
+                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), null, null);
+            assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
+
+            // check the content-location that's returned.
+            String contentLocation = response.getHeaderString("Content-Location");
+            if (DEBUG) {
+                System.out.println("Content Location: " + contentLocation);
+            }
+
+            assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
+            exportStatusUrl = contentLocation;
+            checkGroupExportStatus();
+        } else {
+            System.out.println("Group Export Test Disabled, Skipping");
+        }
+    }
+
+    /**
+     * Disabled due to limitations with writing parquet to minio
+     * https://stackoverflow.com/questions/63174444/how-to-write-parquet-to-minio-from-spark
+     */
+    @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
+    public void testGroupExportToParquet() throws Exception {
+        if (ON) {
+            Response response =
+                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), null, null);
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -505,7 +581,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
             response = doGet(exportStatusUrl, FHIRMediaType.APPLICATION_FHIR_JSON);
             // 202 accept means the request is still under processing
             // 200 mean export is finished
-            assertTrue(response.getStatus() == Response.Status.OK.getStatusCode() || response.getStatus() == Response.Status.ACCEPTED.getStatusCode());
+            assertEquals(Status.Family.familyOf(response.getStatus()), Status.Family.SUCCESSFUL);
             Thread.sleep(5000);
         } while (response.getStatus() == Response.Status.ACCEPTED.getStatusCode());
 
@@ -521,7 +597,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
         if (DEBUG) {
             System.out.println("downloadUrl = " + downloadUrl);
         }
-        
+
         // Verify to make sure there are Groups, Condition and Observation in the output
         // (1) Verify that there is one condition exported
         assertTrue(body.contains("Condition_1.ndjson"));
@@ -543,7 +619,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
         String patientStr = body.substring(body.lastIndexOf("Patient_1.ndjson"));
         patientStr = patientStr.substring(0, patientStr.indexOf("}") + 1);
         assertTrue(patientStr.contains("\"count\": 2"));
-        
+
         verifyDownloadUrl(downloadUrl);
     }
 }

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -136,9 +136,9 @@
                 "cos.bucket.name": "fhir-r4-connectathon",
                 "cos.location": "us",
                 "cos.endpointurl": "fake",
-                "cos.credential.ibm": "Y",
-                "cos.api.key": "fake",
-                "cos.srvinst.id": "fake"
+                "cos.credential.ibm": "N",
+                "cos.access.key": "fake",
+                "cos.secret.key": "fake"
             },
             "implementation_type": "cos",
             "batch-uri": "https://localhost:9443/ibm/api/batch/jobinstances",
@@ -150,7 +150,8 @@
             "cosFileMaxResources": 500000,
             "cosFileMaxSize": 209715200,
             "validBaseUrls": [],
-            "useFhirServerTrustStore": false
+            "useFhirServerTrustStore": true,
+            "enableParquet": false
         }
     }
 }

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -12,7 +12,7 @@
         <feature>websocket-1.1</feature>
         <feature>localConnector-1.0</feature>
         <feature>mpOpenAPI-1.0</feature>
-        <!-- mpJwt-1.1 isn't used by default, 
+        <!-- mpJwt-1.1 isn't used by default,
              but we include it here to avoid NoClassDefFound in our classes that *can* use it -->
         <feature>mpJwt-1.1</feature>
     </featureManager>
@@ -42,8 +42,8 @@
      -->
     <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="-1" httpsPort="9443" onError="FAIL"/>
 
-    <!-- 
-        Modify the trace string below as needed to enable/disable tracing. 
+    <!--
+        Modify the trace string below as needed to enable/disable tracing.
         <logging traceSpecification="*=info" traceFormat="BASIC"/>
         <logging traceSpecification="*=info:com.ibm.fhir.*=finer" traceFormat="BASIC"/>
     -->
@@ -76,7 +76,7 @@
         <fileset dir="${server.config.dir}/config" includes="*.jar"/>
     </library>
 
-    <!-- 
+    <!--
         This sharedlib can contain user-contributed jars that are intended to augment
         the IBM FHIR Server installation (persistence interceptors, persistence layer impl's,
         custom operation impl's, etc.)
@@ -101,7 +101,7 @@
     <webAppSecurity allowFailOverToBasicAuth="true" singleSignonEnabled="false"/>
 
     <!-- Define a basic user registry with a few users. -->
-    <basicRegistry id="basic" realm="BasicRealm"> 
+    <basicRegistry id="basic" realm="BasicRealm">
         <user name="fhiruser" password="change-password"/>
         <user name="fhiradmin" password="change-password"/>
         <group name="FHIRUsers">

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/BulkDataConstants.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/BulkDataConstants.java
@@ -20,6 +20,7 @@ import com.ibm.fhir.operation.bulkdata.config.BulkDataConfigUtil;
  */
 public class BulkDataConstants {
     public static final String MEDIA_TYPE_ND_JSON = "application/fhir+ndjson";
+    public static final String MEDIA_TYPE_PARQUET = "application/fhir+parquet";
 
     // Import
     public static final String INPUT_FORMAT = MEDIA_TYPE_ND_JSON;
@@ -33,9 +34,16 @@ public class BulkDataConstants {
     public static final int IMPORT_MAX_DEFAULT_INPUTS = 5;
 
     // Export
-    public static final String EXPORT_FORMAT = MEDIA_TYPE_ND_JSON;
     public static final List<String> EXPORT_FORMATS =
-            Collections.unmodifiableList(Arrays.asList(MEDIA_TYPE_ND_JSON, "application/ndjson", "ndjson"));
+            Collections.unmodifiableList(Arrays.asList(
+                MEDIA_TYPE_ND_JSON,
+                MEDIA_TYPE_PARQUET
+            ));
+    public static final List<String> NDJSON_VARIANTS =
+            Collections.unmodifiableList(Arrays.asList(
+                "application/ndjson",
+                "ndjson"
+            ));
 
     // Export
     public static final String PARAM_OUTPUT_FORMAT = "_outputFormat";

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/BulkDataConstants.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/BulkDataConstants.java
@@ -13,17 +13,15 @@ import javax.crypto.spec.SecretKeySpec;
 
 import com.ibm.fhir.config.FHIRConfigHelper;
 import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.operation.bulkdata.config.BulkDataConfigUtil;
 
 /**
  * Constants for BulkData operations
  */
 public class BulkDataConstants {
-    public static final String MEDIA_TYPE_ND_JSON = "application/fhir+ndjson";
-    public static final String MEDIA_TYPE_PARQUET = "application/fhir+parquet";
-
     // Import
-    public static final String INPUT_FORMAT = MEDIA_TYPE_ND_JSON;
+    public static final String INPUT_FORMAT = FHIRMediaType.APPLICATION_NDJSON;
     public static final List<String> INPUT_FORMATS = Collections.unmodifiableList(Arrays.asList(INPUT_FORMAT));
     public static final List<String> STORAGE_TYPES =
             Collections
@@ -36,8 +34,8 @@ public class BulkDataConstants {
     // Export
     public static final List<String> EXPORT_FORMATS =
             Collections.unmodifiableList(Arrays.asList(
-                MEDIA_TYPE_ND_JSON,
-                MEDIA_TYPE_PARQUET
+                FHIRMediaType.APPLICATION_NDJSON,
+                FHIRMediaType.APPLICATION_PARQUET
             ));
     public static final List<String> NDJSON_VARIANTS =
             Collections.unmodifiableList(Arrays.asList(

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
@@ -52,7 +52,7 @@ public class ExportOperation extends AbstractOperation {
             String logicalId, String versionId, Parameters parameters, FHIRResourceHelpers resourceHelper)
             throws FHIROperationException {
         // Pick off parameters
-        MediaType outputFormat = BulkDataExportUtil.checkAndConvertToMediaType(operationContext);
+        MediaType outputFormat = BulkDataExportUtil.checkAndConvertToMediaType(parameters);
         Instant since = BulkDataExportUtil.checkAndExtractSince(parameters);
         List<String> types = BulkDataExportUtil.checkAndValidateTypes(parameters);
         List<String> typeFilters = BulkDataExportUtil.checkAndValidateTypeFilters(parameters);
@@ -67,7 +67,7 @@ public class ExportOperation extends AbstractOperation {
                 throw BulkDataExportUtil.buildOperationException("Missing resource type(s)!", IssueType.INVALID);
             }
 
-            response = BulkDataFactory.getTenantInstance().export(logicalId, exportType, outputFormat, since, types, 
+            response = BulkDataFactory.getTenantInstance().export(logicalId, exportType, outputFormat, since, types,
                     typeFilters, operationContext, resourceHelper);
         } else {
             // Unsupported on instance, specific types other than group/patient/system

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
@@ -11,6 +11,9 @@ import java.util.List;
 
 import javax.ws.rs.core.MediaType;
 
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
@@ -53,6 +56,15 @@ public class ExportOperation extends AbstractOperation {
             throws FHIROperationException {
         // Pick off parameters
         MediaType outputFormat = BulkDataExportUtil.checkAndConvertToMediaType(parameters);
+        if (FHIRMediaType.SUBTYPE_FHIR_PARQUET.equals(outputFormat.getSubtype())) {
+            Boolean enableParquet = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_BULKDATA_BATCHJOB_ENABLEPARQUET, false);
+            if (!enableParquet) {
+                throw buildExceptionWithIssue(
+                        "Export to parquet is not enabled; try 'application/fhir+ndjson' or contact the system administrator",
+                        IssueType.INVALID);
+            }
+        }
+
         Instant since = BulkDataExportUtil.checkAndExtractSince(parameters);
         List<String> types = BulkDataExportUtil.checkAndValidateTypes(parameters);
         List<String> typeFilters = BulkDataExportUtil.checkAndValidateTypeFilters(parameters);

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -217,15 +217,19 @@ public class BulkDataClient {
             builder.fhirTypeFilters(properties.get(BulkDataConstants.PARAM_TYPE_FILTER));
         }
 
+        builder.fhirExportFormat(properties.getOrDefault(BulkDataConstants.PARAM_OUTPUT_FORMAT, BulkDataConstants.MEDIA_TYPE_ND_JSON));
+
         String entityStr = JobInstanceRequest.Writer.generate(builder.build(), true);
         Entity<String> entity = Entity.json(entityStr);
         Response r = target.request().post(entity);
 
+        // TODO check the HTTP response status code
+        // e.g. if it comes back with a 4xx or a 500 it may fail on the JobInstanceResponse.Parser.parse!
         String responseStr = r.readEntity(String.class);
 
         // Debug / Dev only
         if (log.isLoggable(Level.FINE)) {
-            log.warning("JSON -> \n" + responseStr);
+            log.warning("$import response (HTTP " + r.getStatus() + ") -> \n" + responseStr);
         }
 
         JobInstanceResponse response = JobInstanceResponse.Parser.parse(responseStr);
@@ -250,6 +254,9 @@ public class BulkDataClient {
 
         WebTarget target = getWebTarget(baseUrl);
         Response r = target.request().get();
+
+        // TODO check the HTTP response status code
+        // e.g. if it comes back with 404 it may fail on the JobInstanceResponse.Parser.parse!
 
         String responseStr = r.readEntity(String.class);
 
@@ -628,11 +635,13 @@ public class BulkDataClient {
         Entity<String> entity = Entity.json(entityStr);
         Response r = target.request().post(entity);
 
+        // TODO check the HTTP response status code
+        // e.g. if it comes back with a 4xx or a 500 it may fail on the JobInstanceResponse.Parser.parse!
         String responseStr = r.readEntity(String.class);
 
         // Debug / Dev only
         if (log.isLoggable(Level.FINE)) {
-            log.warning("$import json -> \n" + responseStr);
+            log.warning("$import response (HTTP " + r.getStatus() + ") -> \n" + responseStr);
         }
 
         JobInstanceResponse response = JobInstanceResponse.Parser.parse(responseStr);

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.code.IssueType;
@@ -217,7 +218,7 @@ public class BulkDataClient {
             builder.fhirTypeFilters(properties.get(BulkDataConstants.PARAM_TYPE_FILTER));
         }
 
-        builder.fhirExportFormat(properties.getOrDefault(BulkDataConstants.PARAM_OUTPUT_FORMAT, BulkDataConstants.MEDIA_TYPE_ND_JSON));
+        builder.fhirExportFormat(properties.getOrDefault(BulkDataConstants.PARAM_OUTPUT_FORMAT, FHIRMediaType.APPLICATION_NDJSON));
 
         String entityStr = JobInstanceRequest.Writer.generate(builder.build(), true);
         Entity<String> entity = Entity.json(entityStr);

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobExecutionResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobExecutionResponse.java
@@ -248,66 +248,85 @@ public class JobExecutionResponse {
             return this;
         }
 
+        @Override
         public Builder fhirResourceType(String fhirResourceType) {
             jobParameter.setFhirResourceType(fhirResourceType);
             return this;
         }
 
+        @Override
         public Builder fhirSearchFromDate(String fhirSearchFromDate) {
             jobParameter.setFhirSearchFromDate(fhirSearchFromDate);
             return this;
         }
 
+        @Override
         public Builder cosBucketName(String cosBucketName) {
             jobParameter.setCosBucketName(cosBucketName);
             return this;
         }
 
+        @Override
         public Builder cosLocation(String cosLocation) {
             jobParameter.setCosLocation(cosLocation);
             return this;
         }
 
+        @Override
         public Builder cosEndpointUrl(String cosEndpointUrl) {
             jobParameter.setCosEndpointUrl(cosEndpointUrl);
             return this;
         }
 
+        @Override
         public Builder cosCredentialIbm(String cosCredentialIbm) {
             jobParameter.setCosCredentialIbm(cosCredentialIbm);
             return this;
         }
 
+        @Override
         public Builder cosApiKey(String cosApiKey) {
             jobParameter.setCosApiKey(cosApiKey);
             return this;
         }
 
+        @Override
         public Builder cosSrvInstId(String cosSrvInstId) {
             jobParameter.setCosSrvInstId(cosSrvInstId);
             return this;
         }
 
+        @Override
         public Builder cosBucketPathPrefix(String cosBucketPathPrefix) {
             jobParameter.setCosBucketPathPrefix(cosBucketPathPrefix);
             return this;
         }
 
+        @Override
         public Builder fhirTenant(String fhirTenant) {
             jobParameter.setFhirTenant(fhirTenant);
             return this;
         }
 
+        @Override
         public Builder fhirDataStoreId(String fhirDataStoreId) {
             jobParameter.setFhirDataStoreId(fhirDataStoreId);
             return this;
         }
 
+        @Override
         public Builder fhirTypeFilters(String fhirTypeFilters) {
             jobParameter.setFhirTypeFilters(fhirTypeFilters);
             return this;
         }
 
+        @Override
+        public Builder fhirExportFormat(String mediaType) {
+            jobParameter.setFhirExportFormat(mediaType);
+            return this;
+        }
+
+        @Override
         public Builder fhirPatientGroupId(String fhirPatientGroupId) {
             jobParameter.setFhirPatientGroupId(fhirPatientGroupId);
             return this;
@@ -331,16 +350,19 @@ public class JobExecutionResponse {
             return response;
         }
 
+        @Override
         public Builder fhirDataSourcesInfo(List<Input> inputs) {
             jobParameter.setInputs(inputs);
             return this;
         }
 
+        @Override
         public Builder fhirStorageType(StorageDetail storageDetails) {
             jobParameter.setStorageDetails(storageDetails);
             return this;
         }
 
+        @Override
         public Builder cosBucketNameOperationOutcome(String cosBucketNameOperationOutcome) {
             jobParameter.setCosOperationBucketNameOo(cosBucketNameOperationOutcome);
             return this;
@@ -456,7 +478,7 @@ public class JobExecutionResponse {
      * Generates JSON from this object.
      */
     public static class Writer {
-        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework. 
+        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework.
         private static final Map<java.lang.String, Object> properties =
                 Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
         private static final JsonGeneratorFactory PRETTY_PRINTING_GENERATOR_FACTORY =

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceRequest.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceRequest.java
@@ -36,6 +36,7 @@ import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
     "jobXMLName": "FhirBulkExportChunkJob",
     "jobParameters": {
         "fhir.resourcetype": "Patient",
+        "fhir.exportFormat": "application/fhir+ndjson",
         "cos.bucket.name": "fhir-r4-connectathon",
         "cos.location": "us",
         "cos.endpointurl": "https://fake.cloud",
@@ -111,76 +112,97 @@ public class JobInstanceRequest {
             return this;
         }
 
+        @Override
         public Builder fhirResourceType(String fhirResourceType) {
             jobParameter.setFhirResourceType(fhirResourceType);
             return this;
         }
 
+        @Override
         public Builder fhirSearchFromDate(String fhirSearchFromDate) {
             jobParameter.setFhirSearchFromDate(fhirSearchFromDate);
             return this;
         }
 
+        @Override
         public Builder cosBucketName(String cosBucketName) {
             jobParameter.setCosBucketName(cosBucketName);
             return this;
         }
 
+        @Override
         public Builder cosLocation(String cosLocation) {
             jobParameter.setCosLocation(cosLocation);
             return this;
         }
 
+        @Override
         public Builder cosEndpointUrl(String cosEndpointUrl) {
             jobParameter.setCosEndpointUrl(cosEndpointUrl);
             return this;
         }
 
+        @Override
         public Builder cosCredentialIbm(String cosCredentialIbm) {
             jobParameter.setCosCredentialIbm(cosCredentialIbm);
             return this;
         }
 
+        @Override
         public Builder cosApiKey(String cosApiKey) {
             jobParameter.setCosApiKey(cosApiKey);
             return this;
         }
 
+        @Override
         public Builder cosSrvInstId(String cosSrvInstId) {
             jobParameter.setCosSrvInstId(cosSrvInstId);
             return this;
         }
 
+        @Override
         public Builder fhirTenant(String fhirTenant) {
             jobParameter.setFhirTenant(fhirTenant);
             return this;
         }
 
+        @Override
         public Builder fhirDataStoreId(String fhirDataStoreId) {
             jobParameter.setFhirDataStoreId(fhirDataStoreId);
             return this;
         }
 
+        @Override
         public Builder fhirPatientGroupId(String fhirPatientGroupId) {
             jobParameter.setFhirPatientGroupId(fhirPatientGroupId);
             return this;
         }
 
+        @Override
         public Builder cosBucketPathPrefix(String cosBucketPathPrefix) {
             jobParameter.setCosBucketPathPrefix(cosBucketPathPrefix);
             return this;
         }
 
+        @Override
         public Builder fhirTypeFilters(String fhirTypeFilters) {
             jobParameter.setFhirTypeFilters(fhirTypeFilters);
             return this;
         }
 
+        @Override
+        public Builder fhirExportFormat(String mediaType) {
+            jobParameter.setFhirExportFormat(mediaType);
+            return this;
+        }
+
+        @Override
         public Builder fhirDataSourcesInfo(List<Input> inputs) {
             jobParameter.setInputs(inputs);
             return this;
         }
 
+        @Override
         public Builder fhirStorageType(StorageDetail storageDetails) {
             jobParameter.setStorageDetails(storageDetails);
             return this;
@@ -191,6 +213,7 @@ public class JobInstanceRequest {
             return request;
         }
 
+        @Override
         public Builder cosBucketNameOperationOutcome(String cosBucketNameOperationOutcome) {
             jobParameter.setCosOperationBucketNameOo(cosBucketNameOperationOutcome);
             return this;
@@ -248,7 +271,7 @@ public class JobInstanceRequest {
      * Generates JSON from this object.
      */
     public static class Writer {
-        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework. 
+        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework.
         private static final Map<java.lang.String, Object> properties =
                 Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
         private static final JsonGeneratorFactory PRETTY_PRINTING_GENERATOR_FACTORY =

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceResponse.java
@@ -277,7 +277,7 @@ public class JobInstanceResponse {
 
             } catch (Exception e) {
                 throw new FHIROperationException(
-                        "Problem parsing the Bulk Export Job's from jsonString response from the server", e);
+                        "Problem parsing the bulk export submission response from the job server", e);
             }
         }
 
@@ -370,7 +370,7 @@ public class JobInstanceResponse {
      * Generates JSON from this object.
      */
     public static class Writer {
-        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework. 
+        // This is an internal model and does not need to honor _pretty printing as it is only communicating with the java batch framework.
         private static final Map<java.lang.String, Object> properties =
                 Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
         private static final JsonGeneratorFactory PRETTY_PRINTING_GENERATOR_FACTORY =

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
@@ -40,6 +40,7 @@ public class JobParameter {
     private String fhirDataStoreId;
     private String fhirPatientGroupId;
     private String fhirTypeFilters;
+    private String fhirExportFormat;
     private List<Input> inputs;
     private StorageDetail storageDetail;
 
@@ -164,6 +165,14 @@ public class JobParameter {
         this.fhirTypeFilters = fhirTypeFilters;
     }
 
+    public String getFhirExportFormat() {
+        return fhirExportFormat;
+    }
+
+    public void setFhirExportFormat(String fhirExportFormat) {
+        this.fhirExportFormat = fhirExportFormat;
+    }
+
     public List<Input> getInputs() {
         return inputs;
     }
@@ -266,6 +275,10 @@ public class JobParameter {
                 generator.write("fhir.typeFilters", parameter.getFhirTypeFilters());
             }
 
+            if (parameter.getFhirExportFormat() != null) {
+                generator.write("fhir.exportFormat", parameter.getFhirExportFormat());
+            }
+
             if (parameter.getInputs() != null) {
                 generator.write("fhir.dataSourcesInfo", writeToBase64(parameter.getInputs()));
             }
@@ -336,6 +349,8 @@ public class JobParameter {
         public Builder fhirDataSourcesInfo(List<Input> inputs);
 
         public Builder fhirStorageType(StorageDetail storageDetail);
+
+        public Builder fhirExportFormat(String mediaType);
     }
 
     public static class Parser {
@@ -430,7 +445,7 @@ public class JobParameter {
 
         /**
          * converts back from input string to objects
-         * 
+         *
          * @param input
          * @return
          * @throws IOException

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/processor/impl/CosExportImpl.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.operation.bulkdata.processor.impl;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -30,6 +31,9 @@ import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
 import com.ibm.fhir.server.util.FHIROperationUtil;
 
+/**
+ * Import from or export to IBM Cloud Object Storage (COS) or similar S3-compatible object stores
+ */
 public class CosExportImpl implements ExportImportBulkData {
     private static final String CLASSNAME = CosExportImpl.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
@@ -46,8 +50,11 @@ public class CosExportImpl implements ExportImportBulkData {
             Instant since, List<String> types, List<String> typeFilters, FHIROperationContext operationContext,
             FHIRResourceHelpers resourceHelper) throws FHIROperationException {
         try {
+            Objects.requireNonNull(outputFormat, "outputFormat");
+
             Map<String, String> tmpProperties = new HashMap<>();
             tmpProperties.putAll(properties);
+
             if (ExportType.GROUP.equals(exportType)) {
                 if (logicalId == null || logicalId.isEmpty()) {
                     throw new FHIROperationException("Group export requires group id!");
@@ -59,6 +66,7 @@ public class CosExportImpl implements ExportImportBulkData {
                 tmpProperties.put(BulkDataConstants.PARAM_TYPE_FILTER, String.join(",", typeFilters));
             }
 
+            tmpProperties.put(BulkDataConstants.PARAM_OUTPUT_FORMAT, outputFormat.toString());
             addBaseUri(operationContext, tmpProperties);
 
             // Submit Job

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -17,6 +17,7 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 import javax.ws.rs.core.MediaType;
 
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Parameters;
@@ -74,7 +75,7 @@ public class BulkDataExportUtil {
                 .filter(p -> BulkDataConstants.PARAM_OUTPUT_FORMAT.equals(p.getName().getValue()))
                 .findFirst();
 
-        String mediaType = BulkDataConstants.MEDIA_TYPE_ND_JSON;
+        String mediaType = FHIRMediaType.APPLICATION_NDJSON;
         if (parameter.isPresent() && parameter.get().getValue().is(com.ibm.fhir.model.type.String.class)) {
             mediaType = retrieveOutputFormat(parameter.get().getValue().as(com.ibm.fhir.model.type.String.class).getValue());
         }
@@ -84,12 +85,12 @@ public class BulkDataExportUtil {
 
     private static String retrieveOutputFormat(String requestedFormat) throws FHIROperationException {
         // If the parameter isn't passed, use application/fhir+ndjson
-        String finalValue = BulkDataConstants.MEDIA_TYPE_ND_JSON;
+        String finalValue = FHIRMediaType.APPLICATION_NDJSON;
 
         if (requestedFormat != null) {
             // Normalize the NDJSON variants to MEDIA_TYPE_ND_JSON
             if (BulkDataConstants.NDJSON_VARIANTS.contains(requestedFormat)) {
-                requestedFormat = BulkDataConstants.MEDIA_TYPE_ND_JSON;
+                requestedFormat = FHIRMediaType.APPLICATION_NDJSON;
             }
 
             // We're checking that it's acceptable.


### PR DESCRIPTION
1. Updates to fhir-operation-bulkdata and fhir-bulkimportexport-webapp
to accept and pass alternative export formats (application/fhir+parquet)

2. Introduction of SparkParquetWriter for using Apache Spark to
introspect a list of JSON strings (e.g. FHIR resources), infer a schema,
and write the schema and data into a parquet file. This approach writes
specific files under a single logical file which is actually a
directory, allowing the schema to change over time.

3. Updates to the System ChunkReader and ChunkWriter for parquet;
instead of writing to a buffer in the reader, we simply add to the
context info and return the Resource objects themselves. Then, in the
writer, we always write a file with whatever resources were passed.
This works because Spark is managing the writes to COS for us and
Parquet has this notion of a multi-part logical file, so we don't need
the tight control over multi-part uploads like in the case of NDJSON.

Also includes miscellaneous cleanup, debug, and style changes.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>