### PR TITLE
issue #1351 - Check SearchParameter search restrictions

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -38,7 +38,7 @@ public class FHIRConfiguration {
 
     // Resources properties
     public static final String PROPERTY_RESOURCES = "fhirServer/resources";
-    public static final String PROPERTY_FIELD_RESOURCES_INCLUDE_OMITTED = "includeOmittedResourceTypes";
+    public static final String PROPERTY_FIELD_RESOURCES_OPEN = "open";
     public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETERS = "searchParameters";
     public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_URL = "url";
     public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_REQUIRED = "required";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -36,8 +36,13 @@ public class FHIRConfiguration {
     public static final String PROPERTY_CAPABILITY_STATEMENT_CACHE = "fhirServer/core/capabilityStatementCacheTimeout";
     public static final String PROPERTY_EXTENDED_CODEABLE_CONCEPT_VALIDATION = "fhirServer/core/extendedCodeableConceptValidation";
 
-    public static final String PROPERTY_SEARCH_PARAMETER_FILTER = "fhirServer/searchParameterFilter";
-
+    // Resources properties
+    public static final String PROPERTY_RESOURCES = "fhirServer/resources";
+    public static final String PROPERTY_FIELD_RESOURCES_INCLUDE_OMITTED = "includeOmittedResourceTypes";
+    public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETERS = "searchParameters";
+    public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_URL = "url";
+    public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_REQUIRED = "required";
+    
     // Auth and security properties
     public static final String PROPERTY_SECURITY_CORS = "fhirServer/security/cors";
     public static final String PROPERTY_SECURITY_BASIC_ENABLED = "fhirServer/security/basic/enabled";

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -301,7 +301,7 @@ public class SearchUtil {
      */
     private static Map<String, List<String>> getFilterRules() throws Exception {
         Map<String, List<String>> result = new HashMap<>();
-        boolean includeOmittedRsrcTypes = true;
+        boolean supportOmittedRsrcTypes = true;
         
         // Retrieve the "resources" config property group.
         PropertyGroup rsrcsGroup = FHIRConfigHelper.getPropertyGroup(FHIRConfiguration.PROPERTY_RESOURCES);
@@ -311,9 +311,9 @@ public class SearchUtil {
                 for (PropertyEntry rsrcsEntry : rsrcsEntries) {
                     
                     // Check special property for including omitted resource types
-                    if (FHIRConfiguration.PROPERTY_FIELD_RESOURCES_INCLUDE_OMITTED.equals(rsrcsEntry.getName())) {
+                    if (FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN.equals(rsrcsEntry.getName())) {
                         if (rsrcsEntry.getValue() instanceof Boolean) {
-                            includeOmittedRsrcTypes = (Boolean) rsrcsEntry.getValue();
+                            supportOmittedRsrcTypes = (Boolean) rsrcsEntry.getValue();
                         }
                         else {
                             throw SearchExceptionUtil.buildNewIllegalStateException();
@@ -353,7 +353,7 @@ public class SearchUtil {
             }
         }
 
-        if (includeOmittedRsrcTypes) {
+        if (supportOmittedRsrcTypes) {
             // All other resource types include all search parameters
             result.put(SearchConstants.WILDCARD, Collections.singletonList(SearchConstants.WILDCARD));
         }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/SearchParameterRestrictionTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/SearchParameterRestrictionTest.java
@@ -1,0 +1,128 @@
+/*
+ * (C) Copyright IBM Corp. 2019, 2020
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.search.parameters;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.search.test.BaseSearchTest;
+import com.ibm.fhir.search.util.SearchUtil;
+
+/**
+ * Tests the detection of search restrictions defined by a SearchParameter.
+ */
+public class SearchParameterRestrictionTest extends BaseSearchTest {
+
+    private static final String TENANT_ID = "tenant7";
+    
+    @Override
+    @BeforeClass
+    public void setup() {
+        FHIRConfiguration.setConfigHome("src/test/resources");
+    }
+
+    @Test
+    public void testMultipleOrAllowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count", Collections.singletonList("eq2,eq3,eq4"));
+        
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+    
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testMultipleOrDisllowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count-basic", Collections.singletonList("eq2,eq3"));
+        
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+    
+    @Test
+    public void testMultipleAndAllowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count", Arrays.asList("eq2","eq3"));
+        
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+    
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testMultipleAndDisallowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count-basic", Arrays.asList("eq2","eq3"));
+        
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testComparatorAllowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count", Collections.singletonList("eq2"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testComparatorDisallowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count-basic", Collections.singletonList("eq2"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+    
+    @Test
+    public void testOtherComparatorDisallowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count-basic", Collections.singletonList("gt2"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testModifierAllowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count:missing", Collections.singletonList("true"));
+        
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testModifierDisallowed() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("multiple-birth-count-basic:missing", Collections.singletonList("true"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+}

--- a/fhir-search/src/test/resources/config/default/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/default/fhir-server-config.json
@@ -1,9 +1,5 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-        "_comment": "Just hiding this property because 'include-all' should be the default",
-		"_searchParameterFilter": {
-			"*": "*"
-		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
@@ -1,23 +1,41 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-		"searchParameterFilter": {
-			"Device": [
-				"patient",
-				"organization"
-			],
-			"Observation": [
-				"code"
-			],
-			"Patient": [
-				"active",
-				"address",
-				"birthdate",
-				"name"
-			],
-			"*": [
-				"*"
-			]
+		"resources": {
+			"includeOmittedResourceTypes": true,
+			"Device": {
+				"searchParameters": {
+					"patient": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-patient"
+					},
+					"organization": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-organization"
+					}
+				}
+			},
+			"Observation": {
+				"searchParameters": {
+					"code": {
+						"url": "http://hl7.org/fhir/SearchParameter/clinical-code"
+					}
+				}
+			},
+			"Patient": {
+				"searchParameters": {
+					"active": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-active"
+					},
+					"address": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-address"
+					},
+					"birthdate": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
+					},
+					"name": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-name"
+					}
+				}
+			}
 		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
@@ -2,7 +2,7 @@
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
 		"resources": {
-			"includeOmittedResourceTypes": true,
+			"open": true,
 			"Device": {
 				"searchParameters": {
 					"patient": {

--- a/fhir-search/src/test/resources/config/tenant2/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant2/fhir-server-config.json
@@ -1,9 +1,5 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-		"_comment": "include all search parameters for all resource types (default)",
-		"searchParameterFilter": {
-			"*": ["*"]
-		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
@@ -1,23 +1,41 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-		"searchParameterFilter": {
-			"Device": [
-				"patient",
-				"organization"
-			],
-			"Observation": [
-				"code"
-			],
-			"Patient": [
-				"active",
-				"address",
-				"birthdate",
-				"name"
-			],
-			"*": [
-				"*"
-			]
+		"resources": {
+			"includeOmittedResourceTypes": true,
+			"Device": {
+				"searchParameters": {
+					"patient": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-patient"
+					},
+					"organization": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-organization"
+					}
+				}
+			},
+			"Observation": {
+				"searchParameters": {
+					"code": {
+						"url": "http://hl7.org/fhir/SearchParameter/clinical-code"
+					}
+				}
+			},
+			"Patient": {
+				"searchParameters": {
+					"active": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-active"
+					},
+					"address": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-address"
+					},
+					"birthdate": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
+					},
+					"name": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-name"
+					}
+				}
+			}
 		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
@@ -2,7 +2,7 @@
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
 		"resources": {
-			"includeOmittedResourceTypes": true,
+			"open": true,
 			"Device": {
 				"searchParameters": {
 					"patient": {

--- a/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
@@ -1,23 +1,41 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-		"searchParameterFilter": {
-			"Device": [
-				"patient",
-				"organization"
-			],
-			"Observation": [
-				"code"
-			],
-			"Patient": [
-				"active",
-				"address",
-				"birthdate",
-				"name"
-			],
-			"*": [
-				"*"
-			]
+		"resources": {
+			"includeOmittedResourceTypes": true,
+			"Device": {
+				"searchParameters": {
+					"patient": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-patient"
+					},
+					"organization": {
+						"url": "http://hl7.org/fhir/SearchParameter/Device-organization"
+					}
+				}
+			},
+			"Observation": {
+				"searchParameters": {
+					"code": {
+						"url": "http://hl7.org/fhir/SearchParameter/clinical-code"
+					}
+				}
+			},
+			"Patient": {
+				"searchParameters": {
+					"active": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-active"
+					},
+					"address": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-address"
+					},
+					"birthdate": {
+						"url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
+					},
+					"name": {
+						"url": "http://hl7.org/fhir/SearchParameter/Patient-name"
+					}
+				}
+			}
 		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
@@ -2,7 +2,7 @@
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
 		"resources": {
-			"includeOmittedResourceTypes": true,
+			"open": true,
 			"Device": {
 				"searchParameters": {
 					"patient": {

--- a/fhir-search/src/test/resources/config/tenant6/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant6/fhir-server-config.json
@@ -1,9 +1,5 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-        "_comment": "Just hiding this property because 'include-all' should be the default",
-		"_searchParameterFilter": {
-			"*": "*"
-		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant7/extension-search-parameters.json
+++ b/fhir-search/src/test/resources/config/tenant7/extension-search-parameters.json
@@ -1,0 +1,144 @@
+{
+	"resourceType": "Bundle",
+	"id": "searchParams",
+	"meta": {
+		"lastUpdated": "2020-07-30T22:37:54.724+11:00"
+	},
+	"type": "collection",
+	"entry": [{
+		"fullUrl": "http://ibm.com/fhir/SearchParameter/Patient-multiple-birth-count",
+		"resource": {
+			"resourceType": "SearchParameter",
+			"id": "Patient-multiple-birth-count",
+			"url": "http://hl7.org/fhir/SearchParameter/Patient-multiple-birth-count",
+			"version": "4.0.0",
+			"name": "multiple-birth-count",
+			"status": "draft",
+			"experimental": false,
+			"date": "2018-12-27T22:37:54+11:00",
+			"publisher": "IBM FHIR Server Test",
+			"contact": [{
+				"telecom": [{
+					"system": "url",
+					"value": "http://ibm.com/fhir"
+				}]
+			},
+			{
+				"telecom": [{
+					"system": "url",
+					"value": "http://ibm.com/fhir"
+				}]
+			}],
+			"description": "The multiple birth count has been provided and satisfies this search value",
+			"code": "multiple-birth-count",
+			"base": ["Patient"],
+			"type": "number",
+			"expression": "(Patient.multipleBirth as integer)",
+			"xpath": "f:Patient/f:multipleBirthInteger",
+			"xpathUsage": "normal",
+			"multipleOr": true,
+			"multipleAnd": true,
+			"modifier": ["missing"],
+			"comparator": ["eq",
+			"ne",
+			"gt",
+			"ge",
+			"lt",
+			"le",
+			"sa",
+			"eb",
+			"ap"],
+			"_comparator": [{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			},
+			{
+				"extension": [{
+					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+					"valueCode": "MAY"
+				}]
+			}]
+		}
+	},
+	{
+		"fullUrl": "http://ibm.com/fhir/SearchParameter/Patient-multiple-birth-count-basic",
+		"resource": {
+			"resourceType": "SearchParameter",
+			"id": "Patient-multiple-birth-count-basic",
+			"url": "http://hl7.org/fhir/SearchParameter/Patient-multiple-birth-count-basic",
+			"version": "4.0.0",
+			"name": "multiple-birth-count-basic",
+			"status": "draft",
+			"experimental": false,
+			"date": "2018-12-27T22:37:54+11:00",
+			"publisher": "IBM FHIR Server Test",
+			"contact": [{
+				"telecom": [{
+					"system": "url",
+					"value": "http://ibm.com/fhir"
+				}]
+			},
+			{
+				"telecom": [{
+					"system": "url",
+					"value": "http://ibm.com/fhir"
+				}]
+			}],
+			"description": "The multiple birth count has been provided and satisfies this search value",
+			"code": "multiple-birth-count-basic",
+			"base": ["Patient"],
+			"type": "number",
+			"expression": "(Patient.multipleBirth as integer)",
+			"xpath": "f:Patient/f:multipleBirthInteger",
+			"xpathUsage": "normal",
+			"multipleOr": false,
+			"multipleAnd": false,
+			"modifier": ["type"],
+			"comparator": ["gt"]
+		}
+	}]
+}

--- a/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
@@ -1,9 +1,41 @@
 {
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
-        "_comment": "Just hiding this property because 'include-all' should be the default",
-		"_searchParameterFilter": {
-			"*": "*"
+		"resources": {
+			"includeOmittedResourceTypes": true,
+			"ExplanationOfBenefit": {
+				"interactions": ["read",
+				"vread",
+				"history",
+				"search"],
+				"searchIncludes": ["ExplanationOfBenefit:patient",
+				"ExplanationOfBenefit:provider",
+				"ExplanationOfBenefit:care-team",
+				"ExplanationOfBenefit:coverage",
+				"ExplanationOfBenefit:insurer"],
+				"searchRevIncludes": [],
+				"searchParameters": {
+					"_id": {
+						"url": "http://hl7.org/fhir/SearchParameter/Resource-id"
+					},
+					"patient": {
+						"url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-patient",
+						"required": true
+					},
+					"_lastUpdated": {
+						"url": "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated"
+					},
+					"type": {
+						"url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-type"
+					},
+					"identifier": {
+						"url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-identifier"
+					},
+					"service-date": {
+						"url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-service-date"
+					}
+				}
+			}
 		}
 	}
 }

--- a/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
@@ -1,0 +1,9 @@
+{
+	"__comment": "FHIR Server configuration",
+	"fhirServer": {
+        "_comment": "Just hiding this property because 'include-all' should be the default",
+		"_searchParameterFilter": {
+			"*": "*"
+		}
+	}
+}

--- a/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
@@ -2,7 +2,7 @@
 	"__comment": "FHIR Server configuration",
 	"fhirServer": {
 		"resources": {
-			"includeOmittedResourceTypes": true,
+			"open": true,
 			"ExplanationOfBenefit": {
 				"interactions": ["read",
 				"vread",

--- a/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
+++ b/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
@@ -2,7 +2,7 @@
 	"__comment": "FHIR Server configuration for mythical tenant id 'tenant1'",
 	"fhirServer": {
 		"resources": {
-			"includeOmittedResourceTypes": true,
+			"open": true,
 			"Observation": {
 				"searchParameters": {
 					"_id": {

--- a/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
+++ b/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
@@ -1,13 +1,34 @@
 {
 	"__comment": "FHIR Server configuration for mythical tenant id 'tenant1'",
 	"fhirServer": {
-		"searchParameterFilter": {
-			"Observation": ["subject",
-			"patient",
-			"value-quantity",
-			"component-value-quantity"],
-			"Resource": ["_id"],
-			"*": ["*"]
+		"resources": {
+			"includeOmittedResourceTypes": true,
+			"Observation": {
+				"searchParameters": {
+					"_id": {
+						"url": "http://hl7.org/fhir/SearchParameter/Resource-id"
+					},
+					"subject": {
+						"url": "http://hl7.org/fhir/SearchParameter/Observation-subject"
+					},
+					"patient": {
+                        "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"
+					},
+					"value-quantity": {
+						"url": "http://hl7.org/fhir/SearchParameter/Observation-value-quantity"
+					},
+					"component-value-quantity": {
+						"url": "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity"
+					}
+				}
+			},
+			"Resource": {
+				"searchParameters": {
+					"_id": {
+						"url": "http://hl7.org/fhir/SearchParameter/Resource-id"
+					}
+				}
+			}
 		},
 		"persistence": {
 			"datasources": {


### PR DESCRIPTION
This update enables checking of SearchParameter search restrictions and updates the FHIR server config file with a resources group that will provide configuration for additional search restrictions. Checking of required search parameters, includes, and revincludes will be in an upcoming commit.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>