### PR TITLE
issue #1480 - introduce new fhir-server-config security group and use

### DIFF
--- a/conformance/fhir-ig-davinci-pdex-plan-net/src/main/java/com/ibm/fhir/ig/davinci/pdex/plan/net/util/IndexGenerator.java
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/src/main/java/com/ibm/fhir/ig/davinci/pdex/plan/net/util/IndexGenerator.java
@@ -23,7 +23,6 @@ import com.ibm.fhir.registry.util.Index.Entry;
 public class IndexGenerator {
     public static void main(String[] args) throws Exception {
         buildAndWriteIndex("hl7/fhir/us/davinci-pdex-plan-net");
-        buildAndWriteIndex("hl7/fhir/uv/vhdir");
     }
 
     private static void buildAndWriteIndex(String packagePath) throws IOException, FileNotFoundException {

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1524,8 +1524,8 @@ through the shared lib at `wlp/user/shared/resources/lib`) |
 |`fhirServer/persistence/datasources`|embedded Derby database: derby/fhirDB|
 |`fhirServer/persistence/jdbc/dataSourceJndiName`|jdbc/fhirProxyDataSource|
 |`fhirServer/persistence/jdbc/bootstrapDb`|false|
-|`fhirServer/security/basic/enabled`|boolean|true|
-|`fhirServer/security/cert/enabled`|boolean|true|
+|`fhirServer/security/basic/enabled`|boolean|false|
+|`fhirServer/security/cert/enabled`|boolean|false|
 |`fhirServer/security/oauth/enabled`|boolean|false|
 |`fhirServer/security/oauth/regUrl`|""|
 |`fhirServer/security/oauth/authUrl`|""|

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1455,6 +1455,9 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/security/oauth/regUrl`|string|The registration URL associated with the OAuth 2.0 authentication/authorization support.|
 |`fhirServer/security/oauth/authUrl`|string|The authorization URL associated with the OAuth 2.0 authentication/authorization support.|
 |`fhirServer/security/oauth/tokenUrl`|string|The token URL associated with the OAuth 2.0 authentication/authorization support.|
+|`fhirServer/security/oauth/manageUrl`|string|The URL where an end-user can view which applications currently have access to data and can make adjustments to these access rights.|
+|`fhirServer/security/oauth/introspectUrl`|string|The URL of the server’s introspection endpoint that can be used to validate a token.|
+|`fhirServer/security/oauth/revokeUrl`|string|The URL to the server’s endpoint that can be used to revoke a token.|
 |`fhirServer/security/oauth/smart/enabled`|boolean|Whether or not the server is enabled for OAuth-based authentication/authorization|
 |`fhirServer/security/oauth/smart/scopes`|array|A list of SMART scopes to advertise in the `.well-known/smart-configuration endpoint|
 |`fhirServer/audit/serviceClassName`|string|The audit service to use. Currently, com.ibm.fhir.audit.logging.impl.WhcAuditCadfLogService and com.ibm.fhir.audit.logging.impl.DisabledAuditLogService are supported.|
@@ -1530,6 +1533,9 @@ through the shared lib at `wlp/user/shared/resources/lib`) |
 |`fhirServer/security/oauth/regUrl`|""|
 |`fhirServer/security/oauth/authUrl`|""|
 |`fhirServer/security/oauth/tokenUrl`|""|
+|`fhirServer/security/oauth/manageUrl`|""|
+|`fhirServer/security/oauth/introspectUrl`|""|
+|`fhirServer/security/oauth/revokeUrl`|""|
 |`fhirServer/security/oauth/smart/enabled`|boolean|false|
 |`fhirServer/security/oauth/smart/scopes`|array|null|
 |`fhirServer/audit/serviceClassName`|""|
@@ -1594,6 +1600,9 @@ must restart the server for that change to take effect.
 |`fhirServer/security/oauth/regUrl`|N|N|
 |`fhirServer/security/oauth/authUrl`|N|N|
 |`fhirServer/security/oauth/tokenUrl`|N|N|
