### PR TITLE
fix: postgres/db2 refresh of the stored procedure

### DIFF
--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
@@ -374,6 +374,10 @@ public class Main {
         if (!MULTITENANT_FEATURE_ENABLED.contains(dbType) && newDb ) {
             populateResourceTypeAndParameterNameTableEntries(null);
         }
+
+        // Let's refresh the procedures and functions.
+        logger.info("Refreshing procedures and functions");
+        updateProcedures();
     }
 
     /**
@@ -475,7 +479,7 @@ public class Main {
                     tx.setRollbackOnly();
                     throw x;
                 }
-                c.commit();
+                // Reminder: Don't fall into the trap, let the connectionPool and Transaction Management handle the transaction commit.
             } catch (SQLException x) {
                 tx.setRollbackOnly();
                 throw translator.translate(x);


### PR DESCRIPTION
- issue updating the stored procedure and function
- Verify the signature of the postgres procedure/function
```
SELECT md5(prosrc),proname FROM pg_proc WHERE proname =
'add_any_resource';
```

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>