### PR TITLE
DropSchema related changes for issue #1595

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -46,7 +46,7 @@ import com.ibm.fhir.database.utils.tenant.UpdateTenantStatusDAO;
  */
 public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDatabaseTypeAdapter {
     private static final Logger logger = Logger.getLogger(CommonDatabaseAdapter.class.getName());
-    
+
     // The target to use for executing our DDL
     protected final IDatabaseTarget target;
 
@@ -287,7 +287,7 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         try {
             runStatement(ddl);
         } catch (UndefinedNameException x) {
-            logger.warning(ddl + "; PROCEDURE not found");
+            logger.warning(ddl + "; FUNCTION not found");
         }
     }
 
@@ -538,14 +538,14 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         if (maxValue != null && maxValue > restartWith) {
             restartWith = maxValue;
         }
-        
+
         // Note the keyword RESTART instead of START.
         final String qname = DataDefinitionUtil.getQualifiedName(schemaName, sequenceName);
         final String ddl = "ALTER SEQUENCE " + qname + " RESTART WITH " + restartWith + " CACHE " + cache;
-        
+
         // so important, we log it
         logger.info(ddl);
-        
+
         runStatement(ddl);
     }
 
@@ -554,13 +554,13 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         // Check input strings are clean
         final String qname = DataDefinitionUtil.getQualifiedName(schemaName, tableName);
         DataDefinitionUtil.assertValidName(columnName);
-        
+
         // modify the CACHE property of the identity column
         final String ddl = "ALTER TABLE " + qname + " ALTER COLUMN " + columnName + " SET CACHE " + cache;
-        
+
         // so important, we log it
         logger.info(ddl);
-        
+
         runStatement(ddl);
     }
 
@@ -634,18 +634,23 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         logger.info("Applying: " + grant); // Grants are very useful to see logged
         runStatement(grant);
     }
-    
+
     @Override
     public void deleteTenantMeta(String adminSchemaName, int tenantId) {
         DeleteTenantDAO dao = new DeleteTenantDAO(adminSchemaName, tenantId);
         runStatement(dao);
     }
-    
+
     @Override
     public void dropIndex(String schemaName, String indexName) {
         // Create the qualified name, making sure the input is also secure
         final String qname = DataDefinitionUtil.getQualifiedName(schemaName, indexName);
         final String ddl = "DROP INDEX " + qname;
-        runStatement(ddl);
+        
+        try {
+            runStatement(ddl);
+        } catch (UndefinedNameException x) {
+            logger.warning(ddl + "; INDEX not found");
+        }
     }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlAdapter.java
@@ -52,7 +52,8 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
         CREATE_PROC,
         DROP_PROC,
         TABLESPACE,
-        ALTER_TABLE_SEQ_CACHE
+        ALTER_TABLE_SEQ_CACHE,
+        DROP_PERMISSION
     }
 
     // Just warn once for each unique message key. This cleans up build logs a lot
@@ -380,5 +381,13 @@ public class PostgreSqlAdapter extends CommonDatabaseAdapter {
         final String ddl = "ALTER TABLE " + qname + " ALTER COLUMN " + columnName + " SET CACHE " + cache;
 
         warnOnce(MessageKey.ALTER_TABLE_SEQ_CACHE, "Not supported in PostgreSQL: " + ddl);
+    }
+
+    @Override
+    public void dropPermission(String schemaName, String permissionName) {
+        final String nm = getQualifiedName(schemaName, permissionName);
+        final String ddl = "DROP PERMISSION " + nm;
+
+        warnOnce(MessageKey.DROP_PERMISSION, "Not supported in PostgreSQL: " + ddl);
     }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlTranslator.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlTranslator.java
