### PR TITLE
Resolves Search Issues #1383 #1384 #1388

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -750,7 +750,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 .append(resourceTypeName).append("_LOGICAL_RESOURCES ").append(chainedLogicalResourceVar);
 
         // If we're dealing with anything other than id, then proceed to add the parameters table.
-        if (!"_id".equals(currentParm.getCode())) {
+        if (currentParm.getNextParameter() != null && !"_id".equals(currentParm.getNextParameter().getCode())) {
             whereClauseSegment.append(", ")
                 .append(QuerySegmentAggregator.tableName(resourceTypeName, currentParm.getNextParameter()))
                 .append(chainedParmVar);
@@ -782,10 +782,12 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 .append(AND)
                 .append(chainedResourceTableAlias)
                 .append("IS_DELETED").append(" <> 'Y'")
-                .append(AND)
-                .append(chainedParmTableAlias).append("LOGICAL_RESOURCE_ID = ")
+                .append(AND);
+        if (currentParm.getNextParameter() != null && !"_id".equals(currentParm.getNextParameter().getCode())) {
+            whereClauseSegment.append(chainedParmTableAlias).append("LOGICAL_RESOURCE_ID = ")
                 .append(chainedResourceTableAlias).append("LOGICAL_RESOURCE_ID")
                 .append(AND);
+        }
     }
 
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -9,19 +9,21 @@ package com.ibm.fhir.persistence.jdbc.util;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.AND;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.BIND_VAR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.CODE_SYSTEM_ID;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.COMMA;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DOT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EQ;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_EXPR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_PERCENT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ESCAPE_UNDERSCORE;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EXISTS;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.FROM;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.IN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.JOIN;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_JOIN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LIKE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.MAX_NUM_OF_COMPOSITE_COMPONENTS;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.NE;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.NOT;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ON;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.OR;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.PARAMETER_TABLE_ALIAS;
@@ -33,8 +35,6 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.TOKEN_VALUE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.UNDERSCORE_WILDCARD;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.WHERE;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.modifierOperatorMap;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.EXISTS;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.NOT;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -90,7 +90,7 @@ import com.ibm.fhir.search.util.SearchUtil;
  * the logical resource, not the resource version.
  * <br>
  * Useful column reference:<br>
- * 
+ *
  * <pre>
  * ------------------------
  * RESOURCE_TYPE_NAME    the formal name of the resource type e.g. 'Patient'
@@ -108,7 +108,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     private final ParameterDAO parameterDao;
     private final ResourceDAO resourceDao;
-    
+
     // Hints to use for certain queries
     private final QueryHints queryHints;
 
@@ -122,7 +122,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * Builds a query that returns the count of the search results that would be
      * found by applying the search parameters
      * contained within the passed search context.
-     * 
+     *
      * @param resourceType
      *                      - The type of resource being searched for.
      * @param searchContext
@@ -168,7 +168,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
     /**
      * Contains logic common to the building of both 'count' resource queries and
      * 'regular' resource queries.
-     * 
+     *
      * @param resourceType
      *                      The type of FHIR resource being searched for.
      * @param searchContext
@@ -276,7 +276,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * the mapping results in the default
      * operator, override the default operator with the passed operator if the
      * passed operator is not null.
-     * 
+     *
      * @param queryParm
      *                        - A valid query Parameter.
      * @param defaultOverride
@@ -309,7 +309,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * Builds a query segment for the passed query parameter.
-     * 
+     *
      * @param resourceType - A valid FHIR Resource type
      * @param queryParm    - A Parameter object describing the name, value and type
      *                     of search parm
@@ -373,7 +373,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 default:
                     throw new FHIRPersistenceNotSupportedException("Parm type not yet supported: " + type.value());
                 }
-            } else { 
+            } else {
                 NearLocationHandler handler = new NearLocationHandler();
                 List<Bounding> boundingAreas;
                 try {
@@ -429,7 +429,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                     // a 'starts with' search value.
                     searchValue = tempSearchValue + PERCENT_WILDCARD;
 
-                    // Specific processing for 
+                    // Specific processing for
                     if (Type.URI.compareTo(queryParm.getType()) == 0
                             && queryParm.getModifier() != null
                             && Modifier.BELOW.compareTo(queryParm.getModifier()) == 0) {
@@ -574,7 +574,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      *
      * <pre>
      * SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID
-     * FROM Observation_LOGICAL_RESOURCES LR 
+     * FROM Observation_LOGICAL_RESOURCES LR
      * JOIN Observation_RESOURCES R ON R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID AND R.IS_DELETED <> 'Y'
      * JOIN (SELECT DISTINCT LOGICAL_RESOURCE_ID FROM Observation_STR_VALUES
      * WHERE(P1.PARAMETER_NAME_ID = 107 AND (p1.STR_VALUE IN
@@ -586,7 +586,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      *                     CP2.PARAMETER_NAME_ID = 5 AND CP2.STR_VALUE = 'Monella')))
      * TMP0 ON TMP0.LOGICAL_RESOURCE_ID = R.LOGICAL_RESOURCE_ID;
      * </pre>
-     * 
+     *
      * @see https://www.hl7.org/fhir/search.html#reference (section 2.1.1.4.13)
      * @param queryParm
      *                  - A Parameter representing a chained query.
@@ -616,7 +616,6 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         while (currentParm != null) {
             QueryParameter nextParameter = currentParm.getNextParameter();
             if (nextParameter != null) {
-                Type nextParmaterType = nextParameter.getType();
                 if (refParmIndex == 0) {
                     // Must build this first piece using px placeholder table alias, which will be replaced with a
                     // generated value in the buildQuery() method.
@@ -649,16 +648,25 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 resourceTypeName = currentParm.getModifierResourceTypeName();
                 // Build this piece: (SELECT 'resource-type-name' || '/' || CLRx.LOGICAL_ID ...
                 whereClauseSegment.append(LEFT_PAREN);
-                appendInnerSelect(whereClauseSegment, currentParm, nextParmaterType, resourceTypeName,
+                appendInnerSelect(whereClauseSegment, currentParm, resourceTypeName,
                         chainedResourceVar, chainedLogicalResourceVar, chainedParmVar);
             } else {
                 // This logic processes the LAST parameter in the chain.
                 // Build this piece: CPx.PARAMETER_NAME_ID = x AND CPx.STR_VALUE = ?
                 if (chainedParmVar == null) {
-                    chainedParmVar            = CP + 1;
+                    chainedParmVar = CP + 1;
                 }
                 Class<?> chainedResourceType = ModelSupport.getResourceType(resourceTypeName);
-                SqlQueryData sqlQueryData = buildQueryParm(chainedResourceType, currentParm, chainedParmVar);
+
+                String code = currentParm.getCode();
+                SqlQueryData sqlQueryData;
+                if (!"_id".equals(code)) {
+                    sqlQueryData = buildQueryParm(chainedResourceType, currentParm, chainedParmVar);
+                } else {
+                    // The code '_id' is only going to be the end of the change as it is a base element.
+                    // We know at this point this is an '_id' and at the tail of the parameter chain
+                    sqlQueryData = buildChainedIdClause(currentParm, chainedParmVar);
+                }
 
                 if (log.isLoggable(Level.FINE)) {
                     log.fine("chained sqlQueryData[" + chainedParmVar + "] = " + sqlQueryData.getQueryString());
@@ -680,6 +688,35 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         return queryData;
     }
 
+    /*
+     * Builds the specific handling for exact matches on _id.
+     * The procedure here is SIMILAR to that of QuerySegmentAggregator.processFromClauseForId
+     *
+     * Results in a query like: CP1.LOGICAL_ID IN (?)
+     */
+    private SqlQueryData buildChainedIdClause(QueryParameter currentParm, String chainedParmVar) {
+        StringBuilder whereClauseSegment = new StringBuilder();
+        List<Object> bindVariables = new ArrayList<>();
+
+        whereClauseSegment
+            .append(chainedParmVar.replace("CP", "CLR")).append(DOT).append("LOGICAL_ID").append(" IN (");
+
+        List<QueryParameterValue> vals = currentParm.getValues();
+        boolean add = false;
+        for (QueryParameterValue v : vals) {
+            if (add) {
+                whereClauseSegment.append(COMMA);
+            } else {
+                add = true;
+            }
+            whereClauseSegment.append(BIND_VAR);
+            bindVariables.add(SqlParameterEncoder.encode(v.getValueCode()));
+        }
+        whereClauseSegment.append(") ");
+
+        return new SqlQueryData(whereClauseSegment.toString(), bindVariables);
+    }
+
     private void appendMidChainParm(StringBuilder whereClauseSegment, QueryParameter currentParm, String chainedParmVar)
             throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException, FHIRPersistenceException {
         Integer parameterNameId = ParameterNamesCache.getParameterNameId(currentParm.getCode());
@@ -694,9 +731,8 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 .append(AND).append(chainedParmVar).append(DOT).append(STR_VALUE).append(IN);
     }
 
-    private void appendInnerSelect(StringBuilder whereClauseSegment, QueryParameter currentParm, Type nextParmaterType,
-            String resourceTypeName,
-            String chainedResourceVar, String chainedLogicalResourceVar, String chainedParmVar) {
+    private void appendInnerSelect(StringBuilder whereClauseSegment, QueryParameter currentParm,
+            String resourceTypeName, String chainedResourceVar, String chainedLogicalResourceVar, String chainedParmVar) {
         String chainedResourceTableAlias = chainedResourceVar + ".";
         String chainedLogicalResourceTableAlias = chainedLogicalResourceVar + ".";
         String chainedParmTableAlias = chainedParmVar + ".";
@@ -711,9 +747,14 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         // Build this piece: FROM Device_RESOURCES CR1, Device_LOGICAL_RESOURCES CLR1, Device_STR_VALUES CP1 WHERE
         whereClauseSegment.append(FROM)
                 .append(resourceTypeName).append("_RESOURCES ").append(chainedResourceVar).append(", ")
-                .append(resourceTypeName).append("_LOGICAL_RESOURCES ").append(chainedLogicalResourceVar).append(", ")
+                .append(resourceTypeName).append("_LOGICAL_RESOURCES ").append(chainedLogicalResourceVar);
+
+        // If we're dealing with anything other than id, then proceed to add the parameters table.
+        if (!"_id".equals(currentParm.getCode())) {
+            whereClauseSegment.append(", ")
                 .append(QuerySegmentAggregator.tableName(resourceTypeName, currentParm.getNextParameter()))
                 .append(chainedParmVar);
+        }
 
         if (Type.COMPOSITE.equals(nextParameter.getType())) {
             if (nextParameter.getValues() != null && !nextParameter.getValues().isEmpty()) {
@@ -734,7 +775,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
         whereClauseSegment.append(" WHERE ");
 
-        // CR1.RESOURCE_ID = CLR1.CURRENT_RESOURCE_ID AND CR1.IS_DELETED <> 'Y' AND 
+        // CR1.RESOURCE_ID = CLR1.CURRENT_RESOURCE_ID AND CR1.IS_DELETED <> 'Y' AND
         // CP1.LOGICAL_RESOURCE_ID = CLR1.LOGICAL_RESOURCE_ID AND
         whereClauseSegment.append(chainedResourceTableAlias).append("RESOURCE_ID = ")
                 .append(chainedLogicalResourceTableAlias).append("CURRENT_RESOURCE_ID")
@@ -751,13 +792,13 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * This method handles the processing of a wildcard chained reference parameter.
      * The wildcard represents ALL FHIR
      * resource types stored in the FHIR database.
-     * 
+     *
      * @throws Exception
      */
     private void processWildcardChainedRefParm(QueryParameter currentParm, String chainedResourceVar,
             String chainedLogicalResourceVar, String chainedParmVar,
             StringBuilder whereClauseSegment, List<Object> bindVariables) throws Exception {
-        final String METHODNAME = "processChainedReferenceParm";
+        final String METHODNAME = "processWildcardChainedRefParm";
         log.entering(CLASSNAME, METHODNAME, currentParm.toString());
 
         String resourceTypeName;
@@ -787,7 +828,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
                 whereClauseSegment.append(LEFT_PAREN);
             }
 
-            appendInnerSelect(whereClauseSegment, currentParm, lastParm.getType(), resourceTypeName, chainedResourceVar,
+            appendInnerSelect(whereClauseSegment, currentParm, resourceTypeName, chainedResourceVar,
                     chainedLogicalResourceVar, chainedParmVar);
 
             // This logic processes the LAST parameter in the chain.
@@ -809,7 +850,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * define resources that are part of a
      * comparment-based search.
      * Example inclusion criteria for AuditEvent in the Patient compartment:
-     * 
+     *
      * <pre>
      * {
      *        "name": "AuditEvent",
@@ -824,7 +865,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * <li>PARAMETER_NAME_ID 13 = 'participant'
      * <li>PARAMETER_NAME_ID 14 = 'patient'
      * <li>PARAMETER_NAME_ID 16 = 'reference'
-     * 
+     *
      * <pre>
      *    SELECT COUNT(R.RESOURCE_ID) FROM
      *    AuditEvent_RESOURCES R, AuditEvent_LOGICAL_RESOURCES LR , AuditEvent_STR_VALUES P1 WHERE
@@ -864,7 +905,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      *                CP1.RESOURCE_ID = CR1.RESOURCE_ID AND
      *                CP1.PARAMETER_NAME_ID=14 AND CP1.STR_VALUE = ?)))));
      * </pre>
-     * 
+     *
      * @throws Exception
      * @see compartments.json for the specificaiton of compartments, resources
      *      contained in each compartment, and the
@@ -1029,8 +1070,8 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         // (P1.PARAMETER_NAME_ID = x AND
         this.populateNameIdSubSegment(whereClauseSegment, queryParm.getCode(), tableAlias);
 
-        // Calls to the NumberParmBehaviorUtil which encapsulates the precision 
-        // selection criteria. 
+        // Calls to the NumberParmBehaviorUtil which encapsulates the precision
+        // selection criteria.
         NumberParmBehaviorUtil.executeBehavior(whereClauseSegment, queryParm, bindVariables, resourceType, tableAlias,
                 this);
         SqlQueryData queryData = new SqlQueryData(whereClauseSegment.toString(), bindVariables);
@@ -1056,8 +1097,8 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
         // (P1.PARAMETER_NAME_ID = x AND
         this.populateNameIdSubSegment(whereClauseSegment, queryParm.getCode(), tableAlias);
 
-        // Calls to the QuantityParmBehaviorUtil which encapsulates the precision 
-        // selection criteria. 
+        // Calls to the QuantityParmBehaviorUtil which encapsulates the precision
+        // selection criteria.
         QuantityParmBehaviorUtil behaviorUtil = new QuantityParmBehaviorUtil();
         behaviorUtil.executeBehavior(whereClauseSegment, queryParm, bindVariables, tableAlias, parameterDao);
         SqlQueryData queryData = new SqlQueryData(whereClauseSegment.toString(), bindVariables);
@@ -1073,7 +1114,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * Creates a query segment for a URI type parameter.
-     * 
+     *
      * @param queryParm  - The query parameter
      * @param tableAlias - An alias for the table to query
      * @return SqlQueryData - An object containing query segment
@@ -1095,7 +1136,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * Creates a query segment for a URI type parameter.
-     * 
+     *
      * @param queryParm  - The query parameter
      * @param tableAlias - An alias for the table to query
      * @return SqlQueryData - An object containing query segment
@@ -1171,7 +1212,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * Populates the parameter name sub-segment of the passed where clause segment.
-     * 
+     *
      * @param whereClauseSegment
      * @param queryParmName
      * @throws FHIRPersistenceException
@@ -1203,7 +1244,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * Use -1 in place of a null literal, otherwise return the literal value
-     * 
+     *
      * @param n
      * @return
      */
@@ -1218,7 +1259,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * criteria. That new Parameter is then
      * passed to the inherited processChainedReferenceParamter() method to generate
      * the required where clause segment.
-     * 
+     *
      * @see https://www.hl7.org/fhir/compartments.html
      * @param queryParm
      *                  - A Parameter representing chained inclusion criterion.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -11,9 +11,9 @@ import static com.ibm.fhir.persistence.jdbc.JDBCConstants.DEFAULT_ORDERING;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.FROM;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.JOIN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.LEFT_PAREN;
-import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.ON;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.PARAMETER_TABLE_ALIAS;
+import static com.ibm.fhir.persistence.jdbc.JDBCConstants.RIGHT_PAREN;
 import static com.ibm.fhir.persistence.jdbc.JDBCConstants.UNION;
 import static com.ibm.fhir.persistence.jdbc.util.type.LastUpdatedParmBehaviorUtil.LAST_UPDATED;
 
@@ -50,7 +50,7 @@ public class QuerySegmentAggregator {
     protected static final String NEW_SELECT_ROOT =
             "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
     protected static final String SELECT_DISTINCT_ROOT = "SELECT DISTINCT LR.LOGICAL_RESOURCE_ID, LR.LOGICAL_ID, LR.CURRENT_RESOURCE_ID";
-    
+
     // Used for chained searches
     protected static final String SELECT_ROOT =
             "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID ";
@@ -63,7 +63,7 @@ public class QuerySegmentAggregator {
     protected static final String SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT = " SELECT COUNT(DISTINCT LR.LOGICAL_RESOURCE_ID) AS CNT ";
     protected static final String WHERE_CLAUSE_ROOT = "WHERE R.IS_DELETED <> 'Y'";
 
-    // Enables the SKIP_WHERE of WHERE clauses. 
+    // Enables the SKIP_WHERE of WHERE clauses.
     public static final String ID = "_id";
     public static final String ID_COLUMN_NAME = "LOGICAL_ID ";
     protected static final Set<String> SKIP_WHERE =
@@ -73,7 +73,7 @@ public class QuerySegmentAggregator {
 
     // Used for whole system search on multiple resource types.
     private List<String> resourceTypes = null;
-    
+
     // Access to hints to use for certain queries. Can be null.
     private final QueryHints queryHints;
 
@@ -99,7 +99,7 @@ public class QuerySegmentAggregator {
 
     /**
      * Constructs a new QueryBuilderHelper
-     * 
+     *
      * @param resourceType - The type of FHIR Resource to be searched for.
      * @param offset       - The beginning index of the first search result.
      * @param pageSize     - The max number of requested search results.
@@ -124,7 +124,7 @@ public class QuerySegmentAggregator {
     /**
      * Adds a query segment, which is a where clause segment corresponding to the
      * passed query Parameter and its encapsulated search values.
-     * 
+     *
      * @param querySegment A piece of a SQL WHERE clause
      * @param queryParm    - The corresponding query parameter
      */
@@ -150,8 +150,8 @@ public class QuerySegmentAggregator {
      * Builds a complete SQL Query based upon the encapsulated query segments and
      * bind variables. The general form of query we are building looks like this:
      *
-     *   SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID  
-     *     FROM Observation_RESOURCES R 
+     *   SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID
+     *     FROM Observation_RESOURCES R
      *     JOIN (
      *   SELECT DISTINCT LR.LOGICAL_RESOURCE_ID, LR.LOGICAL_ID, LR.CURRENT_RESOURCE_ID
      *     FROM Observation_LOGICAL_RESOURCES LR
@@ -162,12 +162,12 @@ public class QuerySegmentAggregator {
      *       ON pv2.PARAMETER_NAME_ID=1396 AND pv2.STR_VALUE = :p2
      *      AND pv2.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID) LR
      *       ON R.LOGICAL_RESOURCE_ID=LR.LOGICAL_RESOURCE_ID
-     *      AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID     
+     *      AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID
      *      AND R.IS_DELETED <> 'Y'
-     * 
+     *
      * The SELECT DISTINCT is required to remove duplicates caused by repeated parameter
      * values.
-     * 
+     *
      * @return SqlQueryData - contains the complete SQL query string and any
      *         associated bind variables.
      * @throws Exception
@@ -183,7 +183,7 @@ public class QuerySegmentAggregator {
             // Join the RESOURCE table after we calculate the distinct set of logical resources.
             // This way, the sort doesn't have to deal with lugging around a large data payload.
             StringBuilder queryString = new StringBuilder();
-            
+
             queryString.append(NEW_SELECT_ROOT);
             queryString.append(FROM);
             queryString.append(resourceType.getSimpleName().toUpperCase() + "_RESOURCES R");
@@ -196,7 +196,7 @@ public class QuerySegmentAggregator {
             queryString.append("     R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID ");
             queryString.append(" AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ");
             queryString.append(" AND R.IS_DELETED <> 'Y'");
-            
+
 
             // Bind Variables
             List<Object> allBindVariables = new ArrayList<>();
@@ -246,7 +246,7 @@ public class QuerySegmentAggregator {
     /**
      * Builds a complete SQL count query based upon the encapsulated query segments
      * and bind variables.
-     * 
+     *
      * @return SqlQueryData - contains the complete SQL count query string and any
      *         associated bind variables.
      * @throws Exception
@@ -267,7 +267,7 @@ public class QuerySegmentAggregator {
             buildFromClause(queryString, simpleName);
             buildWhereClause(queryString, null);
 
-            // An important step here is to add _id then all other values. 
+            // An important step here is to add _id then all other values.
             List<Object> allBindVariables = new ArrayList<>();
             allBindVariables.addAll(idsObjects);
             allBindVariables.addAll(lastUpdatedObjects);
@@ -290,7 +290,7 @@ public class QuerySegmentAggregator {
      * the passed select-root strings.
      * A FHIR system level query spans multiple resource types, and therefore spans
      * multiple tables in the database.
-     * 
+     *
      * @param selectRoot      - The text of the outer SELECT ('SELECT' to 'FROM')
      * @param subSelectRoot   - The text of the inner SELECT root to use in each
      *                        sub-select
@@ -325,7 +325,7 @@ public class QuerySegmentAggregator {
             // Only search the required resource types if any.
             if (this.resourceTypes == null || this.resourceTypes.contains(resourceTypeName)) {
                 // Skip the UNION on the first, and change to indicate
-                // subsequent resourceTypes are to be unioned. 
+                // subsequent resourceTypes are to be unioned.
                 if (resourceTypeProcessed) {
                     queryString.append(UNION);
                 } else {
@@ -342,7 +342,7 @@ public class QuerySegmentAggregator {
                 // need to clear before we call processFromClauseForLastUpdated
                 idsObjects.clear();
                 lastUpdatedObjects.clear();
-                
+
                 // queryString.append(resourceTypeName + "_RESOURCES R");
                 // might need a more sophisticated select for the RESOURCES table
                 // Get the distinct set of logical resources matching the search criteria
@@ -358,7 +358,7 @@ public class QuerySegmentAggregator {
                 queryString.append(JOIN);
                 processFromClauseForLastUpdated(queryString, resourceTypeName);
                 queryString.append(" AS R ");
-                                
+
                 // An important step here is to add _id and _lastUpdated
                 allBindVariables.addAll(idsObjects);
                 allBindVariables.addAll(lastUpdatedObjects);
@@ -367,7 +367,7 @@ public class QuerySegmentAggregator {
                 queryString.append("     R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID ");
                 queryString.append(" AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ");
                 queryString.append(" AND R.IS_DELETED <> 'Y'");
-                
+
                 //Adding all other values to the bind variable list for this resource type.
                 for (SqlQueryData querySegment : this.querySegments) {
                     allBindVariables.addAll(querySegment.getBindVariables());
@@ -395,7 +395,7 @@ public class QuerySegmentAggregator {
      * Builds the FROM clause for the SQL query being generated. The appropriate
      * Resource and Parameter table names are included
      * along with an alias for each table.
-     * 
+     *
      * @return A String containing the FROM clause
      */
     protected void buildFromClause(StringBuilder fromClause, String simpleName) {
@@ -403,7 +403,7 @@ public class QuerySegmentAggregator {
         log.entering(CLASSNAME, METHODNAME);
         idsObjects.clear();
         lastUpdatedObjects.clear();
-        
+
         fromClause.append(FROM);
         processFromClauseForId(fromClause, simpleName); // logical resources
         fromClause.append(" LR ");
@@ -427,23 +427,25 @@ public class QuerySegmentAggregator {
     protected void buildFromClauseSimple(StringBuilder fromClause, String simpleName) {
         final String METHODNAME = "buildFromClauseSimple(StringBuilder fromClause, String simpleName)";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         fromClause.append(FROM);
         processFromClauseForId(fromClause, simpleName); // logical resources
         fromClause.append(" LR ");
 
         log.exiting(CLASSNAME, METHODNAME);
     }
-    
-    
-    
+
+
+
     /*
      * Processes the From Clause for _id, as _id is contained in the
      * LOGICAL_RESOURCES
      * else, return a default table name
-     * 
+     *
+     * The method here is similar to JDBCQueryBuilder.buildChainedIdClause
+     *
      * @param fromClause the non-null StringBuilder
-     * 
+     *
      * @param target is the Target Type for the search
      */
     public void processFromClauseForId(StringBuilder fromClause, String target) {
@@ -451,7 +453,7 @@ public class QuerySegmentAggregator {
          * The not null path uses a DERIVED TABLE.
          * ILR refers to the intermediate Logical resource table and is just a
          * convenient name.
-         * 
+         *
          * The IN clause is effective here to drive a smaller table in the subsequent
          * LEFT INNER JOINS
          * off the derived tables.
@@ -461,7 +463,7 @@ public class QuerySegmentAggregator {
          */
 
         if (!queryParamIds.isEmpty()) {
-            // ID, then special handling. 
+            // ID, then special handling.
             fromClause.append("( SELECT LOGICAL_ID, LOGICAL_RESOURCE_ID, CURRENT_RESOURCE_ID FROM ");
             fromClause.append(target);
             fromClause.append("_LOGICAL_RESOURCES");
@@ -489,7 +491,7 @@ public class QuerySegmentAggregator {
             }
             fromClause.append(" )) ");
         } else {
-            // Not ID, then go to the default. 
+            // Not ID, then go to the default.
             fromClause.append(target);
             fromClause.append("_LOGICAL_RESOURCES");
         }
@@ -505,7 +507,7 @@ public class QuerySegmentAggregator {
             behaviorUtil.buildLastUpdatedDerivedTable(fromClause, target, queryParmLastUpdateds);
             lastUpdatedObjects.addAll(behaviorUtil.getBindVariables());
         } else {
-            // Not _lastUpdated, then go to the default. 
+            // Not _lastUpdated, then go to the default.
             fromClause.append(target);
             fromClause.append("_RESOURCES");
         }
@@ -515,15 +517,15 @@ public class QuerySegmentAggregator {
      * Builds the WHERE clause for the query being generated. This method aggregates
      * the contained query segments, and ties those segments back
      * to the appropriate parameter table alias.
-     * 
+     *
      *  ...
      *  SELECT DISTINCT LR.LOGICAL_RESOURCE_ID, LR.LOGICAL_ID, LR.CURRENT_RESOURCE_ID
      *    FROM Observation_LOGICAL_RESOURCES LR
      *    JOIN Observation_TOKEN_VALUES AS param0
      *      ON param0.PARAMETER_NAME_ID=1191 AND param0.TOKEN_VALUE = :p1
      *     AND param0.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID
-     *  ... 
-     *  
+     *  ...
+     *
      * @param whereClause
      * @param overrideType if not null, then it's the default type used in the
      *                     building of the where clause.
@@ -533,7 +535,7 @@ public class QuerySegmentAggregator {
         final String METHODNAME = "buildWhereClause";
         log.entering(CLASSNAME, METHODNAME);
 
-        // Override the Type is null, then use the default type here. 
+        // Override the Type is null, then use the default type here.
         if (overrideType == null) {
             overrideType = this.resourceType.getSimpleName();
         }
@@ -544,9 +546,9 @@ public class QuerySegmentAggregator {
             SqlQueryData querySegment = this.querySegments.get(i);
             QueryParameter param = this.searchQueryParameters.get(i);
 
-            // Being bold here... this part should NEVER get a NPE. 
+            // Being bold here... this part should NEVER get a NPE.
             // The parameter would not be parsed and passed successfully,
-            // the NPE would have occurred earlier in the stack. 
+            // the NPE would have occurred earlier in the stack.
             String code = param.getCode();
             if (!SKIP_WHERE.contains(code)) {
 
@@ -562,7 +564,7 @@ public class QuerySegmentAggregator {
 
                         final String paramTableAlias = "param" + i;
                         final String onFilter = querySegment.getQueryString().replaceAll(PARAMETER_TABLE_ALIAS + "\\.", paramTableAlias + ".");
-                        
+
                         whereClause.append(JOIN);
                         whereClause.append(tableName(overrideType, param));
                         whereClause.append(" AS " + paramTableAlias);
@@ -604,7 +606,10 @@ public class QuerySegmentAggregator {
                         .append(".LOGICAL_RESOURCE_ID = R.LOGICAL_RESOURCE_ID");
                     }
                 }
-            } // end if SKIP_WHERE
+            } else {
+                // end if SKIP_WHERE
+                System.out.println(whereClause);
+            }
         } // end for
 
         log.exiting(CLASSNAME, METHODNAME);
@@ -664,7 +669,7 @@ public class QuerySegmentAggregator {
      * Adds the appropriate pagination clauses to the passed query string buffer,
      * based on the type
      * of database we're running against.
-     * 
+     *
      * @param queryString A query string buffer.
      * @throws Exception
      */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -363,7 +363,7 @@ public class QuerySegmentAggregator {
                 queryString.append(" AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ");
                 queryString.append(" AND R.IS_DELETED <> 'Y'");
 
-                // An important step here is to add _id, values table bind variables, and then and _lastUpdated
+                // An important step here is to add _id, values table bind variables, and then _lastUpdated
                 allBindVariables.addAll(idsObjects);
                 //Adding all other values to the bind variable list for this resource type.
                 for (SqlQueryData querySegment : this.querySegments) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -198,13 +198,14 @@ public class QuerySegmentAggregator {
             queryString.append(" AND R.IS_DELETED <> 'Y'");
 
 
-            // Bind Variables
+            // An important step here is to add _id, values table bind variables, and then and _lastUpdated
             List<Object> allBindVariables = new ArrayList<>();
             allBindVariables.addAll(idsObjects);
-            allBindVariables.addAll(lastUpdatedObjects);
+
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
+            allBindVariables.addAll(lastUpdatedObjects);
 
             // Add default ordering
             queryString.append(DEFAULT_ORDERING);
@@ -267,13 +268,14 @@ public class QuerySegmentAggregator {
             buildFromClause(queryString, simpleName);
             buildWhereClause(queryString, null);
 
-            // An important step here is to add _id then all other values.
+            // An important step here is to add _id, values table bind variables, and then and _lastUpdated
             List<Object> allBindVariables = new ArrayList<>();
             allBindVariables.addAll(idsObjects);
-            allBindVariables.addAll(lastUpdatedObjects);
+
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
+            allBindVariables.addAll(lastUpdatedObjects);
 
             addOptimizerHint(queryString);
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
@@ -343,7 +345,6 @@ public class QuerySegmentAggregator {
                 idsObjects.clear();
                 lastUpdatedObjects.clear();
 
-                // queryString.append(resourceTypeName + "_RESOURCES R");
                 // might need a more sophisticated select for the RESOURCES table
                 // Get the distinct set of logical resources matching the search criteria
 
@@ -359,19 +360,18 @@ public class QuerySegmentAggregator {
                 processFromClauseForLastUpdated(queryString, resourceTypeName);
                 queryString.append(" AS R ");
 
-                // An important step here is to add _id and _lastUpdated
-                allBindVariables.addAll(idsObjects);
-                allBindVariables.addAll(lastUpdatedObjects);
-
                 queryString.append(ON);
                 queryString.append("     R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID ");
                 queryString.append(" AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ");
                 queryString.append(" AND R.IS_DELETED <> 'Y'");
 
+                // An important step here is to add _id, values table bind variables, and then and _lastUpdated
+                allBindVariables.addAll(idsObjects);
                 //Adding all other values to the bind variable list for this resource type.
                 for (SqlQueryData querySegment : this.querySegments) {
                     allBindVariables.addAll(querySegment.getBindVariables());
                 }
+                allBindVariables.addAll(lastUpdatedObjects);
             }
         }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -198,14 +198,13 @@ public class QuerySegmentAggregator {
             queryString.append(" AND R.IS_DELETED <> 'Y'");
 
 
-            // An important step here is to add _id, values table bind variables, and then and _lastUpdated
+            // An important step here is to add _id, _lastUpdated, and then values table bind variables
             List<Object> allBindVariables = new ArrayList<>();
             allBindVariables.addAll(idsObjects);
-
+            allBindVariables.addAll(lastUpdatedObjects);
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
-            allBindVariables.addAll(lastUpdatedObjects);
 
             // Add default ordering
             queryString.append(DEFAULT_ORDERING);
@@ -268,14 +267,13 @@ public class QuerySegmentAggregator {
             buildFromClause(queryString, simpleName);
             buildWhereClause(queryString, null);
 
-            // An important step here is to add _id, values table bind variables, and then and _lastUpdated
+            // An important step here is to add _id, _lastUpdated, and then values table bind variables
             List<Object> allBindVariables = new ArrayList<>();
             allBindVariables.addAll(idsObjects);
-
+            allBindVariables.addAll(lastUpdatedObjects);
             for (SqlQueryData querySegment : this.querySegments) {
                 allBindVariables.addAll(querySegment.getBindVariables());
             }
-            allBindVariables.addAll(lastUpdatedObjects);
 
             addOptimizerHint(queryString);
             queryData = new SqlQueryData(queryString.toString(), allBindVariables);
@@ -606,10 +604,7 @@ public class QuerySegmentAggregator {
                         .append(".LOGICAL_RESOURCE_ID = R.LOGICAL_RESOURCE_ID");
                     }
                 }
-            } else {
-                // end if SKIP_WHERE
-                System.out.println(whereClause);
-            }
+            } // end if SKIP_WHERE
         } // end for
 
         log.exiting(CLASSNAME, METHODNAME);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/LocationParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/LocationParmBehaviorUtilTest.java
@@ -21,7 +21,6 @@ import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.jdbc.JDBCConstants;
-import com.ibm.fhir.persistence.jdbc.util.JDBCQueryBuilder;
 import com.ibm.fhir.persistence.jdbc.util.type.LocationParmBehaviorUtil;
 import com.ibm.fhir.search.location.bounding.Bounding;
 import com.ibm.fhir.search.location.bounding.BoundingBox;

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/PopulateStaticTablesDerbyTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/PopulateStaticTablesDerbyTest.java
@@ -19,21 +19,18 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.database.utils.api.ITransaction;
 import com.ibm.fhir.model.test.TestUtil;
-import com.ibm.fhir.persistence.jdbc.connection.Action;
-import com.ibm.fhir.persistence.jdbc.connection.DisableAutocommitAction;
 import com.ibm.fhir.persistence.jdbc.connection.FHIRDbConnectionStrategy;
 import com.ibm.fhir.persistence.jdbc.connection.FHIRDbTestConnectionStrategy;
-import com.ibm.fhir.persistence.jdbc.connection.SetSchemaAction;
 
 /**
- * 
+ * Tests the static derby tables.
  */
 public class PopulateStaticTablesDerbyTest {
     private Properties testProps;
 
     // wraps up everything we need for a FHIR/Derby test database
     private DerbyTestHelper testHelper;
- 
+
     public PopulateStaticTablesDerbyTest() throws Exception {
         this.testProps = TestUtil.readTestProperties("test.jdbc.properties");
         assertNotNull(testProps);
@@ -45,12 +42,12 @@ public class PopulateStaticTablesDerbyTest {
         // we have to
         this.testHelper = new DerbyTestHelper(1);
     }
-    
+
     @Test(groups = { "derby" })
     public void testGetDerbyConnectionAndCheckStaticTables() throws Exception {
-                
+
         FHIRDbConnectionStrategy strat = new FHIRDbTestConnectionStrategy(testHelper.getConnectionProvider(), null);
-        
+
         boolean result1 = false;
         boolean result2 = false;
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -37,7 +37,6 @@ import com.ibm.fhir.model.resource.RelatedPerson;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Reference;
-import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.persistence.MultiResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.search.context.FHIRSearchContext;
@@ -50,6 +49,7 @@ import com.ibm.fhir.search.util.SearchUtil;
 public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearchTest {
     private Boolean DEBUG = Boolean.FALSE;
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
     }
@@ -58,16 +58,17 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
         assertNotNull(resource);
         assertNotNull(resource.getId());
 
-        String resourceTypeName = FHIRUtil.getResourceTypeName(resource);
+        String resourceTypeName = resource.getClass().getSimpleName();
         return Reference.builder()
                 .reference(string(resourceTypeName + "/" + resource.getId()))
                 .build();
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
 
-        // this might deserve its own method, but just use setTenant for now 
+        // this might deserve its own method, but just use setTenant for now
         // since its called before creating any resources
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-4:00"));
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
@@ -92,7 +92,7 @@ public class SearchChainTest extends FHIRServerTestBase {
                 .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
-        System.out.println(bundle);
+
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -106,7 +106,7 @@ public class SearchChainTest extends FHIRServerTestBase {
                 .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
-        System.out.println(bundle);
+
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 0);
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
@@ -1,0 +1,113 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Procedure;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.type.code.AdministrativeGender;
+
+/**
+ * The tests execute the chained behavior in order to exercise reference chains.
+ */
+public class SearchChainTest extends FHIRServerTestBase {
+    private String patientId;
+    private String procedureId;
+
+    @Test(groups = { "server-search-chain" })
+    public void testCreatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+        patient = patient.toBuilder().gender(AdministrativeGender.MALE).build();
+
+        Entity<Patient> entity =
+                Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response =
+                target.path("Patient").request()
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        TestUtil.assertResourceEquals(patient, responsePatient);
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient"})
+    public void testCreateProcedure() throws Exception {
+        WebTarget target = getWebTarget();
+
+        Reference reference = Reference.builder()
+                .reference(com.ibm.fhir.model.type.String.of("Patient/" + patientId)).build();
+
+        // Build a new Procedure and then call the 'create' API.
+        Procedure procedure = TestUtil.readExampleResource("json/spec/procedure-example-physical-therapy.json");
+        procedure = procedure.toBuilder().subject(reference).build();
+
+        // Add Subject reference to the procedure
+        Entity<Procedure> entity =
+                Entity.entity(procedure, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Procedure").request()
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        procedureId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Procedure/" + procedureId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchPatientWithId() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure").queryParam("subject:Patient._id", patientId)
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+        System.out.println(bundle);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchPatientWithIdThatDoesntExist() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure").queryParam("subject:Patient._id", patientId + "BAD")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+        System.out.println(bundle);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() == 0);
+    }
+}

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchLastUpdatedIdTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchLastUpdatedIdTest.java
@@ -1,0 +1,261 @@
+/*
+ * (C) Copyright IBM Corp. 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static com.ibm.fhir.model.type.Xhtml.xhtml;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.Id;
+import com.ibm.fhir.model.type.Meta;
+import com.ibm.fhir.model.type.Narrative;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.AdministrativeGender;
+import com.ibm.fhir.model.type.code.NarrativeStatus;
+
+/**
+ * The tests the behavior of _lastUpdated and _id in combination with other search parameters.
+ * These are top level parameters which are used outside of the values tables
+ */
+public class SearchLastUpdatedIdTest extends FHIRServerTestBase {
+    private String patientId;
+
+    protected final String TAG_SYSTEM = "http://ibm.com/fhir/tag";
+    protected final String TAG = UUID.randomUUID().toString();
+
+    private final Map<String, String> TEST_CASES = new LinkedHashMap<String, String>() {
+        private static final long serialVersionUID = -7809685447831223L;
+        {
+            // Test ONLY _id
+            put("ID_ONLY", "_id=PATIENT_ID");
+            put("ID_MULTIPLE_VALUES_ONLY", "_id=PATIENT_ID,PATIENT_ID_2");
+            put("ID_MULTIPLES", "_id=PATIENT_ID,PATIENT_ID_2&_id=PATIENT_ID,PATIENT_ID_2");
+            // Test ONLY a valid code
+            put("NAME_ONLY", "name=PATIENT_NAME");
+            put("NAME_MULTIPLE_VALUES_ONLY", "name=PATIENT_NAME,PATIENT_NAME_2");
+            // Test ONLY Last Updated
+            put("LAST_UPDATED_ONLY", "_lastUpdated=2020");
+            put("LAST_UPDATED_MULTIPLE_VALUES_ONLY", "_lastUpdated=2020,2019");
+            put("LAST_UPDATED_MULTIPLE_ONLY", "_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010");
+            // Test ID with a code `name`
+            put("ID_ONLY_WITH_NAME", "_id=PATIENT_ID&name=PATIENT_NAME");
+            put("ID_MULTIPLE_VALUES_ONLY_WITH_NAME", "_id=PATIENT_ID,PATIENT_ID_2&name=PATIENT_NAME");
+            put("ID_MULTIPLES_WITH_NAME", "_id=PATIENT_ID,PATIENT_ID_2&_id=PATIENT_ID,PATIENT_ID_2&name=PATIENT_NAME");
+            // Test ID with multiple code `name`
+            put("ID_ONLY_WITH_NAMES", "_id=PATIENT_ID&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("ID_MULTIPLE_VALUES_ONLY_WITH_NAMES", "_id=PATIENT_ID,PATIENT_ID_2&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("ID_MULTIPLES_WITH_NAMES", "_id=PATIENT_ID,PATIENT_ID_2&_id=PATIENT_ID,PATIENT_ID_2&name=PATIENT_NAME,PATIENT_NAME_2");
+            // Test ID with multiple code `name`as the first
+            put("ID_ONLY_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_id=PATIENT_ID");
+            put("ID_MULTIPLE_VALUES_ONLY_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_id=PATIENT_ID,PATIENT_ID_2");
+            put("ID_MULTIPLES_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_id=PATIENT_ID,PATIENT_ID_2&_id=PATIENT_ID,PATIENT_ID_2");
+            // Test Last Updated with a code `name`
+            put("LAST_UPDATED_WITH_NAME_ORDER", "name=PATIENT_NAME&_lastUpdated=2020");
+            put("LAST_UPDATED_WITH_NAME", "_lastUpdated=2020&name=PATIENT_NAME");
+            put("LAST_UPDATED_MULTIPLE_VALUES_WITH_NAME", "_lastUpdated=2020,2019&name=PATIENT_NAME");
+            put("LAST_UPDATED_MULTIPLE_WITH_NAME", "_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010&name=PATIENT_NAME");
+            // Test Last Updated with multiple code `name`
+            put("LAST_UPDATED_WITH_NAMES", "_lastUpdated=2020&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("LAST_UPDATED_MULTIPLE_VALUES_WITH_NAMES", "_lastUpdated=2020,2019&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("LAST_UPDATED_MULTIPLE_WITH_NAMES", "_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010&name=PATIENT_NAME,PATIENT_NAME_2");
+            // Test Last Updated with multiple code `name`as the first
+            put("LAST_UPDATED_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=2020");
+            put("LAST_UPDATED_MULTIPLE_VALUES_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=2020,2019");
+            put("LAST_UPDATED_MULTIPLE_WITH_NAMES_ORDER", "name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010");
+            // Test ID and Last Updated with a code `name`
+            put("ID_LAST_UPDATED_WITH_NAME_ORDER", "_id=PATIENT_ID&name=PATIENT_NAME&_lastUpdated=2020");
+            put("ID_LAST_UPDATED_WITH_NAME", "_id=PATIENT_ID&_lastUpdated=2020&name=PATIENT_NAME");
+            put("ID_LAST_UPDATED_MULTIPLE_VALUES_WITH_NAME", "_id=PATIENT_ID&_lastUpdated=2020,2019&name=PATIENT_NAME");
+            put("ID_LAST_UPDATED_MULTIPLE_WITH_NAME", "_id=PATIENT_ID&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010&name=PATIENT_NAME");
+            // Test ID and Last Updated with multiple code `name`
+            put("ID_LAST_UPDATED_WITH_NAMES", "_id=PATIENT_ID&_lastUpdated=2020&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("ID_LAST_UPDATED_MULTIPLE_VALUES_WITH_NAMES", "_id=PATIENT_ID&_lastUpdated=2020,2019&name=PATIENT_NAME,PATIENT_NAME_2");
+            put("ID_LAST_UPDATED_MULTIPLE_WITH_NAMES", "_id=PATIENT_ID&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010&name=PATIENT_NAME,PATIENT_NAME_2");
+            // Test ID and Last Updated with multiple code `name`as the first
+            put("ID_LAST_UPDATED_WITH_NAMES_ORDER", "_id=PATIENT_ID&name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=2020");
+            put("ID_LAST_UPDATED_MULTIPLE_VALUES_WITH_NAMES_ORDER", "_id=PATIENT_ID&name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=2020,2019");
+            put("ID_LAST_UPDATED_MULTIPLE_WITH_NAMES_ORDER", "_id=PATIENT_ID&name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010");
+            // Test All with _tag
+            put("ID_LAST_UPDATED_MULTIPLE_WITH_NAMES_ORDER", "_tag=tag-to-replace&_id=PATIENT_ID&name=PATIENT_NAME,PATIENT_NAME_2&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010");
+            // Test ID and Last Updated
+            put("ID_LAST_UPDATED", "_id=PATIENT_ID&_lastUpdated=2020");
+            put("ID_LAST_UPDATED_MULTIPLE_VALUES", "_id=PATIENT_ID&_lastUpdated=2020,2019");
+            put("ID_LAST_UPDATED_MULTIPLE", "_id=PATIENT_ID&_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010");
+            // Test ID and Last Updated (Alternate Order)
+            put("ID_LAST_UPDATED_WITH_ORDER", "_lastUpdated=2020&_id=PATIENT_ID");
+            put("ID_LAST_UPDATED_MULTIPLE_VALUES_WITH_ORDER", "_lastUpdated=2020,2019&_id=PATIENT_ID");
+            put("ID_LAST_UPDATED_MULTIPLE_WITH_ORDER", "_lastUpdated=le2030,le2019&_lastUpdated=ge2000,ge2010&_id=PATIENT_ID");
+        }
+    };
+
+    private String replaceValues(String input) {
+        return input.replaceAll("PATIENT_ID", patientId)
+                .replaceAll("PATIENT_NAME", "John")
+                .replaceAll("tag-to-replace", TAG);
+    }
+
+    @Test(groups = { "server-search-lastupdatedid" })
+    public void testCreatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+
+        java.lang.String div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p></div>";
+
+        Coding tag =
+                Coding.builder()
+                        .system(Uri.of(TAG_SYSTEM))
+                        .code(Code.of(TAG)).build();
+
+        Meta meta = Meta.builder()
+                .versionId(Id.of("1"))
+                .tag(tag)
+                .build();
+
+        Narrative text = Narrative.builder()
+                .status(NarrativeStatus.GENERATED)
+                .div(xhtml(div))
+                .build();
+
+        patient = patient.toBuilder().meta(meta).text(text).gender(AdministrativeGender.MALE).build();
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request().post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        TestUtil.assertResourceEquals(patient, responsePatient);
+    }
+
+    @Test(groups = { "server-search-lastupdatedid" }, dependsOnMethods = { "testCreatePatient" })
+    public void runTestCasesOnPatient() {
+        for (Entry<String, String> testCase : TEST_CASES.entrySet()) {
+            WebTarget target = getWebTarget();
+            target = target.path("Patient");
+
+            String testCaseName = testCase.getKey();
+            String testCaseUrl = testCase.getValue();
+
+            for (String queryParamSegment : testCaseUrl.split("&")) {
+                String[] parts = queryParamSegment.split("=");
+                target = target.queryParam(parts[0], replaceValues(parts[1]));
+            }
+
+            System.out.println(testCaseName);
+            Response response = target.request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            Bundle bundle = response.readEntity(Bundle.class);
+            assertNotNull(bundle);
+            assertTrue(bundle.getEntry().size() >= 1);
+        }
+    }
+
+    @Test(groups = { "server-search-lastupdatedid" }, dependsOnMethods = { "testCreatePatient" })
+    public void runTestCasesOnSystem() {
+        for (Entry<String, String> testCase : TEST_CASES.entrySet()) {
+            WebTarget target = getWebTarget();
+            target = target.path("/");
+
+            String testCaseName = testCase.getKey();
+            String testCaseUrl = testCase.getValue();
+
+            if (testCaseName.contains("NAME")) {
+                continue;
+            }
+
+            for (String queryParamSegment : testCaseUrl.split("&")) {
+                String[] parts = queryParamSegment.split("=");
+                target = target.queryParam(parts[0], replaceValues(parts[1]));
+            }
+
+            System.out.println(testCaseName);
+            Response response = target.request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            Bundle bundle = response.readEntity(Bundle.class);
+            assertNotNull(bundle);
+            assertTrue(bundle.getEntry().size() >= 1);
+        }
+    }
+
+    @Test(groups = { "server-search-lastupdatedid" }, dependsOnMethods = { "testCreatePatient" })
+    public void runTestCasesOnPatientSorted() {
+        for (Entry<String, String> testCase : TEST_CASES.entrySet()) {
+            WebTarget target = getWebTarget();
+            target = target.path("Patient");
+            target = target.queryParam("_sort","_lastUpdated");
+            String testCaseName = testCase.getKey();
+            String testCaseUrl = testCase.getValue();
+
+            for (String queryParamSegment : testCaseUrl.split("&")) {
+                String[] parts = queryParamSegment.split("=");
+                target = target.queryParam(parts[0], replaceValues(parts[1]));
+            }
+
+            System.out.println(testCaseName);
+            Response response = target.request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            Bundle bundle = response.readEntity(Bundle.class);
+            assertNotNull(bundle);
+            assertTrue(bundle.getEntry().size() >= 1);
+        }
+    }
+
+    @Test(groups = { "server-search-lastupdatedid" }, dependsOnMethods = { "testCreatePatient" })
+    public void runTestCasesOnSystemSorted() {
+        for (Entry<String, String> testCase : TEST_CASES.entrySet()) {
+            WebTarget target = getWebTarget();
+            target = target.path("/");
+
+            String testCaseName = testCase.getKey();
+            String testCaseUrl = testCase.getValue();
+            target = target.queryParam("_sort","_lastUpdated");
+            if (testCaseName.contains("NAME")) {
+                continue;
+            }
+
+            for (String queryParamSegment : testCaseUrl.split("&")) {
+                String[] parts = queryParamSegment.split("=");
+                target = target.queryParam(parts[0], replaceValues(parts[1]));
+            }
+
+            System.out.println(testCaseName);
+            Response response = target.request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            Bundle bundle = response.readEntity(Bundle.class);
+            assertNotNull(bundle);
+            assertTrue(bundle.getEntry().size() >= 1);
+        }
+    }
+}


### PR DESCRIPTION
## fix: Whole system search with multiple _lastUpdated results in incorrect queries #1383



## refactor: Values Table have duplicate data for _id and _lastUpdated #1388
- FHIRPersistenceJDBCImpl filters the codes in the
extractParameterValues step and keeps the parameter values from hitting
the corresponding tables

## fix: Chained Search with _id result in Http Status 500 #1384

URL
`https://localhost:9443/fhir-server/api/v4/Procedure?_count=10&subject:Patient._id=173a1657ba3-b9399454-1c17-4b96-9665-6cb930bc9c36&_page=1`

GENERATES SQL

`SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID  FROM PROCEDURE_RESOURCES R JOIN (SELECT DISTINCT LR.LOGICAL_RESOURCE_ID, LR.LOGICAL_ID, LR.CURRENT_RESOURCE_ID FROM Procedure_LOGICAL_RESOURCES LR  JOIN Procedure_RESOURCES R ON R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID   AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID   AND R.IS_DELETED <> 'Y'  JOIN Procedure_STR_VALUES  AS param0 ON (param0.PARAMETER_NAME_ID=1396 AND (param0.STR_VALUE IN (SELECT 'Patient' || '/' || CLR1.LOGICAL_ID FROM Patient_RESOURCES CR1, Patient_LOGICAL_RESOURCES CLR1, Patient_TOKEN_VALUES CP1 WHERE CR1.RESOURCE_ID = CLR1.CURRENT_RESOURCE_ID AND CR1.IS_DELETED <> 'Y' AND CP1.LOGICAL_RESOURCE_ID = CR1.LOGICAL_RESOURCE_ID AND CLR1.LOGICAL_ID IN (?) ))) AND LR.LOGICAL_RESOURCE_ID = param0.LOGICAL_RESOURCE_ID) AS LR  ON      R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID  AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID  AND R.IS_DELETED <> 'Y' ORDER BY RESOURCE_ID ASC  OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY  searchArgs=[173a1657ba3-b9399454-1c17-4b96-9665-6cb930bc9c36] executionTime=26.225081ms`


Signed-off-by: Paul Bastide <pbastide@us.ibm.com>