### PR TITLE
Confusing error when request is targetted for an invalid tenant id #1792

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/FHIRPersistenceJDBCFactory.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/FHIRPersistenceJDBCFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,7 @@ import com.ibm.fhir.persistence.jdbc.impl.FHIRPersistenceJDBCImpl;
  * Factory which serves up instances of the JDBC persistence implementation.
  */
 public class FHIRPersistenceJDBCFactory implements FHIRPersistenceFactory {
-    
+
     // All instances created by this factory share the common cache object (which is tenant-aware)
     private final FHIRPersistenceJDBCTenantCache tenantCache = new FHIRPersistenceJDBCTenantCache();
 
@@ -29,7 +29,7 @@ public class FHIRPersistenceJDBCFactory implements FHIRPersistenceFactory {
             FHIRPersistenceJDBCCache cache = tenantCache.getCacheForTenantAndDatasource();
             return new FHIRPersistenceJDBCImpl(cache);
         } catch (Exception e) {
-            throw new FHIRPersistenceException("Unexpected exception while creating JDBC persistence layer: ", e); 
+            throw new FHIRPersistenceException("Unexpected exception while creating JDBC persistence layer: '" + e.getMessage() + "'", e);
         }
     }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/cache/FHIRPersistenceJDBCTenantCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/cache/FHIRPersistenceJDBCTenantCache.java
