### PR TITLE
issue #1673 - change default ordering for resource searches

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -96,7 +96,7 @@ public class JDBCConstants {
     public static final String ASCENDING = "ASC";
     public static final String DESCENDING = "DESC";
 
-    public static final String DEFAULT_ORDERING = " ORDER BY RESOURCE_ID ASC ";
+    public static final String DEFAULT_ORDERING = " ORDER BY LOGICAL_RESOURCE_ID ASC ";
     public static final String DEFAULT_ORDERING_WITH_TABLE = " ORDER BY R.RESOURCE_ID ASC ";
 
     // MIN / MAX


### PR DESCRIPTION
Note: I'm opening this PR against Mike's branch for #1218 instead of master because I was already under that branch when I made the change.  If needed, I can cherry-pick it into a new branch off master, but my assumption is that we'll merge Mike's PR soon anyway and so it doesn't matter much.

Previously, we used a default sort of RESOURCE_ID ASC (the row identifier of the resource version being returned).
While investigating #1673, I noticed that removing this sort took this query from 10 seconds down to 3-4 seconds.

However, having *some* sort order is important, so that we get consistent page results.
Upon further inspection, I found that changing the default sort to LOGICAL_RESOURCE_ID (the row identifier of the logical resource row being returned)
yielded a similar performance boost and so this is the proposed change.