### PR TITLE
issue #1272 - simplify searchParameter configuration

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1519,10 +1519,10 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/resources/open`|boolean|Whether resources that are not explicitly listed in the configuration should be supported by the FHIR Server REST layer. When open is set to `false`, only the resources listed in fhir-server-config.json are supported.|
 |`fhirServer/resources/Resource/interactions`|string list|A list of strings that represent the RESTful interactions (create, read, vread, update, patch, delete, history, and/or search) supported for resource types. Omitting this property is equivalent to supporting all FHIR interactions for the supported resources. An empty list, `[]`, can be used to indicate that no REST methods are supported. This property can be overridden for specific resource types via the `fhirServer/resources/<resourceType>/interactions` property.|
 |`fhirServer/resources/Resource/searchParameters`|object|The set of search parameters to support for all supported resource types. Omitting this property is equivalent to supporting all search parameters in the server's registry that apply to resource type "Resource" (all resources). An empty object, `{}`, can be used to indicate that no global search parameters are supported.|
-|`fhirServer/resources/Resource/searchParameters/<code>/url`|string|The URL of the search parameter definition to use for the search parameter `<code>`. Individual resource types may override this value via `fhirServer/resources/<resourceType>/searchParameters/<code>/url`|
+|`fhirServer/resources/Resource/searchParameters/<code>`|string|The URL of the search parameter definition to use for the search parameter `<code>`. Individual resource types may override this value via `fhirServer/resources/<resourceType>/searchParameters/<code>`|
 |`fhirServer/resources/<resourceType>/interactions`|string list|A list of strings that represent the RESTful interactions (create, read, vread, update, patch, delete, history, and/or search) to support for this resource type. For resources without the property, the value of `fhirServer/resources/Resource/interactions` is used.|
 |`fhirServer/resources/<resourceType>/searchParameters`|object|The set of search parameters to support for this resource type. Global search parameters defined on the `Resource` resource can be overridden on a per-resourceType basis.|
-|`fhirServer/resources/<resourceType>/searchParameters/<code>/url`|string|The URL of the search parameter definition to use for the search parameter `<code>` on resources of type `<resourceType>`.|
+|`fhirServer/resources/<resourceType>/searchParameters/<code>`|string|The URL of the search parameter definition to use for the search parameter `<code>` on resources of type `<resourceType>`.|
 |`fhirServer/notifications/common/includeResourceTypes`|string list|A comma-separated list of resource types for which notification event messages should be published.|
 |`fhirServer/notifications/websocket/enabled`|boolean|A boolean flag which indicates whether or not websocket notifications are enabled.|
 |`fhirServer/notifications/kafka/enabled`|boolean|A boolean flag which indicates whether or not kafka notifications are enabled.|
@@ -1606,7 +1606,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/resources/Resource/searchParameters`|null (all global search parameters supported)|
 |`fhirServer/resources/<resourceType>/interactions`|null (inherets from `fhirServer/resources/Resource/interactions`)|
 |`fhirServer/resources/<resourceType>/searchParameters`|null (all type-specific search parameters supported)|
-|`fhirServer/resources/<resourceType>/searchParameters/<code>/url`|null|
+|`fhirServer/resources/<resourceType>/searchParameters/<code>`|null|
 |`fhirServer/notifications/common/includeResourceTypes`|`["*"]`|
 |`fhirServer/notifications/websocket/enabled`|false|
 |`fhirServer/notifications/kafka/enabled`|false|
@@ -1679,10 +1679,10 @@ must restart the server for that change to take effect.
 |`fhirServer/resources/open`|Y|Y|
 |`fhirServer/resources/Resource/interactions`|Y|Y|
 |`fhirServer/resources/Resource/searchParameters`|Y|Y|
-|`fhirServer/resources/Resource/searchParameters/<code>/url`|Y|Y|
+|`fhirServer/resources/Resource/searchParameters/<code>`|Y|Y|
 |`fhirServer/resources/<resourceType>/interactions`|Y|Y|
 |`fhirServer/resources/<resourceType>/searchParameters`|Y|Y|