@@ -113,7 +113,7 @@ public class PostgreSqlTranslator implements IDatabaseTranslator {
 
     @Override
     public boolean isUndefinedName(SQLException x) {
-        return "42X05".equals(x.getSQLState());
+        return "42704".equals(x.getSQLState());
     }
 
     @Override

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlTranslator.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgresql/PostgreSqlTranslator.java
@@ -113,7 +113,11 @@ public class PostgreSqlTranslator implements IDatabaseTranslator {
 
     @Override
     public boolean isUndefinedName(SQLException x) {
-        return "42704".equals(x.getSQLState());
+        String sqlState = x.getSQLState();
+        return "42704".equals(sqlState) ||
+               "42883".equals(sqlState) ||
+               "42P01".equals(sqlState) ||
+               "42P02".equals(sqlState);
     }
 
     @Override

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -85,7 +85,7 @@ The following sections include common values for `OPTIONS`.
 ```
 --prop-file db2.properties
 --schema-name FHIRDATA
---drop-schema
+--drop-schema-fhir
 --drop-admin
 --confirm-drop
 ```

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -30,7 +30,7 @@ su - db2inst1 -c "db2 \"connect to fhirdb\" && db2 \"grant connect on database T
 
 **Note 2:** When creating the database, `PAGESIZE` is important. So *do* use the statement below and not, e.g., the environment variable `DBNAME` of the [Db2 Docker container](https://hub.docker.com/r/ibmcom/db2) to generate the database; otherwise the step *Deploy new schema* below will fail with `SQLCODE=-286, SQLSTATE=42727`.  
 
-To create the PostgreSql database and database user, use the following commands:
+To create the PostgreSQL database and database user, use the following commands:
 
 ``` shell
 psql postgres
@@ -80,16 +80,6 @@ Note: Replace `${VERSION}` with the version of the jar you're using or use the w
 
 The following sections include common values for `OPTIONS`.
 
-### Drop tables from FHIR_ADMIN and FHIRDATA (Db2 only)
-
-```
---prop-file db2.properties
---schema-name FHIRDATA
---drop-schema-fhir
---drop-admin
---confirm-drop
-```
-
 ### Create new schema
 For Db2:
 
@@ -99,7 +89,7 @@ For Db2:
 --create-schemas
 ```
 
-For Postgresql:
+For PostgreSQL:
 
 ```
 --prop-file postgresql.properties
@@ -116,7 +106,7 @@ For Db2:
 --schema-name FHIRDATA
 --update-schema
 ```
-For Postgresql:
+For PostgreSQL:
 
 ```
 --prop-file postgresql.properties
@@ -218,12 +208,57 @@ For Db2:
 --update-proc
 ```
 
-For postgresql:
+For PostgreSQL:
 
 ```
 --prop-file postgresql.properties
 --schema-name fhirdata
 --update-proc
+--db-type postgresql
+```
+
+### Drop the FHIR schema specified by `schema-name` (e.g. FHIRDATA)
+For Db2:
+
+```
+--prop-file db2.properties
+--schema-name FHIRDATA
+--drop-schema-fhir
+--confirm-drop
+```
+
+For PostgreSQL:
+
+```
+--prop-file postgresql.properties
+--schema-name FHIRDATA
+--drop-schema-fhir
+--confirm-drop
+--db-type postgresql
+```
+
+### Drop all tables created by `--create-schemas` (including the FHIR-ADMIN schema)
+For Db2:
+
+```
+--prop-file db2.properties
+--schema-name FHIRDATA
+--drop-schema-fhir
+--drop-schema-batch
+--drop-schema-oauth
+--drop-admin
+--confirm-drop
+```
+
+For PostgreSQL:
+
+```
+--prop-file postgresql.properties
+--schema-name FHIRDATA
+--drop-schema-fhir
+--drop-schema-batch
+--drop-schema-oauth
+--drop-admin
 --db-type postgresql
 ```
 

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/util/CommonUtil.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/util/CommonUtil.java
@@ -32,7 +32,7 @@ import com.ibm.fhir.database.utils.postgresql.PostgreSqlAdapter;
 import com.ibm.fhir.database.utils.postgresql.PostgreSqlPropertyAdapter;
 
 /**
- * 
+ *
  */
 public final class CommonUtil {
     // Random generator for new tenant keys and salts
@@ -88,15 +88,23 @@ public final class CommonUtil {
 
         // Update Schema action
         ps.println("--update-schema");
-        ps.println(" * action to update the schema ");
+        ps.println(" * deploy or update the schema set by '--schema-name'");
 
         // Create Schema action
         ps.println("--create-schemas");
-        ps.println(" * action to create the schema ");
+        ps.println(" * create the database schemas for batch, oauth, and the fhir schema set by '--schema-name'");
 
         // Drop Schema action
-        ps.println("--drop-schema");
-        ps.println(" * action to drop the schema ");
+        ps.println("--drop-schema-fhir");
+        ps.println(" * drop the schema set by '--schema-name'");
+
+        // Drop Schema action
+        ps.println("--drop-schema-batch");
+        ps.println(" * drop the db schema used by liberty's java-batch feature");
+
+        // Drop Schema action
+        ps.println("--drop-schema-oauth");
+        ps.println(" * drop the db schema used by liberty's oauth/openid connect features");
 
         // Uses a specified poolsize
         ps.println("--pool-size poolSize");
@@ -193,7 +201,7 @@ public final class CommonUtil {
             throw new IllegalStateException(e);
         }
     }
-    
+
 
     public static JdbcPropertyAdapter getPropertyAdapter(DbType dbType, Properties props) {
         switch (dbType) {


### PR DESCRIPTION
Previously, if `--drop-schema` was used without `--drop-schema-fhir`, `--drop-schema-oauth`, or `--drop-schema-jbatch` then it completed with success without actually doing anything.

I think what happened is that we were debating two different options for these args:
A. passing some kind of argument to `--drop-schema`, so it might be like `--drop-schema fhir` or `--drop-schema oauth jbatch`; or
B. using explicit flags for dropping the fhir, schema, or oauth tables, so usage would be like `--drop-schema-fhir --drop-schema-oauth`

But somehow we ended up with a combination of the two which I hope we can all agree is not very good.
This pull request modifies the current behavior and turns it into option B, removing support for the `--drop-schema` action.

Note: this PR does *not* actually address issue #1595 ...it only reworks the user experience of the cli so that others can avoid the error that I made initially.