### PR TITLE
Introduce Xhtml.from(String plainText) helper and add javadoc

### DIFF
--- a/fhir-model/pom.xml
+++ b/fhir-model/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>jcip-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${project.version}</version>

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Xhtml.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Xhtml.java
@@ -14,12 +14,17 @@ import javax.annotation.Generated;
 import com.ibm.fhir.model.annotation.Required;
 import com.ibm.fhir.model.util.ValidationSupport;
 import com.ibm.fhir.model.visitor.Visitor;
+import org.owasp.encoder.Encode;
 
 /**
  * XHTML
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Xhtml extends Element {
+    private static final java.lang.String DIV_OPEN = "<div xmlns=\"http://www.w3.org/1999/xhtml\">";
+
+    private static final java.lang.String DIV_CLOSE = "</div>";
+
     @Required
     private final java.lang.String value;
 
@@ -52,12 +57,37 @@ public class Xhtml extends Element {
         return super.hasChildren();
     }
 
+    /**
+     * Factory method for creating Xhtml objects from an XHTML java.lang.String
+     * 
+     * @param value
+     *     A java.lang.String with valid XHTML content
+     */
     public static Xhtml of(java.lang.String value) {
         return Xhtml.builder().value(value).build();
     }
 
+    /**
+     * Factory method for creating Xhtml objects from an XHTML java.lang.String
+     * 
+     * @param value
+     *     A java.lang.String with valid XHTML content
+     */
     public static Xhtml xhtml(java.lang.String value) {
         return Xhtml.builder().value(value).build();
+    }
+
+    /**
+     * Factory method for creating Xhtml objects from a plain text string
+     * 
+     * <p>This method will automatically encode the passed string for use within XHTML,
+     * then wrap it in an XHTML {@code <div>} element with a namespace of {@code http://www.w3.org/1999/xhtml}
+     * 
+     * @param plainText
+     *     The text to encode and wrap for use within a Narrative
+     */
+    public static Xhtml from(java.lang.String plainText) {
+        return Xhtml.builder().value(DIV_OPEN + Encode.forHtmlContent(plainText) + DIV_CLOSE).build();
     }
 
     @Override

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AccountStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AccountStatus.java
@@ -64,6 +64,9 @@ public class AccountStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AccountStatus objects from a passed enum value.
+     */
     public static AccountStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -81,14 +84,38 @@ public class AccountStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AccountStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AccountStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AccountStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AccountStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class AccountStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AccountStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionCardinalityBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionCardinalityBehavior.java
