### PR TITLE
Split COS endpointurl into internal and external

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -701,7 +701,7 @@ To disable the multitenant feature for a particular offering add to your `fhirSe
 #### 3.4.2.4 Database Access TransactionManager Timeout
 The TransactionManager controls the timeout of database queries.  
 
-To expand the transaction timeout value, one can copy over the `transaction-manager-long.xml` from the WLP configDropins from `/disabled` to `/overrides` folder, or set the Environment variable `FHIR_TRANSACTION_MANAGER_TIMEOUT=120s` or enter the value in the server.env file at the root of the WLP instance.  The value should be at least as granular as seconds or minutes.  Example values are 120s or 2m.  You should not lower this below 120s. 
+To expand the transaction timeout value, one can copy over the `transaction-manager-long.xml` from the WLP configDropins from `/disabled` to `/overrides` folder, or set the Environment variable `FHIR_TRANSACTION_MANAGER_TIMEOUT=120s` or enter the value in the server.env file at the root of the WLP instance.  The value should be at least as granular as seconds or minutes.  Example values are 120s or 2m.  You should not lower this below 120s.
 
 # 4 Customization
 You can modify the default server implementation by taking advantage of the IBM FHIR server's extensibility. The following extension points are available:
@@ -1533,7 +1533,8 @@ BulkData web application writes the exported FHIR resources to an IBM Cloud Obje
     "jobParameters": {
         "cos.bucket.name": "exports",
         "cos.location": "us",
-        "cos.endpointurl": "fake",
+        "cos.endpoint.internal": "fake",
+        "cos.endpoint.external": "fake",
         "cos.credential.ibm": "N",
         "cos.api.key": "fake",
         "cos.srvinst.id": "fake"
@@ -1854,7 +1855,8 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/moduleName`|string| Fixed value, always set to fhir-bulkimportexport.war |
 |`fhirServer/bulkdata/jobParameters/cos.bucket.name`|string|Object store bucket name |
 |`fhirServer/bulkdata/jobParameters/cos.location`|string|Object store location |
-|`fhirServer/bulkdata/jobParameters/cos.endpointurl`|string|Object store end point url |
+|`fhirServer/bulkdata/jobParameters/cos.endpoint.internal`|string|Object store end point url used to read/write from COS |
+|`fhirServer/bulkdata/jobParameters/cos.endpoint.external`|string|Object store end point url used in the constructed download URLs|
 |`fhirServer/bulkdata/jobParameters/credential.ibm`|string|If use IBM credential, "Y" or "N" |
 |`fhirServer/bulkdata/jobParameters/cos.api.key`|string|API key for accessing IBM COS |
 |`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|string|Service instance Id for accessing IBM COS |
@@ -2027,7 +2029,8 @@ must restart the server for that change to take effect.
 |`fhirServer/audit/serviceProperties/geoCounty`|N|N|
 |`fhirServer/bulkdata/jobParameters/cos.bucket.name`|Y|Y|
 |`fhirServer/bulkdata/jobParameters/cos.location`|Y|Y|
-|`fhirServer/bulkdata/jobParameters/cos.endpointurl`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.endpoint.internal`|Y|Y|
+|`fhirServer/bulkdata/jobParameters/cos.endpoint.external`|Y|Y|
 |`fhirServer/bulkdata/jobParameters/credential.ibm`|Y|Y|
 |`fhirServer/bulkdata/jobParameters/cos.api.key`|Y|Y|
 |`fhirServer/bulkdata/jobParameters/cos.srvinst.id`|Y|Y|

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportChunkJob.xml
@@ -22,7 +22,8 @@
                 <properties>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
@@ -23,7 +23,8 @@
                 <properties>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
@@ -22,7 +22,8 @@
                 <properties>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
+++ b/fhir-bulkimportexport-webapp/src/main/java/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
@@ -20,7 +20,8 @@
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>
@@ -35,7 +36,8 @@
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.operationoutcomes.bucket.name" value="#{jobParameters['cos.operationoutcomes.bucket.name']}"/>
@@ -50,7 +52,8 @@
                     <property name="fhir.datastoreid" value="#{jobParameters['fhir.datastoreid']}"/>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.bucket.name" value="#{jobParameters['cos.bucket.name']}"/>
@@ -62,7 +65,8 @@
                 <properties>
                     <property name="cos.api.key" value="#{jobParameters['cos.api.key']}"/>
                     <property name="cos.srvinst.id" value="#{jobParameters['cos.srvinst.id']}"/>
