### PR TITLE
Miscelaneous edits to fhirpath and conformance classes

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathElementNode.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathElementNode.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,40 +17,40 @@ import com.ibm.fhir.path.visitor.FHIRPathNodeVisitor;
  */
 public class FHIRPathElementNode extends FHIRPathAbstractNode {
     protected final Element element;
-    
+
     protected FHIRPathElementNode(Builder builder) {
         super(builder);
         this.element = builder.element;
     }
-    
+
     /**
      * The element wrapped by this FHIRPathElementNode
-     * 
+     *
      * @return
      *     the element wrapped by this FHIRPathElementNode
      */
     public Element element() {
         return element;
     }
-    
+
     @Override
     public boolean isElementNode() {
         return true;
     }
-    
+
     /**
      * Indicates whether this FHIRPathElementNode is type compatible with {@link FHIRPathQuantityNode}
-     * 
+     *
      * @return
      *     true if this FHIRPathElementNode is type compatible with {@link FHIRPathQuantityNode}, otherwise false
      */
     public boolean isQuantityNode() {
         return false;
     }
-    
+
     /**
      * Cast this FHIRPathElementNode to a {@link FHIRPathQuantityNode}
-     * 
+     *
      * @return
      *     this FHIRPathElementNode as a {@link FHIRPathQuantityNode}
      * @throws
@@ -59,10 +59,10 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
     public FHIRPathQuantityNode asQuantityNode() {
         return as(FHIRPathQuantityNode.class);
     }
-    
+
     /**
      * Static factory method for creating FHIRPathElementNode instances from an {@link Element}
-     * 
+     *
      * @param element
      *     the element
      * @return
@@ -71,10 +71,10 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
     public static FHIRPathElementNode elementNode(Element element) {
         return FHIRPathElementNode.builder(element).build();
     }
-    
+
     /**
      * Static factory method for creating named FHIRPathElementNode instances from an {@link Element}
-     * 
+     *
      * @param name
      *     the name
      * @param element
@@ -85,7 +85,7 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
     public static FHIRPathElementNode elementNode(String name, Element element) {
         return FHIRPathElementNode.builder(element).name(name).build();
     }
-    
+
     @Override
     public Builder toBuilder() {
         Builder builder = new Builder(type, element);
@@ -94,10 +94,10 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         builder.children = children;
         return builder;
     }
-    
+
     /**
      * Static factory method for creating builder instances from an {@link Element}
-     * 
+     *
      * @param element
      *     the element
      * @return
@@ -106,39 +106,43 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
     public static Builder builder(Element element) {
         return new Builder(FHIRPathType.from(element.getClass()), element);
     }
-    
+
     public static class Builder extends FHIRPathAbstractNode.Builder {
         protected final Element element;
-        
+
         protected Builder(FHIRPathType type, Element element) {
             super(type);
             this.element = element;
         }
-        
+
+        @Override
         public Builder name(String name) {
             return (Builder) super.name(name);
         }
-        
+
         @Override
         public Builder path(String path) {
             return (Builder) super.path(path);
         }
-        
+
+        @Override
         public Builder value(FHIRPathSystemValue value) {
             return (Builder) super.value(value);
         }
-        
+
+        @Override
         public Builder children(FHIRPathNode... children) {
             return (Builder) super.children(children);
         }
-        
+
+        @Override
         public Builder children(Collection<FHIRPathNode> children) {
             return (Builder) super.children(children);
         }
-        
+
         /**
          * Build a FHIRPathElementNode using this builder
-         * 
+         *
          * @return
          *     a new FHIRPathElementNode instance
          */
@@ -147,14 +151,14 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
             return new FHIRPathElementNode(this);
         }
     }