@@ -43,6 +43,9 @@ public class ActionCardinalityBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionCardinalityBehavior objects from a passed enum value.
+     */
     public static ActionCardinalityBehavior of(ValueSet value) {
         switch (value) {
         case SINGLE:
@@ -54,14 +57,38 @@ public class ActionCardinalityBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionCardinalityBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionCardinalityBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionCardinalityBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionCardinalityBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class ActionCardinalityBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionCardinalityBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionConditionKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionConditionKind.java
@@ -50,6 +50,9 @@ public class ActionConditionKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionConditionKind objects from a passed enum value.
+     */
     public static ActionConditionKind of(ValueSet value) {
         switch (value) {
         case APPLICABILITY:
@@ -63,14 +66,38 @@ public class ActionConditionKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionConditionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionConditionKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionConditionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionConditionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ActionConditionKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionConditionKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionGroupingBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionGroupingBehavior.java
@@ -57,6 +57,9 @@ public class ActionGroupingBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionGroupingBehavior objects from a passed enum value.
+     */
     public static ActionGroupingBehavior of(ValueSet value) {
         switch (value) {
         case VISUAL_GROUP:
@@ -70,14 +73,38 @@ public class ActionGroupingBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionGroupingBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionGroupingBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionGroupingBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionGroupingBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -189,10 +216,22 @@ public class ActionGroupingBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionGroupingBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionParticipantType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionParticipantType.java
@@ -57,6 +57,9 @@ public class ActionParticipantType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionParticipantType objects from a passed enum value.
+     */
     public static ActionParticipantType of(ValueSet value) {
         switch (value) {
         case PATIENT:
@@ -72,14 +75,38 @@ public class ActionParticipantType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionParticipantType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ActionParticipantType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionParticipantType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionPrecheckBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionPrecheckBehavior.java
@@ -47,6 +47,9 @@ public class ActionPrecheckBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionPrecheckBehavior objects from a passed enum value.
+     */
     public static ActionPrecheckBehavior of(ValueSet value) {
         switch (value) {
         case YES:
@@ -58,14 +61,38 @@ public class ActionPrecheckBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionPrecheckBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionPrecheckBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionPrecheckBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionPrecheckBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -167,10 +194,22 @@ public class ActionPrecheckBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionPrecheckBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionRelationshipType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionRelationshipType.java
@@ -92,6 +92,9 @@ public class ActionRelationshipType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionRelationshipType objects from a passed enum value.
+     */
     public static ActionRelationshipType of(ValueSet value) {
         switch (value) {
         case BEFORE_START:
@@ -117,14 +120,38 @@ public class ActionRelationshipType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionRelationshipType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -271,10 +298,22 @@ public class ActionRelationshipType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionRelationshipType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionRequiredBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionRequiredBehavior.java
@@ -52,6 +52,9 @@ public class ActionRequiredBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionRequiredBehavior objects from a passed enum value.
+     */
     public static ActionRequiredBehavior of(ValueSet value) {
         switch (value) {
         case MUST:
@@ -65,14 +68,38 @@ public class ActionRequiredBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionRequiredBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionRequiredBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionRequiredBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionRequiredBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class ActionRequiredBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionRequiredBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionSelectionBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActionSelectionBehavior.java
@@ -73,6 +73,9 @@ public class ActionSelectionBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActionSelectionBehavior objects from a passed enum value.
+     */
     public static ActionSelectionBehavior of(ValueSet value) {
         switch (value) {
         case ANY:
@@ -92,14 +95,38 @@ public class ActionSelectionBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActionSelectionBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActionSelectionBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionSelectionBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActionSelectionBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -227,10 +254,22 @@ public class ActionSelectionBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActionSelectionBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActivityDefinitionKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActivityDefinitionKind.java
@@ -135,6 +135,9 @@ public class ActivityDefinitionKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActivityDefinitionKind objects from a passed enum value.
+     */
     public static ActivityDefinitionKind of(ValueSet value) {
         switch (value) {
         case APPOINTMENT:
@@ -172,14 +175,38 @@ public class ActivityDefinitionKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActivityDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActivityDefinitionKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActivityDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActivityDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -369,10 +396,22 @@ public class ActivityDefinitionKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActivityDefinitionKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActivityParticipantType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ActivityParticipantType.java
@@ -57,6 +57,9 @@ public class ActivityParticipantType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ActivityParticipantType objects from a passed enum value.
+     */
     public static ActivityParticipantType of(ValueSet value) {
         switch (value) {
         case PATIENT:
@@ -72,14 +75,38 @@ public class ActivityParticipantType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ActivityParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ActivityParticipantType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActivityParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ActivityParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ActivityParticipantType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ActivityParticipantType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AddressType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AddressType.java
@@ -50,6 +50,9 @@ public class AddressType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AddressType objects from a passed enum value.
+     */
     public static AddressType of(ValueSet value) {
         switch (value) {
         case POSTAL:
@@ -63,14 +66,38 @@ public class AddressType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AddressType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AddressType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AddressType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AddressType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class AddressType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AddressType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AddressUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AddressUse.java
@@ -64,6 +64,9 @@ public class AddressUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AddressUse objects from a passed enum value.
+     */
     public static AddressUse of(ValueSet value) {
         switch (value) {
         case HOME:
@@ -81,14 +84,38 @@ public class AddressUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AddressUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AddressUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AddressUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AddressUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class AddressUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AddressUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AdministrativeGender.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AdministrativeGender.java
@@ -57,6 +57,9 @@ public class AdministrativeGender extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AdministrativeGender objects from a passed enum value.
+     */
     public static AdministrativeGender of(ValueSet value) {
         switch (value) {
         case MALE:
@@ -72,14 +75,38 @@ public class AdministrativeGender extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AdministrativeGender objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AdministrativeGender of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AdministrativeGender objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AdministrativeGender objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class AdministrativeGender extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AdministrativeGender.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AdverseEventActuality.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AdverseEventActuality.java
@@ -43,6 +43,9 @@ public class AdverseEventActuality extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AdverseEventActuality objects from a passed enum value.
+     */
     public static AdverseEventActuality of(ValueSet value) {
         switch (value) {
         case ACTUAL:
@@ -54,14 +57,38 @@ public class AdverseEventActuality extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AdverseEventActuality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AdverseEventActuality of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AdverseEventActuality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AdverseEventActuality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class AdverseEventActuality extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AdverseEventActuality.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AggregationMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AggregationMode.java
@@ -50,6 +50,9 @@ public class AggregationMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AggregationMode objects from a passed enum value.
+     */
     public static AggregationMode of(ValueSet value) {
         switch (value) {
         case CONTAINED:
@@ -63,14 +66,38 @@ public class AggregationMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AggregationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AggregationMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AggregationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AggregationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class AggregationMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AggregationMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceCategory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceCategory.java
@@ -62,6 +62,9 @@ public class AllergyIntoleranceCategory extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceCategory objects from a passed enum value.
+     */
     public static AllergyIntoleranceCategory of(ValueSet value) {
         switch (value) {
         case FOOD:
@@ -77,14 +80,38 @@ public class AllergyIntoleranceCategory extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AllergyIntoleranceCategory of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -201,10 +228,22 @@ public class AllergyIntoleranceCategory extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AllergyIntoleranceCategory.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceCriticality.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceCriticality.java
@@ -52,6 +52,9 @@ public class AllergyIntoleranceCriticality extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceCriticality objects from a passed enum value.
+     */
     public static AllergyIntoleranceCriticality of(ValueSet value) {
         switch (value) {
         case LOW:
@@ -65,14 +68,38 @@ public class AllergyIntoleranceCriticality extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceCriticality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AllergyIntoleranceCriticality of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceCriticality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceCriticality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class AllergyIntoleranceCriticality extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AllergyIntoleranceCriticality.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceSeverity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceSeverity.java
@@ -50,6 +50,9 @@ public class AllergyIntoleranceSeverity extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceSeverity objects from a passed enum value.
+     */
     public static AllergyIntoleranceSeverity of(ValueSet value) {
         switch (value) {
         case MILD:
@@ -63,14 +66,38 @@ public class AllergyIntoleranceSeverity extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AllergyIntoleranceSeverity of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class AllergyIntoleranceSeverity extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AllergyIntoleranceSeverity.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AllergyIntoleranceType.java
@@ -46,6 +46,9 @@ public class AllergyIntoleranceType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceType objects from a passed enum value.
+     */
     public static AllergyIntoleranceType of(ValueSet value) {
         switch (value) {
         case ALLERGY:
@@ -57,14 +60,38 @@ public class AllergyIntoleranceType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AllergyIntoleranceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AllergyIntoleranceType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AllergyIntoleranceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -165,10 +192,22 @@ public class AllergyIntoleranceType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AllergyIntoleranceType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AppointmentStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AppointmentStatus.java
@@ -104,6 +104,9 @@ public class AppointmentStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AppointmentStatus objects from a passed enum value.
+     */
     public static AppointmentStatus of(ValueSet value) {
         switch (value) {
         case PROPOSED:
@@ -131,14 +134,38 @@ public class AppointmentStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AppointmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AppointmentStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AppointmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AppointmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -297,10 +324,22 @@ public class AppointmentStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AppointmentStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionDirectionType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionDirectionType.java
@@ -43,6 +43,9 @@ public class AssertionDirectionType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AssertionDirectionType objects from a passed enum value.
+     */
     public static AssertionDirectionType of(ValueSet value) {
         switch (value) {
         case RESPONSE:
@@ -54,14 +57,38 @@ public class AssertionDirectionType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AssertionDirectionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AssertionDirectionType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionDirectionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionDirectionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class AssertionDirectionType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AssertionDirectionType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionOperatorType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionOperatorType.java
@@ -106,6 +106,9 @@ public class AssertionOperatorType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AssertionOperatorType objects from a passed enum value.
+     */
     public static AssertionOperatorType of(ValueSet value) {
         switch (value) {
         case EQUALS:
@@ -135,14 +138,38 @@ public class AssertionOperatorType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AssertionOperatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AssertionOperatorType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionOperatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionOperatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -303,10 +330,22 @@ public class AssertionOperatorType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AssertionOperatorType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionResponseTypes.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AssertionResponseTypes.java
@@ -113,6 +113,9 @@ public class AssertionResponseTypes extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AssertionResponseTypes objects from a passed enum value.
+     */
     public static AssertionResponseTypes of(ValueSet value) {
         switch (value) {
         case OKAY:
@@ -144,14 +147,38 @@ public class AssertionResponseTypes extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AssertionResponseTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AssertionResponseTypes of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionResponseTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AssertionResponseTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -319,10 +346,22 @@ public class AssertionResponseTypes extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AssertionResponseTypes.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventAction.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventAction.java
@@ -65,6 +65,9 @@ public class AuditEventAction extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AuditEventAction objects from a passed enum value.
+     */
     public static AuditEventAction of(ValueSet value) {
         switch (value) {
         case C:
@@ -82,14 +85,38 @@ public class AuditEventAction extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AuditEventAction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AuditEventAction of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventAction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventAction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -209,10 +236,22 @@ public class AuditEventAction extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AuditEventAction.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventAgentNetworkType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventAgentNetworkType.java
@@ -64,6 +64,9 @@ public class AuditEventAgentNetworkType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AuditEventAgentNetworkType objects from a passed enum value.
+     */
     public static AuditEventAgentNetworkType of(ValueSet value) {
         switch (value) {
         case TYPE_1:
@@ -81,14 +84,38 @@ public class AuditEventAgentNetworkType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AuditEventAgentNetworkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AuditEventAgentNetworkType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventAgentNetworkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventAgentNetworkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class AuditEventAgentNetworkType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AuditEventAgentNetworkType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventOutcome.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/AuditEventOutcome.java
@@ -57,6 +57,9 @@ public class AuditEventOutcome extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating AuditEventOutcome objects from a passed enum value.
+     */
     public static AuditEventOutcome of(ValueSet value) {
         switch (value) {
         case OUTCOME_0:
@@ -72,14 +75,38 @@ public class AuditEventOutcome extends Code {
         }
     }
 
+    /**
+     * Factory method for creating AuditEventOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static AuditEventOutcome of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating AuditEventOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class AuditEventOutcome extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating AuditEventOutcome.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BindingStrength.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BindingStrength.java
@@ -61,6 +61,9 @@ public class BindingStrength extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating BindingStrength objects from a passed enum value.
+     */
     public static BindingStrength of(ValueSet value) {
         switch (value) {
         case REQUIRED:
@@ -76,14 +79,38 @@ public class BindingStrength extends Code {
         }
     }
 
+    /**
+     * Factory method for creating BindingStrength objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static BindingStrength of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BindingStrength objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BindingStrength objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -199,10 +226,22 @@ public class BindingStrength extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating BindingStrength.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductCategory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductCategory.java
@@ -65,6 +65,9 @@ public class BiologicallyDerivedProductCategory extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductCategory objects from a passed enum value.
+     */
     public static BiologicallyDerivedProductCategory of(ValueSet value) {
         switch (value) {
         case ORGAN:
@@ -82,14 +85,38 @@ public class BiologicallyDerivedProductCategory extends Code {
         }
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static BiologicallyDerivedProductCategory of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -209,10 +236,22 @@ public class BiologicallyDerivedProductCategory extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating BiologicallyDerivedProductCategory.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductStatus.java
@@ -43,6 +43,9 @@ public class BiologicallyDerivedProductStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductStatus objects from a passed enum value.
+     */
     public static BiologicallyDerivedProductStatus of(ValueSet value) {
         switch (value) {
         case AVAILABLE:
@@ -54,14 +57,38 @@ public class BiologicallyDerivedProductStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static BiologicallyDerivedProductStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class BiologicallyDerivedProductStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating BiologicallyDerivedProductStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductStorageScale.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BiologicallyDerivedProductStorageScale.java
@@ -50,6 +50,9 @@ public class BiologicallyDerivedProductStorageScale extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductStorageScale objects from a passed enum value.
+     */
     public static BiologicallyDerivedProductStorageScale of(ValueSet value) {
         switch (value) {
         case FARENHEIT:
@@ -63,14 +66,38 @@ public class BiologicallyDerivedProductStorageScale extends Code {
         }
     }
 
+    /**
+     * Factory method for creating BiologicallyDerivedProductStorageScale objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static BiologicallyDerivedProductStorageScale of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductStorageScale objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BiologicallyDerivedProductStorageScale objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class BiologicallyDerivedProductStorageScale extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating BiologicallyDerivedProductStorageScale.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BundleType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/BundleType.java
@@ -94,6 +94,9 @@ public class BundleType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating BundleType objects from a passed enum value.
+     */
     public static BundleType of(ValueSet value) {
         switch (value) {
         case DOCUMENT:
@@ -119,14 +122,38 @@ public class BundleType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating BundleType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static BundleType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BundleType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating BundleType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -275,10 +302,22 @@ public class BundleType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating BundleType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CapabilityStatementKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CapabilityStatementKind.java
@@ -53,6 +53,9 @@ public class CapabilityStatementKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CapabilityStatementKind objects from a passed enum value.
+     */
     public static CapabilityStatementKind of(ValueSet value) {
         switch (value) {
         case INSTANCE:
@@ -66,14 +69,38 @@ public class CapabilityStatementKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CapabilityStatementKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CapabilityStatementKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CapabilityStatementKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CapabilityStatementKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -181,10 +208,22 @@ public class CapabilityStatementKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CapabilityStatementKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanActivityKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanActivityKind.java
@@ -45,6 +45,9 @@ public class CarePlanActivityKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CarePlanActivityKind objects from a passed enum value.
+     */
     public static CarePlanActivityKind of(ValueSet value) {
         switch (value) {
         case APPOINTMENT:
@@ -68,14 +71,38 @@ public class CarePlanActivityKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CarePlanActivityKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CarePlanActivityKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanActivityKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanActivityKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class CarePlanActivityKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CarePlanActivityKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanActivityStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanActivityStatus.java
@@ -93,6 +93,9 @@ public class CarePlanActivityStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CarePlanActivityStatus objects from a passed enum value.
+     */
     public static CarePlanActivityStatus of(ValueSet value) {
         switch (value) {
         case NOT_STARTED:
@@ -118,14 +121,38 @@ public class CarePlanActivityStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CarePlanActivityStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CarePlanActivityStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanActivityStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanActivityStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -273,10 +300,22 @@ public class CarePlanActivityStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CarePlanActivityStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanIntent.java
@@ -37,6 +37,9 @@ public class CarePlanIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CarePlanIntent objects from a passed enum value.
+     */
     public static CarePlanIntent of(ValueSet value) {
         switch (value) {
         case PROPOSAL:
@@ -52,14 +55,38 @@ public class CarePlanIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CarePlanIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CarePlanIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -151,10 +178,22 @@ public class CarePlanIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CarePlanIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CarePlanStatus.java
@@ -83,6 +83,9 @@ public class CarePlanStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CarePlanStatus objects from a passed enum value.
+     */
     public static CarePlanStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class CarePlanStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CarePlanStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CarePlanStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CarePlanStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class CarePlanStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CarePlanStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CareTeamStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CareTeamStatus.java
@@ -65,6 +65,9 @@ public class CareTeamStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CareTeamStatus objects from a passed enum value.
+     */
     public static CareTeamStatus of(ValueSet value) {
         switch (value) {
         case PROPOSED:
@@ -82,14 +85,38 @@ public class CareTeamStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CareTeamStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CareTeamStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CareTeamStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CareTeamStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -209,10 +236,22 @@ public class CareTeamStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CareTeamStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CatalogEntryRelationType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CatalogEntryRelationType.java
@@ -43,6 +43,9 @@ public class CatalogEntryRelationType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CatalogEntryRelationType objects from a passed enum value.
+     */
     public static CatalogEntryRelationType of(ValueSet value) {
         switch (value) {
         case TRIGGERS:
@@ -54,14 +57,38 @@ public class CatalogEntryRelationType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CatalogEntryRelationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CatalogEntryRelationType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CatalogEntryRelationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CatalogEntryRelationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class CatalogEntryRelationType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CatalogEntryRelationType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ChargeItemDefinitionPriceComponentType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ChargeItemDefinitionPriceComponentType.java
@@ -71,6 +71,9 @@ public class ChargeItemDefinitionPriceComponentType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ChargeItemDefinitionPriceComponentType objects from a passed enum value.
+     */
     public static ChargeItemDefinitionPriceComponentType of(ValueSet value) {
         switch (value) {
         case BASE:
@@ -90,14 +93,38 @@ public class ChargeItemDefinitionPriceComponentType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ChargeItemDefinitionPriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ChargeItemDefinitionPriceComponentType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ChargeItemDefinitionPriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ChargeItemDefinitionPriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class ChargeItemDefinitionPriceComponentType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ChargeItemDefinitionPriceComponentType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ChargeItemStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ChargeItemStatus.java
@@ -81,6 +81,9 @@ public class ChargeItemStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ChargeItemStatus objects from a passed enum value.
+     */
     public static ChargeItemStatus of(ValueSet value) {
         switch (value) {
         case PLANNED:
@@ -102,14 +105,38 @@ public class ChargeItemStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ChargeItemStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ChargeItemStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ChargeItemStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ChargeItemStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -245,10 +272,22 @@ public class ChargeItemStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ChargeItemStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClaimResponseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClaimResponseStatus.java
@@ -57,6 +57,9 @@ public class ClaimResponseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ClaimResponseStatus objects from a passed enum value.
+     */
     public static ClaimResponseStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class ClaimResponseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ClaimResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ClaimResponseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClaimResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClaimResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ClaimResponseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ClaimResponseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClaimStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClaimStatus.java
@@ -57,6 +57,9 @@ public class ClaimStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ClaimStatus objects from a passed enum value.
+     */
     public static ClaimStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class ClaimStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ClaimStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ClaimStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClaimStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClaimStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ClaimStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ClaimStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClinicalImpressionStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ClinicalImpressionStatus.java
@@ -35,6 +35,9 @@ public class ClinicalImpressionStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ClinicalImpressionStatus objects from a passed enum value.
+     */
     public static ClinicalImpressionStatus of(ValueSet value) {
         switch (value) {
         case IN_PROGRESS:
@@ -48,14 +51,38 @@ public class ClinicalImpressionStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ClinicalImpressionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ClinicalImpressionStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClinicalImpressionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ClinicalImpressionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -145,10 +172,22 @@ public class ClinicalImpressionStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ClinicalImpressionStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSearchSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSearchSupport.java
@@ -43,6 +43,9 @@ public class CodeSearchSupport extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CodeSearchSupport objects from a passed enum value.
+     */
     public static CodeSearchSupport of(ValueSet value) {
         switch (value) {
         case EXPLICIT:
@@ -54,14 +57,38 @@ public class CodeSearchSupport extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CodeSearchSupport objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CodeSearchSupport of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSearchSupport objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSearchSupport objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class CodeSearchSupport extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CodeSearchSupport.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSystemContentMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSystemContentMode.java
@@ -69,6 +69,9 @@ public class CodeSystemContentMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CodeSystemContentMode objects from a passed enum value.
+     */
     public static CodeSystemContentMode of(ValueSet value) {
         switch (value) {
         case NOT_PRESENT:
@@ -86,14 +89,38 @@ public class CodeSystemContentMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CodeSystemContentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CodeSystemContentMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSystemContentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSystemContentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -217,10 +244,22 @@ public class CodeSystemContentMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CodeSystemContentMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSystemHierarchyMeaning.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CodeSystemHierarchyMeaning.java
@@ -64,6 +64,9 @@ public class CodeSystemHierarchyMeaning extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CodeSystemHierarchyMeaning objects from a passed enum value.
+     */
     public static CodeSystemHierarchyMeaning of(ValueSet value) {
         switch (value) {
         case GROUPED_BY:
@@ -79,14 +82,38 @@ public class CodeSystemHierarchyMeaning extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CodeSystemHierarchyMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CodeSystemHierarchyMeaning of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSystemHierarchyMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CodeSystemHierarchyMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -205,10 +232,22 @@ public class CodeSystemHierarchyMeaning extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CodeSystemHierarchyMeaning.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationPriority.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationPriority.java
@@ -57,6 +57,9 @@ public class CommunicationPriority extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CommunicationPriority objects from a passed enum value.
+     */
     public static CommunicationPriority of(ValueSet value) {
         switch (value) {
         case ROUTINE:
@@ -72,14 +75,38 @@ public class CommunicationPriority extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CommunicationPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CommunicationPriority of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class CommunicationPriority extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CommunicationPriority.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationRequestStatus.java
@@ -83,6 +83,9 @@ public class CommunicationRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CommunicationRequestStatus objects from a passed enum value.
+     */
     public static CommunicationRequestStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class CommunicationRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CommunicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CommunicationRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class CommunicationRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CommunicationRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CommunicationStatus.java
@@ -91,6 +91,9 @@ public class CommunicationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CommunicationStatus objects from a passed enum value.
+     */
     public static CommunicationStatus of(ValueSet value) {
         switch (value) {
         case PREPARATION:
@@ -114,14 +117,38 @@ public class CommunicationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CommunicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CommunicationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CommunicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -267,10 +294,22 @@ public class CommunicationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CommunicationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompartmentCode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompartmentCode.java
@@ -64,6 +64,9 @@ public class CompartmentCode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CompartmentCode objects from a passed enum value.
+     */
     public static CompartmentCode of(ValueSet value) {
         switch (value) {
         case PATIENT:
@@ -81,14 +84,38 @@ public class CompartmentCode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CompartmentCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CompartmentCode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompartmentCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompartmentCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class CompartmentCode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CompartmentCode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompartmentType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompartmentType.java
@@ -64,6 +64,9 @@ public class CompartmentType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CompartmentType objects from a passed enum value.
+     */
     public static CompartmentType of(ValueSet value) {
         switch (value) {
         case PATIENT:
@@ -81,14 +84,38 @@ public class CompartmentType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CompartmentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CompartmentType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompartmentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompartmentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class CompartmentType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CompartmentType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompositionAttestationMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompositionAttestationMode.java
@@ -57,6 +57,9 @@ public class CompositionAttestationMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CompositionAttestationMode objects from a passed enum value.
+     */
     public static CompositionAttestationMode of(ValueSet value) {
         switch (value) {
         case PERSONAL:
@@ -72,14 +75,38 @@ public class CompositionAttestationMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CompositionAttestationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CompositionAttestationMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompositionAttestationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompositionAttestationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class CompositionAttestationMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CompositionAttestationMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompositionStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CompositionStatus.java
@@ -61,6 +61,9 @@ public class CompositionStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CompositionStatus objects from a passed enum value.
+     */
     public static CompositionStatus of(ValueSet value) {
         switch (value) {
         case PRELIMINARY:
@@ -76,14 +79,38 @@ public class CompositionStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CompositionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CompositionStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompositionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CompositionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -199,10 +226,22 @@ public class CompositionStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CompositionStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptMapEquivalence.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptMapEquivalence.java
@@ -107,6 +107,9 @@ public class ConceptMapEquivalence extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConceptMapEquivalence objects from a passed enum value.
+     */
     public static ConceptMapEquivalence of(ValueSet value) {
         switch (value) {
         case RELATEDTO:
@@ -134,14 +137,38 @@ public class ConceptMapEquivalence extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConceptMapEquivalence objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConceptMapEquivalence of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptMapEquivalence objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptMapEquivalence objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -303,10 +330,22 @@ public class ConceptMapEquivalence extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConceptMapEquivalence.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptMapGroupUnmappedMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptMapGroupUnmappedMode.java
@@ -50,6 +50,9 @@ public class ConceptMapGroupUnmappedMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConceptMapGroupUnmappedMode objects from a passed enum value.
+     */
     public static ConceptMapGroupUnmappedMode of(ValueSet value) {
         switch (value) {
         case PROVIDED:
@@ -63,14 +66,38 @@ public class ConceptMapGroupUnmappedMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConceptMapGroupUnmappedMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConceptMapGroupUnmappedMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptMapGroupUnmappedMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptMapGroupUnmappedMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ConceptMapGroupUnmappedMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConceptMapGroupUnmappedMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptSubsumptionOutcome.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConceptSubsumptionOutcome.java
@@ -57,6 +57,9 @@ public class ConceptSubsumptionOutcome extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConceptSubsumptionOutcome objects from a passed enum value.
+     */
     public static ConceptSubsumptionOutcome of(ValueSet value) {
         switch (value) {
         case EQUIVALENT:
@@ -72,14 +75,38 @@ public class ConceptSubsumptionOutcome extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConceptSubsumptionOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConceptSubsumptionOutcome of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptSubsumptionOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConceptSubsumptionOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ConceptSubsumptionOutcome extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConceptSubsumptionOutcome.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConditionalDeleteStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConditionalDeleteStatus.java
@@ -50,6 +50,9 @@ public class ConditionalDeleteStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConditionalDeleteStatus objects from a passed enum value.
+     */
     public static ConditionalDeleteStatus of(ValueSet value) {
         switch (value) {
         case NOT_SUPPORTED:
@@ -63,14 +66,38 @@ public class ConditionalDeleteStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConditionalDeleteStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConditionalDeleteStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConditionalDeleteStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConditionalDeleteStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ConditionalDeleteStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConditionalDeleteStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConditionalReadStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConditionalReadStatus.java
@@ -57,6 +57,9 @@ public class ConditionalReadStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConditionalReadStatus objects from a passed enum value.
+     */
     public static ConditionalReadStatus of(ValueSet value) {
         switch (value) {
         case NOT_SUPPORTED:
@@ -72,14 +75,38 @@ public class ConditionalReadStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConditionalReadStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConditionalReadStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConditionalReadStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConditionalReadStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ConditionalReadStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConditionalReadStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentDataMeaning.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentDataMeaning.java
@@ -57,6 +57,9 @@ public class ConsentDataMeaning extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConsentDataMeaning objects from a passed enum value.
+     */
     public static ConsentDataMeaning of(ValueSet value) {
         switch (value) {
         case INSTANCE:
@@ -72,14 +75,38 @@ public class ConsentDataMeaning extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConsentDataMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConsentDataMeaning of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentDataMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentDataMeaning objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ConsentDataMeaning extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConsentDataMeaning.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentProvisionType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentProvisionType.java
@@ -43,6 +43,9 @@ public class ConsentProvisionType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConsentProvisionType objects from a passed enum value.
+     */
     public static ConsentProvisionType of(ValueSet value) {
         switch (value) {
         case DENY:
@@ -54,14 +57,38 @@ public class ConsentProvisionType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConsentProvisionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConsentProvisionType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentProvisionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentProvisionType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class ConsentProvisionType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConsentProvisionType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentState.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConsentState.java
@@ -71,6 +71,9 @@ public class ConsentState extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConsentState objects from a passed enum value.
+     */
     public static ConsentState of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -90,14 +93,38 @@ public class ConsentState extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConsentState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConsentState of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConsentState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class ConsentState extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConsentState.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConstraintSeverity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ConstraintSeverity.java
@@ -43,6 +43,9 @@ public class ConstraintSeverity extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ConstraintSeverity objects from a passed enum value.
+     */
     public static ConstraintSeverity of(ValueSet value) {
         switch (value) {
         case ERROR:
@@ -54,14 +57,38 @@ public class ConstraintSeverity extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ConstraintSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ConstraintSeverity of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConstraintSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ConstraintSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class ConstraintSeverity extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ConstraintSeverity.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContactPointSystem.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContactPointSystem.java
@@ -84,6 +84,9 @@ public class ContactPointSystem extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ContactPointSystem objects from a passed enum value.
+     */
     public static ContactPointSystem of(ValueSet value) {
         switch (value) {
         case PHONE:
@@ -105,14 +108,38 @@ public class ContactPointSystem extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ContactPointSystem objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ContactPointSystem of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContactPointSystem objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContactPointSystem objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -251,10 +278,22 @@ public class ContactPointSystem extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ContactPointSystem.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContactPointUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContactPointUse.java
@@ -67,6 +67,9 @@ public class ContactPointUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ContactPointUse objects from a passed enum value.
+     */
     public static ContactPointUse of(ValueSet value) {
         switch (value) {
         case HOME:
@@ -84,14 +87,38 @@ public class ContactPointUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ContactPointUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ContactPointUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContactPointUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContactPointUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class ContactPointUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ContactPointUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContractPublicationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContractPublicationStatus.java
@@ -167,6 +167,9 @@ public class ContractPublicationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ContractPublicationStatus objects from a passed enum value.
+     */
     public static ContractPublicationStatus of(ValueSet value) {
         switch (value) {
         case AMENDED:
@@ -204,14 +207,38 @@ public class ContractPublicationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ContractPublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ContractPublicationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContractPublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContractPublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -433,10 +460,22 @@ public class ContractPublicationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ContractPublicationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContractStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContractStatus.java
@@ -167,6 +167,9 @@ public class ContractStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ContractStatus objects from a passed enum value.
+     */
     public static ContractStatus of(ValueSet value) {
         switch (value) {
         case AMENDED:
@@ -204,14 +207,38 @@ public class ContractStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ContractStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ContractStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContractStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContractStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -433,10 +460,22 @@ public class ContractStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ContractStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContributorType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ContributorType.java
@@ -57,6 +57,9 @@ public class ContributorType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ContributorType objects from a passed enum value.
+     */
     public static ContributorType of(ValueSet value) {
         switch (value) {
         case AUTHOR:
@@ -72,14 +75,38 @@ public class ContributorType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ContributorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ContributorType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContributorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ContributorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ContributorType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ContributorType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CoverageStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/CoverageStatus.java
@@ -57,6 +57,9 @@ public class CoverageStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating CoverageStatus objects from a passed enum value.
+     */
     public static CoverageStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class CoverageStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating CoverageStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static CoverageStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CoverageStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating CoverageStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class CoverageStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating CoverageStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DataAbsentReason.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DataAbsentReason.java
@@ -134,6 +134,9 @@ public class DataAbsentReason extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DataAbsentReason objects from a passed enum value.
+     */
     public static DataAbsentReason of(ValueSet value) {
         switch (value) {
         case UNKNOWN:
@@ -171,14 +174,38 @@ public class DataAbsentReason extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DataAbsentReason objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DataAbsentReason of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DataAbsentReason objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DataAbsentReason objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -367,10 +394,22 @@ public class DataAbsentReason extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DataAbsentReason.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DayOfWeek.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DayOfWeek.java
@@ -78,6 +78,9 @@ public class DayOfWeek extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DayOfWeek objects from a passed enum value.
+     */
     public static DayOfWeek of(ValueSet value) {
         switch (value) {
         case MON:
@@ -99,14 +102,38 @@ public class DayOfWeek extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DayOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DayOfWeek of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DayOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DayOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -239,10 +266,22 @@ public class DayOfWeek extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DayOfWeek.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DaysOfWeek.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DaysOfWeek.java
@@ -78,6 +78,9 @@ public class DaysOfWeek extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DaysOfWeek objects from a passed enum value.
+     */
     public static DaysOfWeek of(ValueSet value) {
         switch (value) {
         case MON:
@@ -99,14 +102,38 @@ public class DaysOfWeek extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DaysOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DaysOfWeek of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DaysOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DaysOfWeek objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -239,10 +266,22 @@ public class DaysOfWeek extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DaysOfWeek.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DetectedIssueSeverity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DetectedIssueSeverity.java
@@ -52,6 +52,9 @@ public class DetectedIssueSeverity extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DetectedIssueSeverity objects from a passed enum value.
+     */
     public static DetectedIssueSeverity of(ValueSet value) {
         switch (value) {
         case HIGH:
@@ -65,14 +68,38 @@ public class DetectedIssueSeverity extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DetectedIssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DetectedIssueSeverity of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DetectedIssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DetectedIssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class DetectedIssueSeverity extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DetectedIssueSeverity.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DetectedIssueStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DetectedIssueStatus.java
@@ -94,6 +94,9 @@ public class DetectedIssueStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DetectedIssueStatus objects from a passed enum value.
+     */
     public static DetectedIssueStatus of(ValueSet value) {
         switch (value) {
         case REGISTERED:
@@ -117,14 +120,38 @@ public class DetectedIssueStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DetectedIssueStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DetectedIssueStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DetectedIssueStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DetectedIssueStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -273,10 +300,22 @@ public class DetectedIssueStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DetectedIssueStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCalibrationState.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCalibrationState.java
@@ -57,6 +57,9 @@ public class DeviceMetricCalibrationState extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceMetricCalibrationState objects from a passed enum value.
+     */
     public static DeviceMetricCalibrationState of(ValueSet value) {
         switch (value) {
         case NOT_CALIBRATED:
@@ -72,14 +75,38 @@ public class DeviceMetricCalibrationState extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceMetricCalibrationState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceMetricCalibrationState of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCalibrationState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCalibrationState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class DeviceMetricCalibrationState extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceMetricCalibrationState.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCalibrationType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCalibrationType.java
@@ -57,6 +57,9 @@ public class DeviceMetricCalibrationType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceMetricCalibrationType objects from a passed enum value.
+     */
     public static DeviceMetricCalibrationType of(ValueSet value) {
         switch (value) {
         case UNSPECIFIED:
@@ -72,14 +75,38 @@ public class DeviceMetricCalibrationType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceMetricCalibrationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceMetricCalibrationType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCalibrationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCalibrationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class DeviceMetricCalibrationType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceMetricCalibrationType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCategory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricCategory.java
@@ -57,6 +57,9 @@ public class DeviceMetricCategory extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceMetricCategory objects from a passed enum value.
+     */
     public static DeviceMetricCategory of(ValueSet value) {
         switch (value) {
         case MEASUREMENT:
@@ -72,14 +75,38 @@ public class DeviceMetricCategory extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceMetricCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceMetricCategory of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class DeviceMetricCategory extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceMetricCategory.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricColor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricColor.java
@@ -85,6 +85,9 @@ public class DeviceMetricColor extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceMetricColor objects from a passed enum value.
+     */
     public static DeviceMetricColor of(ValueSet value) {
         switch (value) {
         case BLACK:
@@ -108,14 +111,38 @@ public class DeviceMetricColor extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceMetricColor objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceMetricColor of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricColor objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricColor objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -255,10 +282,22 @@ public class DeviceMetricColor extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceMetricColor.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricOperationalStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceMetricOperationalStatus.java
@@ -57,6 +57,9 @@ public class DeviceMetricOperationalStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceMetricOperationalStatus objects from a passed enum value.
+     */
     public static DeviceMetricOperationalStatus of(ValueSet value) {
         switch (value) {
         case ON:
@@ -72,14 +75,38 @@ public class DeviceMetricOperationalStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceMetricOperationalStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceMetricOperationalStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricOperationalStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceMetricOperationalStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class DeviceMetricOperationalStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceMetricOperationalStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceNameType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceNameType.java
@@ -71,6 +71,9 @@ public class DeviceNameType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceNameType objects from a passed enum value.
+     */
     public static DeviceNameType of(ValueSet value) {
         switch (value) {
         case UDI_LABEL_NAME:
@@ -90,14 +93,38 @@ public class DeviceNameType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceNameType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceNameType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceNameType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceNameType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class DeviceNameType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceNameType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceRequestStatus.java
@@ -83,6 +83,9 @@ public class DeviceRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceRequestStatus objects from a passed enum value.
+     */
     public static DeviceRequestStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class DeviceRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class DeviceRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceUseStatementStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DeviceUseStatementStatus.java
@@ -72,6 +72,9 @@ public class DeviceUseStatementStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DeviceUseStatementStatus objects from a passed enum value.
+     */
     public static DeviceUseStatementStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -91,14 +94,38 @@ public class DeviceUseStatementStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DeviceUseStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DeviceUseStatementStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceUseStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DeviceUseStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -225,10 +252,22 @@ public class DeviceUseStatementStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DeviceUseStatementStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DiagnosticReportStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DiagnosticReportStatus.java
@@ -105,6 +105,9 @@ public class DiagnosticReportStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DiagnosticReportStatus objects from a passed enum value.
+     */
     public static DiagnosticReportStatus of(ValueSet value) {
         switch (value) {
         case REGISTERED:
@@ -132,14 +135,38 @@ public class DiagnosticReportStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DiagnosticReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DiagnosticReportStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DiagnosticReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DiagnosticReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -299,10 +326,22 @@ public class DiagnosticReportStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DiagnosticReportStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DiscriminatorType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DiscriminatorType.java
@@ -67,6 +67,9 @@ public class DiscriminatorType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DiscriminatorType objects from a passed enum value.
+     */
     public static DiscriminatorType of(ValueSet value) {
         switch (value) {
         case VALUE:
@@ -84,14 +87,38 @@ public class DiscriminatorType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DiscriminatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DiscriminatorType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DiscriminatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DiscriminatorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class DiscriminatorType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DiscriminatorType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentConfidentiality.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentConfidentiality.java
@@ -41,6 +41,9 @@ public class DocumentConfidentiality extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DocumentConfidentiality objects from a passed enum value.
+     */
     public static DocumentConfidentiality of(ValueSet value) {
         switch (value) {
         case U:
@@ -60,14 +63,38 @@ public class DocumentConfidentiality extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DocumentConfidentiality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DocumentConfidentiality of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentConfidentiality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentConfidentiality objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -163,10 +190,22 @@ public class DocumentConfidentiality extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DocumentConfidentiality.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentMode.java
@@ -43,6 +43,9 @@ public class DocumentMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DocumentMode objects from a passed enum value.
+     */
     public static DocumentMode of(ValueSet value) {
         switch (value) {
         case PRODUCER:
@@ -54,14 +57,38 @@ public class DocumentMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DocumentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DocumentMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class DocumentMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DocumentMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentReferenceStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentReferenceStatus.java
@@ -50,6 +50,9 @@ public class DocumentReferenceStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DocumentReferenceStatus objects from a passed enum value.
+     */
     public static DocumentReferenceStatus of(ValueSet value) {
         switch (value) {
         case CURRENT:
@@ -63,14 +66,38 @@ public class DocumentReferenceStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DocumentReferenceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DocumentReferenceStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentReferenceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentReferenceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class DocumentReferenceStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DocumentReferenceStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentRelationshipType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/DocumentRelationshipType.java
@@ -57,6 +57,9 @@ public class DocumentRelationshipType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating DocumentRelationshipType objects from a passed enum value.
+     */
     public static DocumentRelationshipType of(ValueSet value) {
         switch (value) {
         case REPLACES:
@@ -72,14 +75,38 @@ public class DocumentRelationshipType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating DocumentRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static DocumentRelationshipType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating DocumentRelationshipType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class DocumentRelationshipType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating DocumentRelationshipType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityRequestPurpose.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityRequestPurpose.java
@@ -59,6 +59,9 @@ public class EligibilityRequestPurpose extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EligibilityRequestPurpose objects from a passed enum value.
+     */
     public static EligibilityRequestPurpose of(ValueSet value) {
         switch (value) {
         case AUTH_REQUIREMENTS:
@@ -74,14 +77,38 @@ public class EligibilityRequestPurpose extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EligibilityRequestPurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EligibilityRequestPurpose of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityRequestPurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityRequestPurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class EligibilityRequestPurpose extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EligibilityRequestPurpose.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityRequestStatus.java
@@ -57,6 +57,9 @@ public class EligibilityRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EligibilityRequestStatus objects from a passed enum value.
+     */
     public static EligibilityRequestStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class EligibilityRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EligibilityRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EligibilityRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class EligibilityRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EligibilityRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityResponsePurpose.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityResponsePurpose.java
@@ -59,6 +59,9 @@ public class EligibilityResponsePurpose extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EligibilityResponsePurpose objects from a passed enum value.
+     */
     public static EligibilityResponsePurpose of(ValueSet value) {
         switch (value) {
         case AUTH_REQUIREMENTS:
@@ -74,14 +77,38 @@ public class EligibilityResponsePurpose extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EligibilityResponsePurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EligibilityResponsePurpose of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityResponsePurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityResponsePurpose objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class EligibilityResponsePurpose extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EligibilityResponsePurpose.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityResponseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EligibilityResponseStatus.java
@@ -57,6 +57,9 @@ public class EligibilityResponseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EligibilityResponseStatus objects from a passed enum value.
+     */
     public static EligibilityResponseStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class EligibilityResponseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EligibilityResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EligibilityResponseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EligibilityResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class EligibilityResponseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EligibilityResponseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnableWhenBehavior.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnableWhenBehavior.java
@@ -43,6 +43,9 @@ public class EnableWhenBehavior extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EnableWhenBehavior objects from a passed enum value.
+     */
     public static EnableWhenBehavior of(ValueSet value) {
         switch (value) {
         case ALL:
@@ -54,14 +57,38 @@ public class EnableWhenBehavior extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EnableWhenBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EnableWhenBehavior of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnableWhenBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnableWhenBehavior objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class EnableWhenBehavior extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EnableWhenBehavior.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EncounterLocationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EncounterLocationStatus.java
@@ -59,6 +59,9 @@ public class EncounterLocationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EncounterLocationStatus objects from a passed enum value.
+     */
     public static EncounterLocationStatus of(ValueSet value) {
         switch (value) {
         case PLANNED:
@@ -74,14 +77,38 @@ public class EncounterLocationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EncounterLocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EncounterLocationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EncounterLocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EncounterLocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class EncounterLocationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EncounterLocationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EncounterStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EncounterStatus.java
@@ -93,6 +93,9 @@ public class EncounterStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EncounterStatus objects from a passed enum value.
+     */
     public static EncounterStatus of(ValueSet value) {
         switch (value) {
         case PLANNED:
@@ -118,14 +121,38 @@ public class EncounterStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EncounterStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EncounterStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EncounterStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EncounterStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -273,10 +300,22 @@ public class EncounterStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EncounterStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EndpointStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EndpointStatus.java
@@ -72,6 +72,9 @@ public class EndpointStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EndpointStatus objects from a passed enum value.
+     */
     public static EndpointStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -91,14 +94,38 @@ public class EndpointStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EndpointStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EndpointStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EndpointStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EndpointStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -225,10 +252,22 @@ public class EndpointStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EndpointStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnrollmentRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnrollmentRequestStatus.java
@@ -57,6 +57,9 @@ public class EnrollmentRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EnrollmentRequestStatus objects from a passed enum value.
+     */
     public static EnrollmentRequestStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class EnrollmentRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EnrollmentRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EnrollmentRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnrollmentRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnrollmentRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class EnrollmentRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EnrollmentRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnrollmentResponseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EnrollmentResponseStatus.java
@@ -57,6 +57,9 @@ public class EnrollmentResponseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EnrollmentResponseStatus objects from a passed enum value.
+     */
     public static EnrollmentResponseStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class EnrollmentResponseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EnrollmentResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EnrollmentResponseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnrollmentResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EnrollmentResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class EnrollmentResponseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EnrollmentResponseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EpisodeOfCareStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EpisodeOfCareStatus.java
@@ -84,6 +84,9 @@ public class EpisodeOfCareStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EpisodeOfCareStatus objects from a passed enum value.
+     */
     public static EpisodeOfCareStatus of(ValueSet value) {
         switch (value) {
         case PLANNED:
@@ -105,14 +108,38 @@ public class EpisodeOfCareStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EpisodeOfCareStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EpisodeOfCareStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EpisodeOfCareStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EpisodeOfCareStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -251,10 +278,22 @@ public class EpisodeOfCareStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EpisodeOfCareStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EventCapabilityMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EventCapabilityMode.java
@@ -43,6 +43,9 @@ public class EventCapabilityMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EventCapabilityMode objects from a passed enum value.
+     */
     public static EventCapabilityMode of(ValueSet value) {
         switch (value) {
         case SENDER:
@@ -54,14 +57,38 @@ public class EventCapabilityMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EventCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EventCapabilityMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EventCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EventCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class EventCapabilityMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EventCapabilityMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EventTiming.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EventTiming.java
@@ -153,6 +153,9 @@ public class EventTiming extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EventTiming objects from a passed enum value.
+     */
     public static EventTiming of(ValueSet value) {
         switch (value) {
         case MORN:
@@ -212,14 +215,38 @@ public class EventTiming extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EventTiming objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EventTiming of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EventTiming objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EventTiming objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -427,10 +454,22 @@ public class EventTiming extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EventTiming.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EvidenceVariableType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/EvidenceVariableType.java
@@ -50,6 +50,9 @@ public class EvidenceVariableType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating EvidenceVariableType objects from a passed enum value.
+     */
     public static EvidenceVariableType of(ValueSet value) {
         switch (value) {
         case DICHOTOMOUS:
@@ -63,14 +66,38 @@ public class EvidenceVariableType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating EvidenceVariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static EvidenceVariableType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EvidenceVariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating EvidenceVariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class EvidenceVariableType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating EvidenceVariableType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExampleScenarioActorType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExampleScenarioActorType.java
@@ -43,6 +43,9 @@ public class ExampleScenarioActorType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ExampleScenarioActorType objects from a passed enum value.
+     */
     public static ExampleScenarioActorType of(ValueSet value) {
         switch (value) {
         case PERSON:
@@ -54,14 +57,38 @@ public class ExampleScenarioActorType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ExampleScenarioActorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ExampleScenarioActorType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExampleScenarioActorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExampleScenarioActorType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class ExampleScenarioActorType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ExampleScenarioActorType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExplanationOfBenefitStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExplanationOfBenefitStatus.java
@@ -57,6 +57,9 @@ public class ExplanationOfBenefitStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ExplanationOfBenefitStatus objects from a passed enum value.
+     */
     public static ExplanationOfBenefitStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class ExplanationOfBenefitStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ExplanationOfBenefitStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ExplanationOfBenefitStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExplanationOfBenefitStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExplanationOfBenefitStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ExplanationOfBenefitStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ExplanationOfBenefitStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExposureState.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExposureState.java
@@ -44,6 +44,9 @@ public class ExposureState extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ExposureState objects from a passed enum value.
+     */
     public static ExposureState of(ValueSet value) {
         switch (value) {
         case EXPOSURE:
@@ -55,14 +58,38 @@ public class ExposureState extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ExposureState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ExposureState of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExposureState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExposureState objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -161,10 +188,22 @@ public class ExposureState extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ExposureState.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExtensionContextType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ExtensionContextType.java
@@ -53,6 +53,9 @@ public class ExtensionContextType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ExtensionContextType objects from a passed enum value.
+     */
     public static ExtensionContextType of(ValueSet value) {
         switch (value) {
         case FHIRPATH:
@@ -66,14 +69,38 @@ public class ExtensionContextType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ExtensionContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ExtensionContextType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExtensionContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ExtensionContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -181,10 +208,22 @@ public class ExtensionContextType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ExtensionContextType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRAllTypes.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRAllTypes.java
@@ -1694,6 +1694,9 @@ public class FHIRAllTypes extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRAllTypes objects from a passed enum value.
+     */
     public static FHIRAllTypes of(ValueSet value) {
         switch (value) {
         case ADDRESS:
@@ -2127,14 +2130,38 @@ public class FHIRAllTypes extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRAllTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRAllTypes of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRAllTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRAllTypes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -3883,10 +3910,22 @@ public class FHIRAllTypes extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRAllTypes.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRDefinedType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRDefinedType.java
@@ -1680,6 +1680,9 @@ public class FHIRDefinedType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRDefinedType objects from a passed enum value.
+     */
     public static FHIRDefinedType of(ValueSet value) {
         switch (value) {
         case ADDRESS:
@@ -2109,14 +2112,38 @@ public class FHIRDefinedType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRDefinedType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRDefinedType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRDefinedType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRDefinedType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -3851,10 +3878,22 @@ public class FHIRDefinedType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRDefinedType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRDeviceStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRDeviceStatus.java
@@ -59,6 +59,9 @@ public class FHIRDeviceStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRDeviceStatus objects from a passed enum value.
+     */
     public static FHIRDeviceStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -74,14 +77,38 @@ public class FHIRDeviceStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRDeviceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRDeviceStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRDeviceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRDeviceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class FHIRDeviceStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRDeviceStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRResourceType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRResourceType.java
@@ -1215,6 +1215,9 @@ public class FHIRResourceType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRResourceType objects from a passed enum value.
+     */
     public static FHIRResourceType of(ValueSet value) {
         switch (value) {
         case ACCOUNT:
@@ -1518,14 +1521,38 @@ public class FHIRResourceType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRResourceType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -2795,10 +2822,22 @@ public class FHIRResourceType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRResourceType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRSubstanceStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRSubstanceStatus.java
@@ -50,6 +50,9 @@ public class FHIRSubstanceStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRSubstanceStatus objects from a passed enum value.
+     */
     public static FHIRSubstanceStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -63,14 +66,38 @@ public class FHIRSubstanceStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRSubstanceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRSubstanceStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRSubstanceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRSubstanceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class FHIRSubstanceStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRSubstanceStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRVersion.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FHIRVersion.java
@@ -183,6 +183,9 @@ public class FHIRVersion extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FHIRVersion objects from a passed enum value.
+     */
     public static FHIRVersion of(ValueSet value) {
         switch (value) {
         case VERSION_0_01:
@@ -234,14 +237,38 @@ public class FHIRVersion extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FHIRVersion objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FHIRVersion of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRVersion objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FHIRVersion objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -479,10 +506,22 @@ public class FHIRVersion extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FHIRVersion.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FamilyHistoryStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FamilyHistoryStatus.java
@@ -58,6 +58,9 @@ public class FamilyHistoryStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FamilyHistoryStatus objects from a passed enum value.
+     */
     public static FamilyHistoryStatus of(ValueSet value) {
         switch (value) {
         case PARTIAL:
@@ -73,14 +76,38 @@ public class FamilyHistoryStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FamilyHistoryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FamilyHistoryStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FamilyHistoryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FamilyHistoryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class FamilyHistoryStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FamilyHistoryStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FilterOperator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FilterOperator.java
@@ -98,6 +98,9 @@ public class FilterOperator extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FilterOperator objects from a passed enum value.
+     */
     public static FilterOperator of(ValueSet value) {
         switch (value) {
         case EQUALS:
@@ -123,14 +126,38 @@ public class FilterOperator extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FilterOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FilterOperator of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FilterOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FilterOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -283,10 +310,22 @@ public class FilterOperator extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FilterOperator.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FlagStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/FlagStatus.java
@@ -51,6 +51,9 @@ public class FlagStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating FlagStatus objects from a passed enum value.
+     */
     public static FlagStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -64,14 +67,38 @@ public class FlagStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating FlagStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static FlagStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FlagStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating FlagStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -177,10 +204,22 @@ public class FlagStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating FlagStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GoalLifecycleStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GoalLifecycleStatus.java
@@ -92,6 +92,9 @@ public class GoalLifecycleStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GoalLifecycleStatus objects from a passed enum value.
+     */
     public static GoalLifecycleStatus of(ValueSet value) {
         switch (value) {
         case PROPOSED:
@@ -117,14 +120,38 @@ public class GoalLifecycleStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GoalLifecycleStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GoalLifecycleStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GoalLifecycleStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GoalLifecycleStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -271,10 +298,22 @@ public class GoalLifecycleStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GoalLifecycleStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GraphCompartmentRule.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GraphCompartmentRule.java
@@ -57,6 +57,9 @@ public class GraphCompartmentRule extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GraphCompartmentRule objects from a passed enum value.
+     */
     public static GraphCompartmentRule of(ValueSet value) {
         switch (value) {
         case IDENTICAL:
@@ -72,14 +75,38 @@ public class GraphCompartmentRule extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GraphCompartmentRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GraphCompartmentRule of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GraphCompartmentRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GraphCompartmentRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class GraphCompartmentRule extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GraphCompartmentRule.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GraphCompartmentUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GraphCompartmentUse.java
@@ -43,6 +43,9 @@ public class GraphCompartmentUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GraphCompartmentUse objects from a passed enum value.
+     */
     public static GraphCompartmentUse of(ValueSet value) {
         switch (value) {
         case CONDITION:
@@ -54,14 +57,38 @@ public class GraphCompartmentUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GraphCompartmentUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GraphCompartmentUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GraphCompartmentUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GraphCompartmentUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class GraphCompartmentUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GraphCompartmentUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GroupMeasure.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GroupMeasure.java
@@ -71,6 +71,9 @@ public class GroupMeasure extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GroupMeasure objects from a passed enum value.
+     */
     public static GroupMeasure of(ValueSet value) {
         switch (value) {
         case MEAN:
@@ -90,14 +93,38 @@ public class GroupMeasure extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GroupMeasure objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GroupMeasure of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GroupMeasure objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GroupMeasure objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class GroupMeasure extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GroupMeasure.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GroupType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GroupType.java
@@ -71,6 +71,9 @@ public class GroupType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GroupType objects from a passed enum value.
+     */
     public static GroupType of(ValueSet value) {
         switch (value) {
         case PERSON:
@@ -90,14 +93,38 @@ public class GroupType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GroupType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GroupType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GroupType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GroupType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class GroupType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GroupType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuidanceResponseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuidanceResponseStatus.java
@@ -71,6 +71,9 @@ public class GuidanceResponseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GuidanceResponseStatus objects from a passed enum value.
+     */
     public static GuidanceResponseStatus of(ValueSet value) {
         switch (value) {
         case SUCCESS:
@@ -90,14 +93,38 @@ public class GuidanceResponseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GuidanceResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GuidanceResponseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuidanceResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuidanceResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class GuidanceResponseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GuidanceResponseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuidePageGeneration.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuidePageGeneration.java
@@ -59,6 +59,9 @@ public class GuidePageGeneration extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GuidePageGeneration objects from a passed enum value.
+     */
     public static GuidePageGeneration of(ValueSet value) {
         switch (value) {
         case HTML:
@@ -74,14 +77,38 @@ public class GuidePageGeneration extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GuidePageGeneration objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GuidePageGeneration of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuidePageGeneration objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuidePageGeneration objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class GuidePageGeneration extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GuidePageGeneration.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuideParameterCode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/GuideParameterCode.java
@@ -111,6 +111,9 @@ public class GuideParameterCode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating GuideParameterCode objects from a passed enum value.
+     */
     public static GuideParameterCode of(ValueSet value) {
         switch (value) {
         case APPLY:
@@ -138,14 +141,38 @@ public class GuideParameterCode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating GuideParameterCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static GuideParameterCode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuideParameterCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating GuideParameterCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -311,10 +338,22 @@ public class GuideParameterCode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating GuideParameterCode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/HTTPVerb.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/HTTPVerb.java
@@ -71,6 +71,9 @@ public class HTTPVerb extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating HTTPVerb objects from a passed enum value.
+     */
     public static HTTPVerb of(ValueSet value) {
         switch (value) {
         case GET:
@@ -90,14 +93,38 @@ public class HTTPVerb extends Code {
         }
     }
 
+    /**
+     * Factory method for creating HTTPVerb objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static HTTPVerb of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating HTTPVerb objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating HTTPVerb objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class HTTPVerb extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating HTTPVerb.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IdentifierUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IdentifierUse.java
@@ -68,6 +68,9 @@ public class IdentifierUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating IdentifierUse objects from a passed enum value.
+     */
     public static IdentifierUse of(ValueSet value) {
         switch (value) {
         case USUAL:
@@ -85,14 +88,38 @@ public class IdentifierUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating IdentifierUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static IdentifierUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IdentifierUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IdentifierUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -215,10 +242,22 @@ public class IdentifierUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating IdentifierUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IdentityAssuranceLevel.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IdentityAssuranceLevel.java
@@ -57,6 +57,9 @@ public class IdentityAssuranceLevel extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating IdentityAssuranceLevel objects from a passed enum value.
+     */
     public static IdentityAssuranceLevel of(ValueSet value) {
         switch (value) {
         case LEVEL1:
@@ -72,14 +75,38 @@ public class IdentityAssuranceLevel extends Code {
         }
     }
 
+    /**
+     * Factory method for creating IdentityAssuranceLevel objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static IdentityAssuranceLevel of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IdentityAssuranceLevel objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IdentityAssuranceLevel objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class IdentityAssuranceLevel extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating IdentityAssuranceLevel.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImagingStudyStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImagingStudyStatus.java
@@ -68,6 +68,9 @@ public class ImagingStudyStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ImagingStudyStatus objects from a passed enum value.
+     */
     public static ImagingStudyStatus of(ValueSet value) {
         switch (value) {
         case REGISTERED:
@@ -85,14 +88,38 @@ public class ImagingStudyStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ImagingStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ImagingStudyStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImagingStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImagingStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -215,10 +242,22 @@ public class ImagingStudyStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ImagingStudyStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImmunizationEvaluationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImmunizationEvaluationStatus.java
@@ -33,6 +33,9 @@ public class ImmunizationEvaluationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ImmunizationEvaluationStatus objects from a passed enum value.
+     */
     public static ImmunizationEvaluationStatus of(ValueSet value) {
         switch (value) {
         case COMPLETED:
@@ -44,14 +47,38 @@ public class ImmunizationEvaluationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ImmunizationEvaluationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ImmunizationEvaluationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImmunizationEvaluationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImmunizationEvaluationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -139,10 +166,22 @@ public class ImmunizationEvaluationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ImmunizationEvaluationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImmunizationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ImmunizationStatus.java
@@ -35,6 +35,9 @@ public class ImmunizationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ImmunizationStatus objects from a passed enum value.
+     */
     public static ImmunizationStatus of(ValueSet value) {
         switch (value) {
         case COMPLETED:
@@ -48,14 +51,38 @@ public class ImmunizationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ImmunizationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ImmunizationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImmunizationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ImmunizationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -145,10 +172,22 @@ public class ImmunizationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ImmunizationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/InvoicePriceComponentType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/InvoicePriceComponentType.java
@@ -71,6 +71,9 @@ public class InvoicePriceComponentType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating InvoicePriceComponentType objects from a passed enum value.
+     */
     public static InvoicePriceComponentType of(ValueSet value) {
         switch (value) {
         case BASE:
@@ -90,14 +93,38 @@ public class InvoicePriceComponentType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating InvoicePriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static InvoicePriceComponentType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating InvoicePriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating InvoicePriceComponentType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class InvoicePriceComponentType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating InvoicePriceComponentType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/InvoiceStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/InvoiceStatus.java
@@ -64,6 +64,9 @@ public class InvoiceStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating InvoiceStatus objects from a passed enum value.
+     */
     public static InvoiceStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -81,14 +84,38 @@ public class InvoiceStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating InvoiceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static InvoiceStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating InvoiceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating InvoiceStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class InvoiceStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating InvoiceStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IssueSeverity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IssueSeverity.java
@@ -58,6 +58,9 @@ public class IssueSeverity extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating IssueSeverity objects from a passed enum value.
+     */
     public static IssueSeverity of(ValueSet value) {
         switch (value) {
         case FATAL:
@@ -73,14 +76,38 @@ public class IssueSeverity extends Code {
         }
     }
 
+    /**
+     * Factory method for creating IssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static IssueSeverity of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IssueSeverity objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class IssueSeverity extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating IssueSeverity.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IssueType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/IssueType.java
@@ -256,6 +256,9 @@ public class IssueType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating IssueType objects from a passed enum value.
+     */
     public static IssueType of(ValueSet value) {
         switch (value) {
         case INVALID:
@@ -325,14 +328,38 @@ public class IssueType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating IssueType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static IssueType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IssueType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating IssueType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -643,10 +670,22 @@ public class IssueType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating IssueType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LinkType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LinkType.java
@@ -65,6 +65,9 @@ public class LinkType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating LinkType objects from a passed enum value.
+     */
     public static LinkType of(ValueSet value) {
         switch (value) {
         case REPLACED_BY:
@@ -80,14 +83,38 @@ public class LinkType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating LinkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static LinkType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LinkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LinkType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class LinkType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating LinkType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LinkageType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LinkageType.java
@@ -53,6 +53,9 @@ public class LinkageType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating LinkageType objects from a passed enum value.
+     */
     public static LinkageType of(ValueSet value) {
         switch (value) {
         case SOURCE:
@@ -66,14 +69,38 @@ public class LinkageType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating LinkageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static LinkageType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LinkageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LinkageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -181,10 +208,22 @@ public class LinkageType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating LinkageType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ListMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ListMode.java
@@ -52,6 +52,9 @@ public class ListMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ListMode objects from a passed enum value.
+     */
     public static ListMode of(ValueSet value) {
         switch (value) {
         case WORKING:
@@ -65,14 +68,38 @@ public class ListMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ListMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class ListMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ListMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ListStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ListStatus.java
@@ -50,6 +50,9 @@ public class ListStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ListStatus objects from a passed enum value.
+     */
     public static ListStatus of(ValueSet value) {
         switch (value) {
         case CURRENT:
@@ -63,14 +66,38 @@ public class ListStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ListStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ListStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ListStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ListStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ListStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ListStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LocationMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LocationMode.java
@@ -44,6 +44,9 @@ public class LocationMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating LocationMode objects from a passed enum value.
+     */
     public static LocationMode of(ValueSet value) {
         switch (value) {
         case INSTANCE:
@@ -55,14 +58,38 @@ public class LocationMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating LocationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static LocationMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LocationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LocationMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -161,10 +188,22 @@ public class LocationMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating LocationMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LocationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/LocationStatus.java
@@ -50,6 +50,9 @@ public class LocationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating LocationStatus objects from a passed enum value.
+     */
     public static LocationStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -63,14 +66,38 @@ public class LocationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating LocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static LocationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating LocationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class LocationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating LocationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MeasureReportStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MeasureReportStatus.java
@@ -50,6 +50,9 @@ public class MeasureReportStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MeasureReportStatus objects from a passed enum value.
+     */
     public static MeasureReportStatus of(ValueSet value) {
         switch (value) {
         case COMPLETE:
@@ -63,14 +66,38 @@ public class MeasureReportStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MeasureReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MeasureReportStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MeasureReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MeasureReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class MeasureReportStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MeasureReportStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MeasureReportType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MeasureReportType.java
@@ -58,6 +58,9 @@ public class MeasureReportType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MeasureReportType objects from a passed enum value.
+     */
     public static MeasureReportType of(ValueSet value) {
         switch (value) {
         case INDIVIDUAL:
@@ -73,14 +76,38 @@ public class MeasureReportType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MeasureReportType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MeasureReportType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MeasureReportType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MeasureReportType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class MeasureReportType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MeasureReportType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MediaStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MediaStatus.java
@@ -91,6 +91,9 @@ public class MediaStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MediaStatus objects from a passed enum value.
+     */
     public static MediaStatus of(ValueSet value) {
         switch (value) {
         case PREPARATION:
@@ -114,14 +117,38 @@ public class MediaStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MediaStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MediaStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MediaStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MediaStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -267,10 +294,22 @@ public class MediaStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MediaStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationAdministrationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationAdministrationStatus.java
@@ -81,6 +81,9 @@ public class MedicationAdministrationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationAdministrationStatus objects from a passed enum value.
+     */
     public static MedicationAdministrationStatus of(ValueSet value) {
         switch (value) {
         case IN_PROGRESS:
@@ -102,14 +105,38 @@ public class MedicationAdministrationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationAdministrationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationAdministrationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationAdministrationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationAdministrationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -245,10 +272,22 @@ public class MedicationAdministrationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationAdministrationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationDispenseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationDispenseStatus.java
@@ -95,6 +95,9 @@ public class MedicationDispenseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationDispenseStatus objects from a passed enum value.
+     */
     public static MedicationDispenseStatus of(ValueSet value) {
         switch (value) {
         case PREPARATION:
@@ -120,14 +123,38 @@ public class MedicationDispenseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationDispenseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationDispenseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationDispenseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationDispenseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -277,10 +304,22 @@ public class MedicationDispenseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationDispenseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationKnowledgeStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationKnowledgeStatus.java
@@ -50,6 +50,9 @@ public class MedicationKnowledgeStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationKnowledgeStatus objects from a passed enum value.
+     */
     public static MedicationKnowledgeStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -63,14 +66,38 @@ public class MedicationKnowledgeStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationKnowledgeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationKnowledgeStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationKnowledgeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationKnowledgeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class MedicationKnowledgeStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationKnowledgeStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestIntent.java
@@ -89,6 +89,9 @@ public class MedicationRequestIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationRequestIntent objects from a passed enum value.
+     */
     public static MedicationRequestIntent of(ValueSet value) {
         switch (value) {
         case PROPOSAL:
@@ -112,14 +115,38 @@ public class MedicationRequestIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationRequestIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -263,10 +290,22 @@ public class MedicationRequestIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationRequestIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestPriority.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestPriority.java
@@ -57,6 +57,9 @@ public class MedicationRequestPriority extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationRequestPriority objects from a passed enum value.
+     */
     public static MedicationRequestPriority of(ValueSet value) {
         switch (value) {
         case ROUTINE:
@@ -72,14 +75,38 @@ public class MedicationRequestPriority extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationRequestPriority of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class MedicationRequestPriority extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationRequestPriority.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationRequestStatus.java
@@ -92,6 +92,9 @@ public class MedicationRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationRequestStatus objects from a passed enum value.
+     */
     public static MedicationRequestStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -115,14 +118,38 @@ public class MedicationRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -269,10 +296,22 @@ public class MedicationRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationStatementStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationStatementStatus.java
@@ -88,6 +88,9 @@ public class MedicationStatementStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationStatementStatus objects from a passed enum value.
+     */
     public static MedicationStatementStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -111,14 +114,38 @@ public class MedicationStatementStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationStatementStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationStatementStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -261,10 +288,22 @@ public class MedicationStatementStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationStatementStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MedicationStatus.java
@@ -50,6 +50,9 @@ public class MedicationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MedicationStatus objects from a passed enum value.
+     */
     public static MedicationStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -63,14 +66,38 @@ public class MedicationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MedicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MedicationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MedicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class MedicationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MedicationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MessageHeaderResponseRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MessageHeaderResponseRequest.java
@@ -57,6 +57,9 @@ public class MessageHeaderResponseRequest extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MessageHeaderResponseRequest objects from a passed enum value.
+     */
     public static MessageHeaderResponseRequest of(ValueSet value) {
         switch (value) {
         case ALWAYS:
@@ -72,14 +75,38 @@ public class MessageHeaderResponseRequest extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MessageHeaderResponseRequest objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MessageHeaderResponseRequest of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MessageHeaderResponseRequest objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MessageHeaderResponseRequest objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class MessageHeaderResponseRequest extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MessageHeaderResponseRequest.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MessageSignificanceCategory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/MessageSignificanceCategory.java
@@ -53,6 +53,9 @@ public class MessageSignificanceCategory extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating MessageSignificanceCategory objects from a passed enum value.
+     */
     public static MessageSignificanceCategory of(ValueSet value) {
         switch (value) {
         case CONSEQUENCE:
@@ -66,14 +69,38 @@ public class MessageSignificanceCategory extends Code {
         }
     }
 
+    /**
+     * Factory method for creating MessageSignificanceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static MessageSignificanceCategory of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MessageSignificanceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating MessageSignificanceCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -181,10 +208,22 @@ public class MessageSignificanceCategory extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating MessageSignificanceCategory.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NameUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NameUse.java
@@ -83,6 +83,9 @@ public class NameUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NameUse objects from a passed enum value.
+     */
     public static NameUse of(ValueSet value) {
         switch (value) {
         case USUAL:
@@ -104,14 +107,38 @@ public class NameUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NameUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NameUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NameUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NameUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class NameUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NameUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NamingSystemIdentifierType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NamingSystemIdentifierType.java
@@ -57,6 +57,9 @@ public class NamingSystemIdentifierType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NamingSystemIdentifierType objects from a passed enum value.
+     */
     public static NamingSystemIdentifierType of(ValueSet value) {
         switch (value) {
         case OID:
@@ -72,14 +75,38 @@ public class NamingSystemIdentifierType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NamingSystemIdentifierType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NamingSystemIdentifierType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NamingSystemIdentifierType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NamingSystemIdentifierType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class NamingSystemIdentifierType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NamingSystemIdentifierType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NamingSystemType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NamingSystemType.java
@@ -51,6 +51,9 @@ public class NamingSystemType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NamingSystemType objects from a passed enum value.
+     */
     public static NamingSystemType of(ValueSet value) {
         switch (value) {
         case CODESYSTEM:
@@ -64,14 +67,38 @@ public class NamingSystemType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NamingSystemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NamingSystemType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NamingSystemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NamingSystemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -177,10 +204,22 @@ public class NamingSystemType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NamingSystemType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NarrativeStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NarrativeStatus.java
@@ -59,6 +59,9 @@ public class NarrativeStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NarrativeStatus objects from a passed enum value.
+     */
     public static NarrativeStatus of(ValueSet value) {
         switch (value) {
         case GENERATED:
@@ -74,14 +77,38 @@ public class NarrativeStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NarrativeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NarrativeStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NarrativeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NarrativeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class NarrativeStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NarrativeStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NoteType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NoteType.java
@@ -50,6 +50,9 @@ public class NoteType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NoteType objects from a passed enum value.
+     */
     public static NoteType of(ValueSet value) {
         switch (value) {
         case DISPLAY:
@@ -63,14 +66,38 @@ public class NoteType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NoteType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NoteType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NoteType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NoteType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class NoteType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NoteType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NutritionOrderIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NutritionOrderIntent.java
@@ -98,6 +98,9 @@ public class NutritionOrderIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NutritionOrderIntent objects from a passed enum value.
+     */
     public static NutritionOrderIntent of(ValueSet value) {
         switch (value) {
         case PROPOSAL:
@@ -123,14 +126,38 @@ public class NutritionOrderIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NutritionOrderIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NutritionOrderIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NutritionOrderIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NutritionOrderIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -283,10 +310,22 @@ public class NutritionOrderIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NutritionOrderIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NutritionOrderStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/NutritionOrderStatus.java
@@ -83,6 +83,9 @@ public class NutritionOrderStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating NutritionOrderStatus objects from a passed enum value.
+     */
     public static NutritionOrderStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class NutritionOrderStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating NutritionOrderStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static NutritionOrderStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NutritionOrderStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating NutritionOrderStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class NutritionOrderStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating NutritionOrderStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationDataType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationDataType.java
@@ -106,6 +106,9 @@ public class ObservationDataType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ObservationDataType objects from a passed enum value.
+     */
     public static ObservationDataType of(ValueSet value) {
         switch (value) {
         case QUANTITY:
@@ -135,14 +138,38 @@ public class ObservationDataType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ObservationDataType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ObservationDataType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationDataType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationDataType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -303,10 +330,22 @@ public class ObservationDataType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ObservationDataType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationRangeCategory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationRangeCategory.java
@@ -50,6 +50,9 @@ public class ObservationRangeCategory extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ObservationRangeCategory objects from a passed enum value.
+     */
     public static ObservationRangeCategory of(ValueSet value) {
         switch (value) {
         case REFERENCE:
@@ -63,14 +66,38 @@ public class ObservationRangeCategory extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ObservationRangeCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ObservationRangeCategory of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationRangeCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationRangeCategory objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ObservationRangeCategory extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ObservationRangeCategory.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ObservationStatus.java
@@ -94,6 +94,9 @@ public class ObservationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ObservationStatus objects from a passed enum value.
+     */
     public static ObservationStatus of(ValueSet value) {
         switch (value) {
         case REGISTERED:
@@ -117,14 +120,38 @@ public class ObservationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ObservationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ObservationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ObservationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -273,10 +300,22 @@ public class ObservationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ObservationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OperationKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OperationKind.java
@@ -43,6 +43,9 @@ public class OperationKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating OperationKind objects from a passed enum value.
+     */
     public static OperationKind of(ValueSet value) {
         switch (value) {
         case OPERATION:
@@ -54,14 +57,38 @@ public class OperationKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating OperationKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static OperationKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OperationKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OperationKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class OperationKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating OperationKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OperationParameterUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OperationParameterUse.java
@@ -43,6 +43,9 @@ public class OperationParameterUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating OperationParameterUse objects from a passed enum value.
+     */
     public static OperationParameterUse of(ValueSet value) {
         switch (value) {
         case IN:
@@ -54,14 +57,38 @@ public class OperationParameterUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating OperationParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static OperationParameterUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OperationParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OperationParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class OperationParameterUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating OperationParameterUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OrientationType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/OrientationType.java
@@ -43,6 +43,9 @@ public class OrientationType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating OrientationType objects from a passed enum value.
+     */
     public static OrientationType of(ValueSet value) {
         switch (value) {
         case SENSE:
@@ -54,14 +57,38 @@ public class OrientationType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating OrientationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static OrientationType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OrientationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating OrientationType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class OrientationType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating OrientationType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParameterUse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParameterUse.java
@@ -43,6 +43,9 @@ public class ParameterUse extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ParameterUse objects from a passed enum value.
+     */
     public static ParameterUse of(ValueSet value) {
         switch (value) {
         case IN:
@@ -54,14 +57,38 @@ public class ParameterUse extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ParameterUse of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParameterUse objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class ParameterUse extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ParameterUse.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipantRequired.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipantRequired.java
@@ -51,6 +51,9 @@ public class ParticipantRequired extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ParticipantRequired objects from a passed enum value.
+     */
     public static ParticipantRequired of(ValueSet value) {
         switch (value) {
         case REQUIRED:
@@ -64,14 +67,38 @@ public class ParticipantRequired extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ParticipantRequired objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ParticipantRequired of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipantRequired objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipantRequired objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -177,10 +204,22 @@ public class ParticipantRequired extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ParticipantRequired.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipantStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipantStatus.java
@@ -59,6 +59,9 @@ public class ParticipantStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ParticipantStatus objects from a passed enum value.
+     */
     public static ParticipantStatus of(ValueSet value) {
         switch (value) {
         case ACCEPTED:
@@ -74,14 +77,38 @@ public class ParticipantStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ParticipantStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ParticipantStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipantStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipantStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class ParticipantStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ParticipantStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ParticipationStatus.java
@@ -59,6 +59,9 @@ public class ParticipationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ParticipationStatus objects from a passed enum value.
+     */
     public static ParticipationStatus of(ValueSet value) {
         switch (value) {
         case ACCEPTED:
@@ -74,14 +77,38 @@ public class ParticipationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ParticipationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ParticipationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ParticipationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -195,10 +222,22 @@ public class ParticipationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ParticipationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PaymentNoticeStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PaymentNoticeStatus.java
@@ -57,6 +57,9 @@ public class PaymentNoticeStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating PaymentNoticeStatus objects from a passed enum value.
+     */
     public static PaymentNoticeStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class PaymentNoticeStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating PaymentNoticeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static PaymentNoticeStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PaymentNoticeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PaymentNoticeStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class PaymentNoticeStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating PaymentNoticeStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PaymentReconciliationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PaymentReconciliationStatus.java
@@ -57,6 +57,9 @@ public class PaymentReconciliationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating PaymentReconciliationStatus objects from a passed enum value.
+     */
     public static PaymentReconciliationStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class PaymentReconciliationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating PaymentReconciliationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static PaymentReconciliationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PaymentReconciliationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PaymentReconciliationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class PaymentReconciliationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating PaymentReconciliationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ProcedureStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ProcedureStatus.java
@@ -91,6 +91,9 @@ public class ProcedureStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ProcedureStatus objects from a passed enum value.
+     */
     public static ProcedureStatus of(ValueSet value) {
         switch (value) {
         case PREPARATION:
@@ -114,14 +117,38 @@ public class ProcedureStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ProcedureStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ProcedureStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ProcedureStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ProcedureStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -267,10 +294,22 @@ public class ProcedureStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ProcedureStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PropertyRepresentation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PropertyRepresentation.java
@@ -64,6 +64,9 @@ public class PropertyRepresentation extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating PropertyRepresentation objects from a passed enum value.
+     */
     public static PropertyRepresentation of(ValueSet value) {
         switch (value) {
         case XML_ATTR:
@@ -81,14 +84,38 @@ public class PropertyRepresentation extends Code {
         }
     }
 
+    /**
+     * Factory method for creating PropertyRepresentation objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static PropertyRepresentation of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PropertyRepresentation objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PropertyRepresentation objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class PropertyRepresentation extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating PropertyRepresentation.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PropertyType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PropertyType.java
@@ -79,6 +79,9 @@ public class PropertyType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating PropertyType objects from a passed enum value.
+     */
     public static PropertyType of(ValueSet value) {
         switch (value) {
         case CODE:
@@ -100,14 +103,38 @@ public class PropertyType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating PropertyType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static PropertyType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PropertyType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PropertyType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -241,10 +268,22 @@ public class PropertyType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating PropertyType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ProvenanceEntityRole.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ProvenanceEntityRole.java
@@ -67,6 +67,9 @@ public class ProvenanceEntityRole extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ProvenanceEntityRole objects from a passed enum value.
+     */
     public static ProvenanceEntityRole of(ValueSet value) {
         switch (value) {
         case DERIVATION:
@@ -84,14 +87,38 @@ public class ProvenanceEntityRole extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ProvenanceEntityRole objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ProvenanceEntityRole of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ProvenanceEntityRole objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ProvenanceEntityRole objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class ProvenanceEntityRole extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ProvenanceEntityRole.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PublicationStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/PublicationStatus.java
@@ -58,6 +58,9 @@ public class PublicationStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating PublicationStatus objects from a passed enum value.
+     */
     public static PublicationStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -73,14 +76,38 @@ public class PublicationStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating PublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static PublicationStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating PublicationStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class PublicationStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating PublicationStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QualityType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QualityType.java
@@ -50,6 +50,9 @@ public class QualityType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating QualityType objects from a passed enum value.
+     */
     public static QualityType of(ValueSet value) {
         switch (value) {
         case INDEL:
@@ -63,14 +66,38 @@ public class QualityType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating QualityType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static QualityType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QualityType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QualityType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class QualityType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating QualityType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuantityComparator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuantityComparator.java
@@ -57,6 +57,9 @@ public class QuantityComparator extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating QuantityComparator objects from a passed enum value.
+     */
     public static QuantityComparator of(ValueSet value) {
         switch (value) {
         case LESS_THAN:
@@ -72,14 +75,38 @@ public class QuantityComparator extends Code {
         }
     }
 
+    /**
+     * Factory method for creating QuantityComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static QuantityComparator of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuantityComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuantityComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class QuantityComparator extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating QuantityComparator.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireItemOperator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireItemOperator.java
@@ -78,6 +78,9 @@ public class QuestionnaireItemOperator extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating QuestionnaireItemOperator objects from a passed enum value.
+     */
     public static QuestionnaireItemOperator of(ValueSet value) {
         switch (value) {
         case EXISTS:
@@ -99,14 +102,38 @@ public class QuestionnaireItemOperator extends Code {
         }
     }
 
+    /**
+     * Factory method for creating QuestionnaireItemOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static QuestionnaireItemOperator of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireItemOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireItemOperator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -239,10 +266,22 @@ public class QuestionnaireItemOperator extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating QuestionnaireItemOperator.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireItemType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireItemType.java
@@ -153,6 +153,9 @@ public class QuestionnaireItemType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating QuestionnaireItemType objects from a passed enum value.
+     */
     public static QuestionnaireItemType of(ValueSet value) {
         switch (value) {
         case GROUP:
@@ -194,14 +197,38 @@ public class QuestionnaireItemType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating QuestionnaireItemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static QuestionnaireItemType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireItemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireItemType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -409,10 +436,22 @@ public class QuestionnaireItemType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating QuestionnaireItemType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireResponseStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/QuestionnaireResponseStatus.java
@@ -67,6 +67,9 @@ public class QuestionnaireResponseStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating QuestionnaireResponseStatus objects from a passed enum value.
+     */
     public static QuestionnaireResponseStatus of(ValueSet value) {
         switch (value) {
         case IN_PROGRESS:
@@ -84,14 +87,38 @@ public class QuestionnaireResponseStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating QuestionnaireResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static QuestionnaireResponseStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating QuestionnaireResponseStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class QuestionnaireResponseStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating QuestionnaireResponseStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferenceHandlingPolicy.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferenceHandlingPolicy.java
@@ -67,6 +67,9 @@ public class ReferenceHandlingPolicy extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ReferenceHandlingPolicy objects from a passed enum value.
+     */
     public static ReferenceHandlingPolicy of(ValueSet value) {
         switch (value) {
         case LITERAL:
@@ -84,14 +87,38 @@ public class ReferenceHandlingPolicy extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ReferenceHandlingPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ReferenceHandlingPolicy of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferenceHandlingPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferenceHandlingPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class ReferenceHandlingPolicy extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ReferenceHandlingPolicy.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferenceVersionRules.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferenceVersionRules.java
@@ -50,6 +50,9 @@ public class ReferenceVersionRules extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ReferenceVersionRules objects from a passed enum value.
+     */
     public static ReferenceVersionRules of(ValueSet value) {
         switch (value) {
         case EITHER:
@@ -63,14 +66,38 @@ public class ReferenceVersionRules extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ReferenceVersionRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ReferenceVersionRules of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferenceVersionRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferenceVersionRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ReferenceVersionRules extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ReferenceVersionRules.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferredDocumentStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ReferredDocumentStatus.java
@@ -61,6 +61,9 @@ public class ReferredDocumentStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ReferredDocumentStatus objects from a passed enum value.
+     */
     public static ReferredDocumentStatus of(ValueSet value) {
         switch (value) {
         case PRELIMINARY:
@@ -76,14 +79,38 @@ public class ReferredDocumentStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ReferredDocumentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ReferredDocumentStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferredDocumentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ReferredDocumentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -199,10 +226,22 @@ public class ReferredDocumentStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ReferredDocumentStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RelatedArtifactType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RelatedArtifactType.java
@@ -93,6 +93,9 @@ public class RelatedArtifactType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RelatedArtifactType objects from a passed enum value.
+     */
     public static RelatedArtifactType of(ValueSet value) {
         switch (value) {
         case DOCUMENTATION:
@@ -116,14 +119,38 @@ public class RelatedArtifactType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RelatedArtifactType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RelatedArtifactType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RelatedArtifactType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RelatedArtifactType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -271,10 +298,22 @@ public class RelatedArtifactType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RelatedArtifactType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RemittanceOutcome.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RemittanceOutcome.java
@@ -57,6 +57,9 @@ public class RemittanceOutcome extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RemittanceOutcome objects from a passed enum value.
+     */
     public static RemittanceOutcome of(ValueSet value) {
         switch (value) {
         case QUEUED:
@@ -72,14 +75,38 @@ public class RemittanceOutcome extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RemittanceOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RemittanceOutcome of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RemittanceOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RemittanceOutcome objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class RemittanceOutcome extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RemittanceOutcome.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RepositoryType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RepositoryType.java
@@ -65,6 +65,9 @@ public class RepositoryType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RepositoryType objects from a passed enum value.
+     */
     public static RepositoryType of(ValueSet value) {
         switch (value) {
         case DIRECTLINK:
@@ -82,14 +85,38 @@ public class RepositoryType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RepositoryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RepositoryType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RepositoryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RepositoryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -209,10 +236,22 @@ public class RepositoryType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RepositoryType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestIntent.java
@@ -98,6 +98,9 @@ public class RequestIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RequestIntent objects from a passed enum value.
+     */
     public static RequestIntent of(ValueSet value) {
         switch (value) {
         case PROPOSAL:
@@ -123,14 +126,38 @@ public class RequestIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RequestIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -283,10 +310,22 @@ public class RequestIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RequestIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestPriority.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestPriority.java
@@ -57,6 +57,9 @@ public class RequestPriority extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RequestPriority objects from a passed enum value.
+     */
     public static RequestPriority of(ValueSet value) {
         switch (value) {
         case ROUTINE:
@@ -72,14 +75,38 @@ public class RequestPriority extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RequestPriority of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class RequestPriority extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RequestPriority.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RequestStatus.java
@@ -83,6 +83,9 @@ public class RequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RequestStatus objects from a passed enum value.
+     */
     public static RequestStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class RequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class RequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchElementType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchElementType.java
@@ -50,6 +50,9 @@ public class ResearchElementType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResearchElementType objects from a passed enum value.
+     */
     public static ResearchElementType of(ValueSet value) {
         switch (value) {
         case POPULATION:
@@ -63,14 +66,38 @@ public class ResearchElementType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResearchElementType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResearchElementType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchElementType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchElementType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ResearchElementType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResearchElementType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchStudyStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchStudyStatus.java
@@ -110,6 +110,9 @@ public class ResearchStudyStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResearchStudyStatus objects from a passed enum value.
+     */
     public static ResearchStudyStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -139,14 +142,38 @@ public class ResearchStudyStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResearchStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResearchStudyStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchStudyStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -311,10 +338,22 @@ public class ResearchStudyStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResearchStudyStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchSubjectStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResearchSubjectStatus.java
@@ -128,6 +128,9 @@ public class ResearchSubjectStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResearchSubjectStatus objects from a passed enum value.
+     */
     public static ResearchSubjectStatus of(ValueSet value) {
         switch (value) {
         case CANDIDATE:
@@ -161,14 +164,38 @@ public class ResearchSubjectStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResearchSubjectStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResearchSubjectStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchSubjectStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResearchSubjectStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -351,10 +378,22 @@ public class ResearchSubjectStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResearchSubjectStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResourceType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResourceType.java
@@ -1215,6 +1215,9 @@ public class ResourceType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResourceType objects from a passed enum value.
+     */
     public static ResourceType of(ValueSet value) {
         switch (value) {
         case ACCOUNT:
@@ -1518,14 +1521,38 @@ public class ResourceType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResourceType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResourceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -2795,10 +2822,22 @@ public class ResourceType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResourceType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResourceVersionPolicy.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResourceVersionPolicy.java
@@ -50,6 +50,9 @@ public class ResourceVersionPolicy extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResourceVersionPolicy objects from a passed enum value.
+     */
     public static ResourceVersionPolicy of(ValueSet value) {
         switch (value) {
         case NO_VERSION:
@@ -63,14 +66,38 @@ public class ResourceVersionPolicy extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResourceVersionPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResourceVersionPolicy of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResourceVersionPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResourceVersionPolicy objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class ResourceVersionPolicy extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResourceVersionPolicy.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResponseType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ResponseType.java
@@ -52,6 +52,9 @@ public class ResponseType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ResponseType objects from a passed enum value.
+     */
     public static ResponseType of(ValueSet value) {
         switch (value) {
         case OK:
@@ -65,14 +68,38 @@ public class ResponseType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ResponseType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ResponseType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResponseType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ResponseType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class ResponseType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ResponseType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RestfulCapabilityMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RestfulCapabilityMode.java
@@ -43,6 +43,9 @@ public class RestfulCapabilityMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RestfulCapabilityMode objects from a passed enum value.
+     */
     public static RestfulCapabilityMode of(ValueSet value) {
         switch (value) {
         case CLIENT:
@@ -54,14 +57,38 @@ public class RestfulCapabilityMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RestfulCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RestfulCapabilityMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RestfulCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RestfulCapabilityMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class RestfulCapabilityMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RestfulCapabilityMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RiskAssessmentStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/RiskAssessmentStatus.java
@@ -94,6 +94,9 @@ public class RiskAssessmentStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating RiskAssessmentStatus objects from a passed enum value.
+     */
     public static RiskAssessmentStatus of(ValueSet value) {
         switch (value) {
         case REGISTERED:
@@ -117,14 +120,38 @@ public class RiskAssessmentStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating RiskAssessmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static RiskAssessmentStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RiskAssessmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating RiskAssessmentStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -273,10 +300,22 @@ public class RiskAssessmentStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating RiskAssessmentStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SPDXLicense.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SPDXLicense.java
@@ -2451,6 +2451,9 @@ public class SPDXLicense extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SPDXLicense objects from a passed enum value.
+     */
     public static SPDXLicense of(ValueSet value) {
         switch (value) {
         case LICENSE_NOT_OPEN_SOURCE:
@@ -3150,14 +3153,38 @@ public class SPDXLicense extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SPDXLicense objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SPDXLicense of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SPDXLicense objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SPDXLicense objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -5663,10 +5690,22 @@ public class SPDXLicense extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SPDXLicense.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchComparator.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchComparator.java
@@ -92,6 +92,9 @@ public class SearchComparator extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SearchComparator objects from a passed enum value.
+     */
     public static SearchComparator of(ValueSet value) {
         switch (value) {
         case EQ:
@@ -117,14 +120,38 @@ public class SearchComparator extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SearchComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SearchComparator of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchComparator objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -271,10 +298,22 @@ public class SearchComparator extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SearchComparator.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchEntryMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchEntryMode.java
@@ -50,6 +50,9 @@ public class SearchEntryMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SearchEntryMode objects from a passed enum value.
+     */
     public static SearchEntryMode of(ValueSet value) {
         switch (value) {
         case MATCH:
@@ -63,14 +66,38 @@ public class SearchEntryMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SearchEntryMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SearchEntryMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchEntryMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchEntryMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class SearchEntryMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SearchEntryMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchModifierCode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchModifierCode.java
@@ -122,6 +122,9 @@ public class SearchModifierCode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SearchModifierCode objects from a passed enum value.
+     */
     public static SearchModifierCode of(ValueSet value) {
         switch (value) {
         case MISSING:
@@ -153,14 +156,38 @@ public class SearchModifierCode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SearchModifierCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SearchModifierCode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchModifierCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchModifierCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -337,10 +364,22 @@ public class SearchModifierCode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SearchModifierCode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchParamType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SearchParamType.java
@@ -96,6 +96,9 @@ public class SearchParamType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SearchParamType objects from a passed enum value.
+     */
     public static SearchParamType of(ValueSet value) {
         switch (value) {
         case NUMBER:
@@ -121,14 +124,38 @@ public class SearchParamType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SearchParamType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SearchParamType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchParamType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SearchParamType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -279,10 +306,22 @@ public class SearchParamType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SearchParamType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SectionMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SectionMode.java
@@ -52,6 +52,9 @@ public class SectionMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SectionMode objects from a passed enum value.
+     */
     public static SectionMode of(ValueSet value) {
         switch (value) {
         case WORKING:
@@ -65,14 +68,38 @@ public class SectionMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SectionMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SectionMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SectionMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SectionMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -179,10 +206,22 @@ public class SectionMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SectionMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SequenceType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SequenceType.java
@@ -50,6 +50,9 @@ public class SequenceType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SequenceType objects from a passed enum value.
+     */
     public static SequenceType of(ValueSet value) {
         switch (value) {
         case AA:
@@ -63,14 +66,38 @@ public class SequenceType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SequenceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SequenceType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SequenceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SequenceType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class SequenceType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SequenceType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestIntent.java
@@ -98,6 +98,9 @@ public class ServiceRequestIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ServiceRequestIntent objects from a passed enum value.
+     */
     public static ServiceRequestIntent of(ValueSet value) {
         switch (value) {
         case PROPOSAL:
@@ -123,14 +126,38 @@ public class ServiceRequestIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ServiceRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ServiceRequestIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -283,10 +310,22 @@ public class ServiceRequestIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ServiceRequestIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestPriority.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestPriority.java
@@ -57,6 +57,9 @@ public class ServiceRequestPriority extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ServiceRequestPriority objects from a passed enum value.
+     */
     public static ServiceRequestPriority of(ValueSet value) {
         switch (value) {
         case ROUTINE:
@@ -72,14 +75,38 @@ public class ServiceRequestPriority extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ServiceRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ServiceRequestPriority of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class ServiceRequestPriority extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ServiceRequestPriority.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/ServiceRequestStatus.java
@@ -83,6 +83,9 @@ public class ServiceRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating ServiceRequestStatus objects from a passed enum value.
+     */
     public static ServiceRequestStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -104,14 +107,38 @@ public class ServiceRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating ServiceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static ServiceRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating ServiceRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -249,10 +276,22 @@ public class ServiceRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating ServiceRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SlicingRules.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SlicingRules.java
@@ -51,6 +51,9 @@ public class SlicingRules extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SlicingRules objects from a passed enum value.
+     */
     public static SlicingRules of(ValueSet value) {
         switch (value) {
         case CLOSED:
@@ -64,14 +67,38 @@ public class SlicingRules extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SlicingRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SlicingRules of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SlicingRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SlicingRules objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -177,10 +204,22 @@ public class SlicingRules extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SlicingRules.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SlotStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SlotStatus.java
@@ -65,6 +65,9 @@ public class SlotStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SlotStatus objects from a passed enum value.
+     */
     public static SlotStatus of(ValueSet value) {
         switch (value) {
         case BUSY:
@@ -82,14 +85,38 @@ public class SlotStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SlotStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SlotStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SlotStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SlotStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -209,10 +236,22 @@ public class SlotStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SlotStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SortDirection.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SortDirection.java
@@ -43,6 +43,9 @@ public class SortDirection extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SortDirection objects from a passed enum value.
+     */
     public static SortDirection of(ValueSet value) {
         switch (value) {
         case ASCENDING:
@@ -54,14 +57,38 @@ public class SortDirection extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SortDirection objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SortDirection of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SortDirection objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SortDirection objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class SortDirection extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SortDirection.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SpecimenContainedPreference.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SpecimenContainedPreference.java
@@ -43,6 +43,9 @@ public class SpecimenContainedPreference extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SpecimenContainedPreference objects from a passed enum value.
+     */
     public static SpecimenContainedPreference of(ValueSet value) {
         switch (value) {
         case PREFERRED:
@@ -54,14 +57,38 @@ public class SpecimenContainedPreference extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SpecimenContainedPreference objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SpecimenContainedPreference of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SpecimenContainedPreference objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SpecimenContainedPreference objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class SpecimenContainedPreference extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SpecimenContainedPreference.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SpecimenStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SpecimenStatus.java
@@ -57,6 +57,9 @@ public class SpecimenStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SpecimenStatus objects from a passed enum value.
+     */
     public static SpecimenStatus of(ValueSet value) {
         switch (value) {
         case AVAILABLE:
@@ -72,14 +75,38 @@ public class SpecimenStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SpecimenStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SpecimenStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SpecimenStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SpecimenStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class SpecimenStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SpecimenStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/Status.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/Status.java
@@ -71,6 +71,9 @@ public class Status extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating Status objects from a passed enum value.
+     */
     public static Status of(ValueSet value) {
         switch (value) {
         case ATTESTED:
@@ -90,14 +93,38 @@ public class Status extends Code {
         }
     }
 
+    /**
+     * Factory method for creating Status objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Status of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating Status objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating Status objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class Status extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating Status.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StrandType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StrandType.java
@@ -43,6 +43,9 @@ public class StrandType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StrandType objects from a passed enum value.
+     */
     public static StrandType of(ValueSet value) {
         switch (value) {
         case WATSON:
@@ -54,14 +57,38 @@ public class StrandType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StrandType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StrandType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StrandType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StrandType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class StrandType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StrandType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureDefinitionKind.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureDefinitionKind.java
@@ -64,6 +64,9 @@ public class StructureDefinitionKind extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureDefinitionKind objects from a passed enum value.
+     */
     public static StructureDefinitionKind of(ValueSet value) {
         switch (value) {
         case PRIMITIVE_TYPE:
@@ -79,14 +82,38 @@ public class StructureDefinitionKind extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureDefinitionKind of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureDefinitionKind objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -205,10 +232,22 @@ public class StructureDefinitionKind extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureDefinitionKind.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapContextType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapContextType.java
@@ -43,6 +43,9 @@ public class StructureMapContextType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapContextType objects from a passed enum value.
+     */
     public static StructureMapContextType of(ValueSet value) {
         switch (value) {
         case TYPE:
@@ -54,14 +57,38 @@ public class StructureMapContextType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapContextType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapContextType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class StructureMapContextType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapContextType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapGroupTypeMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapGroupTypeMode.java
@@ -50,6 +50,9 @@ public class StructureMapGroupTypeMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapGroupTypeMode objects from a passed enum value.
+     */
     public static StructureMapGroupTypeMode of(ValueSet value) {
         switch (value) {
         case NONE:
@@ -63,14 +66,38 @@ public class StructureMapGroupTypeMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapGroupTypeMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapGroupTypeMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapGroupTypeMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapGroupTypeMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class StructureMapGroupTypeMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapGroupTypeMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapInputMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapInputMode.java
@@ -43,6 +43,9 @@ public class StructureMapInputMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapInputMode objects from a passed enum value.
+     */
     public static StructureMapInputMode of(ValueSet value) {
         switch (value) {
         case SOURCE:
@@ -54,14 +57,38 @@ public class StructureMapInputMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapInputMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapInputMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapInputMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapInputMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class StructureMapInputMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapInputMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapModelMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapModelMode.java
@@ -57,6 +57,9 @@ public class StructureMapModelMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapModelMode objects from a passed enum value.
+     */
     public static StructureMapModelMode of(ValueSet value) {
         switch (value) {
         case SOURCE:
@@ -72,14 +75,38 @@ public class StructureMapModelMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapModelMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapModelMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapModelMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapModelMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class StructureMapModelMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapModelMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapSourceListMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapSourceListMode.java
@@ -64,6 +64,9 @@ public class StructureMapSourceListMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapSourceListMode objects from a passed enum value.
+     */
     public static StructureMapSourceListMode of(ValueSet value) {
         switch (value) {
         case FIRST:
@@ -81,14 +84,38 @@ public class StructureMapSourceListMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapSourceListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapSourceListMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapSourceListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapSourceListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class StructureMapSourceListMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapSourceListMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapTargetListMode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapTargetListMode.java
@@ -60,6 +60,9 @@ public class StructureMapTargetListMode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapTargetListMode objects from a passed enum value.
+     */
     public static StructureMapTargetListMode of(ValueSet value) {
         switch (value) {
         case FIRST:
@@ -75,14 +78,38 @@ public class StructureMapTargetListMode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapTargetListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapTargetListMode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapTargetListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapTargetListMode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -197,10 +224,22 @@ public class StructureMapTargetListMode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapTargetListMode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapTransform.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/StructureMapTransform.java
@@ -152,6 +152,9 @@ public class StructureMapTransform extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating StructureMapTransform objects from a passed enum value.
+     */
     public static StructureMapTransform of(ValueSet value) {
         switch (value) {
         case CREATE:
@@ -193,14 +196,38 @@ public class StructureMapTransform extends Code {
         }
     }
 
+    /**
+     * Factory method for creating StructureMapTransform objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static StructureMapTransform of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapTransform objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating StructureMapTransform objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -407,10 +434,22 @@ public class StructureMapTransform extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating StructureMapTransform.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SubscriptionChannelType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SubscriptionChannelType.java
@@ -67,6 +67,9 @@ public class SubscriptionChannelType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SubscriptionChannelType objects from a passed enum value.
+     */
     public static SubscriptionChannelType of(ValueSet value) {
         switch (value) {
         case REST_HOOK:
@@ -84,14 +87,38 @@ public class SubscriptionChannelType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SubscriptionChannelType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SubscriptionChannelType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SubscriptionChannelType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SubscriptionChannelType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -213,10 +240,22 @@ public class SubscriptionChannelType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SubscriptionChannelType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SubscriptionStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SubscriptionStatus.java
@@ -57,6 +57,9 @@ public class SubscriptionStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SubscriptionStatus objects from a passed enum value.
+     */
     public static SubscriptionStatus of(ValueSet value) {
         switch (value) {
         case REQUESTED:
@@ -72,14 +75,38 @@ public class SubscriptionStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SubscriptionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SubscriptionStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SubscriptionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SubscriptionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class SubscriptionStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SubscriptionStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SupplyDeliveryStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SupplyDeliveryStatus.java
@@ -58,6 +58,9 @@ public class SupplyDeliveryStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SupplyDeliveryStatus objects from a passed enum value.
+     */
     public static SupplyDeliveryStatus of(ValueSet value) {
         switch (value) {
         case IN_PROGRESS:
@@ -73,14 +76,38 @@ public class SupplyDeliveryStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SupplyDeliveryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SupplyDeliveryStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SupplyDeliveryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SupplyDeliveryStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class SupplyDeliveryStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SupplyDeliveryStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SupplyRequestStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SupplyRequestStatus.java
@@ -82,6 +82,9 @@ public class SupplyRequestStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SupplyRequestStatus objects from a passed enum value.
+     */
     public static SupplyRequestStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -103,14 +106,38 @@ public class SupplyRequestStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SupplyRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SupplyRequestStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SupplyRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SupplyRequestStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -247,10 +274,22 @@ public class SupplyRequestStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SupplyRequestStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SystemRestfulInteraction.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/SystemRestfulInteraction.java
@@ -37,6 +37,9 @@ public class SystemRestfulInteraction extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating SystemRestfulInteraction objects from a passed enum value.
+     */
     public static SystemRestfulInteraction of(ValueSet value) {
         switch (value) {
         case TRANSACTION:
@@ -52,14 +55,38 @@ public class SystemRestfulInteraction extends Code {
         }
     }
 
+    /**
+     * Factory method for creating SystemRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static SystemRestfulInteraction of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SystemRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating SystemRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -151,10 +178,22 @@ public class SystemRestfulInteraction extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating SystemRestfulInteraction.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskIntent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskIntent.java
@@ -53,6 +53,9 @@ public class TaskIntent extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TaskIntent objects from a passed enum value.
+     */
     public static TaskIntent of(ValueSet value) {
         switch (value) {
         case UNKNOWN:
@@ -78,14 +81,38 @@ public class TaskIntent extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TaskIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TaskIntent of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskIntent objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -193,10 +220,22 @@ public class TaskIntent extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TaskIntent.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskPriority.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskPriority.java
@@ -57,6 +57,9 @@ public class TaskPriority extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TaskPriority objects from a passed enum value.
+     */
     public static TaskPriority of(ValueSet value) {
         switch (value) {
         case ROUTINE:
@@ -72,14 +75,38 @@ public class TaskPriority extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TaskPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TaskPriority of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskPriority objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class TaskPriority extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TaskPriority.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TaskStatus.java
@@ -115,6 +115,9 @@ public class TaskStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TaskStatus objects from a passed enum value.
+     */
     public static TaskStatus of(ValueSet value) {
         switch (value) {
         case DRAFT:
@@ -146,14 +149,38 @@ public class TaskStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TaskStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TaskStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TaskStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -323,10 +350,22 @@ public class TaskStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TaskStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportActionResult.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportActionResult.java
@@ -64,6 +64,9 @@ public class TestReportActionResult extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TestReportActionResult objects from a passed enum value.
+     */
     public static TestReportActionResult of(ValueSet value) {
         switch (value) {
         case PASS:
@@ -81,14 +84,38 @@ public class TestReportActionResult extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TestReportActionResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TestReportActionResult of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportActionResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportActionResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class TestReportActionResult extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TestReportActionResult.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportParticipantType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportParticipantType.java
@@ -50,6 +50,9 @@ public class TestReportParticipantType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TestReportParticipantType objects from a passed enum value.
+     */
     public static TestReportParticipantType of(ValueSet value) {
         switch (value) {
         case TEST_ENGINE:
@@ -63,14 +66,38 @@ public class TestReportParticipantType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TestReportParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TestReportParticipantType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportParticipantType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class TestReportParticipantType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TestReportParticipantType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportResult.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportResult.java
@@ -50,6 +50,9 @@ public class TestReportResult extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TestReportResult objects from a passed enum value.
+     */
     public static TestReportResult of(ValueSet value) {
         switch (value) {
         case PASS:
@@ -63,14 +66,38 @@ public class TestReportResult extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TestReportResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TestReportResult of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportResult objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class TestReportResult extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TestReportResult.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestReportStatus.java
@@ -64,6 +64,9 @@ public class TestReportStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TestReportStatus objects from a passed enum value.
+     */
     public static TestReportStatus of(ValueSet value) {
         switch (value) {
         case COMPLETED:
@@ -81,14 +84,38 @@ public class TestReportStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TestReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TestReportStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestReportStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class TestReportStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TestReportStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestScriptRequestMethodCode.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TestScriptRequestMethodCode.java
@@ -78,6 +78,9 @@ public class TestScriptRequestMethodCode extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TestScriptRequestMethodCode objects from a passed enum value.
+     */
     public static TestScriptRequestMethodCode of(ValueSet value) {
         switch (value) {
         case DELETE:
@@ -99,14 +102,38 @@ public class TestScriptRequestMethodCode extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TestScriptRequestMethodCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TestScriptRequestMethodCode of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestScriptRequestMethodCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TestScriptRequestMethodCode objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -239,10 +266,22 @@ public class TestScriptRequestMethodCode extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TestScriptRequestMethodCode.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TriggerType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TriggerType.java
@@ -87,6 +87,9 @@ public class TriggerType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TriggerType objects from a passed enum value.
+     */
     public static TriggerType of(ValueSet value) {
         switch (value) {
         case NAMED_EVENT:
@@ -110,14 +113,38 @@ public class TriggerType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TriggerType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TriggerType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TriggerType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TriggerType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -259,10 +286,22 @@ public class TriggerType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TriggerType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TypeDerivationRule.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TypeDerivationRule.java
@@ -43,6 +43,9 @@ public class TypeDerivationRule extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TypeDerivationRule objects from a passed enum value.
+     */
     public static TypeDerivationRule of(ValueSet value) {
         switch (value) {
         case SPECIALIZATION:
@@ -54,14 +57,38 @@ public class TypeDerivationRule extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TypeDerivationRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TypeDerivationRule of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TypeDerivationRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TypeDerivationRule objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class TypeDerivationRule extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TypeDerivationRule.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TypeRestfulInteraction.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/TypeRestfulInteraction.java
@@ -47,6 +47,9 @@ public class TypeRestfulInteraction extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating TypeRestfulInteraction objects from a passed enum value.
+     */
     public static TypeRestfulInteraction of(ValueSet value) {
         switch (value) {
         case READ:
@@ -72,14 +75,38 @@ public class TypeRestfulInteraction extends Code {
         }
     }
 
+    /**
+     * Factory method for creating TypeRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static TypeRestfulInteraction of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TypeRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating TypeRestfulInteraction objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -181,10 +208,22 @@ public class TypeRestfulInteraction extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating TypeRestfulInteraction.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/UDIEntryType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/UDIEntryType.java
@@ -71,6 +71,9 @@ public class UDIEntryType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating UDIEntryType objects from a passed enum value.
+     */
     public static UDIEntryType of(ValueSet value) {
         switch (value) {
         case BARCODE:
@@ -90,14 +93,38 @@ public class UDIEntryType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating UDIEntryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static UDIEntryType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating UDIEntryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating UDIEntryType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -223,10 +250,22 @@ public class UDIEntryType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating UDIEntryType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/UnitsOfTime.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/UnitsOfTime.java
@@ -64,6 +64,9 @@ public class UnitsOfTime extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating UnitsOfTime objects from a passed enum value.
+     */
     public static UnitsOfTime of(ValueSet value) {
         switch (value) {
         case S:
@@ -85,14 +88,38 @@ public class UnitsOfTime extends Code {
         }
     }
 
+    /**
+     * Factory method for creating UnitsOfTime objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static UnitsOfTime of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating UnitsOfTime objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating UnitsOfTime objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -211,10 +238,22 @@ public class UnitsOfTime extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating UnitsOfTime.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/Use.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/Use.java
@@ -50,6 +50,9 @@ public class Use extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating Use objects from a passed enum value.
+     */
     public static Use of(ValueSet value) {
         switch (value) {
         case CLAIM:
@@ -63,14 +66,38 @@ public class Use extends Code {
         }
     }
 
+    /**
+     * Factory method for creating Use objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Use of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating Use objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating Use objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class Use extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating Use.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VariableType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VariableType.java
@@ -50,6 +50,9 @@ public class VariableType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating VariableType objects from a passed enum value.
+     */
     public static VariableType of(ValueSet value) {
         switch (value) {
         case DICHOTOMOUS:
@@ -63,14 +66,38 @@ public class VariableType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating VariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static VariableType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VariableType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -175,10 +202,22 @@ public class VariableType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating VariableType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionBase.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionBase.java
@@ -57,6 +57,9 @@ public class VisionBase extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating VisionBase objects from a passed enum value.
+     */
     public static VisionBase of(ValueSet value) {
         switch (value) {
         case UP:
@@ -72,14 +75,38 @@ public class VisionBase extends Code {
         }
     }
 
+    /**
+     * Factory method for creating VisionBase objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static VisionBase of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionBase objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionBase objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class VisionBase extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating VisionBase.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionEyes.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionEyes.java
@@ -43,6 +43,9 @@ public class VisionEyes extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating VisionEyes objects from a passed enum value.
+     */
     public static VisionEyes of(ValueSet value) {
         switch (value) {
         case RIGHT:
@@ -54,14 +57,38 @@ public class VisionEyes extends Code {
         }
     }
 
+    /**
+     * Factory method for creating VisionEyes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static VisionEyes of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionEyes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionEyes objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -159,10 +186,22 @@ public class VisionEyes extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating VisionEyes.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/VisionStatus.java
@@ -57,6 +57,9 @@ public class VisionStatus extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating VisionStatus objects from a passed enum value.
+     */
     public static VisionStatus of(ValueSet value) {
         switch (value) {
         case ACTIVE:
@@ -72,14 +75,38 @@ public class VisionStatus extends Code {
         }
     }
 
+    /**
+     * Factory method for creating VisionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static VisionStatus of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating VisionStatus objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -191,10 +218,22 @@ public class VisionStatus extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating VisionStatus.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/code/XPathUsageType.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/code/XPathUsageType.java
@@ -64,6 +64,9 @@ public class XPathUsageType extends Code {
         return (value != null) ? ValueSet.from(value) : null;
     }
 
+    /**
+     * Factory method for creating XPathUsageType objects from a passed enum value.
+     */
     public static XPathUsageType of(ValueSet value) {
         switch (value) {
         case NORMAL:
@@ -81,14 +84,38 @@ public class XPathUsageType extends Code {
         }
     }
 
+    /**
+     * Factory method for creating XPathUsageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static XPathUsageType of(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating XPathUsageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static String string(java.lang.String value) {
         return of(ValueSet.from(value));
     }
 
+    /**
+     * Inherited factory method for creating XPathUsageType objects from a passed string value.
+     * 
+     * @param value
+     *     A string that matches one of the allowed code values
+     * @throws IllegalArgumentException
+     *     If the passed string cannot be parsed into an allowed code value
+     */
     public static Code code(java.lang.String value) {
         return of(ValueSet.from(value));
     }
@@ -207,10 +234,22 @@ public class XPathUsageType extends Code {
             this.value = value;
         }
 
+        /**
+         * @return
+         *     The java.lang.String value of the code represented by this enum
+         */
         public java.lang.String value() {
             return value;
         }
 
+        /**
+         * Factory method for creating XPathUsageType.ValueSet values from a passed string value.
+         * 
+         * @param value
+         *     A string that matches one of the allowed code values
+         * @throws IllegalArgumentException
+         *     If the passed string cannot be parsed into an allowed code value
+         */
         public static ValueSet from(java.lang.String value) {
             for (ValueSet c : ValueSet.values()) {
                 if (c.value.equals(value)) {


### PR DESCRIPTION
This helper uses the OWASP Encoder (a small java dependency that we were
already using in the project, but not from `fhir-model`) to encode plain
text strings for use within HTML.
In addition to Xhtml javadoc, I also added javadoc for some of the code
subtype methods.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>