@@ -38,7 +38,8 @@ public class FHIRPersistenceJDBCTenantCache {
         FHIRPersistenceJDBCCache result = cacheMap.computeIfAbsent(cacheKey, (k) -> createCache(k));
         if (result == null) {
             // exception handled inside createCache (which will have been logged)
-            throw new IllegalStateException("createCache failed " + cacheKey);
+            // The cacheKey is passed back up since it is the combination of the datastore and the key
+            throw new IllegalStateException("createCache failed for tenant " + FHIRRequestContext.get().getTenantId());
         }
 
         return result;
@@ -68,13 +69,13 @@ public class FHIRPersistenceJDBCTenantCache {
             PropertyGroup pg = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
             if (pg == null) {
                 logger.severe("Missing datasource configuration for '" + dsPropertyName + "'");
-                result = null;
+                throw new IllegalStateException("Missing datasource configuration for " + dsPropertyName);
             } else {
                 int externalSystemCacheSize = pg.getIntProperty("externalSystemCacheSize", 1000);
                 int externalValueCacheSize = pg.getIntProperty("externalValueCacheSize", 100000);
                 return FHIRPersistenceJDBCCacheUtil.create(externalSystemCacheSize, externalValueCacheSize);
             }
-        } catch(IllegalStateException ise) {
+        } catch (IllegalStateException ise) {
             throw ise;
         } catch (Exception x) {
             logger.log(Level.SEVERE, "Failed to load configuration", x);

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/helper/FHIRPersistenceHelper.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/helper/FHIRPersistenceHelper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,7 +29,7 @@ public class FHIRPersistenceHelper implements PersistenceHelper {
 
     // Issue #1366. Keep one instance of each type of persistence factory instead of instantiating it every time
     private final ConcurrentHashMap<String, FHIRPersistenceFactory> persistenceFactoryCache = new ConcurrentHashMap<>();
-    
+
     public FHIRPersistenceHelper() {
         log.entering(this.getClass().getName(), "FHIRPersistenceHelper ctor");
         try {
@@ -42,7 +42,7 @@ public class FHIRPersistenceHelper implements PersistenceHelper {
             log.exiting(this.getClass().getName(), "FHIRPersistenceHelper ctor");
         }
     }
-    
+
     /**
      * Retrieves the name of the factory class that should be instantiated for use by the server.
      * @param factoryPropertyName name of the property that contains the {@link FHIRPersistenceFactory} class name.
@@ -78,22 +78,24 @@ public class FHIRPersistenceHelper implements PersistenceHelper {
             if (log.isLoggable(Level.FINE)) {
                 log.fine("Using FHIR persistence factory class name: " + factoryClassName);
             }
-            
+
             FHIRPersistenceFactory factory = persistenceFactoryCache.computeIfAbsent(factoryClassName, FHIRPersistenceHelper::newInstance );
-            
+
             if (factory != null) {
                 // Call the factory and return the implementation instance.
                 return factory.getInstance();
             } else {
                 throw new FHIRPersistenceException(PROPERTY_PERSISTENCE_FACTORY + " is configured incorrectly");
             }
+        } catch (FHIRPersistenceException fpe) {
+            throw fpe;
         } catch (Throwable t) {
             throw new FHIRPersistenceException(PROPERTY_PERSISTENCE_FACTORY + " is configured incorrectly", t);
         } finally {
             log.exiting(this.getClass().getName(), "getFHIRPersistenceImplementation");
         }
     }
-    
+
     /**
      * Create a new instance of the class
      * @param factoryClassName
@@ -106,10 +108,10 @@ public class FHIRPersistenceHelper implements PersistenceHelper {
         } catch (ClassNotFoundException e) {
             String msg = "An error occurred while trying to load FHIR persistence factory class '" + factoryClassName + "'";
             log.severe(msg + ": " + e);
-            
+
             throw new IllegalStateException("Failed to load persistence implementation class");
         }
-        
+
         try {
             if (FHIRPersistenceFactory.class.isAssignableFrom(factoryClass)) {
                 return (FHIRPersistenceFactory) factoryClass.getDeclaredConstructor().newInstance();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PersistenceLayerServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PersistenceLayerServerTest.java
@@ -20,34 +20,21 @@ import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.test.TestUtil;
 
 /**
- * Check the outcome of the server makes sense
- * <pre>{
-    "resourceType": "OperationOutcome",
-    "id": "c0-a8-56-16-d3b6fc1c-33b9-4b71-9296-e19452064973",
-    "issue": [
-        {
-            "severity": "fatal",
-            "code": "exception",
-            "details": {
-                "text": "FHIRPersistenceException: Unexpected exception while creating JDBC persistence layer: 'createCache failed dummy~default'"
-            }
-        }
-    ]
-}</pre>
+ * Tests for Valid Tenant Configuration
  */
 public class PersistenceLayerServerTest extends FHIRServerTestBase {
 
     @Test(groups = { "server-persistence-layer-tests" })
-    public void testPersistenceLayerResponse() throws Exception {
+    public void testPersistenceLayerResponseBadTenant() throws Exception {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
         Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
         Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Patient").request().header("X-FHIR-TENANT-ID", "IAMNOTAREALTENANT").post(entity, Response.class);
-        assertResponse(response, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
         OperationOutcome responsePatient = response.readEntity(OperationOutcome.class);
         assertEquals(responsePatient.getIssue().get(0).getDetails().getText().getValue(),
-            "FHIRPersistenceException: Unexpected exception while creating JDBC persistence layer: 'createCache failed IAMNOTAREALTENANT~default'");
+            "FHIRException: Tenant configuration does not exist: IAMNOTAREALTENANT");
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PersistenceLayerServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PersistenceLayerServerTest.java
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+
+/**
+ * Check the outcome of the server makes sense
+ * <pre>{
+    "resourceType": "OperationOutcome",
+    "id": "c0-a8-56-16-d3b6fc1c-33b9-4b71-9296-e19452064973",
+    "issue": [
+        {
+            "severity": "fatal",
+            "code": "exception",
+            "details": {
+                "text": "FHIRPersistenceException: Unexpected exception while creating JDBC persistence layer: 'createCache failed dummy~default'"
+            }
+        }
+    ]
+}</pre>
+ */
+public class PersistenceLayerServerTest extends FHIRServerTestBase {
+
+    @Test(groups = { "server-persistence-layer-tests" })
+    public void testPersistenceLayerResponse() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request().header("X-FHIR-TENANT-ID", "IAMNOTAREALTENANT").post(entity, Response.class);
+        assertResponse(response, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        OperationOutcome responsePatient = response.readEntity(OperationOutcome.class);
+        assertEquals(responsePatient.getIssue().get(0).getDetails().getText().getValue(),
+            "FHIRPersistenceException: Unexpected exception while creating JDBC persistence layer: 'createCache failed IAMNOTAREALTENANT~default'");
+    }
+}


### PR DESCRIPTION
- Disambiguates the Error Messages that are bubbled up through the
Persistence Layer
- Add Integration Test

Closes #1792 

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>