### PR TITLE
Issue 1413 - improve error response for unsupported modifiers

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -153,9 +153,7 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, modifiers cannot be used with chained parameters. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
-
-Additionally, the `:missing` modifier is not supported for whole-system search.
+At present, the `:missing` modifier is not supported for whole-system search nor for chained parameter search. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
 
 The `:text` modifier is not supported in this version of the FHIR server and use of this modifier will results in an HTTP 400 error with an `OperationOutcome` that describes the failure.
 

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -127,6 +127,8 @@ The `_count` parameter can be used to return at most 1000 records. If the client
 
 The `:iterate` modifier is not supported for the `_include` parameter (or any other).
 
+The `:missing` modifier is not supported for whole-system search.
+
 The `_total`, `_contained`, and `_containedType` parameters are not supported at this time.
 
 ### Custom search parameters
@@ -152,6 +154,8 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
 At present, modifiers cannot be used with chained parameters. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
+
+Additionally, the `:missing` modifier is not supported for whole-system search.
 
 The `:text` modifier is not supported in this version of the FHIR server and use of this modifier will results in an HTTP 400 error with an `OperationOutcome` that describes the failure.
 
@@ -231,7 +235,7 @@ The IBM FHIR Server does not consider the `Quantity.comparator` field as part of
 URI searches on the IBM FHIR Server are case-sensitive with "exact-match" semantics. The `above` and `below` prefixes can be used to perform path-based matching that is based on the `/` delimiter.
 
 ### Searching on Special Positional Search
