### PR TITLE
issue #1739 - Update _include and _revinclude parameter checking

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1885,6 +1885,7 @@ public class SearchUtil {
         String[] inclusionValueParts;
         String joinResourceType;
         String searchParameterName;
+        String resourceTypeAndParameterName;
         String searchParameterTargetType;
 
         SearchParameter searchParm;
@@ -1904,6 +1905,7 @@ public class SearchUtil {
             }
             joinResourceType = inclusionValueParts[0];
             searchParameterName = inclusionValueParts[1];
+            resourceTypeAndParameterName = joinResourceType + ":" + searchParameterName;
             searchParameterTargetType = inclusionValueParts.length == 3 ? inclusionValueParts[2] : null;
 
             if (SearchConstants.INCLUDE.equals(inclusionKeyword)) {
@@ -1915,7 +1917,7 @@ public class SearchUtil {
                 }
 
                 // Check allowed _include values
-                if (allowedIncludes != null && !allowedIncludes.contains(inclusionValue)) {
+                if (allowedIncludes != null && !allowedIncludes.contains(inclusionValue) && !allowedIncludes.contains(resourceTypeAndParameterName)) {
                     manageException("'" + inclusionValue + "' is not a valid _include parameter value for resource type '"
                             + resourceType.getSimpleName() + "'", lenient);
                     continue;
@@ -1937,7 +1939,7 @@ public class SearchUtil {
                 }
 
                 // Check allowed _revinclude values
-                if (allowedRevIncludes != null && !allowedRevIncludes.contains(inclusionValue)) {
+                if (allowedRevIncludes != null && !allowedRevIncludes.contains(inclusionValue) && !allowedRevIncludes.contains(resourceTypeAndParameterName)) {
                     manageException("'" + inclusionValue + "' is not a valid _revinclude parameter value for resource type '"
                             + resourceType.getSimpleName() + "'", lenient);
                     continue;

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/SearchParameterRestrictionTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/SearchParameterRestrictionTest.java
@@ -144,13 +144,53 @@ public class SearchParameterRestrictionTest extends BaseSearchTest {
     }
 
     @Test
-    public void testIncludeAllowed() throws Exception {
+    public void testIncludeAllowedWithOptionalTargetTypeNotSpecified() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
 
         Map<String, List<String>> queryParameters = new HashMap<>();
         queryParameters.put("_include", Collections.singletonList("Patient:general-practitioner"));
 
         SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testIncludeAllowedWithOptionalTargetTypeSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_include", Collections.singletonList("Patient:general-practitioner:Practitioner"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testIncludeAllowedWithRequiredTargetTypeSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_include", Collections.singletonList("ExplanationOfBenefit:care-team:Practitioner"));
+
+        SearchUtil.parseQueryParameters(ExplanationOfBenefit.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testIncludeNotAllowedWithRequiredTargetTypeNotSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_include", Collections.singletonList("ExplanationOfBenefit:care-team"));
+
+        SearchUtil.parseQueryParameters(ExplanationOfBenefit.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testIncludeNotAllowedWithRequiredTargetTypeNotMatched() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_include", Collections.singletonList("ExplanationOfBenefit:care-team:Organization"));
+
+        SearchUtil.parseQueryParameters(ExplanationOfBenefit.class, queryParameters);
     }
 
     @Test
@@ -214,11 +254,51 @@ public class SearchParameterRestrictionTest extends BaseSearchTest {
     }
 
     @Test
-    public void testRevIncludeAllowed() throws Exception {
+    public void testRevIncludeAllowedWithOptionalTargetTypeNotSpecified() throws Exception {
         FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
 
         Map<String, List<String>> queryParameters = new HashMap<>();
         queryParameters.put("_revinclude", Collections.singletonList("MedicationRequest:intended-performer"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testRevIncludeAllowedWithOptionalTargetTypeSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_revinclude", Collections.singletonList("MedicationRequest:intended-performer:Patient"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test
+    public void testRevIncludeAllowedWithRequiredTargetTypeSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_revinclude", Collections.singletonList("ExplanationOfBenefit:payee:Patient"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testRevIncludeNotAllowedWithRequiredTargetTypeNotSpecified() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_revinclude", Collections.singletonList("ExplanationOfBenefit:payee"));
+
+        SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testRevIncludeNotAllowedWithRequiredTargetTypeNotMatched() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext(TENANT_ID));
+
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        queryParameters.put("_revinclude", Collections.singletonList("ExplanationOfBenefit:payee:Practitioner"));
 
         SearchUtil.parseQueryParameters(Patient.class, queryParameters);
     }

--- a/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant7/fhir-server-config.json
@@ -18,7 +18,7 @@
                 "searchIncludes": [
                     "ExplanationOfBenefit:patient",
                     "ExplanationOfBenefit:provider",
-                    "ExplanationOfBenefit:care-team",
+                    "ExplanationOfBenefit:care-team:Practitioner",
                     "ExplanationOfBenefit:coverage",
                     "ExplanationOfBenefit:insurer",
                     "ExplanationOfBenefit:*"],
@@ -27,6 +27,8 @@
                     "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
                     "_lastUpdated": "http://hl7.org/fhir/SearchParameter/Resource-lastUpdated",
                     "patient": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-patient",
+                    "care-team": "http://hl7.org/fhir/SearchParameter/ExplanationOfBenefit-care-team",
+                    "payee": "http://hl7.org/fhir/SearchParameter/ExplanationOfBenefit-payee",
                     "type": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-type",
                     "identifier": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-identifier",
                     "service-date": "http://hl7.org/fhir/us/carin-bb/SearchParameter/explanationofbenefit-service-date"
@@ -34,7 +36,9 @@
             },
             "Patient": {
                 "searchIncludes": ["Patient:general-practitioner"],
-                "searchRevIncludes": ["MedicationRequest:intended-performer"],
+                "searchRevIncludes": [
+                    "ExplanationOfBenefit:payee:Patient",
+                    "MedicationRequest:intended-performer"],
                 "searchParameterCombinations": ["","_id",
                     "multiple-birth-count",
                     "multiple-birth-count-basic"]


### PR DESCRIPTION
The validity checking of the _include and _revinclude parameters has been updated so if the configuration value does not specify a target resource type, then the parameter value only needs to match on its first two components (regardless of target resource type specified).

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>