+|`fhirServer/security/oauth/manageUrl`|N|N|
+|`fhirServer/security/oauth/introspectUrl`|N|N|
+|`fhirServer/security/oauth/revokeUrl`|N|N|
 |`fhirServer/security/oauth/smart/enabled`|N|N|
 |`fhirServer/security/oauth/smart/scopes`|Y|Y|
 |`fhirServer/audit/serviceClassName`|N|N|
@@ -1841,8 +1850,7 @@ If you are using Liberty as both the openIdConnect server and the openIdConnect 
 * `keytool -importcert -keystore key.jks -storepass Password -alias libertyop -file libertyOP.cer -noprompt`
 
 ### 5.3.3 Advertise the OAuth endpoints via fhir-server-config
-To configure the FHIR Server to advertise the OpenID Connect and OAuth 2.0 endpoints of the providers, specify the following values in the default fhir-server-config.json file:
-* `fhirServer/security/oauth/regUrl`
+To configure the FHIR Server to advertise the OpenID Connect and OAuth 2.0 endpoints of the providers, provide values for at least the following properties in the default fhir-server-config.json file:
 * `fhirServer/security/oauth/authUrl`
 * `fhirServer/security/oauth/tokenUrl`
 
@@ -1850,7 +1858,7 @@ When the Liberty server is the OpenID Connect / OAuth 2.0 provider, use a placeh
 
 These values will be used to populate the corresponding entries in both the server capability statement (`GET [base]/metadata`) and the smart-configuration (`GET [base]/.well-known/smart-configuration`).
 