-Positional Search uses [UCUM units](https://unitsofmeasure.org/ucum.html) of distance measure along with common variants: 
+Positional Search uses [UCUM units](https://unitsofmeasure.org/ucum.html) of distance measure along with common variants:
 
 | Unit of Measure | Variant |
 |-----------------|---------|

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
@@ -90,6 +90,10 @@ public abstract class Resource extends AbstractVisitable {
         return language;
     }
 
+    /**
+     * @return
+     *     true if the resource can be cast to the requested resourceType
+     */
     public <T extends Resource> boolean is(Class<T> resourceType) {
         return resourceType.isInstance(this);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
@@ -64,6 +64,10 @@ public abstract class Element extends AbstractVisitable {
         return extension;
     }
 
+    /**
+     * @return
+     *     true if the element can be cast to the requested elementType
+     */
     public <T extends Element> boolean is(Class<T> elementType) {
         return elementType.isInstance(this);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -471,7 +471,8 @@ public class FHIRUtil {
     }
 
     /**
-     * @return the value of the first extension with a valueString or null if the list has no such extensions
+     * @return the value of the first extension with a url of {@code extensionUrl} and a value of type
+     *     {@code com.ibm.fhir.model.type.String} (or a subclass); null if the list has no such extensions
      */
     private static String getExtensionStringValue(String extensionUrl, List<Extension> extensions) {
         String value = null;

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
@@ -8,17 +8,20 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchDateTest;
 
 public class JDBCSearchDateTest extends AbstractSearchDateTest {
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
 
     public JDBCSearchDateTest() throws Exception {
@@ -42,7 +45,7 @@ public class JDBCSearchDateTest extends AbstractSearchDateTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -50,5 +53,32 @@ public class JDBCSearchDateTest extends AbstractSearchDateTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchDate_instant_chained_missing() throws Exception {
+        super.testSearchDate_instant_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchDate_Period_chained_missing() throws Exception {
+        super.testSearchDate_Period_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchDate_date_chained_missing() throws Exception {
+        super.testSearchDate_date_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchDate_dateTime_chained_missing() throws Exception {
+        super.testSearchDate_dateTime_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNumberTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNumberTest.java
@@ -8,17 +8,20 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchNumberTest;
 
 public class JDBCSearchNumberTest extends AbstractSearchNumberTest {
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
 
     public JDBCSearchNumberTest() throws Exception {
@@ -43,7 +46,7 @@ public class JDBCSearchNumberTest extends AbstractSearchNumberTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -51,5 +54,23 @@ public class JDBCSearchNumberTest extends AbstractSearchNumberTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchNumber_integer_chained_missing() throws Exception {
+        super.testSearchNumber_integer_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchNumber_decimal_chained_missing() throws Exception {
+        super.testSearchNumber_decimal_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchQuantityTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchQuantityTest.java
@@ -8,10 +8,13 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchQuantityTest;
@@ -19,7 +22,7 @@ import com.ibm.fhir.persistence.search.test.AbstractSearchQuantityTest;
 public class JDBCSearchQuantityTest extends AbstractSearchQuantityTest {
 
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
 
     public JDBCSearchQuantityTest() throws Exception {
@@ -44,7 +47,7 @@ public class JDBCSearchQuantityTest extends AbstractSearchQuantityTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -52,5 +55,18 @@ public class JDBCSearchQuantityTest extends AbstractSearchQuantityTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
+        super.testSearchQuantity_Quantity_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchReferenceTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchReferenceTest.java
@@ -8,21 +8,24 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchReferenceTest;
 
 
 public class JDBCSearchReferenceTest extends AbstractSearchReferenceTest {
-    
+
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
-    
+
     public JDBCSearchReferenceTest() throws Exception {
         this.testProps = TestUtil.readTestProperties("test.jdbc.properties");
     }
@@ -45,7 +48,7 @@ public class JDBCSearchReferenceTest extends AbstractSearchReferenceTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -53,5 +56,23 @@ public class JDBCSearchReferenceTest extends AbstractSearchReferenceTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchReference_Reference_chained_missing() throws Exception {
+        super.testSearchReference_Reference_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchReference_uri_chained_missing() throws Exception {
+        super.testSearchReference_uri_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchStringTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchStringTest.java
@@ -8,10 +8,13 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchStringTest;
@@ -20,7 +23,7 @@ import com.ibm.fhir.persistence.search.test.AbstractSearchStringTest;
 public class JDBCSearchStringTest extends AbstractSearchStringTest {
 
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
 
     public JDBCSearchStringTest() throws Exception {
@@ -45,7 +48,7 @@ public class JDBCSearchStringTest extends AbstractSearchStringTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -53,5 +56,22 @@ public class JDBCSearchStringTest extends AbstractSearchStringTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchString_string_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.string:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.string:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-string:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-string:missing", "false");
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchTokenTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchTokenTest.java
@@ -8,10 +8,13 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchTokenTest;
@@ -20,7 +23,7 @@ import com.ibm.fhir.persistence.search.test.AbstractSearchTokenTest;
 public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
 
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
 
     public JDBCSearchTokenTest() throws Exception {
@@ -37,7 +40,7 @@ public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
             this.connectionPool = new PoolConnectionProvider(cp, 1);
         }
     }
-    
+
     @Override
     public FHIRPersistence getPersistenceImpl() throws Exception {
         if (this.connectionPool == null) {
@@ -45,7 +48,7 @@ public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -53,5 +56,28 @@ public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchToken_boolean_chained_missing() throws Exception {
+        super.testSearchToken_boolean_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchToken_code_chained_missing() throws Exception {
+        super.testSearchToken_code_chained_missing();
+    }
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
+        super.testSearchToken_CodeableConcept_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchURITest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchURITest.java
@@ -8,10 +8,13 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractSearchURITest;
@@ -20,7 +23,7 @@ public class JDBCSearchURITest extends AbstractSearchURITest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     public JDBCSearchURITest() throws Exception {
         this.testProps = TestUtil.readTestProperties("test.jdbc.properties");
     }
@@ -43,7 +46,7 @@ public class JDBCSearchURITest extends AbstractSearchURITest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -51,5 +54,18 @@ public class JDBCSearchURITest extends AbstractSearchURITest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters.
+     * https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
+     */
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchURI_uri_chained_missing() throws Exception {
+        super.testSearchURI_uri_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCWholeSystemSearchTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCWholeSystemSearchTest.java
@@ -8,20 +8,23 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
 import com.ibm.fhir.persistence.jdbc.test.util.DerbyInitializer;
 import com.ibm.fhir.persistence.search.test.AbstractWholeSystemSearchTest;
 
 public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
-    
+
     private Properties testProps;
-    
+
     private PoolConnectionProvider connectionPool;
-    
+
     public JDBCWholeSystemSearchTest() throws Exception {
         this.testProps = TestUtil.readTestProperties("test.jdbc.properties");
     }
@@ -36,7 +39,7 @@ public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
             this.connectionPool = new PoolConnectionProvider(cp, 1);
         }
     }
-    
+
     @Override
     public FHIRPersistence getPersistenceImpl() throws Exception {
         if (this.connectionPool == null) {
@@ -44,7 +47,7 @@ public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
         }
         return new FHIRPersistenceJDBCImpl(this.testProps, this.connectionPool);
     }
-    
+
     @Override
     protected void shutdownPools() throws Exception {
         // Mark the pool as no longer in use. This allows the pool to check for
@@ -52,5 +55,12 @@ public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
+    }
+
+
+    @Override
+    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
+    public void testSearchAllUsingIdAndLastUpdatedAndAnyTagOrProfile() throws Exception {
+        super.testSearchAllUsingIdAndLastUpdatedAndAnyTagOrProfile();
     }
 }

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/exception/FHIRPersistenceNotSupportedException.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/exception/FHIRPersistenceNotSupportedException.java
@@ -26,13 +26,13 @@ public class FHIRPersistenceNotSupportedException extends FHIRPersistenceExcepti
     }
 
     @Override
-    public FHIRPersistenceException withIssue(OperationOutcome.Issue... issues) {
+    public FHIRPersistenceNotSupportedException withIssue(OperationOutcome.Issue... issues) {
         super.withIssue(issues);
         return this;
     }
 
     @Override
-    public FHIRPersistenceException withIssue(Collection<OperationOutcome.Issue> issues) {
+    public FHIRPersistenceNotSupportedException withIssue(Collection<OperationOutcome.Issue> issues) {
         super.withIssue(issues);
         return this;
     }

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/exception/FHIRPersistenceNotSupportedException.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/exception/FHIRPersistenceNotSupportedException.java
@@ -12,8 +12,6 @@ import com.ibm.fhir.model.resource.OperationOutcome;
 
 /**
  * Thrown for methods or features not yet fully implemented.
- * @author markd
- *
  */
 public class FHIRPersistenceNotSupportedException extends FHIRPersistenceException {
 
@@ -32,7 +30,7 @@ public class FHIRPersistenceNotSupportedException extends FHIRPersistenceExcepti
         super.withIssue(issues);
         return this;
     }
-    
+
     @Override
     public FHIRPersistenceException withIssue(Collection<OperationOutcome.Issue> issues) {
         super.withIssue(issues);

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -26,22 +26,24 @@ import com.ibm.fhir.model.test.TestUtil;
  * - Date</a> Tests
  */
 public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicDate.json");
     }
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("date");
-        
-        // this might deserve its own method, but just use setTenant for now 
+
+        // this might deserve its own method, but just use setTenant for now
         // since its called before creating any resources
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-4:00"));
         System.out.println(ZoneId.systemDefault());
     }
-    
+
     @Test
     public void testSearchDate_date_Day_noTZ() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the day before
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28");
@@ -78,7 +80,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Seconds_noTZ() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the last second before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59");
@@ -89,7 +91,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59");
-        
+
         // the first second of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00Z");
@@ -103,7 +105,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00");
-        
+
         // a second in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00");
@@ -116,7 +118,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00");
-        
+
         // the last second of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59");
@@ -130,7 +132,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59");
-        
+
         // the first second after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00");
@@ -145,7 +147,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Seconds_EDT() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the last second before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59-04:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59-04:00");
@@ -156,7 +158,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59-04:00");
-        
+
         // the first second of the day
         // This one shouldn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00-04:00");
@@ -170,7 +172,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00-04:00");
-        
+
         // a second in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00-04:00");
@@ -183,7 +185,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00-04:00");
-        
+
         // the last second of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59-04:00");
@@ -197,7 +199,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59-04:00");
-        
+
         // the first second after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00-04:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00-04:00");
@@ -212,9 +214,9 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Seconds_UTC() throws Exception {
         // "date" is 2018-10-29
-        
+
         // we set the system time to GMT-4, so this is really [2018-10-29T04:00:00Z, 2018-10-30T03:59:59.999999]
-        
+
         // the last second before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T03:59:59Z");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-29T03:59:59Z");
@@ -225,7 +227,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-29T03:59:59Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T03:59:59Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T03:59:59Z");
-        
+
         // the first second of the day
         // This one shouldn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T04:00:00Z");
@@ -239,7 +241,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T04:00:00Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T04:00:00Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T04:00:00Z");
-        
+
         // a second in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00Z");
@@ -252,7 +254,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00Z");
-        
+
         // the last second of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T03:59:59Z");
@@ -266,7 +268,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T03:59:59Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-30T03:59:59Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-30T03:59:59Z");
-        
+
         // the first second after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T04:00:00Z");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T04:00:00Z");
@@ -281,7 +283,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Fractions_noTZ() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the last instant before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999");
@@ -292,7 +294,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999");
-        
+
         // the first instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0Z");
@@ -305,7 +307,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0");
-        
+
         // an instant in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0");
@@ -318,7 +320,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0");
-        
+
         // the last instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999");
@@ -331,7 +333,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999");
-        
+
         // the first instant after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0");
@@ -346,7 +348,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Fractions_EDT() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the last instant before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999-04:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999-04:00");
@@ -357,7 +359,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999-04:00");
-        
+
         // the first instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0-04:00");
@@ -370,7 +372,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0-04:00");
-        
+
         // an instant in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0-04:00");
@@ -383,7 +385,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0-04:00");
-        
+
         // the last instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999-04:00");
@@ -396,7 +398,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999-04:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999-04:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999-04:00");
-        
+
         // the first instant after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0-04:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0-04:00");
@@ -411,7 +413,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Fractions_IDT() throws Exception {
         // "date" is 2018-10-29
-        
+
         // the last instant before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999+03:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999+03:00");
@@ -422,7 +424,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999+03:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999+03:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999+03:00");
-        
+
         // the first instant of the day
         // This one shouldn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T00:00:00.0+03:00");
@@ -435,7 +437,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 //        assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T00:00:00.0+03:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T00:00:00.0+03:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T00:00:00.0+03:00");
-        
+
         // an instant in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0+03:00");
@@ -448,7 +450,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0+03:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0+03:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0+03:00");
-        
+
         // the last instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T23:59:59.999999+03:00");
@@ -461,7 +463,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T23:59:59.999999+03:00");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T23:59:59.999999+03:00");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T23:59:59.999999+03:00");
-        
+
         // the first instant after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T00:00:00.0+03:00");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T00:00:00.0+03:00");
@@ -476,9 +478,9 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_Fractions_UTC() throws Exception {
         // "date" is 2018-10-29
-        
+
         // we set the system time to GMT-4, so this is really [2018-10-29T04:00:00Z, 2018-10-30T03:59:59.999999]
-        
+
         // the last instant before 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T03:59:59.999999Z");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-29T03:59:59.999999Z");
@@ -489,7 +491,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-29T03:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T03:59:59.999999Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T03:59:59.999999Z");
-        
+
         // the first instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T04:00:00.0Z");
@@ -502,7 +504,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T04:00:00.0Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T04:00:00.0Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T04:00:00.0Z");
-        
+
         // an instant in the middle of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-29T17:12:00.0Z");
@@ -515,7 +517,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-29T17:12:00.0Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-29T17:12:00.0Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-29T17:12:00.0Z");
-        
+
         // the last instant of the day
         // This one doesn't return the resource because the search range does not include the entire target range.
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T03:59:59.999999Z");
@@ -528,7 +530,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("date", "sa2018-10-30T03:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-30T03:59:59.999999Z");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-30T03:59:59.999999Z");
-        
+
         // the first instant after 2018-10-29
         assertSearchDoesntReturnSavedResource("date",   "2018-10-30T04:00:00.0Z");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-30T04:00:00.0Z");
@@ -605,7 +607,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     public void testSearchDate_dateTime_Day_noTZ() throws Exception {
         // "dateTime" is 2019-12-31T20:00:00-04:00
         assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
-        
+
         // the day before
         assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-30");
         assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-30");
@@ -616,7 +618,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-30");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-30");
         // assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-30");
-        
+
         // the day of
         assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31");
         assertSearchDoesntReturnSavedResource("dateTime", "ne2019-12-31");
@@ -627,7 +629,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31");
-        
+
         // the day after
         assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01");
         assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01");
@@ -637,7 +639,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "ge2020-01-01");
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01");
         assertSearchReturnsSavedResource(     "dateTime", "eb2020-01-01");
-        // This test is very dynamic and is not reliable. 
+        // This test is very dynamic and is not reliable.
         assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01");
     }
     @Test
@@ -645,7 +647,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // "dateTime" is 2019-12-31T20:00:00-04:00
 
         // we set the system to GMT-4, so it should match the timezone of the target dateTime
-        
+
         // the second before
         assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T19:59:59");
         assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T19:59:59");
@@ -656,7 +658,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T19:59:59");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T19:59:59");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T19:59:59");
-        
+
         // the exact second
         assertSearchReturnsSavedResource(     "dateTime",   "2019-12-31T20:00:00");
         assertSearchDoesntReturnSavedResource("dateTime", "ne2019-12-31T20:00:00");
@@ -667,7 +669,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:00");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T20:00:00");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:00");
-        
+
         // the next second
         assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T20:00:01");
         assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T20:00:01");
@@ -683,7 +685,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     public void testSearchDate_dateTime_Seconds_UTC() throws Exception {
         // "dateTime" is 2019-12-31T20:00:00-04:00
         assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
-        
+
         // the second before
         assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T23:59:59Z");
         assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T23:59:59Z");
@@ -694,7 +696,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59Z");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59Z");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59Z");
-        
+
         // the exact second
         assertSearchReturnsSavedResource(     "dateTime",   "2020-01-01T00:00:00Z");
         assertSearchDoesntReturnSavedResource("dateTime", "ne2020-01-01T00:00:00Z");
@@ -705,7 +707,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00Z");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00Z");
         assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00Z");
-        
+
         // the next second
         assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:01Z");
         assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:01Z");
@@ -733,7 +735,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T19:59:59.999999");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T19:59:59.999999");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T19:59:59.999999");
-        
+
         // the exact instant
         // This one does not return the resource because the search value is a single point
         // and the target value is a range from 2019-12-31T20:00:00-04:00 to 2019-12-31T20:00:01-04:00
@@ -747,7 +749,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2019-12-31T20:00:00.0");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T20:00:00.0");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T20:00:00.0");
-        
+
         // the next instant
         assertSearchDoesntReturnSavedResource("dateTime",   "2019-12-31T20:00:00.000001");
         assertSearchReturnsSavedResource(     "dateTime", "ne2019-12-31T20:00:00.000001");
@@ -773,7 +775,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "dateTime", "sa2019-12-31T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2019-12-31T23:59:59.999999Z");
         assertSearchReturnsSavedResource(     "dateTime", "ap2019-12-31T23:59:59.999999Z");
-        
+
         // the exact instant
         // This one does not return the resource because the search value is a single point
         // and the target value is a range from 2019-12-31T20:00:00-04:00 to 2019-12-31T20:00:01-04:00
@@ -787,7 +789,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.0Z");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.0Z");
         assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.0Z");
-        
+
         // the next instant
         assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.000001Z");
         assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:00.000001Z");
@@ -802,7 +804,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_dateTime_chained() throws Exception {
         // "dateTime" is 2019-12-31T20:00:00-04:00
-        
+
         assertSearchReturnsComposition("subject:Basic.dateTime", "2019-12-31T20:00:00-04:00");
         assertSearchDoesntReturnSavedResource("subject:Basic.dateTime", "2025-10-29");
     }
@@ -1493,7 +1495,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29");
-        
+
         // search on the dateTime at the end of the Period-noStart
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-29T17:18:00+04:00");
@@ -1506,7 +1508,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28");
@@ -1518,7 +1520,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-28T23:59:59.999999Z");
@@ -1530,7 +1532,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30");
@@ -1540,7 +1542,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "lt2018-10-30T00:00:00.000001Z");
@@ -1567,7 +1569,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29");
-        
+
         // search on the dateTime at the start of the Period-noEnd
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-29T17:12:00-04:00");
@@ -1581,7 +1583,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29T17:12:00-04:00");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1591,7 +1593,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28T23:59:59.999999Z");
@@ -1601,7 +1603,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28T23:59:59.999999Z");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "lt2018-10-28");
@@ -1616,7 +1618,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30");
-        
+
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "lt2018-10-30T00:00:00.000001Z");
@@ -1660,7 +1662,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "eb2018-10-28,9999-01-01");
         assertSearchReturnsSavedResource("Period", "ap2018-10-28,9999-01-01");
         assertSearchDoesntReturnSavedResource("Period", "ap2010-10-28,9999-01-01");
-        
+
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,2018-10-28");
         assertSearchReturnsSavedResource("Period", "9999-01-01,ne2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,lt2018-10-28");
@@ -1671,11 +1673,13 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,eb2018-10-28");
         assertSearchDoesntReturnSavedResource("Period", "9999-01-01,ap2010-10-28");
     }
+
     // We decided that Periods with no start or end should not even be indexed
     //    @Test
     //    public void testSearchDate_Period_NoStartOrEnd() throws Exception {
     //        assertSearchReturnsSavedResource("Period-noStartOrEnd", "2018-10-29T17:12:44-04:00");
     //    }
+
     // Timing search is not working properly.
     //    @Test
     //    public void testSearchDate_Timing_EventsOnly() throws Exception {
@@ -1693,48 +1697,37 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     //    public void testSearchDate_Timing_BoundPeriod() throws Exception {
     //        testSearchDateReturnsResourceWithExtension("Timing-boundPeriod", "2018-10-29T17:18:00-04:00", "http://example.org/TimingBoundsPeriod");
     //    }
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    //    @Test
-    //    public void testSearchDate_instant_chained_missing() throws Exception {
-    //        assertSearchReturnsSavedResource("subject:Basic.instant:missing", "false");
-    //        assertSearchDoesntReturnSavedResource("subject:Basic.instant:missing", "true");
-    //
-    //        assertSearchReturnsSavedResource("subject:Basic.missing-instant:missing", "true");
-    //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-instant:missing", "false");
-    //    }
-    //  @Test
-    //  public void testSearchDate_Period_chained_missing() throws Exception {
-    //      assertSearchReturnsComposition("subject:Basic.Period:missing", "false");
-    //      assertSearchDoesntReturnComposition("subject:Basic.Period:missing", "true");
-    //
-    //      assertSearchReturnsComposition("subject:Basic.missing-Period:missing", "true");
-    //      assertSearchDoesntReturnComposition("subject:Basic.missing-Period:missing", "false");
-    //  }
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    //    @Test
-    //    public void testSearchDate_date_chained_missing() throws Exception {
-    //        assertSearchReturnsComposition("subject:Basic.date:missing", "false");
-    //        assertSearchDoesntReturnSavedResource("subject:Basic.date:missing", "true");
-    //
-    //        assertSearchReturnsComposition("subject:Basic.missing-date:missing", "true");
-    //        assertSearchDoesntReturnSavedResource("subject:Basic.missing-date:missing", "false");
-    //    }
-    //    @Test
-    //    public void testSearchDate_dateTime_chained_missing() throws Exception {
-    //        assertSearchReturnsComposition("subject:Basic.dateTime:missing", "false");
-    //        assertSearchDoesntReturnComposition("subject:Basic.dateTime:missing", "true");
-    //
-    //        assertSearchReturnsComposition("subject:Basic.missing-dateTime:missing", "true");
-    //        assertSearchDoesntReturnComposition("subject:Basic.missing-dateTime:missing", "false");
-    //    }
+
+    @Test
+    public void testSearchDate_instant_chained_missing() throws Exception {
+        assertSearchReturnsSavedResource("subject:Basic.instant:missing", "false");
+        assertSearchDoesntReturnSavedResource("subject:Basic.instant:missing", "true");
+
+        assertSearchReturnsSavedResource("subject:Basic.missing-instant:missing", "true");
+        assertSearchDoesntReturnSavedResource("subject:Basic.missing-instant:missing", "false");
+    }
+    @Test
+    public void testSearchDate_Period_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.Period:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.Period:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-Period:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-Period:missing", "false");
+    }
+    @Test
+    public void testSearchDate_date_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.date:missing", "false");
+        assertSearchDoesntReturnSavedResource("subject:Basic.date:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-date:missing", "true");
+        assertSearchDoesntReturnSavedResource("subject:Basic.missing-date:missing", "false");
+    }
+    @Test
+    public void testSearchDate_dateTime_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.dateTime:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.dateTime:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-dateTime:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-dateTime:missing", "false");
+    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchNumberTest.java
@@ -26,10 +26,12 @@ import com.ibm.fhir.search.exception.FHIRSearchException;
  */
 public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicNumber.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("number");
     }
@@ -131,7 +133,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
     public void testSearchNumber_decimal() throws Exception {
         // Targeted Value is 99.99
 
-        // Range: 98.5, 99.5 
+        // Range: 98.5, 99.5
         assertSearchDoesntReturnSavedResource("decimal", "99");
 
         // Range: 99.984985, 99.984995
@@ -320,7 +322,7 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
     public void testSearchNumber_Precision() throws Exception {
         // [parameter]=100
         // Value: 100
-        // Precision: 3 
+        // Precision: 3
         // Implied Range: [99.5 ... 100.5)
         // Target: 100.25
         assertSearchReturnsSavedResource("precision", "100");
@@ -349,27 +351,21 @@ public abstract class AbstractSearchNumberTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("precision", "1.0e2");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
+    @Test
+    public void testSearchNumber_integer_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.integer:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.integer:missing", "true");
 
-    //    @Test
-    //    public void testSearchNumber_integer_chained_missing() throws Exception {
-    //        assertSearchReturnsComposition("subject:Basic.integer:missing", "false");
-    //        assertSearchDoesntReturnComposition("subject:Basic.integer:missing", "true");
-    //
-    //        assertSearchReturnsComposition("subject:Basic.missing-integer:missing", "true");
-    //        assertSearchDoesntReturnComposition("subject:Basic.missing-integer:missing", "false");
-    //    }
-    //
-    //    @Test
-    //    public void testSearchNumber_decimal_chained_missing() throws Exception {
-    //        assertSearchReturnsComposition("subject:Basic.decimal:missing", "false");
-    //        assertSearchDoesntReturnComposition("subject:Basic.decimal:missing", "true");
-    //
-    //        assertSearchReturnsComposition("subject:Basic.missing-decimal:missing", "true");
-    //        assertSearchDoesntReturnComposition("subject:Basic.missing-decimal:missing", "false");
-    //    }
+        assertSearchReturnsComposition("subject:Basic.missing-integer:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-integer:missing", "false");
+    }
+
+    @Test
+    public void testSearchNumber_decimal_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.decimal:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.decimal:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-decimal:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-decimal:missing", "false");
+    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchQuantityTest.java
@@ -25,10 +25,12 @@ import com.ibm.fhir.model.test.TestUtil;
  */
 public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicQuantity.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("quantity");
     }
@@ -218,7 +220,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         // assertSearchDoesntReturnSavedResource("Quantity-lessThan", "3||lt");
         // assertSearchReturnsSavedResource("Quantity-lessThan", "lt2||lt");      // < 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThan", "gt2||lt"); // < 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-lessThan", "lt4||lt"); // < 3 may be < 4 
+        assertSearchReturnsSavedResource("Quantity-lessThan", "lt4||lt"); // < 3 may be < 4
         assertSearchDoesntReturnSavedResource("Quantity-lessThan", "gt4||lt"); // < 3 is not > 4
     }
 
@@ -252,7 +254,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "lt2||lte"); // <= 3 may be < 2
         assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "gt2||lte"); // <= 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4 
+        assertSearchReturnsSavedResource("Quantity-lessThanOrEqual", "lt4||lte"); // <= 3 may be < 4
         assertSearchDoesntReturnSavedResource("Quantity-lessThanOrEqual", "gt4||lte"); // <= 3 is not > 4
 
         // <= 3 may be <= 3
@@ -268,7 +270,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
 
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "lt2||gte"); // >= 3 is not < 2
         assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "gt2||gte"); // >= 3 may be > 2
-        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte"); // >= 3 may be < 4 
+        assertSearchReturnsSavedResource("Quantity-greaterThanOrEqual", "lt4||gte"); // >= 3 may be < 4
         assertSearchDoesntReturnSavedResource("Quantity-greaterThanOrEqual", "gt4||gte"); // >= 3 may be > 4
 
         // >= 3 may be <= 3
@@ -290,7 +292,7 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
     public void testSearchQuantity_Range_EQ_Implied() throws Exception {
         // 1e1 has implicit range of 5 - 15
         assertSearchReturnsSavedResource("Range", "1e1||s");
-        
+
         // the range of the search value doesn't fully contain the range of the target value
         assertSearchDoesntReturnSavedResource("Range", "4||s");
         assertSearchDoesntReturnSavedResource("Range", "5||s");
@@ -380,28 +382,21 @@ public abstract class AbstractSearchQuantityTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-Range:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Range:missing", "false");
     }
-    
+
     @Test
     public void testSearchQuantity_Exponent() throws Exception {
         // Value 1.2E+2 should return the value
-        // The value is extracted, and stored in the values tables. 
+        // The value is extracted, and stored in the values tables.
         assertSearchReturnsSavedResource("Quantity-withExponent", "1.2E+2");
         assertSearchReturnsSavedResource("Quantity-withExponent", "120");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
+    @Test
+    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.Quantity:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.Quantity:missing", "true");
 
-    //    @Test
-    //    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
-    //        assertSearchReturnsComposition("subject:Basic.Quantity:missing", "false");
-    //        assertSearchDoesntReturnComposition("subject:Basic.Quantity:missing", "true");
-    //        
-    //        assertSearchReturnsComposition("subject:Basic.missing-Quantity:missing", "true");
-    //        assertSearchDoesntReturnComposition("subject:Basic.missing-Quantity:missing", "false");
-    //    }
+        assertSearchReturnsComposition("subject:Basic.missing-Quantity:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-Quantity:missing", "false");
+    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
@@ -24,30 +24,32 @@ import com.ibm.fhir.model.test.TestUtil;
  */
 public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicReference.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("reference");
     }
 
     @Test
     public void testSearchReference_Reference_relative() throws Exception {
-        // Reference by id really only works when the system knows which resource type(s) 
+        // Reference by id really only works when the system knows which resource type(s)
         // can be referenced from a given element.
-        // TODO does this work if you define the extension in a StructureDefinition 
-        // and declare the allowed types? 
+        // TODO does this work if you define the extension in a StructureDefinition
+        // and declare the allowed types?
 //        assertSearchReturnsSavedResource("Reference-relative", "123");
-        
+
         assertSearchReturnsSavedResource("Reference-relative", "Patient/123");
-        
+
         // TODO if this matched the hostname that the test was running on, would it work?
 //        assertSearchReturnsSavedResource("Reference-relative", "https://example.com/Patient/123");
-        
+
         assertSearchReturnsSavedResource("Reference-relative:Patient", "123");
         assertSearchDoesntReturnSavedResource("Reference-relative:Basic", "123");
-        
+
     }
 
     @Test
@@ -77,8 +79,8 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
         // where the current test was running, would these work?
 //        assertSearchReturnsSavedResource("Reference-absolute", "123");
 //        assertSearchReturnsSavedResource("Reference-absolute", "Patient/123");
-//        assertSearchReturnsSavedResource("Reference-absolute:Patient", "123");        
-        
+//        assertSearchReturnsSavedResource("Reference-absolute:Patient", "123");
+
         assertSearchReturnsSavedResource("Reference-absolute", "https://example.com/Patient/123");
     }
 
@@ -86,7 +88,7 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
     public void testSearchReference_Reference_missing() throws Exception {
         assertSearchReturnsSavedResource("Reference:missing", "false");
         assertSearchDoesntReturnSavedResource("Reference:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-Reference:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Reference:missing", "false");
     }
@@ -105,7 +107,7 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
     public void testSearchReference_uri_missing() throws Exception {
         assertSearchReturnsSavedResource("uri:missing", "false");
         assertSearchDoesntReturnSavedResource("uri:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-uri:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-uri:missing", "false");
     }
@@ -115,26 +117,21 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
         // should the server index the Reference.identifier field if there is no valued reference?
     }
 
