### PR TITLE
add single smart capability to the default list

### DIFF
--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -30,6 +30,7 @@
                     "enabled": false,
                     "scopes": ["openid", "profile", "fhirUser", "launch/patient", "patient/*.*", "offline_access"],
                     "capabilities": [
+                        "sso-openid-connect",
                         "launch-standalone", 
                         "client-public", 
                         "client-confidential-symmetric", 


### PR DESCRIPTION
this is how we advertise support for SMART’s OpenID Connect profile

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>