-|`fhirServer/resources/<resourceType>/searchParameters/<code>/url`|Y|Y|
+|`fhirServer/resources/<resourceType>/searchParameters/<code>`|Y|Y|
 |`fhirServer/notifications/common/includeResourceTypes`|N|N|
 |`fhirServer/notifications/websocket/enabled`|N|N|
 |`fhirServer/notifications/kafka/enabled`|N|N|

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -41,8 +41,6 @@ public class FHIRConfiguration {
     public static final String PROPERTY_FIELD_RESOURCES_OPEN = "open";
     public static final String PROPERTY_FIELD_RESOURCES_INTERACTIONS = "interactions";
     public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETERS = "searchParameters";
-    public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_URL = "url";
-    public static final String PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_REQUIRED = "required";
 
     // Auth and security properties
     public static final String PROPERTY_SECURITY_CORS = "fhirServer/security/cors";

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -313,8 +313,7 @@ public class SearchUtil {
                     if (FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN.equals(rsrcsEntry.getName())) {
                         if (rsrcsEntry.getValue() instanceof Boolean) {
                             supportOmittedRsrcTypes = (Boolean) rsrcsEntry.getValue();
-                        }
-                        else {
+                        } else {
                             throw SearchExceptionUtil.buildNewIllegalStateException();
                         }
                     }
@@ -330,19 +329,10 @@ public class SearchUtil {
                                 List<PropertyEntry> spEntries = spGroup.getProperties();
                                 if (spEntries != null && !spEntries.isEmpty()) {
                                     for (PropertyEntry spEntry : spEntries) {
-
-                                        PropertyGroup spValueGroup = (PropertyGroup) spEntry.getValue();
-                                        if (spValueGroup != null) {
-                                            String url = spValueGroup.getStringProperty(FHIRConfiguration.PROPERTY_FIELD_RESOURCES_SEARCH_PARAMETER_URL);
-                                            if (url == null) {
-                                                throw SearchExceptionUtil.buildNewIllegalStateException();
-                                            }
-                                            searchParameterUrls.add(url);
-                                        }
+                                        searchParameterUrls.add((String) spEntry.getValue());
                                     }
                                 }
-                            }
-                            else {
+                            } else {
                                 searchParameterUrls.add(SearchConstants.WILDCARD);
                             }
                             result.put(resourceType, searchParameterUrls);

--- a/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant1/fhir-server-config.json
@@ -5,35 +5,21 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-patient"
-                    },
-                    "organization": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-organization"
-                    }
+                    "patient": "http://hl7.org/fhir/SearchParameter/Device-patient",
+                    "organization": "http://hl7.org/fhir/SearchParameter/Device-organization"
                 }
             },
             "Observation": {
                 "searchParameters": {
-                    "code": {
-                        "url": "http://hl7.org/fhir/SearchParameter/clinical-code"
-                    }
+                    "code": "http://hl7.org/fhir/SearchParameter/clinical-code"
                 }
             },
             "Patient": {
                 "searchParameters": {
-                    "active": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-active"
-                    },
-                    "address": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-address"
-                    },
-                    "birthdate": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
-                    },
-                    "name": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-name"
-                    }
+                    "active": "http://hl7.org/fhir/SearchParameter/Patient-active",
+                    "address": "http://hl7.org/fhir/SearchParameter/individual-address",
+                    "birthdate": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+                    "name": "http://hl7.org/fhir/SearchParameter/Patient-name"
                 }
             }
         }

--- a/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
@@ -5,35 +5,21 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-patient"
-                    },
-                    "organization": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-organization"
-                    }
+                    "patient": "http://hl7.org/fhir/SearchParameter/Device-patient",
+                    "organization": "http://hl7.org/fhir/SearchParameter/Device-organization"
                 }
             },
             "Observation": {
                 "searchParameters": {
-                    "code": {
-                        "url": "http://hl7.org/fhir/SearchParameter/clinical-code"
-                    }
+                    "code": "http://hl7.org/fhir/SearchParameter/clinical-code"
                 }
             },
             "Patient": {
                 "searchParameters": {
-                    "active": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-active"
-                    },
-                    "address": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-address"
-                    },
-                    "birthdate": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
-                    },
-                    "name": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-name"
-                    }
+                    "active": "http://hl7.org/fhir/SearchParameter/Patient-active",
+                    "address": "http://hl7.org/fhir/SearchParameter/individual-address",
+                    "birthdate": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+                    "name": "http://hl7.org/fhir/SearchParameter/Patient-name"
                 }
             }
         }

--- a/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
@@ -5,35 +5,21 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-patient"
-                    },
-                    "organization": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Device-organization"
-                    }
+                    "patient": "http://hl7.org/fhir/SearchParameter/Device-patient",
+                    "organization": "http://hl7.org/fhir/SearchParameter/Device-organization"
                 }
             },
             "Observation": {
                 "searchParameters": {
-                    "code": {
-                        "url": "http://hl7.org/fhir/SearchParameter/clinical-code"
-                    }
+                    "code": "http://hl7.org/fhir/SearchParameter/clinical-code"
                 }
             },
             "Patient": {
                 "searchParameters": {
-                    "active": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-active"
-                    },
-                    "address": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-address"
-                    },
-                    "birthdate": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
-                    },
-                    "name": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-name"
-                    }
+                    "active": "http://hl7.org/fhir/SearchParameter/Patient-active",
+                    "address": "http://hl7.org/fhir/SearchParameter/individual-address",
+                    "birthdate": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+                    "name": "http://hl7.org/fhir/SearchParameter/Patient-name"
                 }
             }
         }

