### PR TITLE
Add filtering logic in Capabilities.buildInstantiates

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -516,9 +516,15 @@ public class Capabilities extends FHIRResource {
         List<Canonical> instantiates = new ArrayList<>();
         for (CapabilityStatement registeredCapability : registeredCapabilities) {
             if (registeredCapability != null && registeredCapability.getUrl() != null) {
+                boolean isServerCS = false;
+                for(Rest r : registeredCapability.getRest()) {
+                    if (RestfulCapabilityMode.ValueSet.SERVER == r.getMode().getValueAsEnumConstant()) {
+                        isServerCS = true;
+                    }
+                }
                 String url = registeredCapability.getUrl().getValue();
                 // BASE_CAPABILITY_URL and BASE_2_CAPABILITY_URL come from the core spec and shouldn't be advertised
-                if (url != null && !BASE_CAPABILITY_URL.equals(url) && !BASE_2_CAPABILITY_URL.equals(url)) {
+                if (url != null && isServerCS && !BASE_CAPABILITY_URL.equals(url) && !BASE_2_CAPABILITY_URL.equals(url)) {
                     String canonicalValue = url;
                     if (registeredCapability.getVersion() != null && registeredCapability.getVersion().getValue() != null) {
                         canonicalValue = canonicalValue + "|" + registeredCapability.getVersion().getValue();


### PR DESCRIPTION
To avoid advertising support for us-core-client without requiring us
from removing that CapabilityStatement from our packaging of us-core

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>