### PR TITLE
Issue #1661 - Read returns error when invalid search parameters used

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -870,31 +870,35 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
         T resource = null;
         com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = null;
-
-        FHIRSearchContext searchContext = context.getSearchContext();
         List<String> elements = null;
-        //Check if _summary is required
-        if (searchContext != null && searchContext.hasSummaryParameter()) {
-            Set<String> summaryElements = null;
-            SummaryValueSet summary = searchContext.getSummaryParameter();
+        FHIRSearchContext searchContext = context.getSearchContext();
 
-            switch (summary) {
-            case TRUE:
-                summaryElements = JsonSupport.getSummaryElementNames(resourceType);
-                break;
-            case TEXT:
-                summaryElements = SearchUtil.getSummaryTextElementNames(resourceType);
-                break;
-            case DATA:
-                summaryElements = JsonSupport.getSummaryDataElementNames(resourceType);
-                break;
-            default:
-                break;
-            }
+        if (searchContext != null) {
+            elements = searchContext.getElementsParameters();
 
-            if (summaryElements != null) {
-                elements = new ArrayList<String>();
-                elements.addAll(summaryElements);
+            // Only consider _summary if _elements parameter is empty
+            if (elements == null && searchContext.hasSummaryParameter()) {
+                Set<String> summaryElements = null;
+                SummaryValueSet summary = searchContext.getSummaryParameter();
+
+                switch (summary) {
+                case TRUE:
+                    summaryElements = JsonSupport.getSummaryElementNames(resourceType);
+                    break;
+                case TEXT:
+                    summaryElements = SearchUtil.getSummaryTextElementNames(resourceType);
+                    break;
+                case DATA:
+                    summaryElements = JsonSupport.getSummaryDataElementNames(resourceType);
+                    break;
+                default:
+                    break;
+                }
+
+                if (summaryElements != null) {
+                    elements = new ArrayList<String>();
+                    elements.addAll(summaryElements);
+                }
             }
         }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
@@ -6,7 +6,17 @@
 
 package com.ibm.fhir.server.test;
 
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.model.type.Uri.uri;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
@@ -18,17 +28,25 @@ import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.code.AdministrativeGender;
+import com.ibm.fhir.model.util.FHIRUtil;
 
 public class ReadTest extends FHIRServerTestBase {
     private String patientId;
+    private Coding subsettedTag =
+            Coding.builder().system(uri("http://terminology.hl7.org/CodeSystem/v3-ObservationValue"))
+            .code(Code.of("SUBSETTED"))
+            .display(string("subsetted"))
+            .build();
 
     @Test(groups = { "server-read" })
     public void testCreatePatient() throws Exception {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+        Patient patient = TestUtil.readLocalResource("patient-example-a.json");
 
         patient = patient.toBuilder().gender(AdministrativeGender.MALE).build();
         Entity<Patient> entity =
@@ -51,7 +69,7 @@ public class ReadTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
-    public void testReadPatient_elements() {
+    public void testReadPatient_elements() throws Exception {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("Patient/" + patientId)
@@ -60,10 +78,11 @@ public class ReadTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Patient patient = response.readEntity(Patient.class);
         assertNotNull(patient);
+        checkSubsetted(patient, Collections.singletonList("getActive"));
     }
 
     @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
-    public void testReadPatient_summary() {
+    public void testReadPatient_summary() throws Exception {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("Patient/" + patientId)
@@ -72,6 +91,22 @@ public class ReadTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Patient patient = response.readEntity(Patient.class);
         assertNotNull(patient);
+        checkSubsetted(patient, Arrays.asList("getActive", "getBirthDate", "getIdentifier", "getGender",
+            "getLink", "getManagingOrganization", "getName", "getTelecom"));
+    }
+
+    @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_elements_summary() throws Exception {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId)
+                .queryParam("_elements", "active")
+                .queryParam("_summary", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+        checkSubsetted(patient, Collections.singletonList("getActive"));
     }
 
     @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
@@ -84,6 +119,37 @@ public class ReadTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
         assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class),
             "Read only supports general search parameters.");
+    }
+
+    /**
+     * Checks that Patient has the subsetted tag and only the requested elements
+     * (and "mandatory elements")  are present in the Patient.
+     * @param patient the patient
+     * @param methods the methods
+     * @throws Exception an exception
+     */
+    private void checkSubsetted(Patient patient, List<String> methods) throws Exception {
+        assertTrue(FHIRUtil.hasTag(patient, subsettedTag));
+        // Verify that only the requested elements (and "mandatory elements") are
+        // present in the returned Patient.
+        Method[] patientMethods = Patient.class.getDeclaredMethods();
+        for (int i = 0; i < patientMethods.length; i++) {
+            Method patientMethod = patientMethods[i];
+            if (patientMethod.getName().startsWith("get")) {
+                Object elementValue = patientMethod.invoke(patient);
+                if (methods.contains(patientMethod.getName())
+                        || patientMethod.getName().equals("getId")
+                        || patientMethod.getName().equals("getMeta")) {
+                    assertNotNull(elementValue);
+                } else {
+                    if (elementValue instanceof List) {
+                        assertEquals(0, ((List<?>) elementValue).size());
+                    } else {
+                        assertNull(elementValue);
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
@@ -118,7 +118,7 @@ public class ReadTest extends FHIRServerTestBase {
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
         assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class),
-            "Read only supports general search parameters.");
+            "Search parameter '_lastUpdated' is not supported by read.");
     }
 
     /**

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ReadTest.java
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static org.testng.Assert.assertNotNull;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.code.AdministrativeGender;
+
+public class ReadTest extends FHIRServerTestBase {
+    private String patientId;
+
+    @Test(groups = { "server-read" })
+    public void testCreatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+
+        patient = patient.toBuilder().gender(AdministrativeGender.MALE).build();
+        Entity<Patient> entity =
+                Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response =
+                target.path("Patient").request()
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        patientId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/"
+                + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        TestUtil.assertResourceEquals(patient, responsePatient);
+    }
+
+    @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_elements() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId)
+                .queryParam("_elements", "active")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+    }
+
+    @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_summary() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId)
+                .queryParam("_summary", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+    }
+
+    @Test(groups = { "server-read" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_nonGeneralSearchParameter() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId)
+                .queryParam("_lastUpdated", "ge2020-11-02")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class),
+            "Read only supports general search parameters.");
+    }
+
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -715,7 +715,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @param contextResource
      *            a FHIR resource associated with this request
      * @param queryParameters
-     *            for supporting _summary for resource read
+     *            for supporting _elements and _summary for resource read
      * @param checkInteractionAllowed
      *            if true, check if this interaction is allowed per the tenant configuration; if false, assume interaction is allowed
      * @return the Resource
@@ -750,6 +750,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             FHIRSearchContext searchContext = null;
             if (queryParameters != null) {
+                if (!queryParameters.keySet().stream().allMatch(k -> FHIRConstants.GENERAL_PARAMETER_NAMES.contains(k))) {
+                    throw SearchExceptionUtil.buildNewInvalidSearchException(
+                            "Read only supports general search parameters.");
+                }
                 searchContext = SearchUtil.parseQueryParameters(null, null, resourceType, queryParameters,
                         HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -754,12 +754,13 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 boolean lenient = HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference());
 
                 // Determine if any non-general search parameters are specified
-                if (!queryParameters.keySet().stream().allMatch(k -> FHIRConstants.GENERAL_PARAMETER_NAMES.contains(k))) {
-                    FHIRSearchException se = SearchExceptionUtil.buildNewInvalidSearchException("Read only supports general search parameters.");
+                List<String> nonGeneralParams = queryParameters.keySet().stream().filter(k -> !FHIRConstants.GENERAL_PARAMETER_NAMES.contains(k)).collect(Collectors.toList());
+                for (String nonGeneralParam : nonGeneralParams) {
+                    FHIRSearchException se = SearchExceptionUtil.buildNewInvalidSearchException("Search parameter '" + nonGeneralParam + "' is not supported by read.");
                     if (!lenient) {
                         throw se;
                     }
-                    log.log(Level.FINE, "Error while parsing search parameters for resource type " + type, se);
+                    log.log(Level.FINE, "Error while parsing search parameter '" + nonGeneralParam + "' for resource type " + type, se);
                 }
 
                 // Parse search parameters

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -100,6 +100,7 @@ import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.parameters.QueryParameter;
 import com.ibm.fhir.search.util.ReferenceUtil;
 import com.ibm.fhir.search.util.ReferenceValue;
+import com.ibm.fhir.search.exception.SearchExceptionUtil;
 import com.ibm.fhir.search.util.SearchUtil;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.operation.FHIROperationRegistry;


### PR DESCRIPTION
Updated read to support the _elements search parameter, and return an error when invalid search parameters are used.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>