-    
+
     /**
-     * Indicates whether this FHIRPathElementNode is comparable to the parameter
-     * 
+     * Indicates whether this FHIRPathElementNode has a primitive value and is comparable to the parameter
+     *
      * @param other
      *     the other {@link FHIRPathNode}
      * @return
-     *     true if the primitive value of this FHIRPathElementNode is comparable to the primitive value of the parameter, otherwise false
+     *     true if this FHIRPathElementNode has a primitive value and is comparable to the primitive value of the parameter, otherwise false
      */
     @Override
     public boolean isComparableTo(FHIRPathNode other) {
@@ -168,10 +172,10 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         }
         return false;
     }
-    
+
     /**
      * Compare the element wrapped by this FHIRPathElementNode to the parameter
-     * 
+     *
      * @param other
      *     the other {@link FHIRPathNode}
      * @return
@@ -187,10 +191,10 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         }
         return getValue().compareTo(other.getValue());
     }
-    
+
     /**
      * Indicates whether this FHIRPathElementNode is equal to the parameter
-     * 
+     *
      * @param obj
      *     the other {@link Object}
      * @return
@@ -211,7 +215,7 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         FHIRPathNode other = (FHIRPathNode) obj;
         if (hasValue()) {
             if (other instanceof FHIRPathSystemValue) {
-                return getValue().equals((FHIRPathSystemValue) other);
+                return getValue().equals(other);
             }
             if (other.hasValue()) {
                 return getValue().equals(other.getValue());
@@ -222,12 +226,12 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         }
         return false;
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hashCode(element);
     }
-    
+
     @Override
     public String toString() {
         if (hasValue()) {
@@ -235,7 +239,7 @@ public class FHIRPathElementNode extends FHIRPathAbstractNode {
         }
         return super.toString();
     }
-    
+
     @Override
     public void accept(FHIRPathNodeVisitor visitor) {
         visitor.visit(this);

--- a/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathQuantityNode.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathQuantityNode.java
@@ -17,13 +17,13 @@ import com.ibm.fhir.model.type.Quantity;
 /**
  * A {@link FHIRPathElementNode} that wraps a {@link Quantity}
  */
