### PR TITLE
Remove inadvertent dependency on us-core from our base SearchTest

### DIFF
--- a/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
+++ b/fhir-server/liberty-config-tenants/config/tenant1/fhir-server-config.json
@@ -7,7 +7,7 @@
                 "searchParameters": {
                     "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
                     "subject": "http://hl7.org/fhir/SearchParameter/Observation-subject",
-                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                    "patient": "http://hl7.org/fhir/SearchParameter/clinical-patient",
                     "value-quantity": "http://hl7.org/fhir/SearchParameter/Observation-value-quantity",
                     "component-value-quantity": "http://hl7.org/fhir/SearchParameter/Observation-component-value-quantity"
                 }


### PR DESCRIPTION
USCore-specific functionality should be tested as part of our profile tests

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>