### PR TITLE
Private Memory on Db2 results in -930 errors at load #1527

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -574,7 +574,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                     stmt.execute();
                     double dbCallDuration2 = (System.nanoTime() - dbCallStartTime2) / 1e6;
                     if (log.isLoggable(Level.FINE)) {
-                        log.fine("DB search by ids complete. SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2 + "ms");
+                        log.fine("DB update complete. SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2 + "ms");
                     }
                 }
             }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -567,13 +567,15 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             if (large) {
                 // Use the long id to update the record in the database.
                 String largeStmtString = String.format(LARGE_BLOB, getSchemaName(), resource.getResourceType());
-                PreparedStatement ps = connection.prepareStatement(largeStmtString);
-                ps.setLong(1, stmt.getLong(7));
-                long dbCallStartTime2 = System.nanoTime();
-                stmt.execute();
-                double dbCallDuration2 = (System.nanoTime() - dbCallStartTime2) / 1e6;
-                if (log.isLoggable(Level.FINE)) {
-                    log.fine("DB search by ids complete. SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2 + "ms");
+                try (PreparedStatement ps = connection.prepareStatement(largeStmtString);) {
+                    ps.setBytes(1, resource.getData());
+                    ps.setLong(2, stmt.getLong(7));
+                    long dbCallStartTime2 = System.nanoTime();
+                    stmt.execute();
+                    double dbCallDuration2 = (System.nanoTime() - dbCallStartTime2) / 1e6;
+                    if (log.isLoggable(Level.FINE)) {
+                        log.fine("DB search by ids complete. SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2 + "ms");
+                    }
                 }
             }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -56,58 +56,63 @@ import com.ibm.fhir.schema.control.FhirSchemaConstants;
  * and retrieving rows in the IBM FHIR Server resource tables.
  */
 public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
+
     private static final Logger log = Logger.getLogger(ResourceDAOImpl.class.getName());
     private static final String CLASSNAME = ResourceDAOImpl.class.getName();
 
     // Per issue with private memory in db2, we have set this to 1M.
     // Anything larger than 1M is then inserted into the db with an update.
-    private static final String LARGE_BLOB = "UPDATE %s_RESOURCES SET data = ? WHERE resource_id = ?";
+    private static final String LARGE_BLOB = "UPDATE %s_RESOURCES SET DATA = ? WHERE RESOURCE_ID = ?";
 
     public static final String DEFAULT_VALUE_REINDEX_TSTAMP = "1970-01-01 00:00:00";
 
-
     // Read the current version of the resource
     private static final String SQL_READ = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
-                                            "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
-                                           "LR.LOGICAL_ID = ? AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID";
+            "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
+            "LR.LOGICAL_ID = ? AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID";
 
     // Read a specific version of the resource
-    private static final String SQL_VERSION_READ = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
-                                                      "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
-                                                      "LR.LOGICAL_ID = ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID AND R.VERSION_ID = ?";
+    private static final String SQL_VERSION_READ =
+            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
+                    "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
+                    "LR.LOGICAL_ID = ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID AND R.VERSION_ID = ?";
 
     // @formatter:off
     //                                                                                 0
-    //                                                                                 1 2 3 4 5 6 7
+    //                                                                                 1 2 3 4 5 6 7 8
     // @formatter:on
     // Don't forget that we must account for IN and OUT parameters.
-    private static final String SQL_INSERT_WITH_PARAMETERS = "CALL %s.add_any_resource(?,?,?,?,?,?,?)";
+    private static final String SQL_INSERT_WITH_PARAMETERS = "CALL %s.add_any_resource(?,?,?,?,?,?,?,?)";
 
     // Read version history of the resource identified by its logical-id
-    private static final String SQL_HISTORY = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
-                                                 "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
-                                                 "LR.LOGICAL_ID = ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID " +
-                                              "ORDER BY R.VERSION_ID DESC ";
+    private static final String SQL_HISTORY =
+            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
+                    "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
+                    "LR.LOGICAL_ID = ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID " +
+                    "ORDER BY R.VERSION_ID DESC ";
 
     // Count the number of versions we have for the resource identified by its logical-id
     private static final String SQL_HISTORY_COUNT = "SELECT COUNT(R.VERSION_ID) FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE LR.LOGICAL_ID = ? AND " +
-                                                    "R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID";
+            "R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID";
 
-    private static final String SQL_HISTORY_FROM_DATETIME = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
-                                                              "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
-                                                              "LR.LOGICAL_ID = ? AND R.LAST_UPDATED >= ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID " +
-                                                              "ORDER BY R.VERSION_ID DESC ";
+    private static final String SQL_HISTORY_FROM_DATETIME =
+            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
+                    "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE " +
+                    "LR.LOGICAL_ID = ? AND R.LAST_UPDATED >= ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID " +
+                    "ORDER BY R.VERSION_ID DESC ";
 
-    private static final String SQL_HISTORY_FROM_DATETIME_COUNT = "SELECT COUNT(R.VERSION_ID) FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE LR.LOGICAL_ID = ? AND " +
-                                                                  "R.LAST_UPDATED >= ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID";
+    private static final String SQL_HISTORY_FROM_DATETIME_COUNT =
+            "SELECT COUNT(R.VERSION_ID) FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE LR.LOGICAL_ID = ? AND " +
+                    "R.LAST_UPDATED >= ? AND R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID";
 
     private static final String SQL_READ_ALL_RESOURCE_TYPE_NAMES = "SELECT RESOURCE_TYPE_ID, RESOURCE_TYPE FROM RESOURCE_TYPES";
 
     private static final String SQL_READ_RESOURCE_TYPE = "CALL %s.add_resource_type(?, ?)";
 
-    private static final String SQL_SEARCH_BY_IDS = "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
-                                                    "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID AND " +
-                                                    "R.RESOURCE_ID IN ";
+    private static final String SQL_SEARCH_BY_IDS =
+            "SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID " +
+                    "FROM %s_RESOURCES R, %s_LOGICAL_RESOURCES LR WHERE R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID AND " +
+                    "R.RESOURCE_ID IN ";
 
     private static final String SQL_ORDER_BY_IDS = "ORDER BY CASE R.RESOURCE_ID ";
 
@@ -130,13 +135,15 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Constructs a DAO instance suitable for acquiring connections from a JDBC Datasource object.
+     *
      * @param c
      * @param schemaName
      * @param flavor
      * @param trxSyncRegistry
      */
-    public ResourceDAOImpl(Connection c, String schemaName, FHIRDbFlavor flavor, TransactionSynchronizationRegistry trxSynchRegistry, FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd,
-        ParameterTransactionDataImpl ptdi) {
+    public ResourceDAOImpl(Connection c, String schemaName, FHIRDbFlavor flavor, TransactionSynchronizationRegistry trxSynchRegistry,
+            FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd,
+            ParameterTransactionDataImpl ptdi) {
         super(c, schemaName, flavor);
         this.runningInTrx = true;
         this.trxSynchRegistry = trxSynchRegistry;
@@ -147,6 +154,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Constructs a DAO instance for use outside a managed transaction (JEE) environment
+     *
      * @param c
      * @param schemaName
      * @param flavor
@@ -162,6 +170,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Getter for the IResourceReferenceDAO used by this ResourceDAO implementation
+     *
      * @return
      */
     protected IResourceReferenceDAO getResourceReferenceDAO() {
@@ -170,6 +179,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Get the ParameterTransactionDataImpl held by this.
+     *
      * @return the transactionData object. Can be null.
      */
     protected ParameterTransactionDataImpl getTransactionData() {
@@ -178,7 +188,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public Resource read(String logicalId, String resourceType)
-            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "read";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -200,7 +210,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public Resource versionRead(String logicalId, String resourceType, int versionId)
-            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "versionRead";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -223,7 +233,9 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Creates and returns a Resource DTO based on the contents of the passed ResultSet
-     * @param resultSet A ResultSet containing FHIR persistent object data.
+     *
+     * @param resultSet
+     *            A ResultSet containing FHIR persistent object data.
      * @return Resource - A Resource DTO
      * @throws FHIRPersistenceDataAccessException
      */
@@ -253,7 +265,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public List<Resource> history(String resourceType, String logicalId, Timestamp fromDateTime, int offset, int maxResults)
-                                    throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "history";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -281,13 +293,14 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                 }
             }
         } finally {
-            log.exiting(CLASSNAME, METHODNAME, Arrays.toString(new Object[] {resources}));
+            log.exiting(CLASSNAME, METHODNAME, Arrays.toString(new Object[] { resources }));
         }
         return resources;
     }
 
     @Override
-    public int historyCount(String resourceType, String logicalId, Timestamp fromDateTime) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public int historyCount(String resourceType, String logicalId, Timestamp fromDateTime)
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "historyCount";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -327,7 +340,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public int searchCount(SqlQueryData queryData)     throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public int searchCount(SqlQueryData queryData) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "searchCount(SqlQueryData)";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -350,7 +363,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public Map<String, Integer> readAllResourceTypeNames()
-                                         throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+        throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
         final String METHODNAME = "readAllResourceTypeNames";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -373,7 +386,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             }
 
             if (log.isLoggable(Level.FINE)) {
-                dbCallDuration = (System.nanoTime()-dbCallStartTime)/1e6;
+                dbCallDuration = (System.nanoTime() - dbCallStartTime) / 1e6;
                 log.fine("DB read all resource type complete. executionTime=" + dbCallDuration + "ms");
             }
         } catch (Throwable e) {
@@ -389,7 +402,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public Integer readResourceTypeId(String resourceType) throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException  {
+    public Integer readResourceTypeId(String resourceType) throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
         final String METHODNAME = "readResourceTypeId";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -407,7 +420,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             stmt.registerOutParameter(2, Types.INTEGER);
             dbCallStartTime = System.nanoTime();
             stmt.execute();
-            dbCallDuration = (System.nanoTime()-dbCallStartTime)/1e6;
+            dbCallDuration = (System.nanoTime() - dbCallStartTime) / 1e6;
             if (log.isLoggable(Level.FINE)) {
                 log.fine("DB read resource type id complete. executionTime=" + dbCallDuration + "ms");
             }
@@ -441,18 +454,18 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             for (int i = 0; i < queryData.getBindVariables().size(); i++) {
                 Object object = queryData.getBindVariables().get(i);
                 if (object instanceof Timestamp) {
-                    stmt.setTimestamp(i+1, (Timestamp) object, JDBCConstants.UTC);
+                    stmt.setTimestamp(i + 1, (Timestamp) object, JDBCConstants.UTC);
                 } else {
-                    stmt.setObject(i+1, object);
+                    stmt.setObject(i + 1, object);
                 }
             }
             dbCallStartTime = System.nanoTime();
             resultSet = stmt.executeQuery();
-            dbCallDuration = (System.nanoTime()-dbCallStartTime)/1e6;
+            dbCallDuration = (System.nanoTime() - dbCallStartTime) / 1e6;
             if (log.isLoggable(Level.FINE)) {
                 log.fine("DB search for ids complete. " + queryData + "  executionTime=" + dbCallDuration + "ms");
             }
-            while(resultSet.next()) {
+            while (resultSet.next()) {
                 resourceIds.add(resultSet.getLong(1));
             }
         } catch (Throwable e) {
@@ -466,12 +479,14 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
         return resourceIds;
     }
 
-
-     /**
+    /**
      * Adds a resource type/ resource id pair to a candidate collection for population into the ResourceTypesCache.
      * This pair must be present as a row in the FHIR DB RESOURCE_TYPES table.
-     * @param resourceType A valid FHIR resource type.
-     * @param resourceTypeId The corresponding id for the resource type.
+     *
+     * @param resourceType
+     *            A valid FHIR resource type.
+     * @param resourceTypeId
+     *            The corresponding id for the resource type.
      * @throws FHIRPersistenceException
      */
     @Override
@@ -486,7 +501,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                 try {
                     trxSynchRegistry.registerInterposedSynchronization(rtCacheUpdater);
                     log.fine("Registered ResourceTypeCacheUpdater.");
-                } catch(Throwable e) {
+                } catch (Throwable e) {
                     throw new FHIRPersistenceException("Failure registering ResourceTypesCacheUpdater", e);
                 }
             }
@@ -497,11 +512,13 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     }
 
-    protected  Integer getResourceTypeIdFromCaches(String resourceType) {
+    protected Integer getResourceTypeIdFromCaches(String resourceType) {
         // Get resourceTypeId from ResourceTypesCache first.
         Integer resourceTypeId = ResourceTypesCache.getResourceTypeId(resourceType);
-        // If no found, then get resourceTypeId from local newResourceTypeIds in case this id is already in newResourceTypeIds
-        // but has not been updated to ResourceTypesCache yet. newResourceTypeIds is updated to ResourceTypesCache only when the
+        // If no found, then get resourceTypeId from local newResourceTypeIds in case this id is already in
+        // newResourceTypeIds
+        // but has not been updated to ResourceTypesCache yet. newResourceTypeIds is updated to ResourceTypesCache only
+        // when the
         // current transaction is committed.
         if (resourceTypeId == null) {
             resourceTypeId = this.newResourceTypeIds.get(resourceType);
@@ -543,11 +560,10 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             stmt.setString(2, resource.getLogicalId());
 
             // Check for large objects, and branch around it.
-            boolean large = false;
-            if (FhirSchemaConstants.STORED_PROCEDURE_SIZE_LIMIT < resource.getData().length) {
+            boolean large = FhirSchemaConstants.STORED_PROCEDURE_SIZE_LIMIT < resource.getData().length;
+            if (large) {
                 // Outside of the normal flow we have a BIG JSON or XML
-                stmt.setNull(3, java.sql.Types.BLOB);
-                large = true;
+                stmt.setNull(3, Types.BLOB);
             } else {
                 // Normal Flow, we set the data
                 stmt.setBytes(3, resource.getData());
@@ -558,25 +574,27 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             stmt.setString(5, resource.isDeleted() ? "Y": "N");
             stmt.setInt(6, resource.getVersionId());
             stmt.registerOutParameter(7, Types.BIGINT);
+            stmt.registerOutParameter(8, Types.BIGINT);
 
             stmt.execute();
             long latestTime = System.nanoTime();
             double dbCallDuration = (latestTime-dbCallStartTime)/1e6;
 
-            long logicalResourceId = stmt.getLong(7);
-            resource.setId(logicalResourceId);
-
+            resource.setId(stmt.getLong(7));
+            long versionedResourceRowId = stmt.getLong(8);
             if (large) {
-                // Use the long id to update the record in the database.
                 String largeStmtString = String.format(LARGE_BLOB, resource.getResourceType());
                 try (PreparedStatement ps = connection.prepareStatement(largeStmtString)) {
+                    // Use the long id to update the record in the database with the large object.
                     ps.setBytes(1, resource.getData());
-                    ps.setLong(2, logicalResourceId);
+                    ps.setLong(2, versionedResourceRowId);
                     long dbCallStartTime2 = System.nanoTime();
-                    stmt.execute();
+                    int numberOfRows = -1;
+                    ps.execute();
                     double dbCallDuration2 = (System.nanoTime() - dbCallStartTime2) / 1e6;
                     if (log.isLoggable(Level.FINE)) {
-                        log.fine("DB update complete. SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2 + "ms");
+                        log.fine("DB update large blob complete. ROWS=[" + numberOfRows + "] SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2
+                                + "ms");
                     }
                 }
             }
@@ -594,37 +612,37 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                 }
             }
 
-
             if (log.isLoggable(Level.FINE)) {
                 latestTime = System.nanoTime();
                 double totalDuration = (latestTime - dbCallStartTime) / 1e6;
                 double paramInsertDuration = (latestTime-paramInsertStartTime)/1e6;
                 log.fine("Successfully inserted Resource. id=" + resource.getId() + " total=" + totalDuration + "ms, proc=" + dbCallDuration + "ms, param=" + paramInsertDuration + "ms");
             }
-        } catch(FHIRPersistenceDBConnectException | FHIRPersistenceDataAccessException e) {
+        } catch (FHIRPersistenceDBConnectException |
+
+                FHIRPersistenceDataAccessException e) {
             throw e;
-        } catch(SQLIntegrityConstraintViolationException e) {
+        } catch (SQLIntegrityConstraintViolationException e) {
             FHIRPersistenceFKVException fx = new FHIRPersistenceFKVException("Encountered FK violation while inserting Resource.");
             throw severe(log, fx, e);
-        } catch(SQLException e) {
+        } catch (SQLException e) {
             if ("99001".equals(e.getSQLState())) {
                 // this is just a concurrency update, so there's no need to log the SQLException here
                 throw new FHIRPersistenceVersionIdMismatchException("Encountered version id mismatch while inserting Resource");
             } else {
                 FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("SQLException encountered while inserting Resource.");
-                throw severe(log, fx, e);
-            }
-        } catch(Throwable e) {
-            FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure inserting Resource.");
             throw severe(log, fx, e);
-        } finally {
-            this.cleanup(stmt);
-            log.exiting(CLASSNAME, METHODNAME);
         }
-
-        return resource;
+    } catch (Throwable e) {
+        FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure inserting Resource.");
+        throw severe(log, fx, e);
+    } finally {
+        this.cleanup(stmt);
+        log.exiting(CLASSNAME, METHODNAME);
     }
 
+    return resource;
+    }
 
     @Override
     public List<Resource> search(String sqlSelect) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
@@ -643,7 +661,8 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public List<Resource> searchByIds(String resourceType, List<Long> resourceIds) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public List<Resource> searchByIds(String resourceType, List<Long> resourceIds)
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "searchByIds";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -681,12 +700,12 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             stmt = connection.prepareStatement(idQuery.toString());
             dbCallStartTime = System.nanoTime();
             resultSet = stmt.executeQuery();
-            dbCallDuration = (System.nanoTime()-dbCallStartTime)/1e6;
+            dbCallDuration = (System.nanoTime() - dbCallStartTime) / 1e6;
             if (log.isLoggable(Level.FINE)) {
                 log.fine("DB search by ids complete. SQL=[" + idQuery + "]  executionTime=" + dbCallDuration + "ms");
             }
             resources = this.createDTOs(resultSet);
-        } catch(FHIRPersistenceException e) {
+        } catch (FHIRPersistenceException e) {
             throw e;
         } catch (Throwable e) {
             FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure retrieving FHIR Resources");
@@ -720,7 +739,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public List<String> searchStringValues(SqlQueryData queryData)
-            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "searchSTR_VALUES";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -735,6 +754,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     /**
      * Getter for access to the {@link FHIRPersistenceJDBCCache} from subclasses
+     *
      * @return
      */
     protected FHIRPersistenceJDBCCache getCache() {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -142,8 +142,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
      * @param trxSyncRegistry
      */
     public ResourceDAOImpl(Connection c, String schemaName, FHIRDbFlavor flavor, TransactionSynchronizationRegistry trxSynchRegistry,
-            FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd,
-            ParameterTransactionDataImpl ptdi) {
+        FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd, ParameterTransactionDataImpl ptdi) {
         super(c, schemaName, flavor);
         this.runningInTrx = true;
         this.trxSynchRegistry = trxSynchRegistry;
@@ -187,8 +186,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public Resource read(String logicalId, String resourceType)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public Resource read(String logicalId, String resourceType) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "read";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -209,8 +207,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public Resource versionRead(String logicalId, String resourceType, int versionId)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public Resource versionRead(String logicalId, String resourceType, int versionId) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "versionRead";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -264,8 +261,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
     }
 
     @Override
-    public List<Resource> history(String resourceType, String logicalId, Timestamp fromDateTime, int offset, int maxResults)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+    public List<Resource> history(String resourceType, String logicalId, Timestamp fromDateTime, int offset, int maxResults) throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "history";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -300,7 +296,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public int historyCount(String resourceType, String logicalId, Timestamp fromDateTime)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "historyCount";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -363,7 +359,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public Map<String, Integer> readAllResourceTypeNames()
-        throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
+            throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException {
         final String METHODNAME = "readAllResourceTypeNames";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -551,7 +547,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             }
             if (log.isLoggable(Level.FINE)) {
                 log.fine("resourceType=" + resource.getResourceType() + "  resourceTypeId=" + resourceTypeId +
-                         "  acquiredFromCache=" + acquiredFromCache + "  tenantDatastoreCacheName=" + ResourceTypesCache.getCacheNameForTenantDatastore());
+                    "  acquiredFromCache=" + acquiredFromCache + "  tenantDatastoreCacheName=" + ResourceTypesCache.getCacheNameForTenantDatastore());
             }
 
             stmtString = String.format(SQL_INSERT_WITH_PARAMETERS, getSchemaName());
@@ -594,7 +590,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                     double dbCallDuration2 = (System.nanoTime() - dbCallStartTime2) / 1e6;
                     if (log.isLoggable(Level.FINE)) {
                         log.fine("DB update large blob complete. ROWS=[" + numberOfRows + "] SQL=[" + largeStmtString + "]  executionTime=" + dbCallDuration2
-                                + "ms");
+                            + "ms");
                     }
                 }
             }
