### PR TITLE
issue-1517 - Support for variables in JSON configuration files like 'fhir-server-config.json'

### DIFF
--- a/fhir-config/pom.xml
+++ b/fhir-config/pom.xml
@@ -26,8 +26,34 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.9</version>
         </dependency>
     </dependencies>
 </project>

--- a/fhir-config/pom.xml
+++ b/fhir-config/pom.xml
@@ -26,15 +26,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <version>1.7.4</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.5.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.7.4</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.5.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/fhir-config/pom.xml
+++ b/fhir-config/pom.xml
@@ -42,10 +42,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.8.0</version>

--- a/fhir-config/src/main/java/com/ibm/fhir/config/ConfigurationService.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/ConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016,2020
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/ConfigurationServiceTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/ConfigurationServiceTest.java
@@ -15,13 +15,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockObjectFactory;
-
-import org.testng.IObjectFactory;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.ConfigurationService;
@@ -29,13 +24,7 @@ import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
 import com.ibm.fhir.config.mock.MockPropertyGroup;
 
-@PrepareForTest(ConfigurationService.class)
 public class ConfigurationServiceTest {
-
-    @ObjectFactory
-    public IObjectFactory getObjectFactory() {
-        return new PowerMockObjectFactory();
-    }
 
     @AfterMethod
     public void cleanUp() {
@@ -82,12 +71,12 @@ public class ConfigurationServiceTest {
 
     @Test
     public void testLoadConfigurationWithEnvironmentVariables() throws Exception {
-        Map<String,String> env = new HashMap<>(System.getenv());
+        Map<String,String> env = new HashMap<>(ConfigurationService.EnvironmentVariables.get());
         env.put("oauth.enabled", "true");
         env.put("oauth.base.url", "http://localhost:9443");
         env.put("oauth.url.path", "/oauth2/endpoint/provider/");
-        PowerMockito.mockStatic(System.class);
-        PowerMockito.when(System.getenv()).thenReturn(env);
+        Mockito.mockStatic(ConfigurationService.EnvironmentVariables.class);
+        Mockito.when(ConfigurationService.EnvironmentVariables.get()).thenReturn(env);
 
         PropertyGroup pg = ConfigurationService.loadConfiguration("fhirConfig.json");
         assertNotNull(pg);

--- a/fhir-config/src/test/resources/fhirConfig.json
+++ b/fhir-config/src/test/resources/fhirConfig.json
@@ -38,6 +38,12 @@
                     "ssl.keystore.type":"PKCS12"
                 }
             }
+        },
+        "oauth": {
+            "enabled":"${oauth.enabled}",
+            "regUrl":"${oauth.base.url}${oauth.url.path}reg",
+            "authUrl":"${oauth.base.url}${oauth.url.path}auth",
+            "tokenUrl":"${oauth.base.url}${oauth.url.path}token"
         }
     }
 }


### PR DESCRIPTION
Use Apache Commons Text’s StringSubstitutor in ConfigurationService’s loadConfiguration method to replace variables in JSON configuration files with the values of the respective envirnoment variables.