-public class FHIRPathQuantityNode extends FHIRPathElementNode {    
+public class FHIRPathQuantityNode extends FHIRPathElementNode {
     private final Quantity quantity;
     private final String quantitySystem;
     private final String quantityCode;
     private final String quantityUnit;
     private final BigDecimal quantityValue;
-    
+
     protected FHIRPathQuantityNode(Builder builder) {
         super(builder);
         quantity = builder.quantity;
@@ -32,93 +32,93 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
         quantityUnit = getQuantityUnit(quantity);
         quantityValue = getQuantityValue(quantity);
     }
-    
+
     /**
      * The quantity wrapped by this FHIRPathQuantityNode
-     * 
+     *
      * @return
      *     the quantity wrapped by this FHIRPathQuantityNode
      */
     public Quantity quantity() {
         return quantity;
     }
-    
+
     /**
      * The system of the quantity wrapped by this FHIRPathQuantityNode
-     * 
+     *
      * @return
      *     the system of the quantity wrapped by this FHIRPathQuantityNode
      */
     public String getQuantitySystem() {
         return quantitySystem;
     }
-    
+
     /**
      * The code of the quantity wrapped by this FHIRPathQuantityNode
-     * 
+     *
      * @return
      *     the code of the quantity wrapped by this FHIRPathQuantityNode
      */
     public String getQuantityCode() {
         return quantityCode;
     }
-    
+
     /**
      * The unit of the quantity wrapped by this FHIRPathQuantityNode
-     * 
+     *
      * @return
      *     the unit of the quantity wrapped by this FHIRPathQuantityNode
      */
     public String getQuantityUnit() {
         return quantityUnit;
     }
-    
+
     /**
      * The {@link BigDecimal} value of the quantity wrapped by this FHIRPathQuantityNode
-     * 
+     *
      * @return
      *     the system of the quantity wrapped by this FHIRPathQuantityNode
      */
     public BigDecimal getQuantityValue() {
         return quantityValue;
     }
-    
+
     private String getQuantitySystem(Quantity quantity) {
         if (quantity.getSystem() != null) {
             return quantity.getSystem().getValue();
         }
         return null;
     }
-    
+
     private String getQuantityCode(Quantity quantity) {
         if (quantity.getCode() != null) {
             return quantity.getCode().getValue();
         }
         return null;
     }
-    
+
     private String getQuantityUnit(Quantity quantity) {
         if (quantity.getUnit() != null) {
             return quantity.getUnit().getValue();
         }
         return null;
     }
-    
+
     private BigDecimal getQuantityValue(Quantity quantity) {
         if (quantity.getValue() != null) {
             return quantity.getValue().getValue();
         }
         return null;
     }
-    
+
     @Override
     public boolean isQuantityNode() {
         return true;
     }
-    
+
     /**
      * Static factory method for creating builder instances from a {@link Quantity} value
-     * 
+     *
      * @param quantity
      *     the {@link Quantity} value
      * @return
@@ -127,35 +127,35 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
     public static Builder builder(Quantity quantity) {
         return new Builder(FHIRPathType.FHIR_QUANTITY, quantity);
     }
-    
+
     public static class Builder extends FHIRPathElementNode.Builder {
         private final Quantity quantity;
-        
+
         protected Builder(FHIRPathType type, Quantity quantity) {
             super(type, quantity);
             this.quantity = quantity;
         }
-        
+
         @Override
         public Builder name(java.lang.String name) {
             return (Builder) super.name(name);
         }
-        
+
         @Override
         public Builder path(String path) {
             return (Builder) super.path(path);
         }
-        
+
         @Override
         public Builder value(FHIRPathSystemValue value) {
             return (Builder) super.value(value);
         }
-        
+
         @Override
         public Builder children(FHIRPathNode... children) {
             return (Builder) super.children(children);
         }
-        
+
         @Override
         public Builder children(Collection<FHIRPathNode> children) {
             return (Builder) super.children(children);
@@ -163,7 +163,7 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
 
         /**
          * Build a FHIRPathQuantityNode instance using this builder
-         * 
+         *
          * @return
          *     a new FHIRPathQuantityNode instance
          */
@@ -172,10 +172,10 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
             return new FHIRPathQuantityNode(this);
         }
     }
-    
+
     /**
      * Add this FHIRPathQuantityNode to another FHIRPathQuantityNode
-     * 
+     *
      * @param node
      *     the other FHIRPathQuantityNode
      * @return
@@ -188,10 +188,10 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
                 .build();
         return FHIRPathQuantityNode.builder(quantity).build();
     }
-    
+
     /**
      * Subtract another FHIRPathQuantityNode from this FHIRPathQuantityNode
-     * 
+     *
      * @param node
      *     the other FHIRPathQuantityNode
      * @return
@@ -204,10 +204,10 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
                 .build();
         return FHIRPathQuantityNode.builder(quantity).build();
     }
-    
+
     /**
      * Indicates whether this FHIRPathQuantityNode is comparable to the parameter
-     * 
+     *
      * @return
      *     true if the parameter or its primitive value is a FHIRPathQuantityNode, a {@link FHIRPathQuantityValue} or a {@FHIRPathNumberValue}, otherwise false
      */
@@ -231,17 +231,27 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
         }
         return false;
     }