@@ -605,7 +601,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
             if (parameters != null) {
                 JDBCIdentityCache identityCache = new JDBCIdentityCacheImpl(cache, this, parameterDao);
                 try (ParameterVisitorBatchDAO pvd = new ParameterVisitorBatchDAO(connection, "FHIR_ADMIN", resource.getResourceType(), true,
-                        resource.getId(), 100, identityCache, resourceReferenceDAO, this.transactionData)) {
+                    resource.getId(), 100, identityCache, resourceReferenceDAO, this.transactionData)) {
                     for (ExtractedParameterValue p: parameters) {
                         p.accept(pvd);
                     }
@@ -631,17 +627,17 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
                 throw new FHIRPersistenceVersionIdMismatchException("Encountered version id mismatch while inserting Resource");
             } else {
                 FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("SQLException encountered while inserting Resource.");
+                throw severe(log, fx, e);
+            }
+        } catch (Throwable e) {
+            FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure inserting Resource.");
             throw severe(log, fx, e);
+        } finally {
+            this.cleanup(stmt);
+            log.exiting(CLASSNAME, METHODNAME);
         }
-    } catch (Throwable e) {
-        FHIRPersistenceDataAccessException fx = new FHIRPersistenceDataAccessException("Failure inserting Resource.");
-        throw severe(log, fx, e);
-    } finally {
-        this.cleanup(stmt);
-        log.exiting(CLASSNAME, METHODNAME);
-    }
 