-    /*
-     * Currently, as documented in our conformance doc, we do not support modifiers on chained parameters.
-     * See https://ibm.github.io/FHIR/Conformance#search-modifiers and
-     * refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-//    @Test
-//    public void testSearchReference_Reference_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.Reference:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.Reference:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-Reference:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-Reference:missing", "false");
-//    }
+    @Test
+    public void testSearchReference_Reference_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.Reference:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.Reference:missing", "true");
 
-//    @Test
-//    public void testSearchReference_uri_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.uri:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.uri:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-uri:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-uri:missing", "false");
-//    }
+        assertSearchReturnsComposition("subject:Basic.missing-Reference:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-Reference:missing", "false");
+    }
+
+    @Test
+    public void testSearchReference_uri_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.uri:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.uri:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-uri:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-uri:missing", "false");
+    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
@@ -26,10 +26,12 @@ import com.ibm.fhir.search.exception.FHIRSearchException;
  */
 public abstract class AbstractSearchStringTest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicString.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("string");
     }
@@ -37,92 +39,86 @@ public abstract class AbstractSearchStringTest extends AbstractPLSearchTest {
     @Test
     public void testSearchString_string() throws Exception {
         assertSearchReturnsSavedResource("string:exact", "testString");
-        
+
         assertSearchReturnsSavedResource("string", "testString");
         assertSearchReturnsSavedResource("string", "test");
-        
+
         assertSearchReturnsSavedResource("string:contains", "String");
         assertSearchReturnsSavedResource("string:contains", "string");
-        
+
         assertSearchDoesntReturnSavedResource("string", "String");
         assertSearchDoesntReturnSavedResource("string:exact", "test");
         assertSearchDoesntReturnSavedResource("string:exact", "teststring");
-        
+
         // TODO add test for diacritics and other unusual characters
     }
-    
+
     @Test
     public void testSearchString_string_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.string:exact", "testString");
-        
+
         assertSearchReturnsComposition("subject:Basic.string", "testString");
         assertSearchReturnsComposition("subject:Basic.string", "test");
-        
+
         assertSearchReturnsComposition("subject:Basic.string:contains", "String");
         assertSearchReturnsComposition("subject:Basic.string:contains", "string");
-        
+
         assertSearchDoesntReturnComposition("subject:Basic.string", "String");
 
         assertSearchDoesntReturnComposition("subject:Basic.string:exact", "test");
         assertSearchDoesntReturnComposition("subject:Basic.string:exact", "teststring");
-        
+
         // TODO add test for diacritics and other unusual characters
     }
