### PR TITLE
Prevent unauthorized access to Patient resource before it happens

### DIFF
--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -47,6 +47,19 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     private static final String BEARER_TOKEN_PREFIX = "Bearer";
     private static final String PATIENT_REF_PREFIX = "Patient/";
 
+    private static final String REQUEST_NOT_PERMITTED = "Requested interaction is not permitted by any of the passed scopes.";
+
+    @Override
+    public void beforeRead(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        DecodedJWT jwt = JWT.decode(getAccessToken());
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        if ("Patient".equals(event.getFhirResourceType()) && !patientIdFromToken.contains(event.getFhirResourceId())) {
+            String msg = "Read of 'Patient/" + event.getFhirResourceId() + "' is not permitted for patient context '" + patientIdFromToken + "'.";
+            throw new FHIRPersistenceInterceptorException(msg)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
+        }
+    }
+
     @Override
     public void beforeCreate(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
@@ -196,9 +209,8 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                     "' is not granted by any of the provided scopes: " + approvedScopes +
                     " with context id(s): " + contextIds);
         }
-        String msg = "Requested interaction is not permitted by any of the passed scopes.";
-        throw new FHIRPersistenceInterceptorException(msg)
-                .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
+        throw new FHIRPersistenceInterceptorException(REQUEST_NOT_PERMITTED)
+                .withIssue(FHIRUtil.buildOperationOutcomeIssue(REQUEST_NOT_PERMITTED, IssueType.FORBIDDEN));
     }
 
     /**

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -51,10 +51,24 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
 
     @Override
     public void beforeRead(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        enforceDirectPatientAcess(event);
+    }
+
+    @Override
+    public void beforeVread(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        enforceDirectPatientAcess(event);
+    }
+
+    @Override
+    public void beforeHistory(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        enforceDirectPatientAcess(event);
+    }
+
+    private void enforceDirectPatientAcess(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
         List<String> patientIdFromToken = getPatientIdFromToken(jwt);
         if ("Patient".equals(event.getFhirResourceType()) && !patientIdFromToken.contains(event.getFhirResourceId())) {
-            String msg = "Read of 'Patient/" + event.getFhirResourceId() + "' is not permitted for patient context '" + patientIdFromToken + "'.";
+            String msg = "Interaction with 'Patient/" + event.getFhirResourceId() + "' is not permitted under patient context '" + patientIdFromToken + "'.";
             throw new FHIRPersistenceInterceptorException(msg)
                     .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.smart.test;
 import static com.ibm.fhir.model.type.String.string;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -150,6 +151,31 @@ public class AuthzPolicyEnforcementTest {
             assertTrue(shouldSucceed(resourceType, OBSERVATION_APPROVED, permission, WRITE_APPROVED));
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceType, OBSERVATION_APPROVED, permission, WRITE_APPROVED));
+        }
+    }
+
+    @Test
+    public void testReadPatient() throws FHIRPersistenceInterceptorException {
+        FHIRRequestContext.get().setHttpHeaders(buildRequestHeaders("patient/Patient.read"));
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, PATIENT_ID);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
+            interceptor.beforeRead(event);
+        } catch (FHIRPersistenceInterceptorException e) {
+            fail("Patient read was not allowed but should have been");
+        }
+
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "bogus");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
+            interceptor.beforeRead(event);
+            fail("Patient read was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
         }
     }
 


### PR DESCRIPTION
This prevents us from leaking information about what patient resources
exist / don't exist on the system, which was deemed useful in case an
implementer uses sensitive data for the Resource.id of the Patient
resources (which still isn't advised).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>