### PR TITLE
issue #1452 - split EvalContext issues and only add errorDetails if constraint failed

### DIFF
--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
@@ -67,7 +67,7 @@ public class USCoreEthnicityExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')");
         System.out.println("result: " + result);
 
-        List<Issue> issues = evaluator.getEvaluationContext().getIssues();
+        List<Issue> issues = evaluator.getEvaluationContext().getSupplementalWarnings();
         issues.forEach(System.out::println);
 
         Assert.assertEquals(result, SINGLETON_TRUE);
@@ -109,10 +109,10 @@ public class USCoreEthnicityExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity')");
         System.out.println("result: " + result);
 
-        List<Issue> issues = evaluator.getEvaluationContext().getIssues();
-        issues.forEach(System.out::println);
-
         Assert.assertEquals(result, SINGLETON_FALSE);
+
+        List<Issue> issues = evaluator.getEvaluationContext().getErrorDetails();
+        issues.forEach(System.out::println);
         Assert.assertEquals(issues.size(), 2);
     }
 

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
@@ -67,7 +67,7 @@ public class USCoreRaceExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')");
         System.out.println("result: " + result);
 
-        List<Issue> issues = evaluator.getEvaluationContext().getIssues();
+        List<Issue> issues = evaluator.getEvaluationContext().getSupplementalWarnings();
         issues.forEach(System.out::println);
 
         Assert.assertEquals(result, SINGLETON_TRUE);