-For example, the following excerpt from a CapabilityStatement shows sample OAuth-related URLs (token, authorize, and register) as values of the `valueUri` elements.
+For example, the following excerpt from a CapabilityStatement shows sample OAuth-related URLs (register, authorize, and token) values in the `valueUri` elements.
 ```
 …
 "rest": [

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -39,13 +39,19 @@ public class FHIRConfiguration {
     public static final String PROPERTY_SEARCH_PARAMETER_FILTER = "fhirServer/searchParameterFilter";
 
     // Auth and security properties
-    public static final String PROPERTY_OAUTH_REGURL = "fhirServer/oauth/regUrl";
-    public static final String PROPERTY_OAUTH_AUTHURL = "fhirServer/oauth/authUrl";
-    public static final String PROPERTY_OAUTH_TOKENURL = "fhirServer/oauth/tokenUrl";
+    public static final String PROPERTY_SECURITY_CORS = "fhirServer/security/cors";
+    public static final String PROPERTY_SECURITY_BASIC_ENABLED = "fhirServer/security/basic/enabled";
+    public static final String PROPERTY_SECURITY_CERT_ENABLED = "fhirServer/security/cert/enabled";
+    public static final String PROPERTY_SECURITY_OAUTH_ENABLED = "fhirServer/security/oauth/enabled";
+    public static final String PROPERTY_SECURITY_SMART_ENABLED = "fhirServer/security/smart/enabled";
+    public static final String PROPERTY_SECURITY_SMART_REGURL = "fhirServer/security/smart/regUrl";
+    public static final String PROPERTY_SECURITY_SMART_AUTHURL = "fhirServer/security/smart/authUrl";
+    public static final String PROPERTY_SECURITY_SMART_TOKENURL = "fhirServer/security/smart/tokenUrl";
+    public static final String PROPERTY_SECURITY_SMART_SCOPES = "fhirServer/security/smart/scopes";
 
-    public static final String PROPERTY_AUTHFILTER_ENABLED = "fhirServer/authFilter/enabled";
-    public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_CLIENT_CN = "fhirServer/authFilter/authorizedClientCertClientCN";
-    public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_ISSUER_OU = "fhirServer/authFilter/authorizedClientCertIssuerOU";
+    public static final String PROPERTY_AUTHFILTER_ENABLED = "fhirServer/security/cert/authFilter/enabled";
+    public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_CLIENT_CN = "fhirServer/security/cert/authFilter/authorizedClientCertClientCN";
+    public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_ISSUER_OU = "fhirServer/security/cert/authFilter/authorizedClientCertIssuerOU";
 
     // Audit config properties
     public static final String PROPERTY_AUDIT_SERVICE_CLASS_NAME = "fhirServer/audit/serviceClassName";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -43,11 +43,11 @@ public class FHIRConfiguration {
     public static final String PROPERTY_SECURITY_BASIC_ENABLED = "fhirServer/security/basic/enabled";
     public static final String PROPERTY_SECURITY_CERT_ENABLED = "fhirServer/security/cert/enabled";
     public static final String PROPERTY_SECURITY_OAUTH_ENABLED = "fhirServer/security/oauth/enabled";
-    public static final String PROPERTY_SECURITY_SMART_ENABLED = "fhirServer/security/smart/enabled";
-    public static final String PROPERTY_SECURITY_SMART_REGURL = "fhirServer/security/smart/regUrl";
-    public static final String PROPERTY_SECURITY_SMART_AUTHURL = "fhirServer/security/smart/authUrl";
-    public static final String PROPERTY_SECURITY_SMART_TOKENURL = "fhirServer/security/smart/tokenUrl";
-    public static final String PROPERTY_SECURITY_SMART_SCOPES = "fhirServer/security/smart/scopes";
+    public static final String PROPERTY_SECURITY_OAUTH_REGURL = "fhirServer/security/smart/regUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_AUTHURL = "fhirServer/security/smart/authUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_TOKENURL = "fhirServer/security/smart/tokenUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_SMART_ENABLED = "fhirServer/security/oauth/smart/enabled";
+    public static final String PROPERTY_SECURITY_OAUTH_SMART_SCOPES = "fhirServer/security/smart/scopes";
 
     public static final String PROPERTY_AUTHFILTER_ENABLED = "fhirServer/security/cert/authFilter/enabled";
     public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_CLIENT_CN = "fhirServer/security/cert/authFilter/authorizedClientCertClientCN";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -43,11 +43,15 @@ public class FHIRConfiguration {
     public static final String PROPERTY_SECURITY_BASIC_ENABLED = "fhirServer/security/basic/enabled";
     public static final String PROPERTY_SECURITY_CERT_ENABLED = "fhirServer/security/cert/enabled";
     public static final String PROPERTY_SECURITY_OAUTH_ENABLED = "fhirServer/security/oauth/enabled";
-    public static final String PROPERTY_SECURITY_OAUTH_REGURL = "fhirServer/security/smart/regUrl";
-    public static final String PROPERTY_SECURITY_OAUTH_AUTHURL = "fhirServer/security/smart/authUrl";
-    public static final String PROPERTY_SECURITY_OAUTH_TOKENURL = "fhirServer/security/smart/tokenUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_REG_URL = "fhirServer/security/smart/regUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_AUTH_URL = "fhirServer/security/smart/authUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_TOKEN_URL = "fhirServer/security/smart/tokenUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_MANAGE_URL = "fhirServer/security/smart/manageUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_INTROSPECT_URL = "fhirServer/security/smart/introspectUrl";
+    public static final String PROPERTY_SECURITY_OAUTH_REVOKE_URL = "fhirServer/security/smart/revokeUrl";
     public static final String PROPERTY_SECURITY_OAUTH_SMART_ENABLED = "fhirServer/security/oauth/smart/enabled";
     public static final String PROPERTY_SECURITY_OAUTH_SMART_SCOPES = "fhirServer/security/smart/scopes";
+    public static final String PROPERTY_SECURITY_OAUTH_SMART_CAPABILITIES = "fhirServer/security/smart/scopes";
 
     public static final String PROPERTY_AUTHFILTER_ENABLED = "fhirServer/security/cert/authFilter/enabled";
     public static final String PROPERTY_AUTHORIZED_CLIENT_CERT_CLIENT_CN = "fhirServer/security/cert/authFilter/authorizedClientCertClientCN";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,15 +24,15 @@ import com.ibm.fhir.core.FHIRUtilities;
  * resulting from loading the configuration, or it could be just a sub-structure within the overall config hierarchy, as
  * a property group can contain other property groups. Internally, there is a JsonObject which holds the actual group of
  * properties and this class provides a high-level API for accessing properties in a hierarchical manner.
- * 
+ *
  * @author padams
  *
  */
 public class PropertyGroup {
 
     /**
-     * This constant represents the separator character used within a hierarchical property name. 
-     * Example: 
+     * This constant represents the separator character used within a hierarchical property name.
+     * Example:
      * <code>fhir-server/server-core/truststoreLocation</code>
      */
     public static final String PATH_ELEMENT_SEPARATOR = "/";
@@ -43,18 +43,18 @@ public class PropertyGroup {
     public PropertyGroup(JsonObject jsonObj) {
         this.jsonObj = jsonObj;
     }
-    
+
     public JsonObject getJsonObj() {
         return jsonObj;
     }
-    
+
     protected void setJsonObj(JsonObject jsonObj) {
         this.jsonObj = jsonObj;
     }
 
     /**
      * Returns a PropertyGroup associated with the specified property.
-     * 
+     *
      * @param propertyName
      *            a hierarchical property name (e.g. "level1/level2/level3") that refers to a property group.
      * @return a PropertyGroup that holds the sub-structure associated with the specified property.
@@ -75,8 +75,9 @@ public class PropertyGroup {
     /**
      * Returns the value of the specified String property or null if it wasn't found.
      * If the value is encoded, then it will be decoded.
+     * 
      * @param propertyName the name of the property to retrieved
-     * @throws Exception 
+     * @throws Exception
      */
     public String getStringProperty(String propertyName) throws Exception {
         return getStringProperty(propertyName, null);
@@ -86,9 +87,9 @@ public class PropertyGroup {
      * Returns the value of the specified String property.  If not found, then
      * 'defaultValue' is returned instead.
      * If the value is encoded, then it will be decoded.
-     * 
+     *
      * @param propertyName the name of the property to retrieve
-     * @throws Exception 
+     * @throws Exception
      */
     public String getStringProperty(String propertyName, String defaultValue) throws Exception {
         String result = defaultValue;
@@ -102,7 +103,7 @@ public class PropertyGroup {
         }
         return result;
     }
-    
+
     /**
      * This is a convenience function that will retrieve an array property, then convert it
      * to a list of Strings by calling toString() on each array element.
@@ -116,7 +117,7 @@ public class PropertyGroup {
         if (array != null) {
             strings = new ArrayList<String>();
             for (int i = 0; i < array.length; i++) {
-                strings.add((String) array[i].toString());
+                strings.add(array[i].toString());
             }
         }
         return strings;
@@ -145,7 +146,7 @@ public class PropertyGroup {
             } else {
                 throw new IllegalArgumentException("Property '" + propertyName + "' must be of type int");
             }
-        } 
+        }
         return result;
     }
 
@@ -171,10 +172,10 @@ public class PropertyGroup {
             } else {
                 throw new IllegalArgumentException("Property '" + propertyName + "' must be of type double");
             }
-        } 
+        }
         return result;
     }
-    
+
     /**
      * Returns the value of the specified boolean property or null if it wasn't found.
      * @param propertyName the name of the property to retrieve
@@ -208,15 +209,16 @@ public class PropertyGroup {
         }
         return result;
     }
-    
+
     /**
      * Returns the value (as an array of Object) of the specified array property.
      * Each element of the returned array will be an instance of Boolean, Integer, Double, String
-     * or PropertyGroup, depending on the value type associated with the property within the 
+     * or PropertyGroup, depending on the value type associated with the property within the
      * underlying JsonObject.
+     * 
      * @param propertyName the name of the property to retrieve
-     * @return
-     * @throws Exception 
+     * @return an array of values from the specified array property or null if the property doesn't exist
+     * @throws Exception
      */
     public Object[] getArrayProperty(String propertyName) throws Exception {
         Object[] result = null;
@@ -230,11 +232,11 @@ public class PropertyGroup {
         }
         return result;
     }
-    
+
     /**
      * Returns the properties contained in the PropertyGroup in the form of a list of
      * PropertyEntry instances.   If no properties exist, then an empty list will be returned.
-     * @throws Exception 
+     * @throws Exception
      */
     public List<PropertyEntry> getProperties() throws Exception {
         List<PropertyEntry> results = new ArrayList<>();
@@ -243,10 +245,11 @@ public class PropertyGroup {
         }
         return results;
     }
-    
+
     /**
      * Returns the String representation of the PropertyGroup instance.
      */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("PropertyGroup[");
@@ -259,7 +262,7 @@ public class PropertyGroup {
      * Converts the specified JsonValue into the appropriate java.lang.* type.
      * @param jsonValue the JsonValue instance to be converted
      * @return an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
-     * @throws Exception 
+     * @throws Exception
      */
     public static Object convertJsonValue(JsonValue jsonValue) throws Exception {
         Object result = null;
@@ -307,10 +310,10 @@ public class PropertyGroup {
         }
         return result;
     }
-    
+
     /**
      * Finds the specified property and returns it as a generic JsonValue.
-     * 
+     *
      * @param propertyName
      *            the possibly hierarchical property name.
      */
@@ -326,7 +329,7 @@ public class PropertyGroup {
 
     /**
      * Splits a potentially hierarchical property name into the individual path elements
-     * 
+     *
      * @param propertyName
      *            a hierarchical property name (e.g. "level1/level2/myProperty"
      * @return
@@ -337,21 +340,21 @@ public class PropertyGroup {
 
     /**
      * This function will find the JSON "sub object" rooted at "this.jsonObj" that is associated with the specified
-     * hierarchical property name. 
-     * <p>For example, consider the following JSON structure: 
+     * hierarchical property name.
+     * <p>For example, consider the following JSON structure:
      * <pre>
-     * { 
-     *     "level1":{ 
+     * {
+     *     "level1":{
      *         "level2":{
-     *             "myProperty":"myValue" 
-     *         } 
-     *     } 
-     * } 
-     * </pre> 
-     * If this function was invoked with a property name of "level1/level2/myProperty", 
+     *             "myProperty":"myValue"
+     *         }
+     *     }
+     * }
+     * </pre>
+     * If this function was invoked with a property name of "level1/level2/myProperty",
      * then the result will be the JsonObject associated with the "level2" field within the JSON
      * structure above.
-     * 
+     *
      * @param pathElements
      *            an array of path elements that make up the hierarchical property name (e.g. {"level1", "level2",
      *            "myProperty"})
@@ -372,19 +375,19 @@ public class PropertyGroup {
 
         return null;
     }
-    
+
     /**
      * This class represents a single property contained within a PropertyGroup.
      */
     public static class PropertyEntry {
         private String name;
         private Object value;
-        
+
         public PropertyEntry(String name, Object value) {
             this.name = name;
             this.value = value;
         }
-        
+
         public String getName() {
             return name;
         }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -294,7 +294,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource(     "date", "sa2018-10-28T23:59:59.999999");
         assertSearchDoesntReturnSavedResource("date", "eb2018-10-28T23:59:59.999999");
         assertSearchReturnsSavedResource(     "date", "ap2018-10-28T23:59:59.999999");
-        
+
         assertSearchDoesntReturnSavedResource("date",   "2018-10-28T23:59:59.999999999");
         assertSearchReturnsSavedResource(     "date", "ne2018-10-28T23:59:59.999999999");
         assertSearchDoesntReturnSavedResource("date", "lt2018-10-28T23:59:59.999999999");
@@ -910,7 +910,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("dateTime", "sa2020-01-01T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("dateTime", "eb2020-01-01T00:00:00.000001Z");
         assertSearchReturnsSavedResource(     "dateTime", "ap2020-01-01T00:00:00.000001Z");
- 
+
         assertSearchDoesntReturnSavedResource("dateTime",   "2020-01-01T00:00:00.000001999Z");
         assertSearchReturnsSavedResource(     "dateTime", "ne2020-01-01T00:00:00.000001999Z");
         assertSearchReturnsSavedResource(     "dateTime", "lt2020-01-01T00:00:00.000001999Z");
@@ -1585,7 +1585,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period", "ap2018-10-28");
         assertSearchReturnsSavedResource("Period", "ap2018-10-29");
         assertSearchReturnsSavedResource("Period", "ap2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period", "ap2019-01-01");
+        assertSearchDoesntReturnSavedResource("Period", "ap2020-01-01");
     }
     @Test
     public void testSearchDate_Period_AP_Hours() throws Exception {

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -21,12 +21,15 @@
                     "authorizedClientCertIssuerOU": ""
                 }
             },
-            "smart": {
+            "oauth": {
                 "enabled": false,
                 "regUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/registration",
                 "authUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/authorize",
                 "tokenUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/token",
-                "supportedScopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"]
+                "smart": {
+                    "enabled": false,
+                    "scopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"]
+                }
             }
         },
         "notifications": {

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -8,15 +8,26 @@
             "conditionalDeleteMaxNumber": 10,
             "serverRegistryResourceProviderEnabled": true
         },
-        "authFilter": {
-            "enabled": false,
-            "authorizedClientCertClientCN": "",
-            "authorizedClientCertIssuerOU": ""
-        },
-        "oauth": {
-            "regUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/registration",
-            "authUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/authorize",
-            "tokenUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/token"
+        "security": {
+            "cors": true,
+            "basic": {
+                "enabled": true
+            },
+            "certificates": {
+                "enabled": true,
+                "authFilter": {
+                    "enabled": false,
+                    "authorizedClientCertClientCN": "",
+                    "authorizedClientCertIssuerOU": ""
+                }
+            },
+            "smart": {
+                "enabled": false,
+                "regUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/registration",
+                "authUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/authorize",
+                "tokenUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/token",
+                "supportedScopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"]
+            }
         },
         "notifications": {
             "common": {

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -28,7 +28,15 @@
                 "tokenUrl": "https://<host>:9443/oauth2/endpoint/oauth2-provider/token",
                 "smart": {
                     "enabled": false,
-                    "scopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"]
+                    "scopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"],
+                    "capabilities": [
+                        "launch-standalone", 
+                        "client-public", 
+                        "client-confidential-symmetric", 
+                        "permission-offline",
+                        "context-standalone-patient",
+                        "permission-patient"
+                    ]
                 }
             }
         },

--- a/fhir-server/liberty-config/server.xml
+++ b/fhir-server/liberty-config/server.xml
@@ -99,6 +99,12 @@
     </dataSource>
 
     <webAppSecurity allowFailOverToBasicAuth="true" singleSignonEnabled="false"/>
+    
+    <cors domain="/"
+        allowedOrigins="*"
+        allowedMethods="GET, DELETE, POST, PUT, HEAD"
+        allowedHeaders="*"
+        maxAge="3600" />
 
     <!-- Define a basic user registry with a few users. -->
     <basicRegistry id="basic" realm="BasicRealm">

--- a/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
@@ -13,6 +13,8 @@ import java.util.logging.Logger;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.Application;
 
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.provider.FHIRJsonPatchProvider;
 import com.ibm.fhir.provider.FHIRJsonProvider;
 import com.ibm.fhir.provider.FHIRProvider;
@@ -61,7 +63,9 @@ public class FHIRApplication extends Application {
                 classes.add(Search.class);
                 classes.add(Update.class);
                 classes.add(VRead.class);
-                classes.add(WellKnown.class);
+                if (FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_SMART_ENABLED, false)) {
+                    classes.add(WellKnown.class);
+                }
             }
             return classes;
         } finally {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/FHIRApplication.java
@@ -63,7 +63,7 @@ public class FHIRApplication extends Application {
                 classes.add(Search.class);
                 classes.add(Update.class);
                 classes.add(VRead.class);
-                if (FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_SMART_ENABLED, false)) {
+                if (FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_OAUTH_SMART_ENABLED, false)) {
                     classes.add(WellKnown.class);
                 }
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -267,7 +267,7 @@ public class Capabilities extends FHIRResource {
                 .cors(com.ibm.fhir.model.type.Boolean.of(fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_CORS, true)));
 
 
-        if (fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_BASIC_ENABLED, true)) {
+        if (fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_BASIC_ENABLED, false)) {
             securityBuilder.service(CodeableConcept.builder()
                 .coding(Coding.builder()
                     .code(Code.of("Basic"))
@@ -275,7 +275,7 @@ public class Capabilities extends FHIRResource {
                     .build())
                 .build());
         }
-        if (fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_CERT_ENABLED, true)) {
+        if (fhirConfig.getBooleanProperty(FHIRConfiguration.PROPERTY_SECURITY_CERT_ENABLED, false)) {
             securityBuilder.service(CodeableConcept.builder()
                 .coding(Coding.builder()
                     .code(Code.of("Certificates"))

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/WellKnown.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/WellKnown.java
@@ -6,13 +6,18 @@
 
 package com.ibm.fhir.server.resources;
 
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_AUTHURL;
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_REGURL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_AUTH_URL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_INTROSPECT_URL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_MANAGE_URL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_REG_URL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_REVOKE_URL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_SMART_CAPABILITIES;
 import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_SMART_SCOPES;
-import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_TOKENURL;
+import static com.ibm.fhir.config.FHIRConfiguration.PROPERTY_SECURITY_OAUTH_TOKEN_URL;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -85,33 +90,60 @@ public class WellKnown extends FHIRResource {
     private JsonObject buildSmartConfig() throws Exception {
         String actualHost = new URI(getRequestUri()).getHost();
 
-        String regURLTemplate = null;
         String authURLTemplate = null;
         String tokenURLTemplate = null;
+        String regURLTemplate = null;
+        String manageURLTemplate = null;
+        String introspectURLTemplate = null;
+        String revokeURLTemplate = null;
         List<String> supportedScopes = null;
+        List<String> capabilities = null;
+
         try {
-            regURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_REGURL, "");
-            authURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_AUTHURL, "");
-            tokenURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_TOKENURL, "");
+            authURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_AUTH_URL, "");
+            tokenURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_TOKEN_URL, "");
+            regURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_REG_URL, "");
+            manageURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_MANAGE_URL, "");
+            introspectURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_INTROSPECT_URL, "");
+            revokeURLTemplate = fhirConfig.getStringProperty(PROPERTY_SECURITY_OAUTH_REVOKE_URL, "");
             Object[] smartScopeObjs = fhirConfig.getArrayProperty(PROPERTY_SECURITY_OAUTH_SMART_SCOPES);
+            Object[] capabilityObjs = fhirConfig.getArrayProperty(PROPERTY_SECURITY_OAUTH_SMART_CAPABILITIES);
             if (smartScopeObjs != null) {
                 supportedScopes = Arrays.asList(Arrays.copyOf(smartScopeObjs, smartScopeObjs.length, String[].class));
             }
+            if (capabilityObjs != null) {
+                capabilities = Arrays.asList(Arrays.copyOf(capabilityObjs, capabilityObjs.length, String[].class));
+            } else {
+                // Set an empty list since capabilities is a required field
+                capabilities = new ArrayList<String>();
+            }
         } catch (Exception e) {
-            log.log(Level.SEVERE, "An error occurred while adding OAuth URLs to the response", e);
+            log.log(Level.SEVERE, "An error occurred while reading the OAuth/SMART properties", e);
         }
-        String regURL = regURLTemplate.replaceAll("<host>", actualHost);
         String authURL = authURLTemplate.replaceAll("<host>", actualHost);
         String tokenURL = tokenURLTemplate.replaceAll("<host>", actualHost);
+        String regURL = regURLTemplate.replaceAll("<host>", actualHost);
+        String manageURL = manageURLTemplate.replaceAll("<host>", actualHost);
+        String introspectURL = introspectURLTemplate.replaceAll("<host>", actualHost);
+        String revokeURL = revokeURLTemplate.replaceAll("<host>", actualHost);
 
         JsonObjectBuilder responseBuilder = Json.createObjectBuilder();
+
+        responseBuilder.add("authorization_endpoint", authURL); // required
+        responseBuilder.add("token_endpoint", tokenURL); // required
 
         if (regURL != null && !regURL.isEmpty()) {
             responseBuilder.add("registration_endpoint", regURL); // recommended
         }
-
-        responseBuilder.add("authorization_endpoint", authURL); // required
-        responseBuilder.add("token_endpoint", tokenURL); // required
+        if (manageURL != null && !manageURL.isEmpty()) {
+            responseBuilder.add("management_endpoint", manageURL); // recommended
+        }
+        if (introspectURL != null && !introspectURL.isEmpty()) {
+            responseBuilder.add("introspection_endpoint", introspectURL); // recommended
+        }
+        if (revokeURL != null && !revokeURL.isEmpty()) {
+            responseBuilder.add("revocation_endpoint", revokeURL); // recommended
+        }
 
         if (supportedScopes != null && !supportedScopes.isEmpty()) {
             responseBuilder.add("scopes_supported", Json.createArrayBuilder(supportedScopes).build()); // recommended
@@ -122,20 +154,12 @@ public class WellKnown extends FHIRResource {
                 .add("token")
                 .add("id_token token")
                 .build());
-        responseBuilder.add("capabilities", Json.createArrayBuilder() // required
-                .add("launch-standalone")
-                .add("client-public")
-                .add("client-confidential-symmetric")
-                .add("permission-offline")
-                // TODO: make this configurable
-                .add("context-standalone-patient")
-                .add("permission-patient")
-//                .add("context-standalone-encounter")
-//                .add("permission-user")
-                .build());
-// management_endpoint: RECOMMENDED, URL where an end-user can view which applications currently have access to data and can make adjustments to these access rights.
-// introspection_endpoint : RECOMMENDED, URL to a server’s introspection endpoint that can be used to validate a token.
-// revocation_endpoint : RECOMMENDED, URL to a server’s revoke endpoint that can be used to revoke a token.
+
+        responseBuilder.add("capabilities", Json.createArrayBuilder(capabilities).build()); // required
+
+// : RECOMMENDED, URL where an end-user can view which applications currently have access to data and can make adjustments to these access rights.
+//  : RECOMMENDED, URL to a server’s introspection endpoint that can be used to validate a token.
+//  : RECOMMENDED, URL to a server’s revoke endpoint that can be used to revoke a token.
 
         return responseBuilder.build();
     }


### PR DESCRIPTION
1. combine our existing "oauth" and "authFilter" fhir-server-config property groups into a single new group called "security".

2. introduce new properties like:
    * fhirServer/security/basic (enabled by default)
    * fhirServer/security/cert (enabled by default)
    * fhirServer/security/smart (disabled by default, with customizable endpoints and scopes)
    * fhirServer/security/cors (default=true)

3. use these values to populate `CapabilityStatement.rest.security`
    * only serve up the Oauth extensions in the CapabilityStatement when fhirServer/security/service is set to `OAuth` or `SMART-on-FHIR`

4. only serve up the `.well-known/smart-capabilities` endpoint when fhirServer/security/service is set to `SMART-on-FHIR`

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>