### PR TITLE
Issue #1905 - VRead returns error when invalid search parameters used

### DIFF
--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1316,7 +1316,6 @@ public class SearchUtil {
      * Parse query parameters for read and vread.
      * @param resourceType the resource type
      * @param queryParameters the query parameters
-     * @param queryString the query string
      * @param interaction read or vread
      * @param lenient true if lenient, false if strict
      * @return the FHIR search context

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1312,6 +1312,35 @@ public class SearchUtil {
         return result;
     }
 
+    /**
+     * Parse query parameters for read and vread.
+     * @param resourceType the resource type
+     * @param queryParameters the query parameters
+     * @param queryString the query string
+     * @param interaction read or vread
+     * @param lenient true if lenient, false if strict
+     * @return the FHIR search context
+     * @throws Exception an exception
+     */
+    public static FHIRSearchContext parseReadQueryParameters(Class<?> resourceType,
+        Map<String, List<String>> queryParameters, String interaction, boolean lenient) throws Exception {
+        String resourceTypeName = resourceType.getSimpleName();
+
+        // Read and vRead only allow general search parameters
+        List<String> nonGeneralParams = queryParameters.keySet().stream().filter(k -> !FHIRConstants.GENERAL_PARAMETER_NAMES.contains(k)).collect(Collectors.toList());
+        for (String nonGeneralParam : nonGeneralParams) {
+            FHIRSearchException se = SearchExceptionUtil.buildNewInvalidSearchException("Search parameter '" + nonGeneralParam
+                + "' is not supported by " + interaction + ".");
+            if (!lenient) {
+                throw se;
+            }
+            log.log(Level.FINE, "Error while parsing search parameter '" + nonGeneralParam + "' for resource type " + resourceTypeName, se);
+        }
+
+        return parseQueryParameters(null, null, resourceType, queryParameters, lenient);
+    }
+
+
     public static FHIRSearchContext parseQueryParameters(String compartmentName, String compartmentLogicalId,
             Class<?> resourceType,
             Map<String, List<String>> queryParameters, String queryString) throws Exception {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -568,6 +568,30 @@ public abstract class FHIRServerTestBase {
         assertFalse(logicalId.isEmpty());
 
         return logicalId;
+    }
+
+    /**
+     * For the specified response, this function will extract the version id value
+     * from the response's Location header. The format of a location header value
+     * should be: <code>[base]/<resource-type>/<id>/_history/<version></code>
+     *
+     * @param response the response object for a REST API invocation
+     * @return the version id value
+     */
+    public String getLocationVersionId(Response response) {
+        String location = response.getLocation().toString();
+        assertNotNull(location);
+        assertFalse(location.isEmpty());
+
+        String[] tokens = location.split("/");
+        assertNotNull(tokens);
+        assertTrue(tokens.length >= 4);
+
+        String versionId = tokens[tokens.length - 1];
+        assertNotNull(versionId);
+        assertFalse(versionId.isEmpty());
+
+        return versionId;
     }
 
     /**

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/VReadTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/VReadTest.java
@@ -1,0 +1,157 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.model.type.Uri.uri;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.code.AdministrativeGender;
+import com.ibm.fhir.model.util.FHIRUtil;
+
+public class VReadTest extends FHIRServerTestBase {
+    private String patientId;
+    private String patientVersion;
+    private Coding subsettedTag =
+            Coding.builder().system(uri("http://terminology.hl7.org/CodeSystem/v3-ObservationValue"))
+            .code(Code.of("SUBSETTED"))
+            .display(string("subsetted"))
+            .build();
+
+    @Test(groups = { "server-vread" })
+    public void testCreatePatient() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("patient-example-a.json");
+
+        patient = patient.toBuilder().gender(AdministrativeGender.MALE).build();
+        Entity<Patient> entity =
+                Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response =
+                target.path("Patient").request()
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id and version id.
+        patientId = getLocationLogicalId(response);
+        patientVersion = getLocationVersionId(response);
+
+        // Next, call the 'vread' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patientId + "/_history/" + patientVersion)
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        TestUtil.assertResourceEquals(patient, responsePatient);
+    }
+
+    @Test(groups = { "server-vread" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_elements() throws Exception {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId + "/_history/" + patientVersion)
+                .queryParam("_elements", "active")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+        checkSubsetted(patient, Collections.singletonList("getActive"));
+    }
+
+    @Test(groups = { "server-vread" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_summary() throws Exception {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId + "/_history/" + patientVersion)
+                .queryParam("_summary", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+        checkSubsetted(patient, Arrays.asList("getActive", "getBirthDate", "getIdentifier", "getGender",
+            "getLink", "getManagingOrganization", "getName", "getTelecom"));
+    }
+
+    @Test(groups = { "server-vread" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_elements_summary() throws Exception {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId + "/_history/" + patientVersion)
+                .queryParam("_elements", "active")
+                .queryParam("_summary", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient patient = response.readEntity(Patient.class);
+        assertNotNull(patient);
+        checkSubsetted(patient, Collections.singletonList("getActive"));
+    }
+
+    @Test(groups = { "server-vread" }, dependsOnMethods = {"testCreatePatient" })
+    public void testReadPatient_nonGeneralSearchParameter() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient/" + patientId + "/_history/" + patientVersion)
+                .queryParam("_lastUpdated", "ge2020-11-02")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class),
+            "Search parameter '_lastUpdated' is not supported by vread.");
+    }
+
+    /**
+     * Checks that Patient has the subsetted tag and only the requested elements
+     * (and "mandatory elements")  are present in the Patient.
+     * @param patient the patient
+     * @param methods the methods
+     * @throws Exception an exception
+     */
+    private void checkSubsetted(Patient patient, List<String> methods) throws Exception {
+        assertTrue(FHIRUtil.hasTag(patient, subsettedTag));
+        // Verify that only the requested elements (and "mandatory elements") are
+        // present in the returned Patient.
+        Method[] patientMethods = Patient.class.getDeclaredMethods();
+        for (int i = 0; i < patientMethods.length; i++) {
+            Method patientMethod = patientMethods[i];
+            if (patientMethod.getName().startsWith("get")) {
+                Object elementValue = patientMethod.invoke(patient);
+                if (methods.contains(patientMethod.getName())
+                        || patientMethod.getName().equals("getId")
+                        || patientMethod.getName().equals("getMeta")) {
+                    assertNotNull(elementValue);
+                } else {
+                    if (elementValue instanceof List) {
+                        assertEquals(0, ((List<?>) elementValue).size());
+                    } else {
+                        assertNull(elementValue);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -140,12 +140,11 @@ public interface FHIRResourceHelpers {
      * @param id
      *            the id of the Resource to be retrieved
      * @param queryParameters
-     *            for supporting _summary for resource read
+     *            for supporting _elements and _summary for resource read
      * @return the Resource
      * @throws Exception
      */
     public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted, Map<String, String> requestProperties, Resource contextResource, MultivaluedMap<String, String> queryParameters) throws Exception;
-
 
     /**
      * Performs a 'read' operation to retrieve a Resource.
@@ -168,6 +167,26 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param versionId
      *            the version id of the Resource to be retrieved
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
+     * @param queryParameters
+     *            for supporting _elements and _summary for resource vread
+     * @return the Resource
+     * @throws Exception
+     */
+    public Resource doVRead(String type, String id, String versionId, Map<String, String> requestProperties, MultivaluedMap<String, String> queryParameters) throws Exception;
+
+    /**
+     * Performs a 'vread' operation by retrieving the specified version of a Resource.
+     *
+     * @param type
+     *            the resource type associated with the Resource to be retrieved
+     * @param id
+     *            the id of the Resource to be retrieved
+     * @param versionId
+     *            the version id of the Resource to be retrieved
+     * @param requestProperties
+     *            additional request properties which supplement the HTTP headers associated with this request
      * @return the Resource
      * @throws Exception
      */

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,6 +21,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
@@ -64,9 +65,10 @@ public class VRead extends FHIRResource {
 
         try {
             checkInitComplete();
+            MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource resource = helper.doVRead(type, id, vid, null);
+            Resource resource = helper.doVRead(type, id, vid, null, queryParameters);
             status = Status.OK;
             ResponseBuilder response = Response.ok().entity(resource);
             response = addHeaders(response, resource);

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/processor/DummyImportExportImplTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/processor/DummyImportExportImplTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020,2021
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -259,6 +259,12 @@ public class DummyImportExportImplTest {
             @Override
             public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
                     Map<String, String> requestProperties, Resource contextResource) throws Exception {
+                return null;
+            }
+
+            @Override
+            public Resource doVRead(String type, String id, String versionId, Map<String, String> requestProperties,
+                MultivaluedMap<String, String> queryParameters) throws Exception {
                 return null;
             }
 


### PR DESCRIPTION
Updated vread to support the _elements and _summary search parameters, and return an error when invalid search parameters are used.

Signed-off-by: Troy Biesterfeld tbieste@us.ibm.com