### PR TITLE
issue #1452 - reduce severity of supplemental issues in conformsTo

### DIFF
--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreEthnicityExtensionTest.java
@@ -10,6 +10,7 @@ import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_FALSE;
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_TRUE;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countErrors;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.countInformation;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countWarnings;
 
 import java.util.Collection;
@@ -211,6 +212,7 @@ public class USCoreEthnicityExtensionTest {
         issues.forEach(System.out::println);
 
         Assert.assertEquals(countWarnings(issues), 1);
-        Assert.assertEquals(countErrors(issues), 3);
+        Assert.assertEquals(countErrors(issues), 2);
+        Assert.assertEquals(countInformation(issues), 1);
     }
 }

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/USCoreRaceExtensionTest.java
@@ -10,6 +10,7 @@ import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_FALSE;
 import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_TRUE;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countErrors;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.countInformation;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countWarnings;
 
 import java.util.Collection;
@@ -211,6 +212,7 @@ public class USCoreRaceExtensionTest {
         issues.forEach(System.out::println);
 
         Assert.assertEquals(countWarnings(issues), 1);
-        Assert.assertEquals(countErrors(issues), 3);
+        Assert.assertEquals(countErrors(issues), 2);
+        Assert.assertEquals(countInformation(issues), 1);
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
@@ -80,7 +80,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
             if (FHIRPathType.FHIR_UNKNOWN_RESOURCE_TYPE.equals(type)) {
                 if (!StructureDefinitionKind.RESOURCE.equals(structureDefinition.getKind())) {
                     // the profile (or base definition) is not applicable to type: UnknownResourceType
-                    generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: UnknownResourceType", node.path());
+                    generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: UnknownResourceType", node.path());
                     return SINGLETON_FALSE;
                 }
 
@@ -91,7 +91,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
 
             if (!ProfileSupport.isApplicable(structureDefinition, modelClass)) {
                 // the profile (or base definition) is not applicable to type: modelClass
-                generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: " + ModelSupport.getTypeName(modelClass), node.path());
+                generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: " + ModelSupport.getTypeName(modelClass), node.path());
                 return SINGLETON_FALSE;
             }
 
@@ -116,7 +116,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
                     Collection<FHIRPathNode> result = evaluator.evaluate(evaluationContext, constraint.expression(), context);
                     if (evaluatesToBoolean(result) && isFalse(result)) {
                         // constraint validation failed
-                        generateIssue(evaluationContext, IssueSeverity.ERROR, IssueType.INVARIANT, constraint.id() + ": " + constraint.description(), node.path());
+                        generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.INVARIANT, constraint.id() + ": " + constraint.description(), node.path());
 
                         // restore parent constraint reference
                         evaluationContext.setConstraint(parentConstraint);

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
@@ -48,7 +48,7 @@ public class MaxValueSetTest {
      */
     @Test
     public void testConstraintGenerator() throws Exception {
-        
+
         // Tests the generation of constraints generated from bindings that include a MaxValueSet extension,
         // by using a Device profile and extensions created specifically for this test.
         //
@@ -72,7 +72,7 @@ public class MaxValueSetTest {
         // Choice: Yes; Optional: Yes; Repeatable: Yes
         //----[test-language-others-opt-extension]
         //-----------------------------------------------
-        
+
         StructureDefinition structureDefinition = FHIRRegistry.getInstance().getResource("http://ibm.com/fhir/StructureDefinition/test-device", StructureDefinition.class);
         ConstraintGenerator generator = new ConstraintGenerator(structureDefinition);
         List<Constraint> constraints = generator.generate();
@@ -89,7 +89,7 @@ public class MaxValueSetTest {
         assertEquals(constraints.size(), 2);
         constraints.forEach(constraint -> compile(constraint.expression()));
         assertEquals(constraints.get(1).expression(), "value.as(CodeableConcept).exists() and value.as(CodeableConcept).memberOf('http://hl7.org/fhir/ValueSet/languages', 'preferred') and value.as(CodeableConcept).memberOf('http://hl7.org/fhir/ValueSet/all-languages', 'required')");
-        
+
         structureDefinition = FHIRRegistry.getInstance().getResource("http://ibm.com/fhir/StructureDefinition/test-language-secondary-extension", StructureDefinition.class);
         generator = new ConstraintGenerator(structureDefinition);
         constraints = generator.generate();
@@ -118,26 +118,26 @@ public class MaxValueSetTest {
         constraints.forEach(constraint -> compile(constraint.expression()));
         assertEquals(constraints.get(1).expression(), "value.as(CodeableConcept).exists() and value.as(CodeableConcept).all(memberOf('http://hl7.org/fhir/ValueSet/languages', 'preferred')) and value.as(CodeableConcept).all(memberOf('http://hl7.org/fhir/ValueSet/all-languages', 'required'))");
     }
-    
+
     /**
      * Tests the validation of a maxValueSet.
      * @throws Exception an exception
      */
     @Test
     public void testValidator() throws Exception {
-        
+
         // No warnings/error
         Device device = buildDevice();
         List<Issue> issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
-        
+
         // Error for missing statusReason
         device = buildDevice().toBuilder().statusReason(Collections.emptyList()).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 1);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
-        
+
         // Warning and error for statusReason
         device = buildDevice().toBuilder().statusReason(Arrays.asList(
                 CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("i-klingon")).build()).build(),
@@ -146,29 +146,29 @@ public class MaxValueSetTest {
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        
+
         // Warning for type
         device = buildDevice().toBuilder()
                 .type(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("i-klingon")).build()).build()).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
-        
+
         // Error for type
         device = buildDevice().toBuilder()
                 .type(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build()).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
-        
+
         // Warning and error for specialization.systemType
         device = buildDevice().toBuilder().specialization(Arrays.asList(
                 Specialization.builder().systemType(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("i-klingon")).build()).build()).build(),
-                Specialization.builder().systemType(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidSystem")).build()).build()).build())).build();                
+                Specialization.builder().systemType(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidSystem")).build()).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        
+
         // Warning and error for safety
         device = buildDevice().toBuilder().safety(Arrays.asList(
                 CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("i-klingon")).build()).build(),
@@ -177,7 +177,7 @@ public class MaxValueSetTest {
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        
+
         // Warning for test-language-primary-extension
         device = buildDevice().toBuilder()
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-primary-extension")
@@ -191,9 +191,10 @@ public class MaxValueSetTest {
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-primary-extension")
                 .value(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
-        assertEquals(FHIRValidationUtil.countErrors(issues), 3);
+        assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
-        
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
+
         // Warning for test-language-secondary-extension
         device = buildDevice().toBuilder()
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-secondary-extension")
@@ -207,9 +208,10 @@ public class MaxValueSetTest {
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-secondary-extension")
                 .value(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
-        assertEquals(FHIRValidationUtil.countErrors(issues), 3);
+        assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
+
         // Warning for test-language-tertiary-extension
         device = buildDevice().toBuilder()
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-tertiary-extension")
@@ -217,16 +219,17 @@ public class MaxValueSetTest {
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        
+
         // Error for test-language-tertiary-extension
         device = buildDevice().toBuilder()
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-tertiary-extension")
                 .value(Code.of("invalidLanguage")).build())).build();
         issues = FHIRValidator.validator().validate(device);
-        assertEquals(FHIRValidationUtil.countErrors(issues), 3);
+        assertEquals(FHIRValidationUtil.countErrors(issues), 2);
         assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
     }
-    
+
     /**
      * Builds a device that will validate successfully.
      * @return a device

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ProfileConstraintTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ProfileConstraintTest.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.validation.test;
 
 import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countErrors;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.countInformation;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countWarnings;
 import static org.testng.Assert.assertEquals;
 
@@ -65,7 +66,8 @@ public class ProfileConstraintTest {
                 .build();
 
         List<Issue> issues = FHIRValidator.validator().validate(coverage);
-        assertEquals(countErrors(issues), 2);
+        assertEquals(countErrors(issues), 1);
         assertEquals(countWarnings(issues), 1);
+        assertEquals(countInformation(issues), 1);
     }
 }


### PR DESCRIPTION
An alternative to #1465

Previously, we added supplemental issues with a Severity of ERROR when
the conformance check failed.
However, we also return false in these cases and so it should be the
caller's responsibility to determine if that will result in an error or
not.
Instead, the detail in these supplemental issues is really just extra
information about the failed conformance check and thus these now have a
severity of "information".

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>