### PR TITLE
issue #1705 - simplified top-level join avoids bad postgresql plan for simple _has queries

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -615,8 +615,8 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
      * Contains special logic for handling chained reference search parameters.
      * <p>
      * Nested sub-selects are built to realize the chaining logic required. Here is
-     * a sample chained query for an
-     * Observation given this search parameter: device:Device.patient.family=Monella
+     * a sample chained query for an Observation given this search parameter:
+     * {@code device:Device.patient.family=Monella}
      *
      * <pre>
      * SELECT R.RESOURCE_ID, R.LOGICAL_RESOURCE_ID, R.VERSION_ID, R.LAST_UPDATED, R.IS_DELETED, R.DATA, LR.LOGICAL_ID
@@ -917,8 +917,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     /**
      * This method is the entry point for processing inclusion criteria, which
-     * define resources that are part of a
-     * comparment-based search.
+     * define resources that are part of a comparment-based search.
      * Example inclusion criteria for AuditEvent in the Patient compartment:
      *
      * <pre>

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -60,7 +60,7 @@ public class QuerySegmentAggregator {
     protected static final String SYSTEM_LEVEL_SELECT_ROOT =
             "SELECT RESOURCE_ID, LOGICAL_RESOURCE_ID, VERSION_ID, LAST_UPDATED, IS_DELETED, DATA, LOGICAL_ID ";
     protected static final String SYSTEM_LEVEL_SUBSELECT_ROOT = SELECT_ROOT;
-    protected static final String SELECT_COUNT_ROOT = "SELECT COUNT(DISTINCT R.RESOURCE_ID) ";
+    protected static final String SELECT_COUNT_ROOT = "SELECT COUNT(DISTINCT R.LOGICAL_RESOURCE_ID) ";
     protected static final String SYSTEM_LEVEL_SELECT_COUNT_ROOT = "SELECT SUM(CNT) ";
     protected static final String SYSTEM_LEVEL_SUBSELECT_COUNT_ROOT = " SELECT COUNT(DISTINCT LR.LOGICAL_RESOURCE_ID) AS CNT ";
     protected static final String WHERE_CLAUSE_ROOT = "WHERE R.IS_DELETED = 'N'";
@@ -411,9 +411,8 @@ public class QuerySegmentAggregator {
         // This is requires for the count queries here
         fromClause.append(JOIN);
         processFromClauseForLastUpdated(fromClause, simpleName);
-        fromClause.append(" R ON R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID ");
-        fromClause.append("  AND R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ");
-        fromClause.append("  AND R.IS_DELETED = 'N' ");
+        fromClause.append(" R ON R.RESOURCE_ID = LR.CURRENT_RESOURCE_ID ")
+                .append(" AND R.IS_DELETED = 'N' ");
 
         log.exiting(CLASSNAME, METHODNAME);
     }

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -160,7 +160,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                     try {
                         SearchParameter inclusionParm = SearchUtil.getSearchParameter(resourceType, searchParmCode);
                         if (inclusionParm != null & inclusionParm.getExpression() != null) {
-                            String expression = SearchUtil.getSearchParameter(resourceType, searchParmCode).getExpression().getValue();
+                            String expression = inclusionParm.getExpression().getValue();
                             Collection<FHIRPathNode> nodes = FHIRPathEvaluator.evaluator().evaluate(resourceContext, expression);
                             for (FHIRPathNode node : nodes) {
                                 String patientRefVal = getPatientRefVal(node);


### PR DESCRIPTION
The `R.LOGICAL_RESOURCE_ID = LR.LOGICAL_RESOURCE_ID` part of this join
is unnecessary because R.RESOURCE_ID is the unique identifier on the
Resources (R) table...so if LR.CURRENT_RESOURCE_ID = R.RESOURCE_ID then
this RESOURCES row will always have a LOGICAL_RESOURCE_ID which matches
the LOGICAL_RESOURCES row.

Making this change changed the processing results of the following query
from over 5 minutes down to under 1 second on my postgresql db with
~30,000 patients and ~300,000 conditions:
`GET [base]/Patient?_has:Condition:patient:code=http://snomed.info/sct|44054006`

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>