--- a/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
@@ -4,36 +4,27 @@
         "resources": {
             "open": true,
             "ExplanationOfBenefit": {
-                "interactions": ["read",
-                "vread",
-                "history",
-                "search"],
-                "searchIncludes": ["ExplanationOfBenefit:patient",
-                "ExplanationOfBenefit:provider",
-                "ExplanationOfBenefit:care-team",
-                "ExplanationOfBenefit:coverage",
-                "ExplanationOfBenefit:insurer"],
+                "interactions": [
+                    "read",
+                    "vread",
+                    "history",
+                    "search"
+                ],
+                "searchIncludes": [
+                    "ExplanationOfBenefit:patient",
+                    "ExplanationOfBenefit:provider",
+                    "ExplanationOfBenefit:care-team",
+                    "ExplanationOfBenefit:coverage",
+                    "ExplanationOfBenefit:insurer"
+                ],
                 "searchRevIncludes": [],
                 "searchParameters": {
-                    "_id": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-id"
-                    },
-                    "patient": {
-                        "url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-patient",
-                        "required": true
-                    },
-                    "_lastUpdated": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated"
-                    },
-                    "type": {
-                        "url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-type"
-                    },
-                    "identifier": {
-                        "url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-identifier"
-                    },
-                    "service-date": {
-                        "url": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-service-date"
-                    }
+                    "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
+                    "_lastUpdated": "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated",
+                    "patient": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-patient",
+                    "type": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-type",
+                    "identifier": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-identifier",
+                    "service-date": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-service-date"
                 }
             }
         }

--- a/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
+++ b/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
@@ -5,28 +5,16 @@
             "open": true,
             "Observation": {
                 "searchParameters": {
-                    "_id": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-id"
-                    },
-                    "subject": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Observation-subject"
-                    },
-                    "patient": {
-                        "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"
-                    },
-                    "value-quantity": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Observation-value-quantity"
-                    },
-                    "component-value-quantity": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity"
-                    }
+                    "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
+                    "subject": "http://hl7.org/fhir/SearchParameter/Observation-subject",
+                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                    "value-quantity": "http://hl7.org/fhir/SearchParameter/Observation-value-quantity",
+                    "component-value-quantity": "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity"
                 }
             },
             "Resource": {
                 "searchParameters": {
-                    "_id": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-id"
-                    }
+                    "_id": "http://hl7.org/fhir/SearchParameter/Resource-id"
                 }
             }
         },

--- a/fhir-server/src/test/resources/config/smart-enabled/fhir-server-config.json
+++ b/fhir-server/src/test/resources/config/smart-enabled/fhir-server-config.json
@@ -6,39 +6,23 @@
             "Patient": {
                 "interactions": ["read", "search"],
                 "searchParameters": {
-                    "_id": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-id"
-                    },
-                    "birthdate": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-birthdate"
-                    },
-                    "gender": {
-                        "url": "http://hl7.org/fhir/SearchParameter/individual-gender"
-                    },
-                    "identifier": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-identifier"
-                    },
-                    "name": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Patient-name"
-                    }
+                    "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
+                    "birthdate": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+                    "gender": "http://hl7.org/fhir/SearchParameter/individual-gender",
+                    "identifier": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+                    "name": "http://hl7.org/fhir/SearchParameter/Patient-name"
                 }
             },
             "Practitioner": {
                 "searchParameters": {
-                    "name": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Practitioner-name"
-                    },
-                    "identifier": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier"
-                    }
+                    "name": "http://hl7.org/fhir/SearchParameter/Practitioner-name",
+                    "identifier": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier"
                 }
             },
             "Resource": {
                 "interactions": ["read", "vread", "history", "search"],
                 "searchParameters": {
-                    "_id": {
-                        "url": "http://hl7.org/fhir/SearchParameter/Resource-id"
-                    }
+                    "_id": "http://hl7.org/fhir/SearchParameter/Resource-id"
                 }
             }
         },


### PR DESCRIPTION
Initially we made each searchParameter its own object so that we could
add additional properties for issue #1351.
However, now we don't think that any additional fields are needed and so
we can simplify the config to be a simple map of SearchParameter  code
-> SearchParameter.url

This format will give us the flexibility of overriding a SearchParameter
code for a given resource type for a given deploy. However, currently
the code from the config is not used...it will only use the url and it
will auto-resolve any conflicting codes.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>