-    
+
     @Test
     public void testSearchString_string_revinclude() throws Exception {
         assertSearchReturnsComposition("subject:Basic.string:exact", "testString");
-        
+
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
         queryParms.put("_revinclude", Collections.singletonList("Composition:subject"));
         queryParms.put("string:exact", Collections.singletonList("testString"));
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-    
-    
+
+
     @Test
     public void testSearchString_string_missing() throws Exception {
         assertSearchReturnsSavedResource("string:missing", "false");
         assertSearchDoesntReturnSavedResource("string:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-string:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-string:missing", "false");
     }
-    
+
     @Test
     public void testSearchString_string_or() throws Exception {
         assertSearchReturnsSavedResource("string:exact", "foo,testString,bar");
         assertSearchDoesntReturnSavedResource("string:exact", "foo\\,testString,bar");
         assertSearchDoesntReturnSavedResource("string:exact", "foo,testString\\,bar");
     }
-    
+
     @Test
     public void testSearchString_string_escaping() throws Exception {
         assertSearchReturnsSavedResource("string:exact", "special testChars & : ; \\$ \\| \\, \\\\");
         assertSearchReturnsSavedResource("string:contains", "& : ; \\$ \\| \\, \\\\");
     }
-    
+
     @Test(expectedExceptions = { FHIRSearchException.class })
     public void testSearchString_string_invalidEscaping() throws Exception {
         runQueryTest(Basic.class, "string", "\\", Integer.MAX_VALUE);
     }
-    
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    
-//    @Test
-//    public void testSearchString_string_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.string:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.string:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-string:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-string:missing", "false");
-//    }
-    
+
+    @Test
+    public void testSearchString_string_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.string:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.string:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-string:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-string:missing", "false");
+    }
+
     @Test
     public void testSearchString_HumanName() throws Exception {
         /*
@@ -140,7 +136,7 @@ public abstract class AbstractSearchStringTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("HumanName", "II");
         assertSearchReturnsSavedResource("HumanName", "Topo Gigio");
     }
-    
+
     @Test
     public void testSearchString_Address() throws Exception {
         /*

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchStringTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -25,10 +25,12 @@ import com.ibm.fhir.model.test.TestUtil;
  */
 public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicToken.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("token");
     }
