### PR TITLE
Issue #1506 - enable parsing dateTime fractional seconds up to 9 digits

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathDateTimeValue.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathDateTimeValue.java
@@ -18,11 +18,13 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAmount;
 import java.util.Collection;
 import java.util.Objects;
 
+import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.path.visitor.FHIRPathNodeVisitor;
 
 /**
@@ -45,7 +47,7 @@ public class FHIRPathDateTimeValue extends FHIRPathAbstractTemporalValue {
                     .optionalStart()
                         .appendPattern(":ss")
                         .optionalStart()
-                            .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
                         .optionalEnd()
                     .optionalEnd()
                 .optionalEnd()
@@ -94,9 +96,11 @@ public class FHIRPathDateTimeValue extends FHIRPathAbstractTemporalValue {
      *     a new FHIRPathDateTimeValue instance
      */
     public static FHIRPathDateTimeValue dateTimeValue(String text) {
-        TemporalAccessor dateTime = text.contains("T") ?
+        TemporalAccessor dateTime = ModelSupport.truncateTime(
+            text.contains("T") ?
                 PARSER_FORMATTER.parseBest(text, ZonedDateTime::from, LocalDateTime::from, LocalDate::from, YearMonth::from, Year::from) :
-                FHIRPathDateValue.PARSER_FORMATTER.parseBest(text, LocalDate::from, YearMonth::from, Year::from);
+                FHIRPathDateValue.PARSER_FORMATTER.parseBest(text, LocalDate::from, YearMonth::from, Year::from),
+            ChronoUnit.MICROS);
         ChronoField precision = getPrecision(dateTime, text);
         return FHIRPathDateTimeValue.builder(dateTime, precision).text(text).build();
     }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathTimeValue.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/FHIRPathTimeValue.java
@@ -13,10 +13,12 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
 import java.util.Collection;
 import java.util.Objects;
 
+import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.path.visitor.FHIRPathNodeVisitor;
 
 /**
@@ -30,7 +32,7 @@ public class FHIRPathTimeValue extends FHIRPathAbstractTemporalValue {
                 .optionalStart()
                     .appendPattern(":ss")
                     .optionalStart()
-                        .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
                     .optionalEnd()
                 .optionalEnd()
             .optionalEnd()
@@ -74,7 +76,7 @@ public class FHIRPathTimeValue extends FHIRPathAbstractTemporalValue {
      *     a new FHIRPathTimeValue instance
      */
     public static FHIRPathTimeValue timeValue(String text) {
-        LocalTime time = LocalTime.parse(text, PARSER_FORMATTER);
+        LocalTime time = ModelSupport.truncateTime(LocalTime.parse(text, PARSER_FORMATTER), ChronoUnit.MICROS);
         ChronoField precision = getPrecision(time, text);
         return FHIRPathTimeValue.builder(time, precision).text(text).build();
     }

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/DateTimeComparisonTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/DateTimeComparisonTest.java
@@ -19,6 +19,7 @@ import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
+import com.ibm.fhir.path.exception.FHIRPathException;
 
 public class DateTimeComparisonTest {
     @Test
@@ -58,4 +59,176 @@ public class DateTimeComparisonTest {
         Collection<FHIRPathNode> result = evaluator.evaluate("@2012-04-15T15:00:00Z = @2012-04-15T10:00:00");
         assertEquals(result, empty());
     }
+
+    @Test
+    public void testDateTimeComparison6() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@2012-04-15T15:00:00.123456789 = @2012-04-15T15:00:00.123456");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testDateTimeComparison7() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@2012-04-15T15:00:00.123456789 < @2012-04-15T15:00:00.123457");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testDateTimeComparison8() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@2012-04-15T15:00:00.123457 > @2012-04-15T15:00:00.123456789");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+    
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison9() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@-1010 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison10() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2010:XX < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison11() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2010-05:XX < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison12() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2010-05-32 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison13() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2010-05:0001:30:30 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison14() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T29 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison15() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T01:78:00 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison16() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T01:30:99 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison17() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T01:30:-1 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison18() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T01:30:20.1234567890 < now()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testDateTimeComparison19() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@2019-10-11T01:30:20.123456789:05-00 < now()");
+    }
+
+    @Test
+    public void testTimeComparison1() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T12:00:00 < @T12:00:01");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison2() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T12:00:00 > @T11:59:59");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison3() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T12:00:00 = @T12:00:00");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison4() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T00:00:00 < timeOfDay()");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison5() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.123456789 = @T15:00:00.123456");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison6() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.123456789 < @T15:00:00.123457");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison7() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.123457 > @T15:00:00.123456789");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison8() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.1 > @T15:00:00");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison9() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.123 > @T15:00:00.122");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test
+    public void testTimeComparison10() throws Exception {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        Collection<FHIRPathNode> result = evaluator.evaluate("@T15:00:00.123456 > @T15:00:00.123455");
+        assertEquals(result, SINGLETON_TRUE);
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testTimeComparison14() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@T29 < timeOfDay()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testTimeComparison15() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@T01:78:00 < timeOfDay()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testTimeComparison16() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@T01:30:99 < timeOfDay()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testTimeComparison17() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@T01:30:-1 < timeOfDay()");
+    }
+
+    @Test(expectedExceptions = FHIRPathException.class)
+    public void testTimeComparison18() throws Exception {
+        FHIRPathEvaluator.evaluator().evaluate("@T01:30:20.1234567890 < timeOfDay()");
+    }
+
 }


### PR DESCRIPTION
Signed-off-by: Mike Schroeder <mschroed@us.ibm.com>