-                    <property name="cos.endpointurl" value="#{jobParameters['cos.endpointurl']}"/>
+                    <property name="cos.endpoint.internal" value="#{jobParameters['cos.endpoint.internal']}"/>
+                    <property name="cos.endpoint.external" value="#{jobParameters['cos.endpoint.external']}"/>
                     <property name="cos.location" value="#{jobParameters['cos.location']}"/>
                     <property name="cos.credential.ibm" value="#{jobParameters['cos.credential.ibm']}"/>
                     <property name="cos.operationoutcomes.bucket.name" value="#{jobParameters['cos.operationoutcomes.bucket.name']}"/>

--- a/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
+++ b/fhir-bulkimportexport-webapp/src/main/java/com/ibm/fhir/jbatch/bulkdata/common/Constants.java
@@ -56,7 +56,7 @@ public class Constants {
     // Job parameters
     public static final String COS_API_KEY = "cos.api.key";
     public static final String COS_SRVINST_ID = "cos.srvinst.id";
-    public static final String COS_ENDPOINT_URL = "cos.endpointurl";
+    public static final String COS_ENDPOINT_URL = "cos.endpoint.internal";
     public static final String COS_LOCATION = "cos.location";
     public static final String COS_BUCKET_NAME = "cos.bucket.name";
     public static final String COS_IS_IBM_CREDENTIAL = "cos.credential.ibm";

--- a/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
@@ -131,7 +131,8 @@
             "jobParameters": {
                 "cos.bucket.name": "fhirbulkdata",
                 "cos.location": "us",
-                "cos.endpointurl": "https://minio:9000",
+                "cos.endpoint.internal": "https://minio:9000",
+                "cos.endpoint.external": "https://minio:9000",
                 "cos.credential.ibm": "N",
                 "cos.api.key": "minio",
                 "cos.srvinst.id": "change-password"

--- a/fhir-server/liberty-config/config/default/fhir-server-config-postgresql.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-postgresql.json
@@ -69,7 +69,8 @@
             "jobParameters": {
                 "cos.bucket.name": "fhir-r4-connectathon",
                 "cos.location": "us",
-                "cos.endpointurl": "fake",
+                "cos.endpoint.internal": "fake",
+                "cos.endpoint.external": "fake",
                 "cos.credential.ibm": "Y",
                 "cos.api.key": "fake",
                 "cos.srvinst.id": "fake"

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -133,7 +133,8 @@
             "jobParameters": {
                 "cos.bucket.name": "fhir-r4-connectathon",
                 "cos.location": "us",
-                "cos.endpointurl": "fake",
+                "cos.endpoint.internal": "fake",
+                "cos.endpoint.external": "fake",
                 "cos.credential.ibm": "N",
                 "cos.access.key": "fake",
                 "cos.secret.key": "fake"

--- a/fhir-tools/src/main/resources/.gitignore
+++ b/fhir-tools/src/main/resources/.gitignore
@@ -1,0 +1,1 @@
+/modelClasses

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -179,7 +179,8 @@ public class BulkDataClient {
         builder.moduleName(properties.get(BulkDataConfigUtil.MODULE_NAME));
         builder.cosBucketName(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_BUCKET));
         builder.cosLocation(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_LOCATION));
-        builder.cosEndpointUrl(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT));
+        builder.cosEndpointInternal(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT_INTERNAL));
+        builder.cosEndpointExternal(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT_EXTERNAL));
         builder.cosCredentialIbm(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_IBM));
         builder.cosApiKey(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_KEY));
         builder.cosSrvInstId(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ID));
@@ -532,7 +533,7 @@ public class BulkDataClient {
         String resourceTypes = response.getJobParameters().getFhirResourceType();
         String cosBucketPathPrefix = response.getJobParameters().getCosBucketPathPrefix();
 
-        String baseCosUrl = properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT);
+        String baseCosUrl = properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT_EXTERNAL);
         String bucket = properties.get(BulkDataConfigUtil.JOB_PARAMETERS_BUCKET);
 
         String request = "$import";
@@ -613,7 +614,8 @@ public class BulkDataClient {
         builder.cosBucketName(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_BUCKET));
         builder.cosBucketNameOperationOutcome(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_BUCKET));
         builder.cosLocation(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_LOCATION));