@@ -41,20 +43,20 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchToken_boolean() throws Exception {
-        // For token parameters on elements of type ContactPoint, uri, or boolean, 
+        // For token parameters on elements of type ContactPoint, uri, or boolean,
         // the presence of the pipe symbol SHALL NOT be used - only the [parameter]=[code] form is allowed
         assertSearchReturnsSavedResource("boolean", "true");
         assertSearchDoesntReturnSavedResource("boolean", "false");
     }
-    
+
     @Test
     public void testSearchToken_boolean_chained() throws Exception {
-        // For token parameters on elements of type ContactPoint, uri, or boolean, 
+        // For token parameters on elements of type ContactPoint, uri, or boolean,
         // the presence of the pipe symbol SHALL NOT be used - only the [parameter]=[code] form is allowed
         assertSearchReturnsComposition("subject:Basic.boolean", "true");
         assertSearchDoesntReturnComposition("subject:Basic.boolean", "false");
     }
-    
+
     @Test
     public void testSearchToken_boolean_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -63,13 +65,13 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-    
-    
+
+
     @Test
     public void testSearchToken_boolean_missing() throws Exception {
         assertSearchReturnsSavedResource("boolean:missing", "false");
         assertSearchDoesntReturnSavedResource("boolean:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-boolean:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-boolean:missing", "false");
     }
@@ -79,105 +81,99 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("code", "code");
         assertSearchReturnsSavedResource("code", "|code");
     }
-    
+
     @Test
     public void testSearchToken_code_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.code", "code");
         assertSearchReturnsComposition("subject:Basic.code", "|code");
     }