@@ -109,10 +109,10 @@ public class USCoreRaceExtensionTest {
         Collection<FHIRPathNode> result = evaluator.evaluate(extension, "conformsTo('http://hl7.org/fhir/us/core/StructureDefinition/us-core-race')");
         System.out.println("result: " + result);
 
-        List<Issue> issues = evaluator.getEvaluationContext().getIssues();
-        issues.forEach(System.out::println);
-
         Assert.assertEquals(result, SINGLETON_FALSE);
+
+        List<Issue> issues = evaluator.getEvaluationContext().getErrorDetails();
+        issues.forEach(System.out::println);
         Assert.assertEquals(issues.size(), 2);
     }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -1331,7 +1331,8 @@ public class FHIRPathEvaluator {
         private final Map<String, Collection<FHIRPathNode>> externalConstantMap = new HashMap<>();
 
         private Constraint constraint;
-        private final List<Issue> issues = new ArrayList<>();
+        private final List<Issue> supplementalWarnings = new ArrayList<>();
+        private final List<Issue> errorDetails = new ArrayList<>();
 
         /**
          * Create an empty evaluation context, evaluating stand-alone expressions
@@ -1494,32 +1495,56 @@ public class FHIRPathEvaluator {
         }
 
         /**
-         * Get the list of supplemental issues that were generated during evaluation
+         * Get the list of supplemental warnings that were generated during evaluation
          *
-         * <p>Supplemental issues are used to convey additional information about the evaluation to the client
+         * <p>Supplemental warnings are used to convey additional information about the evaluation to the client
          *
          * @return
-         *     the list of supplemental issues that were generated during evaluation
+         *     the list of supplemental warnings that were generated during evaluation
          */
-        public List<Issue> getIssues() {
-            return issues;
+        public List<Issue> getSupplementalWarnings() {
+            return supplementalWarnings;
         }
 
         /**
-         * Clear the list of supplemental issues that were generated during evaluation
+         * Get a list of issues containing additional error details that were generated during evaluation
+         *
+         * <p>Error detail is kept in-context until cleared; this is useful for reporting more meaningful errors
+         * in constraints that are further "up the stack".
+         *
+         * @return
+         *     a potentially-empty list of issues with error details that were generated during evaluation
+         */
+        public List<Issue> getErrorDetails() {
+            return errorDetails;
+        }
+
+        /**
+         * Clear the list of supplemental warnings and/or error details that were generated during evaluation
          */
         public void clearIssues() {
-            issues.clear();
+            supplementalWarnings.clear();
+            errorDetails.clear();
         }
 
         /**
-         * Indicates whether this evaluation context has supplemental issues that were generated during evaluation
+         * Indicates whether this evaluation context has supplemental warnings that were generated during evaluation
          *
          * @return
-         *     true if this evaluation context has supplemental issues that were generated during evaluation, otherwise false
+         *     true if this evaluation context has supplemental warnings that were generated during evaluation, otherwise false
          */
-        public boolean hasIssues() {
-            return !issues.isEmpty();
+        public boolean hasSupplementalWarnings() {
+            return !supplementalWarnings.isEmpty();
+        }
+
+        /**
+         * Indicates whether this evaluation context has additional detail that is associated with a constraint failure
+         *
+         * @return
+         *     true if this evaluation context has error details that were generated during evaluation, otherwise false
+         */
+        public boolean hasErrorDetails() {
+            return !errorDetails.isEmpty();
         }
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
@@ -80,7 +80,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
             if (FHIRPathType.FHIR_UNKNOWN_RESOURCE_TYPE.equals(type)) {
                 if (!StructureDefinitionKind.RESOURCE.equals(structureDefinition.getKind())) {
                     // the profile (or base definition) is not applicable to type: UnknownResourceType
-                    generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: UnknownResourceType", node.path());
+                    generateErrorDetail(evaluationContext, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: UnknownResourceType", node.path());
                     return SINGLETON_FALSE;
                 }
 
@@ -91,7 +91,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
 
             if (!ProfileSupport.isApplicable(structureDefinition, modelClass)) {
                 // the profile (or base definition) is not applicable to type: modelClass
-                generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: " + ModelSupport.getTypeName(modelClass), node.path());
+                generateErrorDetail(evaluationContext, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: " + ModelSupport.getTypeName(modelClass), node.path());
                 return SINGLETON_FALSE;
             }
 
@@ -116,7 +116,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
                     Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, constraint.expression(), context);
                     if (evaluatesToBoolean(result) && isFalse(result)) {
                         // constraint validation failed
-                        generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVARIANT, constraint.id() + ": " + constraint.description(), node.path());
+                        generateErrorDetail(evaluationContext, IssueType.INVARIANT, constraint.id() + ": " + constraint.description(), node.path());
 
                         // restore parent constraint reference
                         evaluationContext.setConstraint(parentConstraint);
@@ -132,7 +132,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
             // restore parent constraint reference
             evaluationContext.setConstraint(parentConstraint);
         } else {
-            generateIssue(evaluationContext, IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, "Conformance check was not performed: profile (or base definition) '" + url + "' is not supported", node.path());
+            generateSupplementalWarning(evaluationContext, IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, "Conformance check was not performed: profile (or base definition) '" + url + "' is not supported", node.path());
         }
 
         return SINGLETON_TRUE;

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ExpandFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ExpandFunction.java
@@ -28,7 +28,6 @@ import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.Uri;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
@@ -83,7 +82,7 @@ public class ExpandFunction extends FHIRPathAbstractTermFunction {
         ValueSet valueSet = getResource(arguments, ValueSet.class);
         if (!isExpanded(valueSet) && !service.isExpandable(valueSet)) {
             String url = (valueSet.getUrl() != null) ? valueSet.getUrl().getValue() : null;
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "ValueSet with url '" + url + "' is not expandable", "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.NOT_SUPPORTED, "ValueSet with url '" + url + "' is not expandable", "%terminologies");
             return empty();
         }
         Parameters parameters = getParameters(arguments);

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractFunction.java
@@ -34,13 +34,13 @@ public abstract class FHIRPathAbstractFunction implements FHIRPathFunction {
         throw new UnsupportedOperationException("Function: '" + getName() + "' is not supported");
     }
 
-    protected void generateIssue(
+    protected void generateSupplementalWarning(
             EvaluationContext evaluationContext,
             IssueSeverity severity,
             IssueType code,
             String description,
             String expression) {
-        evaluationContext.getIssues().add(Issue.builder()
+        evaluationContext.getSupplementalWarnings().add(Issue.builder()
             .severity(severity)
             .code(code)
             .details(CodeableConcept.builder()
@@ -49,6 +49,21 @@ public abstract class FHIRPathAbstractFunction implements FHIRPathFunction {
             .expression(string(expression))
             .build());
     }
+
+    protected void generateErrorDetail(
+        EvaluationContext evaluationContext,
+        IssueType code,
+        String description,
+        String expression) {
+    evaluationContext.getErrorDetails().add(Issue.builder()
+        .severity(IssueSeverity.ERROR)
+        .code(code)
+        .details(CodeableConcept.builder()
+            .text(string(description))
+            .build())
+        .expression(string(expression))
+        .build());
+}
 
     @Override
     public boolean equals(Object obj) {

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/LookupFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/LookupFunction.java
@@ -23,7 +23,6 @@ import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
@@ -69,7 +68,7 @@ public class LookupFunction extends FHIRPathAbstractTermFunction {
         Parameters parameters = getParameters(arguments);
         LookupOutcome outcome = service.lookup(coding, LookupParameters.from(parameters));
         if (outcome == null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "Lookup cannot be performed", "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.NOT_SUPPORTED, "Lookup cannot be performed", "%terminologies");
             return empty();
         }
         return singleton(FHIRPathResourceNode.resourceNode(outcome.toParameters()));

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ResolveFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ResolveFunction.java
@@ -100,7 +100,7 @@ public class ResolveFunction extends FHIRPathAbstractFunction {
                 FHIRPathType type = isResourceType(resourceType) ? FHIRPathType.from(resourceType) : FHIRPathType.FHIR_UNKNOWN_RESOURCE_TYPE;
 
                 if (referenceReference != null && FHIRPathType.FHIR_UNKNOWN_RESOURCE_TYPE.equals(type)) {
-                    generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.INFORMATIONAL, "Resource type could not be inferred from reference: " + referenceReference, node.path());
+                    generateSupplementalWarning(evaluationContext, IssueSeverity.INFORMATION, IssueType.INFORMATIONAL, "Resource type could not be inferred from reference: " + referenceReference, node.path());
                 }
 
                 result.add(FHIRPathResourceNode.resourceNode(type));

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/SubsumedByFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/SubsumedByFunction.java
@@ -17,7 +17,6 @@ import java.util.List;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
@@ -50,7 +49,7 @@ public class SubsumedByFunction extends FHIRPathAbstractTermFunction {
         ConceptSubsumptionOutcome outcome = service.subsumes(codingA, codingB);
 
         if (outcome == null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "Subsumption cannot be tested", getElementNode(context).path());
+            generateErrorDetail(evaluationContext, IssueType.NOT_SUPPORTED, "Subsumption cannot be tested", getElementNode(context).path());
             return empty();
         }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/SubsumesFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/SubsumesFunction.java
@@ -18,7 +18,6 @@ import java.util.List;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
@@ -63,7 +62,7 @@ public class SubsumesFunction extends FHIRPathAbstractTermFunction {
         ConceptSubsumptionOutcome outcome = service.subsumes(codingA, codingB);
 
         if (outcome == null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.NOT_SUPPORTED, "Subsumption cannot be tested", (arguments.size() == 1) ? getElementNode(context).path() : "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.NOT_SUPPORTED, "Subsumption cannot be tested", (arguments.size() == 1) ? getElementNode(context).path() : "%terminologies");
             return empty();
         }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/TranslateFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/TranslateFunction.java
@@ -25,7 +25,6 @@ import com.ibm.fhir.model.type.Boolean;
 import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.Element;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
@@ -73,7 +72,7 @@ public class TranslateFunction extends FHIRPathAbstractTermFunction {
                 service.translate(conceptMap, codedElement.as(CodeableConcept.class), TranslationParameters.from(parameters)) :
                 service.translate(conceptMap, codedElement.as(Coding.class), TranslationParameters.from(parameters));
         if (outcome.getMessage() != null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.NOT_FOUND, outcome.getMessage().getValue(), "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.NOT_FOUND, outcome.getMessage().getValue(), "%terminologies");
         }
         return singleton(FHIRPathResourceNode.resourceNode(outcome.toParameters()));
     }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateCSFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateCSFunction.java
@@ -27,7 +27,6 @@ import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
@@ -80,7 +79,7 @@ public class ValidateCSFunction extends FHIRPathAbstractTermFunction {
                 service.validateCode(codeSystem, codedElement.as(CodeableConcept.class), ValidationParameters.from(parameters)) :
                 service.validateCode(codeSystem, codedElement.as(Coding.class), ValidationParameters.from(parameters));
         if (Boolean.FALSE.equals(outcome.getResult()) && outcome.getMessage() != null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.CODE_INVALID, outcome.getMessage().getValue(), "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.CODE_INVALID, outcome.getMessage().getValue(), "%terminologies");
         }
         return singleton(FHIRPathResourceNode.resourceNode(outcome.toParameters()));
     }
@@ -95,17 +94,17 @@ public class ValidateCSFunction extends FHIRPathAbstractTermFunction {
                     return true;
                 }
             }
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.CODE_INVALID, "CodeableConcept does not contain a coding element that matches the specified CodeSystem url and/or version", "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.CODE_INVALID, "CodeableConcept does not contain a coding element that matches the specified CodeSystem url and/or version", "%terminologies");
             return false;
         }
         // codedElement.is(Coding.class)
         Coding coding = codedElement.as(Coding.class);
         if (coding.getSystem() != null && codeSystem.getUrl() != null && !coding.getSystem().equals(codeSystem.getUrl())) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.CODE_INVALID, "Coding system does not match the specified CodeSystem url", "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.CODE_INVALID, "Coding system does not match the specified CodeSystem url", "%terminologies");
             return false;
         }
         if (coding.getVersion() != null && codeSystem.getVersion() != null && !coding.getVersion().equals(codeSystem.getVersion())) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.CODE_INVALID, "Coding version does not match the specified CodeSystem version", "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.CODE_INVALID, "Coding version does not match the specified CodeSystem version", "%terminologies");
             return false;
         }
         return true;

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateVSFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateVSFunction.java
@@ -27,7 +27,6 @@ import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
@@ -77,7 +76,7 @@ public class ValidateVSFunction extends FHIRPathAbstractTermFunction {
                 service.validateCode(valueSet, codedElement.as(CodeableConcept.class), ValidationParameters.from(parameters)) :
                 service.validateCode(valueSet, codedElement.as(Coding.class), ValidationParameters.from(parameters));
         if (Boolean.FALSE.equals(outcome.getResult()) && outcome.getMessage() != null) {
-            generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.CODE_INVALID, outcome.getMessage().getValue(), "%terminologies");
+            generateErrorDetail(evaluationContext, IssueType.CODE_INVALID, outcome.getMessage().getValue(), "%terminologies");
         }
         return singleton(FHIRPathResourceNode.resourceNode(outcome.toParameters()));
     }

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
@@ -133,8 +133,8 @@ public class MemberOfFunctionTest {
         EvaluationContext evaluationContext = new EvaluationContext(Code.of("x"));
         Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, "$this.memberOf('http://ibm.com/fhir/ValueSet/vs1', 'extensible')");
 
-        Assert.assertEquals(evaluationContext.getIssues().size(), 2);
-        Issue issue = evaluationContext.getIssues().get(0);
+        Assert.assertEquals(evaluationContext.getSupplementalWarnings().size(), 2);
+        Issue issue = evaluationContext.getSupplementalWarnings().get(0);
         Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);
         Assert.assertEquals(result, SINGLETON_TRUE);
@@ -147,8 +147,8 @@ public class MemberOfFunctionTest {
         EvaluationContext evaluationContext = new EvaluationContext(Code.of("x"));
         Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, "$this.memberOf('http://ibm.com/fhir/ValueSet/vs1', 'preferred')");
 
-        Assert.assertEquals(evaluationContext.getIssues().size(), 2);
-        Issue issue = evaluationContext.getIssues().get(0);
+        Assert.assertEquals(evaluationContext.getSupplementalWarnings().size(), 2);
+        Issue issue = evaluationContext.getSupplementalWarnings().get(0);
         Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);
         Assert.assertEquals(result, SINGLETON_TRUE);

--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -350,9 +350,8 @@ public class FHIRValidator {
                         issues.add(issue(severity, IssueType.INVARIANT, constraint.id() + ": " + constraint.description(), contextNode));
                         // Add any error details from the evaluation context as well
                         issues.addAll(evaluationContext.getErrorDetails());
-                    } else {
-                        issues.addAll(evaluationContext.getSupplementalWarnings());
                     }
+                    issues.addAll(evaluationContext.getSupplementalWarnings());
                     evaluationContext.clearIssues();
 
                     if (log.isLoggable(Level.FINER)) {


### PR DESCRIPTION
1. split EvaluationContext.issues into 2 lists:  supplementalWarnings and errorDetails
2. from FHIRValidator, only add errorDetails to the resulting issue list if the constraint actually fails

This addresses the issue because if the overall constraint is true, this will prevent us from adding the erroneous error details for the part of the "or" clause that failed.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>