### PR TITLE
Duplicate Job Parameters fhir.dataSourcesInfo are created #1855

### DIFF
--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -308,9 +308,6 @@ public class JobParameter {
                 type = parameter.getStorageDetails().getType();
             }
 
-            if (parameter.getInputs() != null) {
-                generator.write("fhir.dataSourcesInfo", writeToBase64(parameter.getInputs()));
-            }
             generator.write("import.fhir.storagetype", type);
 
             if (parameter.getIncomingUrl() != null) {


### PR DESCRIPTION
- Removed the duplicate serialization of the fhir.dataSourcesInfo

closes #1855 

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>