-    
+
     @Test
     public void testSearchToken_code_missing() throws Exception {
         assertSearchReturnsSavedResource("code:missing", "false");
         assertSearchDoesntReturnSavedResource("code:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-code:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-code:missing", "false");
     }
 
-    /*
-     * Currently, as documented in our conformance statement, we do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    
-//    @Test
-//    public void testSearchToken_boolean_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.boolean:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.boolean:missing", "true");
-//
-//        assertSearchReturnsComposition("subject:Basic.missing-boolean:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-boolean:missing", "false");
-//    }
-//    
-//    @Test
-//    public void testSearchToken_code_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.code:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.code:missing", "true");
-//
-//        assertSearchReturnsComposition("subject:Basic.missing-code:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-code:missing", "false");
-//    }
-//    
-//    @Test
-//    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.CodeableConcept:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:missing", "true");
-//
-//        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-CodeableConcept:missing", "false");
-//    }
+    @Test
+    public void testSearchToken_boolean_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.boolean:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.boolean:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-boolean:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-boolean:missing", "false");
+    }
+
+    @Test
+    public void testSearchToken_code_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.code:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.code:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-code:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-code:missing", "false");
+    }
+
+    @Test
+    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.CodeableConcept:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-CodeableConcept:missing", "false");
+    }
 
     @Test
     public void testSearchToken_CodeableConcept() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept", "code");
         assertSearchReturnsSavedResource("CodeableConcept", "http://example.org/codesystem|code");
 //        assertSearchReturnsSavedResource("CodeableConcept", "http://example.org/codesystem|");
-        
+
         // This shouldn't return any results because the CodeableConcept has a system
 //        assertSearchDoesntReturnSavedResource("CodeableConcept", "|code");
     }
-    
+
     @Test
     public void testSearchToken_CodeableConcept_or() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept", "foo,code,bar");
         assertSearchDoesntReturnSavedResource("CodeableConcept", "foo\\,code,bar");
         assertSearchDoesntReturnSavedResource("CodeableConcept", "foo,code\\,bar");
     }
-    
+
     @Test
     public void testSearchToken_CodeableConcept_escaped() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept", "http://example.org/codesystem|code");
         assertSearchDoesntReturnSavedResource("CodeableConcept", "http://example.org/codesystem\\|code");
     }
-    
+
     @Test
     public void testSearchToken_CodeableConcept_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.CodeableConcept", "code");
         assertSearchReturnsComposition("subject:Basic.CodeableConcept", "http://example.org/codesystem|code");
 //        assertSearchReturnsComposition("subject:Basic.CodeableConcept", "http://example.org/codesystem|");
-        
+
         // This shouldn't return any results because the CodeableConcept has a system
 //        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept", "|code");
     }
-    
+
     @Test
     public void testSearchDate_CodeableConcept_multiCoded() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept-multiCoded", "http://example.org/codesystem|code");
         assertSearchReturnsSavedResource("CodeableConcept-multiCoded", "http://example.org/othersystem|code");
     }
-    
+
     // Currently CodeableConcepts with no code are skipped
 //    @Test
 //    public void testSearchDate_CodeableConcept_NoCode() throws Exception {
 //        assertSearchReturnsSavedResource("CodeableConcept-noCode", "http://example.org/codesystem|");
 //    }
-    
+
     @Test
     public void testSearchToken_CodeableConcept_missing() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept:missing", "false");
         assertSearchDoesntReturnSavedResource("CodeableConcept:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-CodeableConcept:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-CodeableConcept:missing", "false");
     }
@@ -187,51 +183,51 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Coding", "code");
         assertSearchReturnsSavedResource("Coding", "http://example.org/codesystem|code");
 //        assertSearchReturnsSavedResource("Coding", "http://example.org/codesystem|");
-        
+
         // This shouldn't return any results because the Coding has a system
 //        assertSearchDoesntReturnSavedResource("Coding", "|code");
     }
-    
+
     @Test
     public void testSearchToken_Coding_or() throws Exception {
         assertSearchReturnsSavedResource("Coding", "foo,code,bar");
         assertSearchDoesntReturnSavedResource("Coding", "foo\\,code,bar");
         assertSearchDoesntReturnSavedResource("Coding", "foo,code\\,bar");
     }
-    
+
     @Test
     public void testSearchToken_Coding_escaped() throws Exception {
         assertSearchReturnsSavedResource("Coding", "http://example.org/codesystem|code");
         assertSearchDoesntReturnSavedResource("Coding", "http://example.org/codesystem\\|code");
     }
-    
+
     @Test
     public void testSearchToken_Coding_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.Coding", "code");
         assertSearchReturnsComposition("subject:Basic.Coding", "http://example.org/codesystem|code");
 //        assertSearchReturnsComposition("subject:Basic.Coding", "http://example.org/codesystem|");
-        
+
         // This shouldn't return any results because the Coding has a system
 //        assertSearchDoesntReturnComposition("subject:Basic.Coding", "|code");
     }
-    
+
     @Test
     public void testSearchDate_Coding_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("Coding-noSystem", "code");
         assertSearchReturnsSavedResource("Coding-noSystem", "|code");
     }
-    
+
     // Currently codings with no code are skipped
 //    @Test
 //    public void testSearchDate_Coding_NoCode() throws Exception {
 //        assertSearchReturnsSavedResource("Coding-noCode", "http://example.org/codesystem|");
 //    }
-    
+
     @Test
     public void testSearchToken_Coding_missing() throws Exception {
         assertSearchReturnsSavedResource("Coding:missing", "false");
         assertSearchDoesntReturnSavedResource("Coding:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-Coding:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Coding:missing", "false");
     }
@@ -241,57 +237,57 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
      * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
      */
-    
+
 //    @Test
 //    public void testSearchToken_Coding_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.Coding:missing", "false");
 //        assertSearchDoesntReturnComposition("subject:Basic.Coding:missing", "true");
-//        
+//
 //        assertSearchReturnsComposition("subject:Basic.missing-Coding:missing", "true");
 //        assertSearchDoesntReturnComposition("subject:Basic.missing-Coding:missing", "false");
 //    }
-    
+
     @Test
     public void testSearchToken_Identifier() throws Exception {
         assertSearchReturnsSavedResource("Identifier", "code");
         assertSearchReturnsSavedResource("Identifier", "http://example.org/identifiersystem|code");
 //        assertSearchReturnsSavedResource("Identifier", "http://example.org/identifiersystem|");
-        
+
         // This shouldn't return any results because the Identifier has a system
 //        assertSearchDoesntReturnSavedResource("Identifier", "|code");
     }
-    
+
     @Test
     public void testSearchToken_Identifier_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.Identifier", "code");
         assertSearchReturnsComposition("subject:Basic.Identifier", "http://example.org/identifiersystem|code");
 //        assertSearchReturnsComposition("subject:Basic.Identifier", "http://example.org/identifiersystem|");
-        
+
         // This shouldn't return any results because the Identifier has a system
 //        assertSearchDoesntReturnComposition("subject:Basic.Identifier", "|code");
     }
-    
+
     @Test
     public void testSearchDate_Identifier_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("Identifier-noSystem", "code");
         assertSearchReturnsSavedResource("Identifier-noSystem", "|code");
     }
-    
+
     // Currently identifiers with no value are skipped
 //    @Test
 //    public void testSearchDate_Identifier_NoValue() throws Exception {
 //        assertSearchReturnsSavedResource("Identifier-noValue", "http://example.org/identifiersystem|");
 //    }
-    
+
     @Test
     public void testSearchToken_Identifier_missing() throws Exception {
         assertSearchReturnsSavedResource("Identifier:missing", "false");
         assertSearchDoesntReturnSavedResource("Identifier:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-Identifier:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-Identifier:missing", "false");
     }
