### PR TITLE
issue #1881 - add logic to allow reading of provenance resources

### DIFF
--- a/fhir-model/src/test/java/com/ibm/fhir/model/test/TestUtil.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/test/TestUtil.java
@@ -283,6 +283,19 @@ public class TestUtil {
     }
 
     /**
+     * Create a minimal resource of the specified type. Only required fields are present and all data is absent.
+     *
+     * @param type
+     *            the type of the resource to be returned
+     * @return the resource
+     * @throws Exception
+     * @implNote this function creates the resource via {@link #getMinimalResource(ResourceType, Format)} by specifying JSON format
+     */
+    public static <T extends Resource> T getMinimalResource(ResourceType type) throws Exception {
+        return getMinimalResource(type, Format.JSON);
+    }
+
+    /**
      * This function reads the contents of a minimal example resource file of the specified type and format from
      * fhir-examples, and returns a resource of the specified resource type and format.
      *
@@ -304,5 +317,4 @@ public class TestUtil {
             return FHIRParser.parser(format).parse(reader);
         }
     }
-
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1465,8 +1465,8 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
     }
 
     /**
-     * Augment the given allParameters list with ibm-internal parameters represents relationships
-     * of the fhirResource to its compartments. These parameter values are subsequently used
+     * Augment the given allParameters list with ibm-internal parameters that represent relationships
+     * between the fhirResource to its compartments. These parameter values are subsequently used
      * to improve the performance of compartment-based FHIR search queries. See
      * {@link CompartmentUtil#makeCompartmentParamName(String)} for details on how the
      * parameter name is composed for each relationship.

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/ReferenceUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/ReferenceUtil.java
@@ -42,9 +42,21 @@ public class ReferenceUtil {
      * Processes a Reference value from the FHIR model and interprets
      * it according to https://www.hl7.org/fhir/references.html#2.3.0
      *
-     * @param ref
-     * @param fullUrl the server
-     * @return
+     * <p>Absolute literal references will be converted to relative references if their base matches baseUrl.
+     *
+     * <p>The resulting ReferenceValue will contained an inferred ReferenceType
+     * and the structure of the ReferenceValue.value will vary accordingly:
+     * <ol>
+     * <li>LITERAL_RELATIVE: the id of the referenced resource</li>
+     * <li>LITERAL_ABSOLUTE: the full URI of the reference</li>
+     * <li>LOGICAL: the Identifier.value (Identifier.system is not presently stored)</li>
+     * <li>DISPLAY_ONLY: null</li>
+     * <li>INVALID: null</li>
+     * </ol>
+     *
+     * @param ref a non-null FHIR Reference object
+     * @param baseUrl the base URL used to determine whether to convert absolute references to relative references
+     * @return a structured representation of the reference value that varies by its inferred reference type
      */
     public static ReferenceValue createReferenceValueFrom(Reference ref, String baseUrl) {
         String value;

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/ReferenceValue.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/ReferenceValue.java
@@ -21,18 +21,24 @@ public class ReferenceValue {
         INVALID           // Not a valid reference
     }
 
-    // The type of the resource this reference points to. Can be null
     private final String targetResourceType;
 
-    // The value of the reference
     private final String value;
 
-    // The reference type
     private final ReferenceType type;
 
-    // Option version number to support versioned references when we need this
     private final Integer version;
 
+    /**
+     * @param targetResourceType
+     *          The resource type of the resource being referenced; can be null
+     * @param value
+     *          The value of the reference; the expected format of the value will vary based on the reference type
+     * @param type
+     *          The ReferenceType of the reference (LITERAL_RELATIVE | LITERAL_ABSOLUTE | LOGICAL | DISPLAY_ONLY | INVALID)
+     * @param version
+     *          The version of the target resource as specified in the reference, or null if the reference is not versioned
+     */
     public ReferenceValue(String targetResourceType, String value, ReferenceType type, Integer version) {
         this.targetResourceType = targetResourceType;
         this.value = value;
@@ -42,7 +48,7 @@ public class ReferenceValue {
 
 
     /**
-     * @return the targetResourceType
+     * @return the type of the resource this reference points to; can be null
      */
     public String getTargetResourceType() {
         return targetResourceType;
@@ -50,7 +56,7 @@ public class ReferenceValue {
 
 
     /**
-     * @return the value
+     * @return the value of the reference; the expected format of the value will vary based on the reference type
      */
     public String getValue() {
         return value;
@@ -58,7 +64,7 @@ public class ReferenceValue {
 
 
     /**
-     * @return the type
+     * @return the type of the reference itself
      */
     public ReferenceType getType() {
         return type;
@@ -66,7 +72,7 @@ public class ReferenceValue {
 
 
     /**
-     * @return the version
+     * @return the version of the target resource as specified in the reference, or null if the reference is not versioned
      */
     public Integer getVersion() {
         return version;

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -2238,7 +2238,8 @@ public class SearchUtil {
      * @param compartmentRefParams a map of parameter names to a set of compartment names (resource types)
      * @return a map of compartment name to a set of unique compartment reference values
      */
-    public static Map<String, Set<CompartmentReference>> extractCompartmentParameterValues(Resource fhirResource, Map<String, Set<java.lang.String>> compartmentRefParams) throws FHIRSearchException {
+    public static Map<String, Set<CompartmentReference>> extractCompartmentParameterValues(Resource fhirResource,
+            Map<String, Set<java.lang.String>> compartmentRefParams) throws FHIRSearchException {
         final Map<String, Set<CompartmentReference>> result = new HashMap<>();
         final String resourceType = fhirResource.getClass().getSimpleName();
 

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
@@ -1,11 +1,9 @@
-package com.ibm.fhir.server.test;
 /*
  * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-
+package com.ibm.fhir.server.test;
 
 import java.util.ArrayList;
 import java.util.function.Function;
@@ -28,7 +26,6 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedExceptio
 
 /**
  * Mock implementation of FHIRPersistence for use during testing.
- *
  */
 public class MockPersistenceImpl implements FHIRPersistence {
     int id = 0;
@@ -40,7 +37,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
         SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                 .success(true)
                 .resource(updatedResource);
-    	return resultBuilder.build();
+        return resultBuilder.build();
     }
 
     @SuppressWarnings("unchecked")

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -228,7 +228,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
      * then reject the request unless each Provenance targets at least one resource in the response bundle
      *
      * @throws IllegalStateException if the baseUrl cannot be computed from the request context
-     * @throws FHIRPersistenceInterceptorException if the list of provenanceTargets contains
+     * @throws FHIRPersistenceInterceptorException if access to one or more Provenance resources is denied
      */
     private void enforceProvenance(List<List<Reference>> provenanceTargets, Set<String> relativeResourcePaths)
             throws FHIRPersistenceInterceptorException {

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -266,7 +266,8 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                     if (result.isSuccess() && checkCompartment(result.getResource(), CompartmentType.PATIENT, contextIds)) {
                         allow = true;
                         break;
-                    } if (log.isLoggable(Level.FINE)){
+                    }
+                    if (!result.isSuccess() && log.isLoggable(Level.FINE)) {
                         log.fine("Skipping target " + referenceValue.getTargetResourceType() + "/" + referenceValue.getType() +
                                 "' during enforcement due to a read failure: " + result.getOutcome());
                     }

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -6,15 +6,12 @@
 
 package com.ibm.fhir.smart;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -24,7 +21,6 @@ import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.model.resource.Bundle;
-import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Provenance;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.resource.SearchParameter;
@@ -37,6 +33,9 @@ import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.SingleResourceResult;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.interceptor.FHIRPersistenceEvent;
 import com.ibm.fhir.persistence.interceptor.FHIRPersistenceInterceptor;
 import com.ibm.fhir.persistence.interceptor.FHIRPersistenceInterceptorException;
@@ -71,6 +70,19 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     @Override
     public void beforeHistory(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         enforceDirectPatientAccess(event);
+    }
+
+    private void enforceDirectPatientAccess(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        if ("Patient".equals(event.getFhirResourceType())) {
+            DecodedJWT jwt = JWT.decode(getAccessToken());
+            List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+            if (!patientIdFromToken.contains(event.getFhirResourceId())) {
+                String msg = "Interaction with 'Patient/" + event.getFhirResourceId() +
+                        "' is not permitted under patient context '" + patientIdFromToken + "'.";
+                throw new FHIRPersistenceInterceptorException(msg)
+                        .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
+            }
+        }
     }
 
     /**
@@ -127,7 +139,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                         // NOTE: We currently do not support OR'd compartment searches, nor do we currently expect more than one patient ID to be
                         // specified in the authorization token (see getPatientIdFromToken()). We will use the first ID specified for the compartment search.
                         FHIRSearchContext compartmentSearchContext = SearchUtil.parseQueryParameters("Patient", patientIdFromToken.get(0),
-                            ModelSupport.getResourceType(event.getFhirResourceType()), Collections.emptyMap(), searchContext.isLenient());
+                                ModelSupport.getResourceType(event.getFhirResourceType()), Collections.emptyMap(), searchContext.isLenient());
                         searchContext.getSearchParameters().addAll(compartmentSearchContext.getSearchParameters());
                     }
                 } catch (Exception e) {
@@ -135,16 +147,6 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                     throw new FHIRPersistenceInterceptorException(msg).withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.EXCEPTION));
                 }
             }
-        }
-    }
-
-    private void enforceDirectPatientAccess(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
-        DecodedJWT jwt = JWT.decode(getAccessToken());
-        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
-        if ("Patient".equals(event.getFhirResourceType()) && !patientIdFromToken.contains(event.getFhirResourceId())) {
-            String msg = "Interaction with 'Patient/" + event.getFhirResourceId() + "' is not permitted under patient context '" + patientIdFromToken + "'.";
-            throw new FHIRPersistenceInterceptorException(msg)
-                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }
     }
 
@@ -163,31 +165,50 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     @Override
     public void beforeUpdate(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        List<Scope> scopesFromToken = getScopesFromToken(jwt);
+
         // First, check READ permission on the existing resource to ensure we don't write over something that
         // the user doesn't have access to
-        enforce(event.getPrevFhirResource(), getPatientIdFromToken(jwt), Permission.READ, getScopesFromToken(jwt));
-        enforce(event.getFhirResource(), getPatientIdFromToken(jwt), Permission.WRITE, getScopesFromToken(jwt));
+        enforce(event.getPrevFhirResource(), patientIdFromToken, Permission.READ, scopesFromToken);
+        enforce(event.getFhirResource(), patientIdFromToken, Permission.WRITE, scopesFromToken);
     }
 
     @Override
     public void afterRead(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
-        enforce(event.getFhirResource(), getPatientIdFromToken(jwt), Permission.READ, getScopesFromToken(jwt));
+        Resource resource = event.getFhirResource();
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        List<Scope> scopesFromToken = getScopesFromToken(jwt);
+
+        enforceDirectProvenanceAccess(event, resource, patientIdFromToken, scopesFromToken);
+        enforce(resource, patientIdFromToken, Permission.READ, scopesFromToken);
     }
 
     @Override
     public void afterVread(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
-        enforce(event.getFhirResource(), getPatientIdFromToken(jwt), Permission.READ, getScopesFromToken(jwt));
+        Resource resource = event.getFhirResource();
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        List<Scope> scopesFromToken = getScopesFromToken(jwt);
+
+        enforceDirectProvenanceAccess(event, resource, patientIdFromToken, scopesFromToken);
+        enforce(resource, patientIdFromToken, Permission.READ, scopesFromToken);
     }
 
     @Override
     public void afterHistory(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        List<Scope> scopesFromToken = getScopesFromToken(jwt);
+
         if (event.getFhirResource() instanceof Bundle) {
             for ( Bundle.Entry entry : ((Bundle) event.getFhirResource()).getEntry()) {
-                if (entry.getResource() != null) {
-                    enforce(entry.getResource(), getPatientIdFromToken(jwt), Permission.READ, getScopesFromToken(jwt));
+                Resource resource = entry.getResource();
+
+                if (resource != null) {
+                    enforceDirectProvenanceAccess(event, resource, patientIdFromToken, scopesFromToken);
+                    enforce(resource, patientIdFromToken, Permission.READ, scopesFromToken);
                 }
             }
         } else {
@@ -196,43 +217,35 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
         }
     }
 
-    @Override
-    public void afterSearch(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
-        DecodedJWT jwt = JWT.decode(getAccessToken());
-        List<List<Reference>> provenanceTargets = new ArrayList<>();
-        Set<String> relativeResourcePaths = new HashSet<>();
-
-        if (event.getFhirResource() instanceof Bundle) {
-            for ( Bundle.Entry entry : ((Bundle)event.getFhirResource()).getEntry() ) {
-                if (entry.getResource() != null) {
-                    Resource resource = entry.getResource();
-                    if (resource instanceof Provenance) {
-                        // skip enforcement of provenance resources, but keep track of their targets
-                        provenanceTargets.add(((Provenance) resource).getTarget());
-                    } else {
-                        enforce(resource, getPatientIdFromToken(jwt), Permission.READ, getScopesFromToken(jwt));
-                        relativeResourcePaths.add(resource.getClass().getSimpleName() + "/" + resource.getId());
-                    }
+    private void enforceDirectProvenanceAccess(FHIRPersistenceEvent event, Resource resource, List<String> patientIdFromToken, List<Scope> scopesFromToken)
+            throws FHIRPersistenceInterceptorException {
+        if (resource instanceof Provenance) {
+            if (!isAllowed(((Provenance) resource).getTarget(), event.getPersistenceImpl(), patientIdFromToken, Permission.READ, scopesFromToken)) {
+                String msg = Permission.READ + " permission to 'Provenance/" + resource.getId() +
+                        "' with context id(s): " + patientIdFromToken +
+                        " requires access to one or more of its target resources.";
+                if (log.isLoggable(Level.FINE)) {
+                    log.fine(msg);
                 }
+                throw new FHIRPersistenceInterceptorException(msg)
+                        .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
             }
-
-            enforceProvenance(provenanceTargets, relativeResourcePaths);
-        } else {
-            throw new IllegalStateException("Expected event resource of type Bundle but found " +
-                    event.getFhirResource().getClass().getSimpleName());
         }
     }
 
     /**
-     * If the search result contains one or more Provenance resources,
-     * then reject the request unless each Provenance targets at least one resource in the response bundle
+     * Determine whether authorization to one or more referenced resources is granted by the end user in the form of scope strings
      *
+     * @param references a list of resource references; this method will dereference only relative literal references
+     * @param persistence the FHIRPersistence implementation to use for dereferencing the literal references
+     * @param contextIds an identifier for the current context (e.g. patient or user) as determined by the scope strings
+     * @param requiredPermission
+     * @param approvedScopes a list of SMART scopes associated with the request
      * @throws IllegalStateException if the baseUrl cannot be computed from the request context
-     * @throws FHIRPersistenceInterceptorException if access to one or more Provenance resources is denied
+     * @throws FHIRPersistenceInterceptorException if the interaction is not permitted
      */
-    private void enforceProvenance(List<List<Reference>> provenanceTargets, Set<String> relativeResourcePaths)
-            throws FHIRPersistenceInterceptorException {
-        if (provenanceTargets.isEmpty()) return;
+    private boolean isAllowed(List<Reference> references, FHIRPersistence persistence, List<String> contextIds, Permission requiredPermission, List<Scope> approvedScopes) {
+        boolean allow = false;
 
         String baseUrl;
         try {
@@ -241,25 +254,62 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
             throw new IllegalStateException("Unexpected error while computing the service baseUrl for ");
         }
 
-        for (List<Reference> targets : provenanceTargets) {
-            boolean allow = false;
-            for (Reference r : targets) {
-                ReferenceValue referenceValue = ReferenceUtil.createReferenceValueFrom(r, baseUrl);
-                if (ReferenceValue.ReferenceType.LITERAL_RELATIVE == referenceValue.getType()) {
-                    if (relativeResourcePaths.contains(referenceValue.getTargetResourceType() + "/" + referenceValue.getValue())) {
+        for (Reference ref : references) {
+            ReferenceValue referenceValue = ReferenceUtil.createReferenceValueFrom(ref, baseUrl);
+            if (ReferenceValue.ReferenceType.LITERAL_RELATIVE == referenceValue.getType()) {
+                Class<? extends Resource> resourceType = ModelSupport.getResourceType(referenceValue.getTargetResourceType());
+                try {
+                    SingleResourceResult<? extends Resource> result = executeRead(persistence, referenceValue, resourceType);
+
+                    if (result.isSuccess() && checkCompartment(result.getResource(), CompartmentType.PATIENT, contextIds)) {
                         allow = true;
                         break;
+                    } if (log.isLoggable(Level.FINE)){
+                        log.fine("Skipping target " + referenceValue.getTargetResourceType() + "/" + referenceValue.getType() +
+                                "' during enforcement due to a read failure: " + result.getOutcome());
                     }
-                } else if (log.isLoggable(Level.FINE)){
-                    log.fine("Skipping target '" + referenceValue.getValue() + "' of type '" + referenceValue.getType() +
-                            "' during enforcement of Provenance access.");
+                } catch (FHIRPersistenceException e) {
+                    if (log.isLoggable(Level.FINE)){
+                        log.log(Level.FINE, "Skipping target '" + referenceValue.getTargetResourceType() + "/" + referenceValue.getType() +
+                            "' during enforcement due to an error while reading.", e);
+                    }
+                }
+            } else if (log.isLoggable(Level.FINE)){
+                log.fine("Skipping target '" + referenceValue.getValue() + "' of type '" + referenceValue.getType() +
+                        "' during enforcement of Provenance access.");
+            }
+        }
+
+        return allow;
+    }
+
+    private SingleResourceResult<? extends Resource> executeRead(FHIRPersistence persistence, ReferenceValue referenceValue,
+            Class<? extends Resource> resourceType) throws FHIRPersistenceException {
+        SingleResourceResult<? extends Resource> result;
+        if (referenceValue.getVersion() == null) {
+            result = persistence.read(null, resourceType, referenceValue.getValue());
+        } else {
+            result = persistence.vread(null, resourceType,
+                referenceValue.getValue(), referenceValue.getVersion().toString());
+        }
+        return result;
+    }
+
+    @Override
+    public void afterSearch(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
+        DecodedJWT jwt = JWT.decode(getAccessToken());
+        List<String> patientIdFromToken = getPatientIdFromToken(jwt);
+        List<Scope> scopesFromToken = getScopesFromToken(jwt);
+
+        if (event.getFhirResource() instanceof Bundle) {
+            for ( Bundle.Entry entry : ((Bundle) event.getFhirResource()).getEntry() ) {
+                if (entry.getResource() != null) {
+                    enforce(entry.getResource(), patientIdFromToken, Permission.READ, scopesFromToken);
                 }
             }
-
-            if (!allow) {
-                throw new FHIRPersistenceInterceptorException(REQUEST_NOT_PERMITTED)
-                        .withIssue(FHIRUtil.buildOperationOutcomeIssue(REQUEST_NOT_PERMITTED, IssueType.FORBIDDEN));
-            }
+        } else {
+            throw new IllegalStateException("Expected event resource of type Bundle but found " +
+                    event.getFhirResource().getClass().getSimpleName());
         }
     }
 
@@ -274,6 +324,28 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
      */
     private void enforce(Resource resource, List<String> contextIds, Permission requiredPermission, List<Scope> approvedScopes)
             throws FHIRPersistenceInterceptorException {
+        if (!isAllowed(resource, contextIds, requiredPermission, approvedScopes)) {
+            if (log.isLoggable(Level.FINE)) {
+                log.fine(requiredPermission.value() + " permission for '" + resource.getClass().getSimpleName() + "/" + resource.getId() +
+                        "' is not granted by any of the provided scopes: " + approvedScopes +
+                        " with context id(s): " + contextIds);
+            }
+            throw new FHIRPersistenceInterceptorException(REQUEST_NOT_PERMITTED)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(REQUEST_NOT_PERMITTED, IssueType.FORBIDDEN));
+        }
+    }
+
+    /**
+     * Determine whether authorization to a given resource is granted by the end user in the form of scope strings
+     *
+     * @param resource the resource to check
+     * @param contextIds an identifier for the current context (e.g. patient or user) as determined by the scope strings
+     * @param requiredPermission
+     * @param approvedScopes a list of SMART scopes associated with the request
+     * @throws FHIRPersistenceInterceptorException if the interaction is not permitted
+     */
+    private boolean isAllowed(Resource resource, List<String> contextIds, Permission requiredPermission, List<Scope> approvedScopes)
+            throws FHIRPersistenceInterceptorException {
         Objects.requireNonNull(resource, "resource");
         Objects.requireNonNull(contextIds, "contextIds");
 
@@ -287,70 +359,98 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                 .collect(Collectors.groupingBy(s -> s.getContextType()));
 
         if (approvedScopeMap.containsKey(ContextType.PATIENT)) {
-            // If the target resource is the Patient resource which matches the in-context patient, allow it
-            if (resource instanceof Patient && resource.getId() != null && contextIds.contains(resource.getId())) {
+            if (resource instanceof Provenance) {
+                // Addressed for issue #1881, Provenance is a special-case:  a Patient-compartment resource type that
+                // we want to allow access to if and only if the patient has access to one or more resources that it targets.
+
+                // In the case of search, Provenance resources can be in the response bundle for two reasons:
+                // 1. direct search
+                // 2. _revinclude from a different resource type
+                // For case 1, the search is already scoped to the patient compartment and therefore only approved resources should be included
+                // For case 2, only Provenance resources which target to another resource in the response bundle will be included and therefor we
+                // can base the access decision on those resources rather than the Provenance
+
+                // In the case of read/vread/history, access to Provenance will be handled elsewhere;
+                // not by its Patient compartment membership but by the membership of the resources which it targets
                 if (log.isLoggable(Level.FINE)) {
-                    log.fine(requiredPermission.value() + " permission for 'Patient/" + resource.getId() +
-                        "' is granted via scope " + approvedScopeMap.get(ContextType.PATIENT) +
-                        " with patient context '" + resource.getId() + "'");
+                    log.fine(requiredPermission.value() + " permission for 'Provenance/" + resource.getId() +
+                        "' is granted via scope " + approvedScopeMap.get(ContextType.PATIENT));
                 }
-                return;
+                return true;
             }
 
             // Else, see if the target resource belongs to the Patient compartment of the in-context patient
-            try {
-                if (!CompartmentUtil.getCompartmentResourceTypes("Patient").contains(resourceType)) {
-                    // If the resource is not in the patient compartment, allow it
-                    // TODO: this may be overly broad...how do we appropriately scope user access to non-Patient resources?
-                    return;
-                }
-
-                List<String> inclusionCriteria = CompartmentUtil
-                        .getCompartmentResourceTypeInclusionCriteria(CompartmentType.PATIENT.getValue(), resourceType);
-
-                EvaluationContext resourceContext = new FHIRPathEvaluator.EvaluationContext(resource);
-
-                for (String searchParmCode : inclusionCriteria) {
-                    try {
-                        SearchParameter inclusionParm = SearchUtil.getSearchParameter(resourceType, searchParmCode);
-                        if (inclusionParm != null & inclusionParm.getExpression() != null) {
-                            String expression = inclusionParm.getExpression().getValue();
-                            Collection<FHIRPathNode> nodes = FHIRPathEvaluator.evaluator().evaluate(resourceContext, expression);
-                            for (FHIRPathNode node : nodes) {
-                                String patientRefVal = getPatientRefVal(node);
-                                if (patientRefVal != null && contextIds.contains(patientRefVal)) {
-                                    if (log.isLoggable(Level.FINE)) {
-                                        log.fine(requiredPermission.value() + " permission for '" + resource.getClass().getSimpleName() + "/" + resource.getId() +
-                                            "' is granted via scope " + approvedScopeMap.get(ContextType.PATIENT) +
-                                            " with patient context '" + patientRefVal + "'");
-                                    }
-                                    return;
-                                }
-                            }
-                        }
-                    } catch (Exception e) {
-                        log.log(Level.WARNING, "Unexpected exception while processing inclusionCriteria '" + searchParmCode +
-                                "' in the Patient compartment for resource type " + resourceType, e);
-                    }
-                }
-            } catch (FHIRSearchException e) {
-                log.log(Level.WARNING, "Unexpected exception while enforcing authorization policy in the Patient compartment"
-                        + " for resource type " + resourceType, e);
-            }
+            return checkCompartment(resource, CompartmentType.PATIENT, contextIds);
         }
 
         if (approvedScopeMap.containsKey(ContextType.USER)) {
             throw new UnsupportedOperationException("SMART scopes with context type 'user' are not yet supported.");
         }
 
+        return false;
+    }
 
-        if (log.isLoggable(Level.FINE)) {
-            log.fine(requiredPermission.value() + " permission for '" + resource.getClass().getSimpleName() + "/" + resource.getId() +
-                    "' is not granted by any of the provided scopes: " + approvedScopes +
-                    " with context id(s): " + contextIds);
+    /**
+     * Internal helper for checking compartment membership
+     *
+     * @param resource
+     * @param compartmentType
+     * @param contextIds
+     * @return true if the resource is in one of the compartment defined by the compartmentType and the contextIds
+     *          or if the resource type is not applicable for the given compartmentType
+     */
+    private boolean checkCompartment(Resource resource, CompartmentType compartmentType, List<String> contextIds) {
+        String resourceType = resource.getClass().getSimpleName();
+        String compartment = compartmentType.getValue();
+
+        // If the target resource type matches the compartment type, allow it if the id is one of the passed contextIds
+        if (compartmentType.getValue().equals(resourceType) && resource.getId() != null && contextIds.contains(resource.getId())) {
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("Bypassing compartment check for the compartment identity resource " + resourceType + "/" + resource.getId());
+            }
+            return true;
         }
-        throw new FHIRPersistenceInterceptorException(REQUEST_NOT_PERMITTED)
-                .withIssue(FHIRUtil.buildOperationOutcomeIssue(REQUEST_NOT_PERMITTED, IssueType.FORBIDDEN));
+
+        try {
+            if (!CompartmentUtil.getCompartmentResourceTypes(compartment).contains(resourceType)) {
+                // If the resource type is not applicable for the patient compartment, allow it
+                // TODO: this may be overly broad...how do we appropriately scope user access to non-Patient resources?
+                return true;
+            }
+
+            List<String> inclusionCriteria = CompartmentUtil
+                    .getCompartmentResourceTypeInclusionCriteria(compartment, resourceType);
+
+            EvaluationContext resourceContext = new FHIRPathEvaluator.EvaluationContext(resource);
+
+            for (String searchParmCode : inclusionCriteria) {
+                try {
+                    SearchParameter inclusionParm = SearchUtil.getSearchParameter(resourceType, searchParmCode);
+                    if (inclusionParm != null & inclusionParm.getExpression() != null) {
+                        String expression = inclusionParm.getExpression().getValue();
+                        Collection<FHIRPathNode> nodes = FHIRPathEvaluator.evaluator().evaluate(resourceContext, expression);
+                        for (FHIRPathNode node : nodes) {
+                            String patientRefVal = getPatientRefVal(node);
+                            if (patientRefVal != null && contextIds.contains(patientRefVal)) {
+                                if (log.isLoggable(Level.FINE)) {
+                                    log.fine(resourceType + "/" + resource.getId() +
+                                        "' is in " + compartment + " compartment '" + patientRefVal + "'");
+                                }
+                                return true;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.log(Level.WARNING, "Unexpected exception while processing inclusionCriteria '" + searchParmCode +
+                            "' in the " + compartment + " compartment for resource type " + resourceType, e);
+                }
+            }
+        } catch (FHIRSearchException e) {
+            log.log(Level.WARNING, "Unexpected exception while enforcing authorization policy in the " + compartment + " compartment"
+                    + " for resource type " + resourceType, e);
+        }
+
+        return false;
     }
 
     /**

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -35,6 +35,8 @@ import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.SingleResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.interceptor.FHIRPersistenceEvent;
 import com.ibm.fhir.persistence.interceptor.FHIRPersistenceInterceptor;
@@ -285,14 +287,10 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
 
     private SingleResourceResult<? extends Resource> executeRead(FHIRPersistence persistence, ReferenceValue referenceValue,
             Class<? extends Resource> resourceType) throws FHIRPersistenceException {
-        SingleResourceResult<? extends Resource> result;
-        if (referenceValue.getVersion() == null) {
-            result = persistence.read(null, resourceType, referenceValue.getValue());
-        } else {
-            result = persistence.vread(null, resourceType,
-                referenceValue.getValue(), referenceValue.getVersion().toString());
-        }
-        return result;
+        FHIRPersistenceContext freshContext = FHIRPersistenceContextFactory.createPersistenceContext(null);
+        return referenceValue.getVersion() == null ?
+                persistence.read(freshContext, resourceType, referenceValue.getValue()) :
+                persistence.vread(freshContext, resourceType, referenceValue.getValue(), referenceValue.getVersion().toString());
     }
 
     @Override

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -48,7 +48,7 @@ import com.ibm.fhir.smart.Scope.Permission;
 
 public class AuthzPolicyEnforcementTest {
     private static final String PATIENT_ID =     "11111111-1111-1111-1111-111111111111";
-    private static final String OBSERVATION_ID = "22222222-2222-2222-2222-222222222222";
+    private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111111";
 
     private static final List<ResourceType.ValueSet> PATIENT_APPROVED =
             Arrays.asList(ResourceType.ValueSet.PATIENT, ResourceType.ValueSet.RESOURCE);

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
@@ -1,0 +1,130 @@
+/*
+ * (C) Copyright IBM Corp. 2017, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.smart.test;
+
+import java.time.Instant;
+import java.util.function.Function;
+
+import com.ibm.fhir.model.resource.Observation;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
+import com.ibm.fhir.persistence.MultiResourceResult;
+import com.ibm.fhir.persistence.ResourcePayload;
+import com.ibm.fhir.persistence.SingleResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
+
+/**
+ * Mock implementation of FHIRPersistence for use during testing.
+ *
+ */
+public class MockPersistenceImpl implements FHIRPersistence {
+    Patient patient = null;
+    Observation observation = null;
+
+    public MockPersistenceImpl(Patient patient, Observation observation) {
+        this.patient = patient;
+        this.observation = observation;
+    }
+
+    @Override
+    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+        return null;
+    }
+
+    @Override
+    public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
+        throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+
+        if (resourceType == Patient.class) {
+            return new SingleResourceResult.Builder<T>()
+                    .success(true)
+                    .resource((T)patient)
+                    .build();
+        }
+
+        if (resourceType == Observation.class) {
+            return new SingleResourceResult.Builder<T>()
+                    .success(true)
+                    .resource((T)observation)
+                    .build();
+        }
+
+        return null;
+    }
+
+    @Override
+    public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
+        throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+
+        if (resourceType == Patient.class) {
+            return new SingleResourceResult.Builder<T>()
+                    .success(true)
+                    .resource((T)patient)
+                    .build();
+        }
+
+        if (resourceType == Observation.class) {
+            return new SingleResourceResult.Builder<T>()
+                    .success(true)
+                    .resource((T)observation)
+                    .build();
+        }
+
+        return null;
+    }
+
+    @Override
+    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException {
+    	return null;
+    }
+
+    @Override
+    public <T extends Resource> MultiResourceResult<T> history(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
+        return null;
+    }
+
+    @Override
+    public MultiResourceResult<Resource> search(FHIRPersistenceContext context, Class<? extends Resource> resourceType) throws FHIRPersistenceException {
+        return null;
+    }
+
+    @Override
+    public boolean isTransactional() {
+        return false;
+    }
+
+    @Override
+    public FHIRPersistenceTransaction getTransaction() {
+        return null;
+    }
+
+    @Override
+    public OperationOutcome getHealth() throws FHIRPersistenceException {
+        return null;
+    }
+
+    @Override
+    public int reindex(FHIRPersistenceContext context, OperationOutcome.Builder oob, Instant tstamp, String resourceLogicalId) throws FHIRPersistenceException {
+        return 0;
+    }
+
+    @Override
+    public String generateResourceId() {
+        return null;
+    }
+
+    @Override
+    public ResourcePayload fetchResourcePayloads(Class<? extends Resource> resourceType, Instant fromLastModified, Instant toLastModified,
+            Function<ResourcePayload, Boolean> process) throws FHIRPersistenceException {
+        return null;
+    }
+}


### PR DESCRIPTION
For search, skip compartment checking; direct Provenance search is already scoped to the patient compartment
and for revincluded Provenance we will let the access to the targeted resources carry the day.
For direct access (read/vread/history) we will read the targets of the Provenance and allow the access if the user
has access to one or more of them.

Additionally, I beefed up the javadoc for
ReferenceUtil.createReferenceValueFrom and ReferenceValue from
fhir-search since I had to study them to use them.

Finally, I added a variant of TestUtil.getMinimalResource which doesn't
force the Format argument (which is almost never relevant).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>