### PR TITLE
Make the 'compartment param not found' warning conditional

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -2288,7 +2288,7 @@ public class SearchUtil {
                                 }
                             }
                         }
-                    } else {
+                    } else if (!useStoredCompartmentParam()) {
                        log.warning("Compartment parameter not found: [" + resourceType + "] '" + searchParm + "'. This will stop compartment searches from working correctly.");
                     }
                 }


### PR DESCRIPTION
If `useStoredCompartmentParam` is set to true, then we shouldn't need the compartment inclusion parameters to be externally visible.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>