-    
+
     /*
      * Currently, documented in our conformance statement. We do not support
      * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
@@ -302,11 +298,11 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 //    public void testSearchToken_Identifier_chained_missing() throws Exception {
 //        assertSearchReturnsComposition("subject:Basic.Identifier:missing", "false");
 //        assertSearchDoesntReturnComposition("subject:Basic.Identifier:missing", "true");
-//        
+//
 //        assertSearchReturnsComposition("subject:Basic.missing-Identifier:missing", "true");
 //        assertSearchDoesntReturnComposition("subject:Basic.missing-Identifier:missing", "false");
 //    }
-    
+
     @Test
     public void testSearchToken_ContactPoint() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint", "(555) 675 5745");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
@@ -21,14 +21,16 @@ import com.ibm.fhir.model.test.TestUtil;
 
 /**
  * <a href="https://hl7.org/fhir/r4/search.html#uri">FHIR Specification: Search - uri</a>
- * 
+ *
  */
 public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
 
+    @Override
     protected Basic getBasicResource() throws Exception {
         return TestUtil.readExampleResource("json/ibm/basic/BasicURI.json");
     }
 
+    @Override
     protected void setTenant() throws Exception {
         FHIRRequestContext.get().setTenantId("uri");
     }
@@ -37,22 +39,22 @@ public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
     public void testSearchURI_uri() throws Exception {
         assertSearchReturnsSavedResource("uri", "http://hl7.org/fhir/DSTU2");
         assertSearchReturnsSavedResource("uri", "urn:uuid:53fefa32-1111-2222-3333-55ee120877b7");
-        
+
         // Matches are supposed to be precise (e.g. case, accent, and escape sensitive), but aren't
         assertSearchDoesntReturnSavedResource("uri", "http://hl7.org/fhir/DSTU");
         assertSearchDoesntReturnSavedResource("uri", "xttp://hl7.org/fhir/DSTU2");
         assertSearchDoesntReturnSavedResource("uri", "urn:uuid:53fefa32-1111-2222-3333-55ee120877b");
-        
+
         // case tests
         assertSearchDoesntReturnSavedResource("uri", "http://HL7.org/FHIR/dstu2");
         assertSearchDoesntReturnSavedResource("uri", "urn:uuid:53FEFA32-1111-2222-3333-55EE120877B7");
-        
+
         // accent tests
         assertSearchReturnsSavedResource("uri", "http://åé");
         assertSearchDoesntReturnSavedResource("uri", "http://ae");
         assertSearchDoesntReturnSavedResource("uri", "http://HL7.org/FHIR/dstü2");
     }
-    
+
     @Test
     public void testSearchURI_uri_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.uri", "http://hl7.org/fhir/DSTU2");
@@ -61,10 +63,10 @@ public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
         assertSearchDoesntReturnComposition("subject:Basic.uri", "http://HL7.org/FHIR/dstu2");
         assertSearchDoesntReturnComposition("subject:Basic.uri", "http://hl7.org/fhir/DSTU");
         assertSearchDoesntReturnComposition("subject:Basic.uri", "urn:uuid:53FEFA32-1111-2222-3333-55EE120877B7");
-        
+
         // TODO add test for diacritics and other unusual characters
     }
-    
+
     @Test
     public void testSearchURI_uri_revinclude() throws Exception {
         Map<String, List<String>> queryParms = new HashMap<String, List<String>>(1);
@@ -73,14 +75,14 @@ public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, savedResource));
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
-    
-    
+
+
     @Test
     public void testSearchURI_uri_below() throws Exception {
         assertSearchDoesntReturnSavedResource("uri:below", "http://hl7.org/fhir/");
         assertSearchReturnsSavedResource("uri:below", "http://hl7.org/fhir");
     }
-    
+
     @Test
     public void testUriAbove() throws Exception {
         assertSearchDoesntReturnSavedResource("uri:above", "FHIR/dstu2");
@@ -88,28 +90,22 @@ public abstract class AbstractSearchURITest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("uri:above", "http://hl7.org/fhir/DSTU2/Fred");
         assertSearchReturnsSavedResource("uri:above", "http://hl7.org/fhir/DSTU2/Fred/Wilma");
     }
-    
+
     @Test
     public void testSearchURI_uri_missing() throws Exception {
         assertSearchReturnsSavedResource("uri:missing", "false");
         assertSearchDoesntReturnSavedResource("uri:missing", "true");
-        
+
         assertSearchReturnsSavedResource("missing-uri:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-uri:missing", "false");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    
-//    @Test
-//    public void testSearchURI_uri_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.uri:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.uri:missing", "true");
-//        
-//        assertSearchReturnsComposition("subject:Basic.missing-uri:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-uri:missing", "false");
-//    }
+    @Test
+    public void testSearchURI_uri_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.uri:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.uri:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-uri:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-uri:missing", "false");
+    }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchURITest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -274,6 +274,7 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
         List<String> falseString = Collections.singletonList("false");
         queryParms.put("_id", savedId);
         queryParms.put("_lastUpdated", savedLastUpdated);
