### PR TITLE
fix: test that doesn't account for year shifts

### DIFF
--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/BetweenFunctionTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/BetweenFunctionTest.java
@@ -14,6 +14,8 @@ import static org.testng.Assert.fail;
 
 import java.math.BigDecimal;
 import java.time.DateTimeException;
+import java.time.Year;
+import java.time.temporal.ChronoField;
 import java.util.Collection;
 
 import org.testng.annotations.Test;

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/BetweenFunctionTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/BetweenFunctionTest.java
@@ -121,6 +121,7 @@ public class BetweenFunctionTest {
             .build();
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         Collection<FHIRPathNode> result = evaluator.evaluate(patient, "between(Patient.birthDate, today(), 'years')");
-        assertEquals(getQuantityValue(result), quantityValue(new BigDecimal(50), "years"));
+        int diff = Year.now().get(ChronoField.YEAR) - 2020;
+        assertEquals(getQuantityValue(result), quantityValue(new BigDecimal(50 + diff), "years"));
     }
 }


### PR DESCRIPTION
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>