### PR TITLE
Issue #1446 - enable parsing dateTime fractional seconds up to 9 digits

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
@@ -29,10 +29,13 @@ import com.ibm.fhir.model.visitor.Visitor;
  * A date, date-time or partial date (e.g. just year or year + month). If hours and minutes are specified, a time zone 
  * SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be 
  * provided due to schema type constraints but may be zero-filled and may be ignored. Dates SHALL be valid dates.
+ * If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any 
+ * fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond 
+ * precision when stored.
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class DateTime extends Element {
-    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("yyyy").optionalStart().appendPattern("-MM").optionalStart().appendPattern("-dd").optionalStart().appendPattern("'T'HH:mm:ss").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().appendPattern("XXX").optionalEnd().optionalEnd().optionalEnd().toFormatter();
+    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("yyyy").optionalStart().appendPattern("-MM").optionalStart().appendPattern("-dd").optionalStart().appendPattern("'T'HH:mm:ss").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().appendPattern("XXX").optionalEnd().optionalEnd().optionalEnd().toFormatter();
 
     private final TemporalAccessor value;
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
@@ -29,7 +29,8 @@ import com.ibm.fhir.model.visitor.Visitor;
  * A date, date-time or partial date (e.g. just year or year + month). If hours and minutes are specified, a time zone 
  * SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be 
  * provided due to schema type constraints but may be zero-filled and may be ignored. Dates SHALL be valid dates.
- * If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any 
+ * 
+ * <p>If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any 
  * fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond 
  * precision when stored.
  */

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
@@ -23,10 +23,12 @@ import com.ibm.fhir.model.visitor.Visitor;
 
 /**
  * An instant in time - known at least to the second
+ * Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
+ * specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Instant extends Element {
-    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().appendPattern("XXX").toFormatter();
+    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd'T'HH:mm:ss").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().appendPattern("XXX").toFormatter();
 
     private final ZonedDateTime value;
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
@@ -23,7 +23,8 @@ import com.ibm.fhir.model.visitor.Visitor;
 
 /**
  * An instant in time - known at least to the second
- * Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
+ * 
+ * <p>Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
  * specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
@@ -22,7 +22,8 @@ import com.ibm.fhir.model.visitor.Visitor;
 
 /**
  * A time during the day, with no date specified
- * Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
+ * 
+ * <p>Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
  * specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
@@ -10,20 +10,24 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Objects;
 
 import javax.annotation.Generated;
 
+import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.ValidationSupport;
 import com.ibm.fhir.model.visitor.Visitor;
 
 /**
  * A time during the day, with no date specified
+ * Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds 
+ * specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Time extends Element {
-    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().toFormatter();
+    public static final DateTimeFormatter PARSER_FORMATTER = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().toFormatter();
 
     private final LocalTime value;
 
@@ -31,7 +35,7 @@ public class Time extends Element {
 
     private Time(Builder builder) {
         super(builder);
-        value = builder.value;
+        value = ModelSupport.truncateTime(builder.value, ChronoUnit.MICROS);
         ValidationSupport.requireValueOrChildren(this);
     }
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
@@ -899,6 +899,13 @@ public final class ModelSupport {
     }
 
     /**
+     * @return a copy of the passed LocalTime with the time truncated to {@code unit}
+     */
+    public static LocalTime truncateTime(LocalTime time, ChronoUnit unit) {
+        return time == null ? null : time.truncatedTo(unit);
+    }
+
+    /**
      * @return a copy of the passed TemporalAccessor with the time truncated to {@code unit}
      */
     public static TemporalAccessor truncateTime(TemporalAccessor ta, ChronoUnit unit) {

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
@@ -252,7 +252,9 @@ public class DateTimeTest {
         Time.of(LocalTime.now());
         Time.of(LocalTime.MIDNIGHT);
         Time.of(LocalTime.now(ZoneId.of("UTC+2")));
+        Time.of(LocalTime.of(13,20,23,123456789));
         // Valid string values
+        Time.of("20:00:00.112000000");
         Time.of("20:00:00.112000");
         Time.of("20:00:00.112");
         Time.of("20:00:00");
@@ -260,22 +262,27 @@ public class DateTimeTest {
 
     @Test(groups = { "time-tests" }, expectedExceptions = DateTimeParseException.class)
     public void testTimeStringInputWithShortDateValue() throws Exception {
-        DateTime.of("20:00");
+        Time.of("20:00");
     }
 
     @Test(groups = { "time-tests" }, expectedExceptions = DateTimeParseException.class)
     public void testTimeStringInputWithShortDateValue2() throws Exception {
-        DateTime.of("20");
+        Time.of("20");
     }
 
     @Test(groups = { "time-tests" }, expectedExceptions = DateTimeParseException.class)
     public void testTimeStringInputWithShortDateValue3() throws Exception {
-        DateTime.of("8:00:00");
+        Time.of("8:00:00");
     }
 
     @Test(groups = { "time-tests" }, expectedExceptions = DateTimeParseException.class)
     public void testTimeStringInputWithIllegalChars() throws Exception {
-        DateTime.of("20:FF:00");
+        Time.of("20:FF:00");
+    }
+
+    @Test(groups = { "time-tests" }, expectedExceptions = DateTimeParseException.class)
+    public void testTimeStringInputWithTooMuchPrecision() throws Exception {
+        Time.of("20:00:00.1234567890");
     }
 
     @Test(groups = { "time-tests" }, expectedExceptions = NullPointerException.class)
@@ -292,4 +299,10 @@ public class DateTimeTest {
     public void testTimePrecise() throws Exception {
         assertTrue(Time.of("20:00:00.112000").getValue().isAfter(Time.of("20:00:00").getValue()));
     }
+
+    @Test(groups = { "time-tests" })
+    public void testTimeTruncation() throws Exception {
+        assertTrue(Time.of("20:00:00.112000").getValue().equals(Time.of("20:00:00.112000999").getValue()));
+    }
+
 }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/DateTimeTest.java
@@ -35,10 +35,16 @@ public class DateTimeTest {
     public void testInstantWithValidStringInputs() throws Exception{
         // Without miscro-second
         Instant.of("2018-12-31T20:00:00-04:00");
+        // With nano-second
+        Instant.of("2018-12-31T20:00:00.112000000-04:00");
         // With micro-second
         Instant.of("2018-12-31T20:00:00.112000-04:00");
         // With short micro-second
         Instant.of("2018-12-31T20:00:00.112-04:00");
+        // With temporal nano-second
+        Instant.of(ZonedDateTime.of(2020,8,25,13,20,23,123456789,ZoneId.systemDefault()));
+        // With temporal micro-second
+        Instant.of(ZonedDateTime.of(2020,8,25,13,20,23,123456,ZoneId.systemDefault()));
     }
 
     @Test(groups = { "instant-tests" })
@@ -76,6 +82,11 @@ public class DateTimeTest {
         Instant.of("2018-aa-bbT20:00:00-04:00");
     }
 
+    @Test(groups = { "instant-tests" }, expectedExceptions = DateTimeParseException.class)
+    public void testInstantStringInputWithTooMuchPrecision() throws Exception {
+        Instant.of("2018-12-31T20:00:00.1234567890-04:00");
+    }
+
     @Test(groups = { "instant-tests" }, expectedExceptions = NullPointerException.class)
     public void testInstantStringInputWithNull() throws Exception {
         Instant.of((String)null);
@@ -90,6 +101,12 @@ public class DateTimeTest {
     public void testInstantPrecise() throws Exception {
         assertTrue(Instant.of("2018-12-31T20:00:00.112-04:00").getValue()
                 .isAfter(Instant.of(("2018-12-31T20:00:00.111-04:00")).getValue()));
+    }
+
+    @Test(groups = { "instant-tests" })
+    public void testInstantTruncation() throws Exception {
+        assertTrue(Instant.of("2018-12-31T20:00:00.112000-04:00").getValue()
+                .equals(Instant.of(("2018-12-31T20:00:00.112000999-04:00")).getValue()));
     }
 
     @Test(groups = { "date-tests" })
@@ -141,12 +158,14 @@ public class DateTimeTest {
         assertFalse(DateTime.now().isPartial());
         assertFalse(DateTime.now(ZoneOffset.UTC).isPartial());
         // Valid TemporalAccessor values
+        assertFalse(DateTime.of(ZonedDateTime.of(2020,8,25,13,20,23,123456789,ZoneId.systemDefault())).isPartial());
         assertFalse(DateTime.of(ZonedDateTime.now()).isPartial());
         assertFalse(DateTime.of(ZonedDateTime.now(ZoneOffset.UTC)).isPartial());
         assertTrue(DateTime.of(LocalDate.now()).isPartial());
         assertTrue(DateTime.of(YearMonth.now()).isPartial());
         assertTrue(DateTime.of(Year.now()).isPartial());
         // Valid string values
+        assertFalse(DateTime.of("2018-12-31T20:00:00.123456789-04:00").isPartial());
         assertFalse(DateTime.of("2018-12-31T20:00:00.112000-04:00").isPartial());
         assertFalse(DateTime.of("2018-12-31T20:00:00-04:00").isPartial());
         assertFalse(DateTime.of("2018-12-31T20:00:00.112-04:00").isPartial());
@@ -210,13 +229,24 @@ public class DateTimeTest {
         DateTime.of("18");
     }
 
+    @Test(groups = { "datetime-tests" }, expectedExceptions = DateTimeParseException.class)
+    public void testDateTimeStringInputWithTooMuchPrecision() throws Exception {
+        DateTime.of("2018-12-31T20:00:00.1234567890-04:00");
+    }
+
     @Test(groups = { "datetime-tests" })
     public void testDateTimePrecise() throws Exception {
         assertTrue(java.time.Instant.from(DateTime.of("2018-12-31T20:00:00.112-04:00").getValue())
                 .isAfter(java.time.Instant.from(DateTime.of("2018-12-31T20:00:00.111-04:00").getValue())));
     }
 
-    @Test(groups = { "time-tests" })
+    @Test(groups = { "datetime-tests" })
+    public void testDateTimeTruncation() throws Exception {
+        assertTrue(java.time.Instant.from(DateTime.of("2018-12-31T20:00:00.112000-04:00").getValue())
+                .equals(java.time.Instant.from(DateTime.of("2018-12-31T20:00:00.112000999-04:00").getValue())));
+    }
+
+     @Test(groups = { "time-tests" })
     public void testTimeWithValidInputs() throws Exception{
         // localTime
         Time.of(LocalTime.now());

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -888,7 +888,7 @@ public class CodeGenerator {
             List<String> javadocLines = new ArrayList<>(Arrays.asList(getElementDefinition(structureDefinition, path).getString("definition").split(System.lineSeparator())));
             if (isDateTime(structureDefinition)) {
                 javadocLines.add("If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
-            } else if (isInstant(structureDefinition)) {
+            } else if (isInstant(structureDefinition) || isTime(structureDefinition)) {
                 javadocLines.add("Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
             }
             cb.javadoc(javadocLines);
@@ -940,7 +940,7 @@ public class CodeGenerator {
             }
 
             if (isTime(structureDefinition)) {
-                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"HH:mm:ss\").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().toFormatter()").newLine();
+                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"HH:mm:ss\").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().toFormatter()").newLine();
             }
 
             if (isBoolean(structureDefinition)) {
@@ -1047,8 +1047,8 @@ public class CodeGenerator {
                                 String types = getChoiceTypeNames(elementDefinition).stream().map(s -> s + ".class").collect(Collectors.joining(", "));
                                 cb.assign(fieldName, "ValidationSupport.choiceElement(builder." + fieldName + ", " + quote(elementName) + ", " + types + ")");
                             } else {
-                                // Instant and DateTime values require special handling
-                                if ((isInstant(structureDefinition) || isDateTime(structureDefinition))
+                                // Instant, DateTime, and Time values require special handling
+                                if ((isInstant(structureDefinition) || isDateTime(structureDefinition) || isTime(structureDefinition))
                                         && "value".equals(fieldName)) {
                                     cb.assign(fieldName, "ModelSupport.truncateTime(builder.value, ChronoUnit.MICROS)");
                                 } else {
@@ -1950,6 +1950,8 @@ public class CodeGenerator {
 
         if (isTime(structureDefinition)) {
             imports.add("java.time.LocalTime");
+            imports.add("java.time.temporal.ChronoUnit");
+            imports.add("com.ibm.fhir.model.util.ModelSupport");
         }
 
         if (isDate(structureDefinition) || isDateTime(structureDefinition) || isInstant(structureDefinition) || isTime(structureDefinition)) {

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -885,7 +885,13 @@ public class CodeGenerator {
                 }
             }
 
-            cb.javadoc(Arrays.asList(getElementDefinition(structureDefinition, path).getString("definition").split(System.lineSeparator())));
+            List<String> javadocLines = new ArrayList<>(Arrays.asList(getElementDefinition(structureDefinition, path).getString("definition").split(System.lineSeparator())));
+            if (isDateTime(structureDefinition)) {
+                javadocLines.add("If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
+            } else if (isInstant(structureDefinition)) {
+                javadocLines.add("Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
+            }
+            cb.javadoc(javadocLines);
 
             String className = nested ? titleCase(path.substring(path.lastIndexOf(".") + 1)) : titleCase(structureDefinition.getString("name"));
             if (nested) {
@@ -922,7 +928,7 @@ public class CodeGenerator {
             cb._class(mods, className, _super);
 
             if (isDateTime(structureDefinition)) {
-                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"yyyy\").optionalStart().appendPattern(\"-MM\").optionalStart().appendPattern(\"-dd\").optionalStart().appendPattern(\"'T'HH:mm:ss\").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().appendPattern(\"XXX\").optionalEnd().optionalEnd().optionalEnd().toFormatter()").newLine();
+                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"yyyy\").optionalStart().appendPattern(\"-MM\").optionalStart().appendPattern(\"-dd\").optionalStart().appendPattern(\"'T'HH:mm:ss\").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().appendPattern(\"XXX\").optionalEnd().optionalEnd().optionalEnd().toFormatter()").newLine();
             }
 
             if (isDate(structureDefinition)) {
@@ -930,7 +936,7 @@ public class CodeGenerator {
             }
 
             if (isInstant(structureDefinition)) {
-                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"yyyy-MM-dd'T'HH:mm:ss\").optionalStart().appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true).optionalEnd().appendPattern(\"XXX\").toFormatter()").newLine();
+                cb.field(mods("public", "static", "final"), "DateTimeFormatter", "PARSER_FORMATTER", "new DateTimeFormatterBuilder().appendPattern(\"yyyy-MM-dd'T'HH:mm:ss\").optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd().appendPattern(\"XXX\").toFormatter()").newLine();
             }
 
             if (isTime(structureDefinition)) {

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -887,9 +887,9 @@ public class CodeGenerator {
 
             List<String> javadocLines = new ArrayList<>(Arrays.asList(getElementDefinition(structureDefinition, path).getString("definition").split(System.lineSeparator())));
             if (isDateTime(structureDefinition)) {
-                javadocLines.add("If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
+                javadocLines.addAll(Arrays.asList("", "If seconds are specified, fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored."));
             } else if (isInstant(structureDefinition) || isTime(structureDefinition)) {
-                javadocLines.add("Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored.");
+                javadocLines.addAll(Arrays.asList("", "Fractions of seconds may be specified up to nanosecond precision (9 digits). However, any fractions of seconds specified to greater than microsecond precision (6 digits) will be truncated to microsecond precision when stored."));
             }
             cb.javadoc(javadocLines);
 


### PR DESCRIPTION
Signed-off-by: Mike Schroeder <mschroed@us.ibm.com>