-        builder.cosEndpointUrl(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT));
+        builder.cosEndpointInternal(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT_INTERNAL));
+        builder.cosEndpointExternal(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ENDPOINT_EXTERNAL));
         builder.cosCredentialIbm(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_IBM));
         builder.cosApiKey(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_KEY));
         builder.cosSrvInstId(properties.get(BulkDataConfigUtil.JOB_PARAMETERS_ID));

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/BulkDataConfigUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/BulkDataConfigUtil.java
@@ -28,7 +28,8 @@ public class BulkDataConfigUtil {
 
     public static final String JOB_PARAMETERS_BUCKET = "cos.bucket.name";
     public static final String JOB_PARAMETERS_LOCATION = "cos.location";
-    public static final String JOB_PARAMETERS_ENDPOINT = "cos.endpointurl";
+    public static final String JOB_PARAMETERS_ENDPOINT_INTERNAL = "cos.endpoint.internal";
+    public static final String JOB_PARAMETERS_ENDPOINT_EXTERNAL = "cos.endpoint.external";
     public static final String JOB_PARAMETERS_TENANT = "fhir.tenant";
     public static final String JOB_PARAMETERS_IBM = "cos.credential.ibm";
     public static final String JOB_PARAMETERS_KEY = "cos.api.key";
@@ -66,7 +67,8 @@ public class BulkDataConfigUtil {
         if (jobParameters != null) {
             properties.put(JOB_PARAMETERS_BUCKET, jobParameters.getStringProperty(JOB_PARAMETERS_BUCKET));
             properties.put(JOB_PARAMETERS_LOCATION, jobParameters.getStringProperty(JOB_PARAMETERS_LOCATION));
-            properties.put(JOB_PARAMETERS_ENDPOINT, jobParameters.getStringProperty(JOB_PARAMETERS_ENDPOINT));
+            properties.put(JOB_PARAMETERS_ENDPOINT_INTERNAL, jobParameters.getStringProperty(JOB_PARAMETERS_ENDPOINT_INTERNAL));
+            properties.put(JOB_PARAMETERS_ENDPOINT_EXTERNAL, jobParameters.getStringProperty(JOB_PARAMETERS_ENDPOINT_EXTERNAL));
             properties.put(JOB_PARAMETERS_TENANT, jobParameters.getStringProperty(JOB_PARAMETERS_TENANT));
             properties.put(JOB_PARAMETERS_IBM, jobParameters.getStringProperty(JOB_PARAMETERS_IBM));
             properties.put(JOB_PARAMETERS_KEY, jobParameters.getStringProperty(JOB_PARAMETERS_KEY));

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobExecutionResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobExecutionResponse.java
@@ -273,8 +273,14 @@ public class JobExecutionResponse {
         }
 
         @Override
-        public Builder cosEndpointUrl(String cosEndpointUrl) {
-            jobParameter.setCosEndpointUrl(cosEndpointUrl);
+        public Builder cosEndpointInternal(String cosEndpointUrl) {
+            jobParameter.setCosEndpointInternal(cosEndpointUrl);
+            return this;
+        }
+
+        @Override
+        public Builder cosEndpointExternal(String cosEndpointUrl) {
+            jobParameter.setCosEndpointExternal(cosEndpointUrl);
             return this;
         }
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceRequest.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceRequest.java
@@ -39,7 +39,8 @@ import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
         "fhir.exportFormat": "application/fhir+ndjson",
         "cos.bucket.name": "fhir-r4-connectathon",
         "cos.location": "us",
-        "cos.endpointurl": "https://fake.cloud",
+        "cos.endpoint.internal": "https://fake.cloud",
+        "cos.endpoint.external": "https://fake.cloud",
         "cos.credential.ibm": "Y",
         "cos.api.key": "key",
         "cos.srvinst.id": "crn:v1:bluemix:public:cloud-object-storage:global:a/fake::",
@@ -137,8 +138,14 @@ public class JobInstanceRequest {
         }
 
         @Override
-        public Builder cosEndpointUrl(String cosEndpointUrl) {
-            jobParameter.setCosEndpointUrl(cosEndpointUrl);
+        public Builder cosEndpointInternal(String cosEndpointUrl) {
+            jobParameter.setCosEndpointInternal(cosEndpointUrl);
+            return this;
+        }
+
+        @Override
+        public Builder cosEndpointExternal(String cosEndpointUrl) {
+            jobParameter.setCosEndpointExternal(cosEndpointUrl);
             return this;
         }
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
@@ -49,7 +49,8 @@ public class JobParameter {
     private String cosBucketName;
     private String cosOperationBucketNameOo;
     private String cosLocation;
-    private String cosEndpointUrl;
+    private String cosEndpointInternal;
+    private String cosEndpointExternal;
     private String cosCredentialIbm;
     private String cosApiKey;
     private String cosSrvInstId;
@@ -111,12 +112,20 @@ public class JobParameter {
         this.cosLocation = cosLocation;
     }
 
-    public String getCosEndpointUrl() {
-        return cosEndpointUrl;
+    public String getCosEndpointInternal() {
+        return cosEndpointInternal;
     }
 
-    public void setCosEndpointUrl(String cosEndpointUrl) {
-        this.cosEndpointUrl = cosEndpointUrl;
+    public String getCosEndpointExternal() {
+        return cosEndpointExternal;
+    }
+
+    public void setCosEndpointInternal(String cosEndpointUrl) {
+        this.cosEndpointInternal = cosEndpointUrl;
+    }
+
+    public void setCosEndpointExternal(String cosEndpointUrl) {
+        this.cosEndpointExternal = cosEndpointUrl;
     }
 
     public String getCosCredentialIbm() {
@@ -240,10 +249,11 @@ public class JobParameter {
                 generator.write("cos.operationoutcomes.bucket.name", parameter.getCosOperationBucketNameOo());
             }
 
-            if (withSensitive) {
-                if (parameter.getCosEndpointUrl() != null) {
-                    generator.write("cos.endpointurl", parameter.getCosEndpointUrl());
-                }
+            if (parameter.getCosEndpointInternal() != null) {
+                generator.write("cos.endpoint.internal", parameter.getCosEndpointInternal());
+            }
+            if (parameter.getCosEndpointExternal() != null) {
+                generator.write("cos.endpoint.external", parameter.getCosEndpointExternal());
             }
             if (parameter.getCosLocation() != null) {
                 generator.write("cos.location", parameter.getCosLocation());
@@ -346,7 +356,9 @@ public class JobParameter {
 
         public Builder cosLocation(String cosLocation);
 
-        public Builder cosEndpointUrl(String cosEndpointUrl);
+        public Builder cosEndpointInternal(String cosEndpointUrl);
+
+        public Builder cosEndpointExternal(String cosEndpointUrl);
 
         public Builder cosCredentialIbm(String cosCredentialIbm);
 
@@ -406,9 +418,14 @@ public class JobParameter {
                 builder.cosLocation(cosLocation);
             }
 
-            if (obj.containsKey("cos.endpointurl")) {
-                String cosEndpointUrl = obj.getString("cos.endpointurl");
-                builder.cosEndpointUrl(cosEndpointUrl);
+            if (obj.containsKey("cos.endpoint.internal")) {
+                String cosEndpointUrl = obj.getString("cos.endpoint.internal");
+                builder.cosEndpointInternal(cosEndpointUrl);
+            }
+
+            if (obj.containsKey("cos.endpoint.external")) {
+                String cosEndpointUrl = obj.getString("cos.endpoint.external");
+                builder.cosEndpointExternal(cosEndpointUrl);
             }
 
             if (obj.containsKey("cos.credential.ibm")) {
@@ -500,23 +517,24 @@ public class JobParameter {
 
     @Override
     public String toString() {
-        return "JobParameter [fhirResourceType=" + fhirResourceType + 
-                ", fhirSearchFromDate=" + fhirSearchFromDate + 
-                ", fhirTenant=" + fhirTenant + 
-                ", fhirDataStoreId=" + fhirDataStoreId + 
-                ", fhirPatientGroupId=" + fhirPatientGroupId + 
-                ", fhirTypeFilters=" + fhirTypeFilters + 
-                ", fhirExportFormat=" + fhirExportFormat + 
-                ", inputs=" + inputs + 
-                ", storageDetail=" + storageDetail + 
-                ", incomingUrl=" + incomingUrl + 
-                ", cosBucketName=" + cosBucketName + 
-                ", cosOperationBucketNameOo=" + cosOperationBucketNameOo + 
-                ", cosLocation=" + cosLocation + 
-                ", cosEndpointUrl=" + cosEndpointUrl + 
-                ", cosCredentialIbm=" + cosCredentialIbm + 
-                ", cosApiKey=" + cosApiKey + 
-                ", cosSrvInstId=" + cosSrvInstId + 
+        return "JobParameter [fhirResourceType=" + fhirResourceType +
+                ", fhirSearchFromDate=" + fhirSearchFromDate +
+                ", fhirTenant=" + fhirTenant +
+                ", fhirDataStoreId=" + fhirDataStoreId +
+                ", fhirPatientGroupId=" + fhirPatientGroupId +
+                ", fhirTypeFilters=" + fhirTypeFilters +
+                ", fhirExportFormat=" + fhirExportFormat +
+                ", inputs=" + inputs +
+                ", storageDetail=" + storageDetail +
+                ", incomingUrl=" + incomingUrl +
+                ", cosBucketName=" + cosBucketName +
+                ", cosOperationBucketNameOo=" + cosOperationBucketNameOo +
+                ", cosLocation=" + cosLocation +
+                ", cosEndpointInternal=" + cosEndpointInternal +
+                ", cosEndpointExternal=" + cosEndpointExternal +
+                ", cosCredentialIbm=" + cosCredentialIbm +
+                ", cosApiKey=" + cosApiKey +
+                ", cosSrvInstId=" + cosSrvInstId +
                 ", cosBucketPathPrefix=" + cosBucketPathPrefix + "]";
     }
 }

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobRestTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/model/BulkExportJobRestTest.java
@@ -311,7 +311,8 @@ public class BulkExportJobRestTest {
                         "        \"fhir.resourcetype\": \"Patient\",\n" +
                         "        \"cos.bucket.name\": \"fhir-r4-connectathon\",\n" +
                         "        \"cos.location\": \"us\",\n" +
-                        "        \"cos.endpointurl\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.internal\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.external\": \"https://fake.cloud\",\n" +
                         "        \"cos.credential.ibm\": \"Y\",\n" +
                         "        \"cos.api.key\": \"key\",\n" +
                         "        \"cos.srvinst.id\": \"crn:v1:bluemix:public:cloud-object-storage:global:a/<>::\",\n" +
@@ -363,7 +364,8 @@ public class BulkExportJobRestTest {
                         "        \"fhir.resourcetype\": \"Patient\",\n" +
                         "        \"cos.bucket.name\": \"fhir-r4-connectathon\",\n" +
                         "        \"cos.location\": \"us\",\n" +
-                        "        \"cos.endpointurl\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.internal\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.external\": \"https://fake.cloud\",\n" +
                         "        \"cos.credential.ibm\": \"Y\",\n" +
                         "        \"cos.api.key\": \"key\",\n" +
                         "        \"cos.srvinst.id\": \"crn:v1:bluemix:public:cloud-object-storage:global:a/<>::\",\n" +
@@ -713,7 +715,8 @@ public class BulkExportJobRestTest {
                         "        \"fhir.resourcetype\": \"Patient\",\n" +
                         "        \"cos.bucket.name\": \"fhir-r4-connectathon\",\n" +
                         "        \"cos.location\": \"us\",\n" +
-                        "        \"cos.endpointurl\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.internal\": \"https://fake.cloud\",\n" +
+                        "        \"cos.endpoint.external\": \"https://fake.cloud\",\n" +
                         "        \"cos.credential.ibm\": \"Y\",\n" +
                         "        \"cos.api.key\": \"key\",\n" +
                         "        \"cos.srvinst.id\": \"crn:v1:bluemix:public:cloud-object-storage:global:a/<>::\",\n" +

--- a/operation/fhir-operation-bulkdata/src/test/resources/testdata/config/default/fhir-server-config.json
+++ b/operation/fhir-operation-bulkdata/src/test/resources/testdata/config/default/fhir-server-config.json
@@ -8,7 +8,8 @@
             "jobParameters": {
                 "cos.bucket.name": "fhir-r4-connectathon",
                 "cos.location": "us",
-                "cos.endpointurl": "fake",
+                "cos.endpoint.internal": "fake",
+                "cos.endpoint.external": "fake",
                 "fhir.tenant": "default",
                 "cos.credential.ibm": "Y",
                 "cos.api.key": "fake",


### PR DESCRIPTION
When running on VPC, the cos URL used by the application should be the
"direct" one.  However, we still need to use the "public" one for the
donwload urls in the final response.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>