### PR TITLE
HREX - Update .index.json

### DIFF
--- a/conformance/fhir-ig-davinci-hrex/CHANGELOG.md
+++ b/conformance/fhir-ig-davinci-hrex/CHANGELOG.md
@@ -3,3 +3,5 @@
     - From `($this.agent.who.resolve().is Practitioner or Device) implies exists()`
     - To `(($this.agent.who.resolve() is Practitioner) or ($this.agent.who.resolve() is Device)) implies exists()`
 - removed invalid ImplementationGuide parameters `copyrightyear`, `releaselabel`, and more
+
+18 DEC 2020 - Removed invalid entry in the .index.json

--- a/conformance/fhir-ig-davinci-hrex/src/main/resources/hl7/fhir/us/davinci-hrex/package/.index.json
+++ b/conformance/fhir-ig-davinci-hrex/src/main/resources/hl7/fhir/us/davinci-hrex/package/.index.json
@@ -16,12 +16,6 @@
       "version": "0.2.0"
     },
     {
-      "filename": "Bundle-subscription-notification-with-document.json",
-      "resourceType": "Bundle",
-      "id": "subscription-notification-with-document",
-      "type": "history"
-    },
-    {
       "filename": "SearchParameter-hrex-coverage-subscriber.json",
       "resourceType": "SearchParameter",
       "id": "hrex-coverage-subscriber",


### PR DESCRIPTION
Warning about invalid entry when discovering HREX profile. 
An example snuck into the .index.json. 

Fixes this warning on startup
fhir-server_1  | [WARNING ] Skipping index entry 2 due to one or more missing required fields, beginning with: url

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>