### PR TITLE
Issue #1877 - Fix search ap prefix to find partial range overlaps

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -48,7 +48,6 @@ public class DateParmBehaviorUtil {
         // Query: AND ((
         whereClauseSegment.append(AND).append(LEFT_PAREN).append(LEFT_PAREN);
 
-        // Initially we don't want to
         boolean parmValueProcessed = false;
         for (QueryParameterValue value : queryParm.getValues()) {
             // If multiple values are present, we need to OR them together.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/type/DateParmBehaviorUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,11 +44,11 @@ public class DateParmBehaviorUtil {
     public void executeBehavior(StringBuilder whereClauseSegment, QueryParameter queryParm,
             List<Timestamp> bindVariables,
             String tableAlias) {
-        // Start the Clause 
+        // Start the Clause
         // Query: AND ((
         whereClauseSegment.append(AND).append(LEFT_PAREN).append(LEFT_PAREN);
 
-        // Initially we don't want to 
+        // Initially we don't want to
         boolean parmValueProcessed = false;
         for (QueryParameterValue value : queryParm.getValues()) {
             // If multiple values are present, we need to OR them together.
@@ -56,11 +56,11 @@ public class DateParmBehaviorUtil {
                 // OR
                 whereClauseSegment.append(RIGHT_PAREN).append(OR).append(LEFT_PAREN);
             } else {
-                // Signal to the downstream to treat any subsequent value as an OR condition 
+                // Signal to the downstream to treat any subsequent value as an OR condition
                 parmValueProcessed = true;
             }
 
-            // Let's get the prefix. 
+            // Let's get the prefix.
             Prefix prefix = value.getPrefix();
             if (prefix == null) {
                 // Default to EQ
@@ -72,14 +72,14 @@ public class DateParmBehaviorUtil {
             buildPredicates(whereClauseSegment, bindVariables, tableAlias, prefix, lowerBound, upperBound);
         }
 
-        // End the Clause started above, and closes the parameter expression. 
+        // End the Clause started above, and closes the parameter expression.
         // Query: )))
         whereClauseSegment.append(RIGHT_PAREN).append(RIGHT_PAREN).append(RIGHT_PAREN);
     }
 
     /**
      * builds query elements based on prefix type.
-     * 
+     *
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias
@@ -128,6 +128,7 @@ public class DateParmBehaviorUtil {
             // AP - Approximate - Relative
             // -10% of the Lower Bound
             // +10% of the Upper Bound
+            // the range of the search value overlaps with the range of the target value
             buildApproxRangeClause(whereClauseSegment, bindVariables, tableAlias, lowerBound, upperBound);
             break;
         case NE:
@@ -146,7 +147,7 @@ public class DateParmBehaviorUtil {
 
     /**
      * builds the common clause
-     * 
+     *
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias
@@ -162,7 +163,7 @@ public class DateParmBehaviorUtil {
 
     /**
      * builds equals range
-     * 
+     *
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias
@@ -186,7 +187,7 @@ public class DateParmBehaviorUtil {
 
     /**
      * builds approximate range clause
-     * 
+     *
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias
@@ -198,9 +199,9 @@ public class DateParmBehaviorUtil {
         // @formatter:off
         whereClauseSegment
                 .append(LEFT_PAREN)
-                     .append(tableAlias).append(DOT).append(DATE_START).append(GTE).append(BIND_VAR)
+                     .append(tableAlias).append(DOT).append(DATE_END).append(GTE).append(BIND_VAR)
                 .append(AND)
-                     .append(tableAlias).append(DOT).append(DATE_END).append(LTE).append(BIND_VAR)
+                     .append(tableAlias).append(DOT).append(DATE_START).append(LTE).append(BIND_VAR)
                 .append(RIGHT_PAREN);
         // @formatter:on
 
@@ -210,7 +211,7 @@ public class DateParmBehaviorUtil {
 
     /**
      * build not equals range clause
-     * 
+     *
      * @param whereClauseSegment
      * @param bindVariables
      * @param tableAlias

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DateParmBehaviorUtilTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/DateParmBehaviorUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,7 +35,7 @@ public class DateParmBehaviorUtilTest {
     private static final Level LOG_LEVEL = Level.FINE;
 
     //---------------------------------------------------------------------------------------------------------
-    // Supporting Methods: 
+    // Supporting Methods:
     @BeforeClass
     public static void before() throws FHIRException {
         FHIRRequestContext.get().setTenantId("date");
@@ -256,7 +256,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
+                " AND (((Date.DATE_END >= ? AND Date.DATE_START <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);
@@ -271,7 +271,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?)) OR ((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
+                " AND (((Date.DATE_END >= ? AND Date.DATE_START <= ?)) OR ((Date.DATE_END >= ? AND Date.DATE_START <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);
@@ -286,7 +286,7 @@ public class DateParmBehaviorUtilTest {
         List<Timestamp> expectedBindVariables = new ArrayList<>();
 
         String expectedSql =
-                " AND (((Date.DATE_START >= ? AND Date.DATE_END <= ?)) OR ((Date.DATE_START >= ? AND Date.DATE_END <= ?))))";
+                " AND (((Date.DATE_END >= ? AND Date.DATE_START <= ?)) OR ((Date.DATE_END >= ? AND Date.DATE_START <= ?))))";
         runTest(queryParm,
                 expectedBindVariables,
                 expectedSql, "Date", true);

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1678,7 +1678,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-29");
 
         // search on the dateTime at the end of the Period-noStart
         // the range of the search value doesn't fully contain the range of the target value
@@ -1691,7 +1691,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-29T17:18:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-29T17:18:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-29T17:18:00-04:00");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28");
@@ -1703,7 +1703,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "ge2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-28");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999Z");
@@ -1715,7 +1715,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999Z");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-28T23:59:59.999999999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-28T23:59:59.999999999Z");
@@ -1727,7 +1727,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noStart", "le2018-10-29T23:59:59.999999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-28T23:59:59.999999999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "eb2018-10-28T23:59:59.999999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-28T23:59:59.999999999Z");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30");
@@ -1737,7 +1737,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-30");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30T00:00:00.000001Z");
@@ -1747,7 +1747,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001Z");
 
         assertSearchDoesntReturnSavedResource("Period-noStart", "2018-10-30T00:00:00.000001999Z");
         assertSearchReturnsSavedResource("Period-noStart", "ne2018-10-30T00:00:00.000001999Z");
@@ -1757,7 +1757,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Period-noStart", "ge2018-10-30T00:00:00.000001999Z");
         assertSearchDoesntReturnSavedResource("Period-noStart", "sa2018-10-30T00:00:00.000001999Z");
         assertSearchReturnsSavedResource("Period-noStart", "eb2018-10-30T00:00:00.000001999Z");
-        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001999Z");
+        assertSearchReturnsSavedResource("Period-noStart", "ap2018-10-30T00:00:00.000001999Z");
+
+        // ap has 10% leeway of the gap between now and the date, so pick a sufficiently late date
+        assertSearchDoesntReturnSavedResource("Period-noStart", "ap2098-10-30");
     }
     @Test
     public void testSearchDate_Period_NoEnd() throws Exception {
@@ -1774,7 +1777,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-29");
 
         // search on the dateTime at the start of the Period-noEnd
         // the range of the search value doesn't fully contain the range of the target value
@@ -1788,7 +1791,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-29T17:12:00-04:00");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-29T17:12:00-04:00");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-29T17:12:00-04:00");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-29T17:12:00-04:00");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28");
@@ -1798,7 +1801,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-28");
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-28");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28T23:59:59.999999Z");
@@ -1808,7 +1811,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-28T23:59:59.999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28T23:59:59.999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28T23:59:59.999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28T23:59:59.999999Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-28T23:59:59.999999Z");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-28T23:59:59.999999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-28T23:59:59.999999999Z");
@@ -1818,7 +1821,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-28T23:59:59.999999999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "sa2018-10-28T23:59:59.999999999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-28T23:59:59.999999999Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2010-10-28T23:59:59.999999999Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-28T23:59:59.999999999Z");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30");
@@ -1833,7 +1836,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-28");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-30");
 
         assertSearchDoesntReturnSavedResource("Period-noEnd", "2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ne2018-10-30T00:00:00.000001Z");
@@ -1845,7 +1848,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30T00:00:00.000001Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30T00:00:00.000001Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30T00:00:00.000001Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-30T00:00:00.000001Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T00:00:00.000000Z");
 
@@ -1859,9 +1862,12 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000001999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "sa2018-10-30T00:00:00.000001999Z");
         assertSearchDoesntReturnSavedResource("Period-noEnd", "eb2018-10-30T00:00:00.000001999Z");
-        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2018-10-30T00:00:00.000001999Z");
+        assertSearchReturnsSavedResource("Period-noEnd", "ap2018-10-30T00:00:00.000001999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-30T00:00:00.000000999Z");
         assertSearchReturnsSavedResource("Period-noEnd", "ge2018-10-29T00:00:00.000000999Z");
+
+        // ap has 10% leeway of the gap between now and the date, so pick a sufficiently early date
+        assertSearchDoesntReturnSavedResource("Period-noEnd", "ap2000-10-28");
     }
     @Test
     public void testSearchDate_Period_chained() throws Exception {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,6 +35,7 @@ import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.resource.AllergyIntolerance;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
+import com.ibm.fhir.model.resource.CarePlan;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.Observation.Component;
 import com.ibm.fhir.model.resource.OperationOutcome;
@@ -70,6 +71,7 @@ public class SearchTest extends FHIRServerTestBase {
     private String allergyIntoleranceId;
     private String practitionerRoleId;
     private String provenanceId;
+    private String carePlanId;
     private Patient patient4DuplicationTest = null;
     // Some of the tests run with tenant1 and datastore study1;
     // The others run with the default tenant and the default datastore.
@@ -1496,4 +1498,38 @@ public class SearchTest extends FHIRServerTestBase {
         assertNotNull(allergyIntolerance);
         assertEquals(allergyIntoleranceId, allergyIntolerance.getId());
     }
+
+    @Test(groups = { "server-search" })
+    public void test_SearchCarePlan_APDate() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Create the CarePlan that has a start date but no end date
+        CarePlan carePlan = TestUtil.readLocalResource("CarePlan.json");
+        Entity<CarePlan> entity =
+                Entity.entity(carePlan, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response =
+                target.path("CarePlan").request()
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+        carePlanId = getLocationLogicalId(response);
+
+        // Search for the CarePlan with an approximate date search
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_id", carePlanId);
+        parameters.searchParam("date", "ap2021-01-01");
+        FHIRResponse fhirResponse = client._search("CarePlan", parameters);
+        assertResponse(fhirResponse.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = fhirResponse.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() == 1);
+        CarePlan responseCarePlan = null;
+        for (Bundle.Entry entry : bundle.getEntry()) {
+            if (entry.getResource() != null && entry.getResource() instanceof CarePlan) {
+                responseCarePlan = (CarePlan) entry.getResource();
+            }
+        }
+        assertNotNull(responseCarePlan);
+        assertEquals(carePlanId, responseCarePlan.getId());
+    }
+
 }

--- a/fhir-server-test/src/test/resources/testdata/CarePlan.json
+++ b/fhir-server-test/src/test/resources/testdata/CarePlan.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "CarePlan",
+  "text": {
+    "status": "additional",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Care Plan</div>"
+  },
+  "status": "active",
+  "intent": "plan",
+  "subject": {
+    "display": "John Doe"
+  },
+  "period": {
+    "start": "2020-06-01"
+  }
+}


### PR DESCRIPTION
Fixed the search approximate prefix, ap, to find partial range overlaps instead of complete range overlaps.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>