-    return resource;
+        return resource;
     }
 
     @Override
@@ -662,7 +658,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public List<Resource> searchByIds(String resourceType, List<Long> resourceIds)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "searchByIds";
         log.entering(CLASSNAME, METHODNAME);
 
@@ -739,7 +735,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
 
     @Override
     public List<String> searchStringValues(SqlQueryData queryData)
-        throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
+            throws FHIRPersistenceDataAccessException, FHIRPersistenceDBConnectException {
         final String METHODNAME = "searchSTR_VALUES";
         log.entering(CLASSNAME, METHODNAME);
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ResourceDAOImpl.java
@@ -142,7 +142,7 @@ public class ResourceDAOImpl extends FHIRDbDAOImpl implements ResourceDAO {
      * @param trxSyncRegistry
      */
     public ResourceDAOImpl(Connection c, String schemaName, FHIRDbFlavor flavor, TransactionSynchronizationRegistry trxSynchRegistry,
-        FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd, ParameterTransactionDataImpl ptdi) {
+            FHIRPersistenceJDBCCache cache, IResourceReferenceDAO rrd, ParameterTransactionDataImpl ptdi) {
         super(c, schemaName, flavor);
         this.runningInTrx = true;
         this.trxSynchRegistry = trxSynchRegistry;

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaConstants.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaConstants.java
@@ -10,6 +10,10 @@ package com.ibm.fhir.schema.control;
  * Constants related to Schema creation and updating.
  */
 public class FhirSchemaConstants {
+
+    // This limit is used to limit db2 size in a stored procedure.
+    public static final int STORED_PROCEDURE_SIZE_LIMIT = 1048576;
+
     // A lower pool size is selected as default to limit the likelihood of contention on the DBMS.
     // Standard connection/thread pool size
     public static final int DEFAULT_POOL_SIZE = 1;
@@ -18,7 +22,7 @@ public class FhirSchemaConstants {
     public static final int MAX_SEARCH_STRING_BYTES = 1024;
     public static final int MAX_TOKEN_VALUE_BYTES = 1024;
     public static final int LOGICAL_ID_BYTES = 255;
-    
+
     // Currently a constant admin schema name
     public static final String FHIR_ADMIN = "FHIR_ADMIN";
 
@@ -43,7 +47,7 @@ public class FhirSchemaConstants {
     public static final int REFERENCES_SEQUENCE_START = 1;
     public static final int REFERENCES_SEQUENCE_CACHE = 1000;
     public static final int REFERENCES_SEQUENCE_INCREMENT = 20;
-    
+
     // Tenant constants
     public static final String MT_ID = "MT_ID";
     public static final String TENANT_HASH = "TENANT_HASH";
@@ -129,7 +133,7 @@ public class FhirSchemaConstants {
     // Initial partition range values for table create
     public static final int PART_LOWER = 0;
     public static final int PART_UPPER = 0;
-    
+
     // Table for Normalization of References (Internal and External)
     public static final String LOCAL_REFERENCES = "LOCAL_REFERENCES";
     public static final String REF_LOGICAL_RESOURCE_ID = "REF_LOGICAL_RESOURCE_ID";
@@ -137,19 +141,19 @@ public class FhirSchemaConstants {
 //    public static final String EXTERNAL_SYSTEM_ID = "EXTERNAL_SYSTEM_ID";
 //    public static final String EXTERNAL_SYSTEM_NAME = "EXTERNAL_SYSTEM_NAME";
 //    public static final String EXTERNAL_REFERENCES = "EXTERNAL_REFERENCES";
-    
+
     // For V0006 (issue #1366) token_values become normalized to improve storage efficiency
     public static final String COMMON_TOKEN_VALUES = "COMMON_TOKEN_VALUES";
     public static final String COMMON_TOKEN_VALUE_ID = "COMMON_TOKEN_VALUE_ID";
-    
+
     // The table mapping a resource to its (shared) token values
     public static final String RESOURCE_TOKEN_REFS = "RESOURCE_TOKEN_REFS";
     public static final String REF_RESOURCE_TYPE_ID = "REF_RESOURCE_TYPE_ID";
     public static final String REF_VERSION_ID = "REF_VERSION_ID";
-    
+
     // View suffix to overlay the new common_token_values and resource_token_refs tables
     public static final String TOKEN_VALUES_V = "TOKEN_VALUES_V";
-    
+
     public static final String LOGICAL_RESOURCE_COMPARTMENTS = "LOGICAL_RESOURCE_COMPARTMENTS";
     public static final String COMPARTMENT_LOGICAL_RESOURCE_ID = "COMPARTMENT_LOGICAL_RESOURCE_ID";
     public static final String COMPARTMENT_NAME_ID = "COMPARTMENT_NAME_ID";

--- a/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
+++ b/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
@@ -17,7 +17,7 @@
 -- ----------------------------------------------------------------------------
     ( IN p_resource_type                 VARCHAR( 36 OCTETS),
       IN p_logical_id                    VARCHAR(255 OCTETS), 
-      IN p_payload                          BLOB(1M),
+      IN p_payload                          BLOB(1048576),
       IN p_last_updated                TIMESTAMP,
       IN p_is_deleted                       CHAR(  1),
       IN p_version                           INT,

--- a/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
+++ b/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
@@ -13,15 +13,17 @@
 -- p_last_updated the last_updated time given by the FHIR server
 -- p_is_deleted: the soft delete flag
 -- p_version_id: the version id if this is a replicated message
+-- o_logical_resource_id: output field returning the newly assigned logical_resource_id value
 -- o_resource_id: output field returning the newly assigned resource_id value
 -- ----------------------------------------------------------------------------
-    ( IN p_resource_type                 VARCHAR( 36 OCTETS),
-      IN p_logical_id                    VARCHAR(255 OCTETS), 
-      IN p_payload                          BLOB(1048576),
-      IN p_last_updated                TIMESTAMP,
-      IN p_is_deleted                       CHAR(  1),
-      IN p_version                           INT,
-      OUT o_logical_resource_id            BIGINT
+    ( IN p_resource_type                VARCHAR( 36 OCTETS),
+      IN p_logical_id                   VARCHAR(255 OCTETS), 
+      IN p_payload                         BLOB(1048576),
+      IN p_last_updated               TIMESTAMP,
+      IN p_is_deleted                      CHAR(  1),
+      IN p_version                          INT,
+      OUT o_logical_resource_id          BIGINT,
+      OUT o_resource_row_id              BIGINT
     )
     LANGUAGE SQL
     MODIFIES SQL DATA
@@ -198,4 +200,7 @@ BEGIN
   -- only the logical_resource_id is the target of any FK, so there's no need to return
   -- the resource_id (which is now private to the _resources tables).
   SET o_logical_resource_id = v_logical_resource_id;
+
+  -- Resource Row Id which is used to set large blobs
+  SET o_resource_row_id = v_resource_id;
 END

--- a/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
+++ b/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
@@ -17,7 +17,7 @@
 -- ----------------------------------------------------------------------------
     ( IN p_resource_type                 VARCHAR( 36 OCTETS),
       IN p_logical_id                    VARCHAR(255 OCTETS), 
-      IN p_payload                          BLOB(10M),
+      IN p_payload                          BLOB(1M),
       IN p_last_updated                TIMESTAMP,
       IN p_is_deleted                       CHAR(  1),
       IN p_version                           INT,

--- a/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
+++ b/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
@@ -196,9 +196,7 @@ BEGIN
     -- JDBC statements.
   END IF;
 
-  -- Hand back the id of the logical resource we created earlier. In the new R4 schema
-  -- only the logical_resource_id is the target of any FK, so there's no need to return
-  -- the resource_id (which is now private to the _resources tables).
+  -- Hand back the id of the logical resource we created earlier
   SET o_logical_resource_id = v_logical_resource_id;
 
   -- Resource Row Id which is used to set large blobs

--- a/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
+++ b/fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql
@@ -17,7 +17,7 @@
 -- ----------------------------------------------------------------------------
     ( IN p_resource_type                 VARCHAR( 36 OCTETS),
       IN p_logical_id                    VARCHAR(255 OCTETS), 
-      IN p_payload                          BLOB(2147483647),
+      IN p_payload                          BLOB(10M),
       IN p_last_updated                TIMESTAMP,
       IN p_is_deleted                       CHAR(  1),
       IN p_version                           INT,

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/db2/LargeResourceTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/db2/LargeResourceTest.java
@@ -1,0 +1,116 @@
+/*
+ * (C) Copyright IBM Corp. 2017,2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test.db2;
+
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Base64Binary;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.server.test.FHIRServerTestBase;
+
+/**
+ * This test checks LARGE files are branching correctly in the Stored Procedure
+ * this test is opaque to any other persistence layer and the history is properly returned.
+ */
+public class LargeResourceTest extends FHIRServerTestBase {
+    private Patient v1Patient;
+    private Patient v2Patient;
+
+    /**
+     * Creates a small patient.
+     */
+    @Test(groups = { "large-resource" })
+    public void testCreatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request().post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        String patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        v1Patient = responsePatient;
+
+        TestUtil.assertResourceEquals(patient, responsePatient);
+    }
+
+    /**
+     * Updates and ensure the large resource is returned correctly on the same version.
+     */
+    @Test(groups = { "large-resource" }, dependsOnMethods = { "testCreatePatient" })
+    public void testUpdatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+
+        SecureRandom random = new SecureRandom();
+        byte bytes[] = new byte[10000000];
+        random.nextBytes(bytes);
+        String value = Base64.getEncoder().encodeToString(bytes);
+
+        //@formatter:off
+        patient =
+                patient.toBuilder().id(v1Patient.getId())
+                .extension(Extension.builder()
+                    .url("http://ibm.com/fhir/large-large-large/testExtension")
+                    .value(Base64Binary.builder().value(value).build()).build())
+                .build();
+        //@formatter:on
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+
+        // Now call the 'update' API.
+        String targetPath = "Patient/" + patient.getId();
+        Response response = target.path(targetPath).request().put(entity, Response.class);
+        assertResponse(response, Response.Status.OK.getStatusCode());
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patient.getId()).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        v2Patient = responsePatient;
+
+        TestUtil.assertResourceEquals(patient, v2Patient);
+    }
+
+    /**
+     * make sure the large resource didn't replace the small resource (v1)
+     */
+    @Test(groups = { "large-resource" }, dependsOnMethods = { "testUpdatePatient" })
+    public void testVreadPatient() {
+        WebTarget target = getWebTarget();
+
+        // Call the 'version read' API to retrieve the original created version of the
+        // Patient.
+        String targetPath = "Patient/" + v1Patient.getId() + "/_history/"
+                + v1Patient.getMeta().getVersionId().getValue();
+        Response response = target.path(targetPath).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patientToCheck = response.readEntity(Patient.class);
+        assertNotNull(patientToCheck);
+        TestUtil.assertResourceEquals(patientToCheck, v1Patient);
+    }
+}


### PR DESCRIPTION
This error is only on the Db2 and isolated to the Db2 stored procedure - add_any_resource.

Scenario
- Load a Bundle with multiple if not hundreds of resources in a simultaneous way within a single Connection
- Note, the Bundle can be set as Transaction or Batch.
- Db2 with 8GB of memory without INSTANCE_MEMORY=Automatic
- The simultaneous load with ~10 to 20 threads.
- The result is *SQL0930N There is not enough storage available to process the statement*.

I monitored the db2 memory under load using db2tmrk, db2pd and generated some tests which indicate the following is accurate (other memory expands to about 600GB). 

In the underlying Memory Allocation, the 2GB size cause a block of memory to be reserved, where it accumulates. So if a new large request comes up requiring substantial chunk of memory, this chunk can only be freshly acquired from so far unused range of addresses, or it may fail.  If the p_payload is lowered to 10M, then the code operates as expected and the same workload can function with 200 threads. Note, it's dependent on the number of CALL to add_any_resource.

This PR is opened to discuss in more detail on an approach.  
I'd like to lower the 2GB to 10M.  

Alternatives, 
1. If needed we can branch to a LARGE size Stored Procedure if the file is larger than 10M.
2. If needed we can raise to 100M, it'd give a decent overhead.

Reference: https://www.ibm.com/support/pages/db2-content-management-application-may-receive-sql0930n
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>