-    
+
     private boolean isComparableTo(FHIRPathQuantityNode other) {
-        return getQuantityValue() != null && other.getQuantityValue() != null && 
-                ((getQuantitySystem() != null && other.getQuantitySystem() != null && getQuantitySystem().equals(other.getQuantitySystem()) && 
-                        getQuantityCode() != null && other.getQuantityCode() != null && getQuantityCode().equals(other.getQuantityCode())) || 
-                        (getQuantityUnit() != null && other.getQuantityUnit() != null && getQuantityUnit().equals(other.getQuantityUnit())));
+        return getQuantityValue() != null && other.getQuantityValue() != null &&
+            (
+                (
+                    getQuantitySystem() != null && other.getQuantitySystem() != null &&
+                    getQuantitySystem().equals(other.getQuantitySystem()) &&
+                    getQuantityCode() != null && other.getQuantityCode() != null &&
+                    getQuantityCode().equals(other.getQuantityCode())
+                )
+                ||
+                (
+                    getQuantityUnit() != null && other.getQuantityUnit() != null &&
+                    getQuantityUnit().equals(other.getQuantityUnit())
+                )
+            );
     }
-    
+
     /**
      * Compare the quantity value wrapped by this FHIRPathQuantityNode to the parameter
-     * 
+     *
      * @param other
      *     the other {@link FHIRPathNode}
      * @return
@@ -269,10 +279,10 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
         FHIRPathNumberValue numberValue = (other instanceof FHIRPathNumberValue) ? (FHIRPathNumberValue) other : (FHIRPathNumberValue) other.getValue();
         return getQuantityValue().compareTo(numberValue.decimal());
     }
-    
+
     /**
      * Indicates whether the quantity value wrapped by this FHIRPathQuantityNode is equal the parameter (or its primitive value)
-     * 
+     *
      * @param obj
      *     the other {@link Object}
      * @return
@@ -309,7 +319,7 @@ public class FHIRPathQuantityNode extends FHIRPathElementNode {
         FHIRPathNumberValue numberValue = (other instanceof FHIRPathNumberValue) ? (FHIRPathNumberValue) other : (FHIRPathNumberValue) other.getValue();
         return getQuantityValue().compareTo(numberValue.decimal()) == 0;
     }
-    
+
     @Override
     public String toString() {
         if (hasValue()) {

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -942,9 +942,14 @@ public class FHIRPathEvaluator {
                 FHIRPathNode leftNode = leftIterator.next();
                 FHIRPathNode rightNode = rightIterator.next();
 
-                if (hasTemporalValue(leftNode) && hasTemporalValue(rightNode) && !leftNode.isComparableTo(rightNode)) {
+                if (hasTemporalValue(leftNode) && hasTemporalValue(rightNode) &&
+                        !getTemporalValue(leftNode).precision().equals(getTemporalValue(rightNode).precision())) {
                     return false;
                 }
+                // TODO: change to this when we update to a newer version of the test file
+//                if (hasTemporalValue(leftNode) && hasTemporalValue(rightNode) && !leftNode.isComparableTo(rightNode)) {
+//                    return false;
+//                }
             }
 
             return true;

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -32,7 +32,6 @@ import static com.ibm.fhir.path.util.FHIRPathUtil.hasStringValue;
 import static com.ibm.fhir.path.util.FHIRPathUtil.hasSystemValue;
 import static com.ibm.fhir.path.util.FHIRPathUtil.hasTemporalValue;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isCodedElementNode;
-import static com.ibm.fhir.path.util.FHIRPathUtil.isComparableTo;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isFalse;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isQuantityNode;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isSingleton;
@@ -52,6 +51,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -797,6 +797,8 @@ public class FHIRPathEvaluator {
                     // For backwards compatibility per: https://jira.hl7.org/projects/FHIR/issues/FHIR-26605
                     FHIRPathFunction memberOfFunction = FHIRPathFunction.registry().getFunction("memberOf");
                     result = memberOfFunction.apply(evaluationContext, left, Collections.singletonList(right));
+                } else if (left.isEmpty()) {
+                    result = empty();
                 } else if (right.containsAll(left)) {
                     result = SINGLETON_TRUE;
                 }
@@ -901,7 +903,7 @@ public class FHIRPathEvaluator {
                 return SINGLETON_FALSE;
             }
 
-            if (!isComparableTo(left, right)) {
+            if (!validateEqualityOperands(left, right)) {
                 indentLevel--;
                 return empty();
             }
@@ -926,6 +928,26 @@ public class FHIRPathEvaluator {
 
             indentLevel--;
             return result;
+        }
+
+        private boolean validateEqualityOperands(Collection<FHIRPathNode> left, Collection<FHIRPathNode> right) {
+            if (left.size() != right.size()) {
+                throw new IllegalArgumentException();
+            }
+
+            Iterator<FHIRPathNode> leftIterator = left.iterator();
+            Iterator<FHIRPathNode> rightIterator = right.iterator();
+
+            while (leftIterator.hasNext() && rightIterator.hasNext()) {
+                FHIRPathNode leftNode = leftIterator.next();
+                FHIRPathNode rightNode = rightIterator.next();
+
+                if (hasTemporalValue(leftNode) && hasTemporalValue(rightNode) && !leftNode.isComparableTo(rightNode)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         @Override
@@ -1126,6 +1148,7 @@ public class FHIRPathEvaluator {
                     .collect(Collectors.toList());
 
             indentLevel--;
+
             return result;
         }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
@@ -815,27 +815,6 @@ public final class FHIRPathUtil {
         return count;
     }
 
-    public static boolean isComparableTo(Collection<FHIRPathNode> left, Collection<FHIRPathNode> right) {
-        if (left.size() != right.size()) {
-            throw new IllegalArgumentException();
-        }
-
-        Iterator<FHIRPathNode> leftIterator = left.iterator();
-        Iterator<FHIRPathNode> rightIterator = right.iterator();
-
-        while (leftIterator.hasNext() && rightIterator.hasNext()) {
-            FHIRPathNode leftNode = leftIterator.next();
-            FHIRPathNode rightNode = rightIterator.next();
-
-            if (hasTemporalValue(leftNode) && hasTemporalValue(rightNode) &&
-                    !getTemporalValue(leftNode).precision().equals(getTemporalValue(rightNode).precision())) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     public static boolean hasTemporalValue(FHIRPathNode node) {
         return (node instanceof FHIRPathTemporalValue) ||
                 (node.getValue() instanceof FHIRPathTemporalValue);

--- a/fhir-profile/src/main/java/com/ibm/fhir/profile/ConstraintGenerator.java
+++ b/fhir-profile/src/main/java/com/ibm/fhir/profile/ConstraintGenerator.java
@@ -41,6 +41,7 @@ import com.ibm.fhir.model.type.Identifier;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BindingStrength;
 import com.ibm.fhir.model.type.code.DiscriminatorType;
+import com.ibm.fhir.model.type.code.SlicingRules;
 import com.ibm.fhir.model.util.ModelSupport;
 
 /**
@@ -219,6 +220,21 @@ public class ConstraintGenerator {
                                     joiner.add(generateValueConstraint(dNode));
                                 } else if (hasVocabularyConstraint(dNode.elementDefinition)) {
                                     joiner.add(generateVocabularyConstraint(dNode.elementDefinition));
+                                } else {
+                                    log.fine("Discriminator has no value or vocabulary constraint");
+                                }
+                            } else {
+                                // no discriminator in the slice
+                                if (SlicingRules.CLOSED.equals(slicing.getRules())) {
+                                    // in the case of a closed slice with no discriminator
+                                    // we use the absence of the discriminator field to determine we're in this slice
+                                    String dPath = discriminator.getPath().getValue();
+                                    joiner.add(dPath + ".exists().not()");
+                                } else {
+                                    // setting false will cause the `implies` to short-circuit,
+                                    // effectively skipping the constraints on this slice
+                                    joiner.add("false");
+                                    log.fine("Slice for '" + id + "' is open and missing discriminator");
                                 }
                             }
                         }


### PR DESCRIPTION
1. add "left.isEmpty() check to `in` operator
2. rename isComparableTo to validateEqualityOperands and move to private
method
3. added else clauses in constraintgenerator to workaround carin BB
issues
4. some formatting changes

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>