### PR TITLE
Issue #1870 - Fix extraneous '&' in compartment search response links

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/uri/UriBuilder.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/uri/UriBuilder.java
@@ -105,8 +105,10 @@ public class UriBuilder {
     private void appendSearchParameters() {
         if (!context.getSearchParameters().isEmpty()) {
             Predicate<String> stringIsEmpty = String::isEmpty;
-            String searchParameters = context.getSearchParameters().stream().map(p -> serializeSearchParmToQueryString(p))
-                    .filter(stringIsEmpty.negate()).collect(Collectors.joining(SearchConstants.AND_CHAR_STR));
+            String searchParameters = context.getSearchParameters().stream()
+                    .map(p -> serializeSearchParmToQueryString(p))
+                    .filter(stringIsEmpty.negate())
+                    .collect(Collectors.joining(SearchConstants.AND_CHAR_STR));
             if (!searchParameters.isEmpty()) {
                 queryString.append(SearchConstants.AND_CHAR);
                 queryString.append(searchParameters);

--- a/fhir-search/src/test/java/com/ibm/fhir/search/uri/test/UriTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/uri/test/UriTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +11,7 @@ import static org.testng.Assert.assertEquals;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.testng.annotations.Test;
@@ -24,7 +25,7 @@ import com.ibm.fhir.search.util.SearchUtil;
 
 /**
  * Test class for the URI Builder
- * 
+ *
  * @author pbastide
  *
  */
@@ -42,23 +43,40 @@ public class UriTest {
         QueryParameter parameter = new QueryParameter(Type.TOKEN, "_security", null, null, values);
 
         List<QueryParameter> searchParameters = new ArrayList<>();
-        
+
         searchParameters.add(parameter);
-        
+
         QueryParameterValue value2 = new QueryParameterValue();
         value2.setValueString("tag");
         List<QueryParameterValue> values2 = Arrays.asList(value2);
         QueryParameter parameter2 = new QueryParameter(Type.TOKEN, "_fudge", null, null, values2);
         searchParameters.add(parameter2);
-        
+
 
         FHIRSearchContext ctx = FHIRSearchContextFactory.createSearchContext();
         ctx.setPageNumber(1);
         ctx.setPageSize(10);
         ctx.setSearchParameters(searchParameters);
 
-        assertEquals(SearchUtil.buildSearchSelfUri(requestUriString, ctx), 
+        assertEquals(SearchUtil.buildSearchSelfUri(requestUriString, ctx),
             incoming);
+    }
+
+    @Test
+    public void testUriWithOnlyCompartmentInclusionSearchParmeter() throws URISyntaxException {
+        String expectedUri = "https://localhost:9443/fhir-server/api/v4/Patient/1234/Observation?_count=10&_page=1";
+        String requestUriString = expectedUri.split("\\?")[0];
+
+        FHIRSearchContext ctx = FHIRSearchContextFactory.createSearchContext();
+        ctx.setPageNumber(1);
+        ctx.setPageSize(10);
+        QueryParameter inclusionParameter = new QueryParameter(Type.REFERENCE, null, null, null, true);
+        QueryParameterValue value = new QueryParameterValue();
+        value.setValueString("Patient/1234");
+        inclusionParameter.getValues().add(value);
+        ctx.setSearchParameters(Collections.singletonList(inclusionParameter));
+
+        assertEquals(SearchUtil.buildSearchSelfUri(requestUriString, ctx), expectedUri);
     }
 
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -641,7 +641,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertTrue(bundle.getEntry().size() >= 1);
         // verify link does not include consecutive '&' characters
         assertTrue(bundle.getLink().size() >= 1);
-        assertTrue(!bundle.getLink().get(0).getUrl().getValue().contains("&&"));
+        assertFalse(bundle.getLink().get(0).getUrl().getValue().contains("&&"));
     }
 
     @Test(groups = { "server-search" }, dependsOnMethods = {"testCreateObservation" })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -639,6 +639,9 @@ public class SearchTest extends FHIRServerTestBase {
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
+        // verify link does not include consecutive '&' characters
+        assertTrue(bundle.getLink().size() >= 1);
+        assertTrue(!bundle.getLink().get(0).getUrl().getValue().contains("&&"));
     }
 
     @Test(groups = { "server-search" }, dependsOnMethods = {"testCreateObservation" })


### PR DESCRIPTION
Fixes extraneous '&' characters in compartment search response links.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>