### PR TITLE
fix: site unable to compile due to invalid export variable in a recent gatsby-remark-plugin update

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "gatsby-theme-carbon": "^1.24.3",
     "gatsby-theme-carbon-starter": "0.0.7",
     "gatsby-source-filesystem": "^2.3.8",
-    "gatsby-transformer-remark": "^2.8.13",
+    "gatsby-transformer-remark": "2.8.13",
     "markdown-it": "^11.0.0",
     "react": "^16.13.1",
     "react-copy-to-clipboard": "^5.0.2",


### PR DESCRIPTION
fix: site unable to compile due to invalid export variable in a recent gatsby-remark-plugin update

The invalid update was about 4 hours ago, I locked in the version in package.json

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>