+        queryParms.put("_tag:missing", falseString);
         queryParms.put("_profile:missing", falseString);
 
         if (DEBUG) {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -6,11 +6,11 @@
 
 package com.ibm.fhir.persistence.search.test;
 
+import static com.ibm.fhir.model.test.TestUtil.isResourceInResponse;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import static com.ibm.fhir.model.test.TestUtil.isResourceInResponse;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.format.Format;
@@ -258,6 +259,28 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
         List<Resource> resources =
                 runQueryTest(Resource.class,
                         "_tag", TAG);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchAllUsingIdAndLastUpdatedAndAnyTagOrProfile() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        List<String> savedId = Collections.singletonList(savedResource.getId());
+
+        String dateTime = savedResource.getMeta().getLastUpdated().getValue().toString();
+        List<String> savedLastUpdated = Collections.singletonList(dateTime);
+        List<String> falseString = Collections.singletonList("false");
+        queryParms.put("_id", savedId);
+        queryParms.put("_lastUpdated", savedLastUpdated);
+        queryParms.put("_profile:missing", falseString);
+
+        if (DEBUG) {
+            generateOutput(savedResource);
+        }
+
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
         assertNotNull(resources);
         assertEquals(resources.size(), 1, "Number of resources returned");
         assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameter.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameter.java
@@ -19,7 +19,7 @@ import com.ibm.fhir.search.SearchConstants.Prefix;
 import com.ibm.fhir.search.SearchConstants.Type;
 
 /**
- * general type of parameter. 
+ * general type of parameter.
  */
 public class QueryParameter {
     private Type type = null;
@@ -73,6 +73,7 @@ public class QueryParameter {
         return this.nextParameter != null && !this.isInclusionCriteria;
     }
 
+    @Override
     public String toString() {
         StringBuilder buffer = new StringBuilder();
 
@@ -157,8 +158,8 @@ public class QueryParameter {
 
     /**
      * The returned value is intentionally not abstract. The order is important.
-     * 
-     * @return
+     *
+     * @return A non-null linked list of parameters that starts from the nextParameter.
      */
     public LinkedList<QueryParameter> getChain() {
 

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameter.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/QueryParameter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -49,6 +49,7 @@ import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.UnsignedInt;
@@ -501,7 +502,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         try {
             String resourceTypeName = type;
             if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+                throw buildUnsupportedResourceTypeException(type);
             }
 
             Class<? extends Resource> resourceType =
@@ -683,7 +684,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         try {
             String resourceTypeName = type;
             if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+                throw buildUnsupportedResourceTypeException(type);
             }
 
             Class<? extends Resource> resourceType = getResourceType(resourceTypeName);
@@ -761,7 +762,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         try {
             String resourceTypeName = type;
             if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+                throw buildUnsupportedResourceTypeException(type);
             }
 
             Class<? extends Resource> resourceType =
@@ -836,7 +837,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         try {
             String resourceTypeName = type;
             if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+                throw buildUnsupportedResourceTypeException(type);
             }
 
             Class<? extends Resource> resourceType =
@@ -913,7 +914,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // Check to see if it's supported, else, throw a bad request.
             // If this is removed, it'll result in nullpointer when processing the request
             if (!ModelSupport.isResourceType(type)) {
-                throw buildUnsupportedResourceTypeException(type, IssueType.NOT_SUPPORTED);
+                throw buildUnsupportedResourceTypeException(type);
             }
 
             Class<? extends Resource> resourceType =
@@ -1161,7 +1162,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
                             .extension(Extension.builder()
                                 .url(EXTENSION_URL +  "/not-supported-detail")
-                                .value(string("interaction"))
+                                .value(Code.of("interaction"))
                                 .build())
                             .build();
                     throw buildRestException(msg, extendedIssueType);
@@ -1304,7 +1305,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
                         .extension(Extension.builder()
                             .url(EXTENSION_URL +  "/not-supported-detail")
-                            .value(string("interaction"))
+                            .value(Code.of("interaction"))
                             .build())
                         .build();
                 throw buildRestException(msg, extendedIssueType);
@@ -1379,9 +1380,20 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         }
     }
 
-    private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName, IssueType issueType)
+    private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName)
             throws FHIROperationException {
-        return buildRestException("'" + resourceTypeName + "' is not a valid resource type.", issueType);
+        String msg = "'" + resourceTypeName + "' is not a valid resource type.";
+        Issue issue = OperationOutcome.Issue.builder()
+                .severity(IssueSeverity.FATAL)
+                .code(IssueType.NOT_SUPPORTED.toBuilder()
+                        .extension(Extension.builder()
+                            .url(EXTENSION_URL +  "/not-supported-detail")
+                            .value(Code.of("resource"))
+                            .build())
+                        .build())
+                .details(CodeableConcept.builder().text(string(msg)).build())
+                .build();
+        return new FHIROperationException(msg).withIssue(issue);
     }
 
     private FHIROperationException buildRestException(String msg, IssueType issueType) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/IssueTypeToHttpStatusMapper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/IssueTypeToHttpStatusMapper.java
@@ -21,7 +21,7 @@ public class IssueTypeToHttpStatusMapper {
      * Custom extension used by the IBM FHIR Server for marking which precondition has failed (if any)
      */
     private static final String EXTENSION_URL_HTTP_FAILED_PRECONDITION = "http://ibm.com/fhir/extension/http-failed-precondition";
-    
+
     /**
      * Custom extension used by the IBM FHIR Server for marking what it was that wasn't supported:
      * resource | interaction
@@ -38,7 +38,7 @@ public class IssueTypeToHttpStatusMapper {
         }
         return issueListToStatus(oo.getIssue());
     }
-    
+
     /**
      * @return an HTTP response status based on the first issue contained within the OperationOutcomeIssue list with a code;
      *         Response.Status.INTERNAL_SERVER_ERROR if it is null or empty
@@ -54,8 +54,8 @@ public class IssueTypeToHttpStatusMapper {
                             FHIRUtil.getExtensionStringValue(code, EXTENSION_URL_HTTP_FAILED_PRECONDITION) != null) {
                         return Status.PRECONDITION_FAILED;
                     } else if (issueType == IssueType.ValueSet.NOT_SUPPORTED &&
-                            "interaction".equals(FHIRUtil.getExtensionStringValue(code, EXTENSION_URL_NOT_SUPPORTED_DETAIL))) {
-                        return Status.BAD_REQUEST;
+                            "resource".equals(FHIRUtil.getExtensionStringValue(code, EXTENSION_URL_NOT_SUPPORTED_DETAIL))) {
+                        return Status.NOT_FOUND;
                     }
                     return issueTypeToResponseCode(issueType);
                 }
@@ -63,7 +63,7 @@ public class IssueTypeToHttpStatusMapper {
         }
         return Status.INTERNAL_SERVER_ERROR;
     }
-    
+
     private static Status issueTypeToResponseCode(IssueType.ValueSet value) {
         switch (value) {
         case INFORMATIONAL:
@@ -74,6 +74,7 @@ public class IssueTypeToHttpStatusMapper {
         case THROTTLED:     // Consider HTTP 429?
             return Status.FORBIDDEN;
         case PROCESSING:
+        case NOT_SUPPORTED:
         case BUSINESS_RULE: // Consider HTTP 422?
         case CODE_INVALID:  // Consider HTTP 422?
         case EXTENSION:     // Consider HTTP 422?
@@ -96,7 +97,6 @@ public class IssueTypeToHttpStatusMapper {
         case UNKNOWN:
             return Status.UNAUTHORIZED;
         case NOT_FOUND:
-        case NOT_SUPPORTED:
             return Status.NOT_FOUND;
         case TOO_LONG:
             return Status.REQUEST_ENTITY_TOO_LARGE;

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -116,7 +116,7 @@ public class CodeGenerator {
 
     private static final String URI_PATTERN = "\\S*";
     private static final String STRING_PATTERN = "[ \\r\\n\\t\\S]+";
-    
+
     private static final String ALL_LANG_VALUE_SET_URL = "http://hl7.org/fhir/ValueSet/all-languages";
 
     public CodeGenerator(Map<String, JsonObject> structureDefinitionMap, Map<String, JsonObject> codeSystemMap, Map<String, JsonObject> valueSetMap) {
@@ -1248,7 +1248,7 @@ public class CodeGenerator {
             }
         }
     }
-    
+
     /**
      * Gets the name of the validationSupport method to use to validate the syntax-based value set.
      * @param valueSet the value set
@@ -1896,6 +1896,9 @@ public class CodeGenerator {
     private void generateIsAsMethods(JsonObject structureDefinition, CodeBuilder cb) {
         String name = structureDefinition.getString("name");
         if ("Resource".equals(name)) {
+            cb.javadocStart()
+                .javadocReturn("true if the resource can be cast to the requested resourceType")
+                .javadocEnd();
             cb.method(mods("public"), "<T extends Resource> boolean", "is", params("Class<T> resourceType"))
                 ._return("resourceType.isInstance(this)")
             .end().newLine();
@@ -1908,6 +1911,9 @@ public class CodeGenerator {
             .end().newLine();
         }
         if ("Element".equals(name)) {
+            cb.javadocStart()
+                .javadocReturn("true if the element can be cast to the requested elementType")
+                .javadocEnd();
             cb.method(mods("public"), "<T extends Element> boolean", "is", params("Class<T> elementType"))
                 ._return("elementType.isInstance(this)")
             .end().newLine();
@@ -3300,7 +3306,7 @@ public class CodeGenerator {
         }
         return null;
     }
-    
+
     private String getMinValueSet(JsonObject binding) {
         for (JsonValue extension : binding.getOrDefault("extension", JsonArray.EMPTY_JSON_ARRAY).asJsonArray()) {
             if (extension.asJsonObject().getString("url").endsWith("minValueSet")) {


### PR DESCRIPTION
 1. uncomment the chained_missing search tests from the fhir-persistence module
 2. update FHIRPersistenceJDBCImpl.checkModifiers to throw a FHIRPersistenceNotSupportedException for chained params with a modifier
 3. override these search tests in the fhir-persistence-jdbc concrete subtypes and add an exception expectation
    
 separately, i found and opened issue #1415, documented the current limitation, and made a similar "fix":

 4. add a search test to AbstractWholeSystemSearchTest
 5. update FHIRPersistenceJDBCImpl.checkModifiers to throw a FHIRPersistenceNotSupportedException for whole-system search params with the missing modifier
 6. override that search test in JDBCWholeSystemSearchTest to expect that exception

finally,

7. added javadoc for Element.is (and Resource.is)
8. added issue of type NOT_SUPPORTED to FHIRPersistenceNotSupportedException for unsupported modifiers
9. added not-supported-detail extension for requests to unsupported
    resource type endpoints and flipped logic in IssueTypeToHttpStatusMapper
    so that only NOT_SUPPORTED issues with the "resource" extension are
    turned into 404 (NOT_FOUND) errors