### PR TITLE
Issue #1718 - Update handling of _type and other singleton search params

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-04 01:00:00 -0400
+date:   2021-02-04 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -114,8 +114,13 @@ In addition, the following search parameters are supported on all resources:
 * `_has`
 
 These parameters can be used while searching any single resource type or while searching across resource types (whole system search).
-The `_type` parameter is special in that it is only applicable for whole system search. The `_has` parameter has two restrictions:
-* `_has` cannot be used with whole system search.
+
+The `_type` parameter has two restrictions:
+* It may only be used with whole system search.
+* It may only be specified once in a search.
+
+The `_has` parameter has two restrictions:
+* It cannot be used with whole system search.
 * The search parameter specified at the end of its chain cannot be a search result parameter.
 
 The `_text`, `_content`, `_list`, `_query`, and `_filter` parameters are not supported at this time.
@@ -128,7 +133,9 @@ Finally, the specification defines a set of "Search result parameters" for contr
 * `_summary`
 * `_elements`
 
-The `_count` parameter can be used to request up to 1000 resources matching the search criteria. An attempt to exceed this `_count` limit will not be honored and returned resources will be capped at 1000. Any associated `_include` or `_revinclude` resources are not considered in the `_count` limit. 
+The `_sort`, `_count`, `_summary`, and `_elements` parameters may each only be specified once in a search.
+
+The `_count` parameter can be used to request up to 1000 resources matching the search criteria. An attempt to exceed this `_count` limit will not be honored and returned resources will be capped at 1000. Any associated `_include` or `_revinclude` resources are not considered in the `_count` limit.
 
 The `_include` and `_revinclude` parameters can be used to return resources related to the primary search results, in order to reduce the overall network delay of repeated retrievals of related resources. The number of `_include` or `_revinclude` resources returned for a single page of primary search results will be limited to 1000. If the number of included resources to be returned exceeds 1000, the search will fail. For example, if the primary search result is one resource and the number of included resources is 1000, the search will succeed. However, if the primary search result is one resource and the number of included resources is 1001, the search will fail. It is possible that an included resource could be referenced by more than one primary search result. Duplicate included resources will be removed before search results are returned, so a resource will not appear in the search results more than once. A resource is considered a duplicate if a primary resource or another included resource with the same logical ID and version already exists in the search results. 
 

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-04 12:00:00 -0400
+date:   2021-02-05 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -117,7 +117,7 @@ These parameters can be used while searching any single resource type or while s
 
 The `_type` parameter has two restrictions:
 * It may only be used with whole system search.
-* It may only be specified once in a search.
+* It may only be specified once in a search. In `lenient` mode, only the first occurrence is used; additional occurrences are ignored.
 
 The `_has` parameter has two restrictions:
 * It cannot be used with whole system search.
@@ -133,7 +133,7 @@ Finally, the specification defines a set of "Search result parameters" for contr
 * `_summary`
 * `_elements`
 
-The `_sort`, `_count`, `_summary`, and `_elements` parameters may each only be specified once in a search.
+The `_sort`, `_count`, `_summary`, and `_elements` parameters may each only be specified once in a search. In `lenient` mode, only the first occurrence of each of these parameters is used; additional occurrences are ignored.
 
 The `_count` parameter can be used to request up to 1000 resources matching the search criteria. An attempt to exceed this `_count` limit will not be honored and returned resources will be capped at 1000. Any associated `_include` or `_revinclude` resources are not considered in the `_count` limit.
 
@@ -280,6 +280,9 @@ Positional Search uses [UCUM units](https://unitsofmeasure.org/ucum.html) of dis
 |FEET|ft, fts, foot|
 
 Note, the use of the surrounding bracket, such as `[mi_us]` is optional; `mi_us` is also valid.
+
+### Search parameters
+
 
 ## HL7 FHIR R4 (v4.0.1) errata
 We add information here as we find issues with the artifacts provided with this version of the specification.

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ModelSupport.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -896,6 +896,17 @@ public final class ModelSupport {
      */
     public static boolean isResourceType(String name) {
         return RESOURCE_TYPE_MAP.containsKey(name);
+    }
+
+    /**
+     * @param name
+     *            the resource type name in titlecase to match the corresponding model class name
+     * @return true if {@code name} is a valid FHIR resource name; otherwise false
+     * @implSpec this method returns false for abstract types like {@code Resource} and {@code DomainResource}
+     */
+    public static boolean isConcreteResourceType(String name) {
+        Class<?> modelClass = RESOURCE_TYPE_MAP.get(name);
+        return modelClass != null && !isAbstract(modelClass);
     }
 
     /**

--- a/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/SearchConstants.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -96,6 +96,10 @@ public class SearchConstants {
 
     // set as unmodifiable
     public static final List<String> SYSTEM_LEVEL_SORT_PARAMETER_NAMES = Collections.unmodifiableList(Arrays.asList("_id", "_lastUpdated"));
+
+    // set as unmodifiable
+    public static final List<String> SEARCH_SINGLETON_PARAMETER_NAMES =
+            Collections.unmodifiableList(Arrays.asList(SORT, COUNT, PAGE, SUMMARY, ELEMENTS, RESOURCE_TYPE));
 
     // Empty Query String
     public static final String EMPTY_QUERY_STRING = "";

--- a/fhir-search/src/main/java/com/ibm/fhir/search/sort/Sort.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/sort/Sort.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -38,9 +38,9 @@ public class Sort {
     public enum Direction {
 
         // r4 - https://www.hl7.org/fhir/r4/search.html#sort
-        // uses chars as an optimization choice to compare rather than a string to string for a single char. 
-        // Each item in the comma separated list is a search parameter, optionally with a '-' prefix. The prefix 
-        // indicates decreasing order; in its absence, the parameter is applied in increasing order. 
+        // uses chars as an optimization choice to compare rather than a string to string for a single char.
+        // Each item in the comma separated list is a search parameter, optionally with a '-' prefix. The prefix
+        // indicates decreasing order; in its absence, the parameter is applied in increasing order.
         // previously increasing was ASCENDING and decreasing was DESCENDING.
         DECREASING('-'),
         INCREASING('+');
@@ -58,7 +58,7 @@ public class Sort {
         /**
          * from value is converted to a sort direction based on the use of '-' else it's
          * assumed to be the default increasing.
-         * 
+         *
          * @param value
          * @return
          */
@@ -77,57 +77,57 @@ public class Sort {
     }
 
     /**
-     * @param resourceType
-     * @param context
-     * @param sortQueryParmValues
-     * @param lenient
-     * @throws Exception
+     * Parses the _sort parameter.
+     * @param resourceType the resource type
+     * @param context the search context
+     * @param sortParmValue the parameter value
+     * @param lenient true if lenient, false if strict
+     * @throws Exception an exception
      */
     public void parseSortParameter(Class<?> resourceType, FHIRSearchContext context,
-            List<String> sortQueryParmValues, boolean lenient) throws Exception {
-        parseSortParameter(resourceType.getSimpleName(), context, sortQueryParmValues, lenient);
+            String sortParmValue, boolean lenient) throws Exception {
+        parseSortParameter(resourceType.getSimpleName(), context, sortParmValue, lenient);
     }
 
     /**
-     * @param resourceTypeName
-     * @param context
-     * @param sortQueryParmValues
-     * @param lenient
-     * @throws Exception
+     * Parses the _sort parameter.
+     * @param resourceTypeName the resource type name
+     * @param context the search context
+     * @param sortParmValue the parameter value
+     * @param lenient true if lenient, false if strict
+     * @throws Exception an exception
      */
     public void parseSortParameter(String resourceTypeName, FHIRSearchContext context,
-            List<String> sortQueryParmValues, boolean lenient) throws Exception {
+            String sortParmValue, boolean lenient) throws Exception {
 
-        for (String sortParmCodes : sortQueryParmValues) {
-            for (String sortParmCode : sortParmCodes.split(",")) {
-                // Each parameter now includes the direction.
-                Sort.Direction sortDirection = Direction.fromValue(sortParmCode);
+        for (String sortParmCode : sortParmValue.split(",")) {
+            // Each parameter now includes the direction.
+            Sort.Direction sortDirection = Direction.fromValue(sortParmCode);
 
-                // In the case, where we are DECREASING, we need to treat the CODE in a special 
-                // way by stripping the directional indicator. 
-                if (Sort.Direction.DECREASING.compareTo(sortDirection) == 0) {
-                    sortParmCode = sortParmCode.substring(1);
-                }
+            // In the case, where we are DECREASING, we need to treat the CODE in a special
+            // way by stripping the directional indicator.
+            if (Sort.Direction.DECREASING.compareTo(sortDirection) == 0) {
+                sortParmCode = sortParmCode.substring(1);
+            }
 
-                // Per the FHIR spec, the _sort parameter value is a search parameter. We need to determine what
-                // type of search parameter.
-                SearchParameter sortParmProxy = SearchUtil.getSearchParameter(resourceTypeName, sortParmCode);
-                if (!isUndefinedOrLenient(resourceTypeName, sortParmCode, sortParmProxy, lenient)) {
-                    SearchConstants.Type sortParmType =
-                            SearchConstants.Type.fromValue(sortParmProxy.getType().getValue());
-                    SortParameter sortParm = new SortParameter(sortParmCode, sortParmType, sortDirection);
+            // Per the FHIR spec, the _sort parameter value is a search parameter. We need to determine what
+            // type of search parameter.
+            SearchParameter sortParmProxy = SearchUtil.getSearchParameter(resourceTypeName, sortParmCode);
+            if (!isUndefinedOrLenient(resourceTypeName, sortParmCode, sortParmProxy, lenient)) {
+                SearchConstants.Type sortParmType =
+                        SearchConstants.Type.fromValue(sortParmProxy.getType().getValue());
+                SortParameter sortParm = new SortParameter(sortParmCode, sortParmType, sortDirection);
 
-                    checkSystemLevel(resourceTypeName, sortParm.getCode());
+                checkSystemLevel(resourceTypeName, sortParm.getCode());
 
-                    context.getSortParameters().add(sortParm);
-                }
+                context.getSortParameters().add(sortParm);
             }
         }
     }
 
     /**
      * checks to see if undefined as a SearchParameter or Lenient
-     * 
+     *
      * @param resourceTypeName
      * @param sortParmCode
      * @param sortParmProxy
@@ -140,12 +140,12 @@ public class Sort {
         boolean result = sortParmProxy == null;
         if (result) {
             String msg = buildUndefinedSortParamMessage(resourceTypeName, sortParmCode);
-            
+
             // Stop Processing if not lenient
             if (!lenient) {
                 throw SearchExceptionUtil.buildNewInvalidSearchException(msg);
             }
-            
+
             log.fine(msg);
         }
         return result;
@@ -153,7 +153,7 @@ public class Sort {
 
     /**
      * check system level searches with DESC/ASC are ONLY with _id and _lastUpdated
-     * 
+     *
      * @param resourceTypeName one of the FHIR Resources, and must be a non-null
      *                         value
      * @param code             the code to check.
@@ -169,7 +169,7 @@ public class Sort {
 
     /**
      * builds exception message when the sort parameter used is undefined.
-     * 
+     *
      * @param sortParmCode the code that is passed in
      * @return String representing the exception message
      */
@@ -183,7 +183,7 @@ public class Sort {
 
     /**
      * builds exception message when the sort parameter used is undefined.
-     * 
+     *
      * @param resourceTypeName the specific FHIR Resource passed in or general
      *                         RESOURCE
      * @param sortParmCode     the code that is passed in

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -743,7 +743,7 @@ public class SearchUtil {
                 || queryParameters.containsKey(SearchConstants.REVINCLUDE)) {
             // Make sure _sort is not present with _include and/or _revinclude.
             // TODO: do we really need to forbid this?
-           if (queryParameters.containsKey(SearchConstants.SORT)) {
+            if (queryParameters.containsKey(SearchConstants.SORT)) {
                 throw SearchExceptionUtil.buildNewInvalidSearchException(
                         "_sort search result parameter not supported with _include or _revinclude.");
             }
@@ -762,7 +762,7 @@ public class SearchUtil {
                 String resTypes = queryParameters.get(SearchConstants.RESOURCE_TYPE).get(0);
                 List<String> tmpResourceTypes = Arrays.asList(resTypes.split("\\s*,\\s*"));
                 for (String resType : tmpResourceTypes) {
-                    if (ModelSupport.isResourceType(resType)) {
+                    if (ModelSupport.isConcreteResourceType(resType)) {
                         resourceTypes.add(resType);
                     } else {
                         manageException("_type search parameter has invalid resource type: " + resType, lenient);

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -727,37 +728,50 @@ public class SearchUtil {
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
         context.setLenient(lenient);
         List<QueryParameter> parameters = new ArrayList<>();
+        HashSet<String> resourceTypes = new LinkedHashSet<>();
 
-        // Make sure _sort is not present with _include and/or _revinclude.
-        // TODO: do we really need to forbid this?
-        if (queryParameters.containsKey(SearchConstants.SORT) &&
-                (queryParameters.containsKey(SearchConstants.INCLUDE)
-                        || queryParameters.containsKey(SearchConstants.REVINCLUDE))) {
-            throw SearchExceptionUtil.buildNewInvalidSearchException(
-                    "_sort search result parameter not supported with _include or _revinclude.");
+        // Check for duplicate parameters that are supposed to be specified at most once
+        for (Entry<String, List<String>> entry : queryParameters.entrySet()) {
+            String name = entry.getKey();
+            if (isSearchSingletonParameter(name) && entry.getValue().size() > 1) {
+                manageException("Search parameter '" + name + "' is specified multiple times", lenient);
+            }
         }
-        HashSet<String> resourceTypes = new HashSet<>();
-        if (Resource.class.equals(resourceType)) {
+
+        // Check for unsupported uses of _include/_revinclude
+        if (queryParameters.containsKey(SearchConstants.INCLUDE)
+                || queryParameters.containsKey(SearchConstants.REVINCLUDE)) {
+            // Make sure _sort is not present with _include and/or _revinclude.
+            // TODO: do we really need to forbid this?
+           if (queryParameters.containsKey(SearchConstants.SORT)) {
+                throw SearchExceptionUtil.buildNewInvalidSearchException(
+                        "_sort search result parameter not supported with _include or _revinclude.");
+            }
             // Because _include and _revinclude searches all require certain resource type modifier in
             // search parameter, so we just don't support it.
-            if (queryParameters.containsKey(SearchConstants.INCLUDE)
-                        || queryParameters.containsKey(SearchConstants.REVINCLUDE)) {
+            if (Resource.class.equals(resourceType)) {
                 throw SearchExceptionUtil.buildNewInvalidSearchException(
                         "system search not supported with _include or _revinclude.");
             }
+        }
 
-            if (queryParameters.containsKey(SearchConstants.RESOURCE_TYPE)) {
-                for (String resTypes : queryParameters.get(SearchConstants.RESOURCE_TYPE)) {
-                    List<String> tmpResourceTypes = Arrays.asList(resTypes.split("\\s*,\\s*"));
-                    for (String resType : tmpResourceTypes) {
-                        if (ModelSupport.isResourceType(resType)) {
-                            resourceTypes.add(resType);
-                        } else {
-                            manageException("_type search parameter has invalid resource type:" + resType, lenient);
-                            continue;
-                        }
+        // Check for unsupported uses of _type
+        if (queryParameters.containsKey(SearchConstants.RESOURCE_TYPE)) {
+            if (Resource.class.equals(resourceType)) {
+                // Only first value is used, which matches behavior of other parameters that are supposed to be specified at most once
+                String resTypes = queryParameters.get(SearchConstants.RESOURCE_TYPE).get(0);
+                List<String> tmpResourceTypes = Arrays.asList(resTypes.split("\\s*,\\s*"));
+                for (String resType : tmpResourceTypes) {
+                    if (ModelSupport.isResourceType(resType)) {
+                        resourceTypes.add(resType);
+                    } else {
+                        manageException("_type search parameter has invalid resource type: " + resType, lenient);
+                        continue;
                     }
                 }
+            }
+            else {
+                manageException("_type search parameter is only supported with system search", lenient);
             }
         }
 
@@ -1430,6 +1444,10 @@ public class SearchUtil {
         return SearchConstants.SEARCH_RESULT_PARAMETER_NAMES.contains(name);
     }
 
+    public static boolean isSearchSingletonParameter(String name) {
+        return SearchConstants.SEARCH_SINGLETON_PARAMETER_NAMES.contains(name);
+    }
+
     public static boolean isGeneralParameter(String name) {
         return FHIRConstants.GENERAL_PARAMETER_NAMES.contains(name);
     }
@@ -1459,13 +1477,15 @@ public class SearchUtil {
             } else if (SearchConstants.PAGE.equals(name)) {
                 int pageNumber = Integer.parseInt(first);
                 context.setPageNumber(pageNumber);
-            } else if (SearchConstants.SORT.equals(name)) {
+            } else if (SearchConstants.SORT.equals(name) && first != null) {
                 // in R4, we only look for _sort
-                sort.parseSortParameter(resourceTypeName, context, values, lenient);
+                // Only first value is used, which matches behavior of other parameters that are supposed to be specified at most once
+                sort.parseSortParameter(resourceTypeName, context, first, lenient);
             } else if (name.startsWith(SearchConstants.INCLUDE) || name.startsWith(SearchConstants.REVINCLUDE)) {
                 parseInclusionParameter(resourceType, context, name, values, lenient);
-            } else if (SearchConstants.ELEMENTS.equals(name)) {
-                parseElementsParameter(resourceType, context, values, lenient);
+            } else if (SearchConstants.ELEMENTS.equals(name) && first != null) {
+                // Only first value is used, which matches behavior of other parameters that are supposed to be specified at most once
+                parseElementsParameter(resourceType, context, first, lenient);
             } else if (SearchConstants.SUMMARY.equals(name) && first != null) {
                 context.setSummaryParameter(SummaryValueSet.from(first));
             }
@@ -2190,24 +2210,21 @@ public class SearchUtil {
      * @throws Exception
      */
     private static void parseElementsParameter(Class<?> resourceType, FHIRSearchContext context,
-            List<String> elementLists, boolean lenient) throws Exception {
+            String elements, boolean lenient) throws Exception {
 
         Set<String> resourceFieldNames = JsonSupport.getElementNames(resourceType);
 
-        for (String elements : elementLists) {
-
-            // For other parameters, we pass the comma-separated list of values to the PL
-            // but for elements, we need to process that here
-            for (String elementName : elements.split(SearchConstants.BACKSLASH_NEGATIVE_LOOKBEHIND + ",")) {
-                if (elementName.startsWith("_")) {
-                    throw SearchExceptionUtil.buildNewInvalidSearchException("Invalid element name: " + elementName);
-                }
-                if (!resourceFieldNames.contains(elementName)) {
-                    manageException("Unknown element name: " + elementName, lenient);
-                    continue;
-                }
-                context.addElementsParameter(elementName);
+        // For other parameters, we pass the comma-separated list of values to the PL
+        // but for elements, we need to process that here
+        for (String elementName : elements.split(SearchConstants.BACKSLASH_NEGATIVE_LOOKBEHIND + ",")) {
+            if (elementName.startsWith("_")) {
+                throw SearchExceptionUtil.buildNewInvalidSearchException("Invalid element name: " + elementName);
             }
+            if (!resourceFieldNames.contains(elementName)) {
+                manageException("Unknown element name: " + elementName, lenient);
+                continue;
+            }
+            context.addElementsParameter(elementName);
         }
     }
 

--- a/fhir-search/src/test/java/com/ibm/fhir/search/sort/test/SortParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/sort/test/SortParameterParseTest.java
@@ -11,7 +11,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -288,8 +287,8 @@ public class SortParameterParseTest extends BaseSearchTest {
         String searchParmValue = "Practioner/1";
 
         // Build up the QueryParameters
-        queryParameters.put("_sort", Arrays.asList(sortParmCode1 + "," + sortParmCode2, directionDesc.value() + sortParmCode3 + "," + directionDesc.value()
-                + sortParmCode4, sortParmCode5));
+        queryParameters.put("_sort", Collections.singletonList(sortParmCode1 + "," + sortParmCode2 + "," +
+                directionDesc.value() + sortParmCode3 + "," + directionDesc.value() + sortParmCode4 + "," + sortParmCode5));
         queryParameters.put(searchParmName, Collections.singletonList(searchParmValue));
 
         searchContext = SearchUtil.parseQueryParameters(resourceType, queryParameters);

--- a/fhir-search/src/test/java/com/ibm/fhir/search/sort/test/SortTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/sort/test/SortTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -47,7 +47,7 @@ public class SortTest extends BaseSearchTest {
     /**
      * Tests an invalid direction modifier on the _sort query parameter.
      * This now throws as it's invalid parameter name-value
-     * 
+     *
      * @throws Exception
      */
     @Test(expectedExceptions = FHIRSearchException.class)
@@ -151,10 +151,10 @@ public class SortTest extends BaseSearchTest {
     public void testParseSortParameterAsc() throws Exception {
         Class<?> resourceType = Patient.class;
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
-        List<String> sortQueryParmValues = Arrays.asList("_id");
+        String sortQueryParmValue = "_id";
         boolean lenient = false;
 
-        sort.parseSortParameter(resourceType, context, sortQueryParmValues, lenient);
+        sort.parseSortParameter(resourceType, context, sortQueryParmValue, lenient);
         assertEquals(context.getSortParameters().size(), 1);
         assertEquals(context.getSortParameters().get(0).getDirection().value(), '+');
     }
@@ -163,10 +163,10 @@ public class SortTest extends BaseSearchTest {
     public void testParseSortParameterDesc() throws Exception {
         Class<?> resourceType = Patient.class;
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
-        List<String> sortQueryParmValues = Arrays.asList("-_id");
+        String sortQueryParmValue = "-_id";
         boolean lenient = false;
 
-        sort.parseSortParameter(resourceType, context, sortQueryParmValues, lenient);
+        sort.parseSortParameter(resourceType, context, sortQueryParmValue, lenient);
         assertEquals(context.getSortParameters().size(), 1);
         assertEquals(context.getSortParameters().get(0).getDirection().value(), '-');
     }
@@ -175,31 +175,31 @@ public class SortTest extends BaseSearchTest {
     public void testParseSortParameterResourceDesc() throws Exception {
         Class<?> resourceType = Resource.class;
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
-        List<String> sortQueryParmValues = Arrays.asList("-_id");
+        String sortQueryParmValue = "-_id";
         boolean lenient = false;
 
-        sort.parseSortParameter(resourceType, context, sortQueryParmValues, lenient);
+        sort.parseSortParameter(resourceType, context, sortQueryParmValue, lenient);
         assertEquals(context.getSortParameters().size(), 1);
         assertEquals(context.getSortParameters().get(0).getDirection().value(), '-');
     }
-    
+
     @Test(expectedExceptions = {FHIRSearchException.class})
     public void testParseSortParameterResourceBad() throws Exception {
         Class<?> resourceType = Observation.class;
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
-        List<String> sortQueryParmValues = Arrays.asList("-component-code2");
+        String sortQueryParmValue = "-component-code2";
         boolean lenient = false;
-        sort.parseSortParameter(resourceType, context, sortQueryParmValues, lenient);
+        sort.parseSortParameter(resourceType, context, sortQueryParmValue, lenient);
     }
-    
+
     @Test(expectedExceptions = {})
     public void testParseSortParameterResourceBadAsLenient() throws Exception {
         Class<?> resourceType = Observation.class;
         FHIRSearchContext context = FHIRSearchContextFactory.createSearchContext();
-        List<String> sortQueryParmValues = Arrays.asList("-component-code2");
+        String sortQueryParmValue = "-component-code2";
         boolean lenient = true;
-        sort.parseSortParameter(resourceType, context, sortQueryParmValues, lenient);
-        
+        sort.parseSortParameter(resourceType, context, sortQueryParmValue, lenient);
+
         assertTrue(context.getSortParameters().isEmpty());
     }
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ElementsParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ElementsParameterParseTest.java
@@ -27,7 +27,7 @@ import com.ibm.fhir.search.util.SearchUtil;
 /**
  * This testng test class contains methods that test the parsing of the search result _elements parameter in the
  * SearchUtil class.
- * 
+ *
  * @author markd
  * @author pbastide
  *
@@ -72,7 +72,7 @@ public class ElementsParameterParseTest extends BaseSearchTest {
         Map<String, List<String>> queryParameters = new HashMap<>();
         Class<Patient> resourceType = Patient.class;
 
-        queryParameters.put("_elements", Arrays.asList("id", "contact", "bogus", "name"));
+        queryParameters.put("_elements", Collections.singletonList("id,contact,bogus,name"));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters, true);
         assertNotNull(context);
         assertNotNull(context.getElementsParameters());
@@ -90,7 +90,31 @@ public class ElementsParameterParseTest extends BaseSearchTest {
         Map<String, List<String>> queryParameters = new HashMap<>();
         Class<Patient> resourceType = Patient.class;
 
-        queryParameters.put("_elements", Arrays.asList("id", "contact", "bogus", "name"));
+        queryParameters.put("_elements", Collections.singletonList("id,contact,bogus,name"));
+        SearchUtil.parseQueryParameters(resourceType, queryParameters, false);
+    }
+
+    @Test
+    public void testFake_multiElementParams_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        Class<Patient> resourceType = Patient.class;
+
+        queryParameters.put("_elements", Arrays.asList("id","contact","bogus","name"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters, true);
+        assertNotNull(context);
+        assertNotNull(context.getElementsParameters());
+        assertEquals(1, context.getElementsParameters().size());
+
+        String selfUri = SearchUtil.buildSearchSelfUri("http://example.com/" + resourceType.getSimpleName(), context);
+        assertTrue(selfUri.contains("id"), selfUri + " does not contain expected elements param 'id'");
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testFake_multiElementParams_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        Class<Patient> resourceType = Patient.class;
+
+        queryParameters.put("_elements", Arrays.asList("id","contact","bogus","name"));
         SearchUtil.parseQueryParameters(resourceType, queryParameters, false);
     }
 
@@ -100,7 +124,7 @@ public class ElementsParameterParseTest extends BaseSearchTest {
         Class<Patient> resourceType = Patient.class;
         String queryString = "&_elements=name";
 
-        queryParameters.put("_elements", Arrays.asList("name"));
+        queryParameters.put("_elements", Collections.singletonList("name"));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters);
         assertNotNull(context);
         assertNotNull(context.getElementsParameters());
@@ -116,15 +140,15 @@ public class ElementsParameterParseTest extends BaseSearchTest {
         Map<String, List<String>> queryParameters = new HashMap<>();
         Class<Patient> resourceType = Patient.class;
 
-        queryParameters.put("_elements", Arrays.asList("name", "photo", "identifier"));
+        queryParameters.put("_elements", Collections.singletonList("name,photo,identifier"));
         FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters);
         assertNotNull(context);
         assertNotNull(context.getElementsParameters());
 
         assertEquals(context.getElementsParameters().size(), 3);
-        for (String element : context.getElementsParameters()) {
-            assertTrue(queryParameters.get("_elements").contains(element));
-        }
+        assertTrue(context.getElementsParameters().contains("name"));
+        assertTrue(context.getElementsParameters().contains("photo"));
+        assertTrue(context.getElementsParameters().contains("identifier"));
 
         String selfUri = SearchUtil.buildSearchSelfUri("http://example.com/" + resourceType.getSimpleName(), context);
         assertTrue(selfUri.contains("name"), selfUri + " does not contain expected elements param 'name'");

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/PageCountParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/PageCountParameterParseTest.java
@@ -1,0 +1,149 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.search.test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.search.SearchConstants;
+import com.ibm.fhir.search.context.FHIRSearchContext;
+import com.ibm.fhir.search.util.SearchUtil;
+
+/**
+ * This testng test class contains methods that test the parsing of the _page and _count parameter in the
+ * SearchUtil class.
+ *
+ * @author tbieste
+ *
+ */
+public class PageCountParameterParseTest extends BaseSearchTest {
+
+    @Test
+    public void testPageAndCount() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_page", Arrays.asList("2"));
+        queryParameters.put("_count", Arrays.asList("20"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+        assertNotNull(context);
+        assertEquals(context.getPageNumber(), 2);
+        assertEquals(context.getPageSize(), 20);
+    }
+
+    @Test
+    public void testPageAndCountAboveMax() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_page", Arrays.asList("2"));
+        queryParameters.put("_count", Arrays.asList(String.valueOf(SearchConstants.MAX_PAGE_SIZE + 1)));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Patient.class, queryParameters);
+        assertNotNull(context);
+        assertEquals(context.getPageNumber(), 2);
+        assertEquals(context.getPageSize(), SearchConstants.MAX_PAGE_SIZE);
+    }
+
+    @Test
+    public void testPageAndCountInvalid_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_page", Arrays.asList("invalid"));
+        queryParameters.put("_count", Arrays.asList("-1"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Patient.class, queryParameters, true);
+        assertNotNull(context);
+        assertEquals(context.getPageNumber(), 1);
+        assertEquals(context.getPageSize(), 10);
+    }
+
+    @Test
+    public void testPageAndCountInvalidPage_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_page", Arrays.asList("invalid"));
+        queryParameters.put("_count", Arrays.asList("20"));
+        try {
+            SearchUtil.parseQueryParameters(Patient.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "An error occurred while parsing parameter '_page'.");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+    @Test
+    public void testPageAndCountInvalidCount_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_page", Arrays.asList("2"));
+        queryParameters.put("_count", Arrays.asList("-1"));
+        try {
+            SearchUtil.parseQueryParameters(Patient.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "An error occurred while parsing parameter '_count'.");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+    @Test
+    public void testPageAndCountMultipleParams_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_page", Arrays.asList("3", "4"));
+        queryParameters.put("_count", Arrays.asList("30", "40"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Patient.class, queryParameters, true);
+        assertNotNull(context);
+        assertEquals(context.getPageNumber(), 3);
+        assertEquals(context.getPageSize(), 30);
+    }
+
+    @Test
+    public void testPageAndCountMultiplePageParams_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_page", Arrays.asList("3", "4"));
+        queryParameters.put("_count", Arrays.asList("30"));
+        try {
+            SearchUtil.parseQueryParameters(Patient.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "Search parameter '_page' is specified multiple times");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+    @Test
+    public void testPageAndCountMultipleCountParams_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_page", Arrays.asList("3"));
+        queryParameters.put("_count", Arrays.asList("30", "40"));
+        try {
+            SearchUtil.parseQueryParameters(Patient.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "Search parameter '_count' is specified multiple times");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+}

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/SummaryParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/SummaryParameterParseTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -26,7 +26,7 @@ import com.ibm.fhir.search.util.SearchUtil;
 /**
  * This testng test class contains methods that test the parsing of the search result _summary parameter in the
  * SearchUtil class.
- * 
+ *
  * @author Albert Wang
  *
  */
@@ -43,20 +43,36 @@ public class SummaryParameterParseTest extends BaseSearchTest {
         assertNotNull(context.getSummaryParameter());
         assertEquals(context.getSummaryParameter(), SummaryValueSet.TRUE);
     }
-    
-    
+
     @Test
-    public void testSummaryMultiple() throws Exception {
+    public void testSummaryMultiple_lenient() throws Exception {
         Map<String, List<String>> queryParameters = new HashMap<>();
         Class<Patient> resourceType = Patient.class;
 
         queryParameters.put("_summary", Arrays.asList("data","true"));
-        FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters);
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(resourceType, queryParameters, true);
         assertNotNull(context);
         assertNotNull(context.getSummaryParameter());
         assertEquals(context.getSummaryParameter(), SummaryValueSet.DATA);
     }
-    
+
+    @Test
+    public void testSummaryMultiple_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        Class<Patient> resourceType = Patient.class;
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_summary", Arrays.asList("data","true"));
+        try {
+            SearchUtil.parseQueryParameters(resourceType, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "Search parameter '_summary' is specified multiple times");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
     @Test
     public void testSummaryInvalid_lenient() throws Exception {
         Map<String, List<String>> queryParameters = new HashMap<>();
@@ -67,21 +83,21 @@ public class SummaryParameterParseTest extends BaseSearchTest {
         assertNotNull(context);
         assertNull(context.getSummaryParameter());
     }
-    
-    
+
     @Test
     public void testSummaryInvalid_strict() throws Exception {
         Map<String, List<String>> queryParameters = new HashMap<>();
         Class<Patient> resourceType = Patient.class;
-        boolean isSummaryValueCorrect = true;
+        boolean isExceptionThrown = false;
 
         queryParameters.put("_summary", Arrays.asList("invalid"));
         try {
             SearchUtil.parseQueryParameters(resourceType, queryParameters, false);
         } catch(Exception ex) {
-            isSummaryValueCorrect = false;
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "An error occurred while parsing parameter '_summary'.");
         }
-        assertTrue(!isSummaryValueCorrect);
+        assertTrue(isExceptionThrown);
     }
 
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
@@ -1,0 +1,143 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.search.test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.search.context.FHIRSearchContext;
+import com.ibm.fhir.search.util.SearchUtil;
+
+/**
+ * This testng test class contains methods that test the parsing of the search result _type parameter in the
+ * SearchUtil class.
+ *
+ * @author tbieste
+ *
+ */
+public class TypeParameterParseTest extends BaseSearchTest {
+
+    @Test
+    public void testType() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Arrays.asList("Patient"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Resource.class, queryParameters);
+        assertNotNull(context);
+        assertNotNull(context.getSearchResourceTypes());
+        assertEquals(context.getSearchResourceTypes().size(), 1);
+        assertTrue(context.getSearchResourceTypes().contains("Patient"));
+    }
+
+    @Test
+    public void testTypeMultiple() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Collections.singletonList("Patient,Practitioner"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Resource.class, queryParameters);
+        assertNotNull(context);
+        assertNotNull(context.getSearchResourceTypes());
+        assertEquals(context.getSearchResourceTypes().size(), 2);
+        assertTrue(context.getSearchResourceTypes().contains("Patient"));
+        assertTrue(context.getSearchResourceTypes().contains("Practitioner"));
+    }
+
+    @Test
+    public void testTypeNonSystemSearch_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Arrays.asList("Patient"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Patient.class, queryParameters, true);
+        assertNotNull(context);
+        assertNull(context.getSearchResourceTypes());
+    }
+
+    @Test
+    public void testTypeNonSystemSearch_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_type", Arrays.asList("Patient"));
+        try {
+            SearchUtil.parseQueryParameters(Patient.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "_type search parameter is only supported with system search");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+    @Test
+    public void testTypeMultipleParams_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Arrays.asList("Patient", "Practitioner"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Resource.class, queryParameters, true);
+        assertNotNull(context);
+        assertNotNull(context.getSearchResourceTypes());
+        assertEquals(context.getSearchResourceTypes().size(), 1);
+        assertTrue(context.getSearchResourceTypes().contains("Patient"));
+    }
+
+    @Test
+    public void testTypeMultipleParams_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_type", Arrays.asList("Patient", "Practitioner"));
+        try {
+            SearchUtil.parseQueryParameters(Resource.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "Search parameter '_type' is specified multiple times");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+    @Test
+    public void testTypeInvalid_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Collections.singletonList("invalid,Practitioner"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Resource.class, queryParameters, true);
+        assertNotNull(context);
+        assertNotNull(context.getSearchResourceTypes());
+        assertEquals(context.getSearchResourceTypes().size(), 1);
+        assertTrue(context.getSearchResourceTypes().contains("Practitioner"));
+    }
+
+    @Test
+    public void testTypeInvalid_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_type", Collections.singletonList("invalid,Practitioner"));
+        try {
+            SearchUtil.parseQueryParameters(Resource.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "_type search parameter has invalid resource type: invalid");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
+}

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
@@ -140,4 +140,30 @@ public class TypeParameterParseTest extends BaseSearchTest {
         assertTrue(isExceptionThrown);
     }
 
+    @Test
+    public void testTypeAbstract_lenient() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+
+        queryParameters.put("_type", Collections.singletonList("Resource"));
+        FHIRSearchContext context = SearchUtil.parseQueryParameters(Resource.class, queryParameters, true);
+        assertNotNull(context);
+        assertNull(context.getSearchResourceTypes());
+    }
+
+    @Test
+    public void testTypeAbstract_strict() throws Exception {
+        Map<String, List<String>> queryParameters = new HashMap<>();
+        boolean isExceptionThrown = false;
+
+        queryParameters.put("_type", Collections.singletonList("Resource"));
+        try {
+            SearchUtil.parseQueryParameters(Resource.class, queryParameters, false);
+        } catch(Exception ex) {
+            isExceptionThrown = true;
+            assertEquals(ex.getMessage(), "_type search parameter has invalid resource type: Resource");
+
+        }
+        assertTrue(isExceptionThrown);
+    }
+
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -576,7 +576,7 @@ public class SearchTest extends FHIRServerTestBase {
         Response response =
                 target.path("Observation").queryParam("subject", "Patient/"
                         + patientId).queryParam("_include", "Observation:subject")
-                .queryParam("_elements", "status", "category", "subject")
+                .queryParam("_elements", "status,category,subject")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .header("X-FHIR-TENANT-ID", tenantName)
                 .header("X-FHIR-DSID", dataStoreId)

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SortingTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SortingTest.java
@@ -309,7 +309,7 @@ public class SortingTest extends FHIRServerTestBase {
         assertTrueNaturalOrderingString(list);
     }
 
-    // Patient?gender=male&_sort=family
+    // Patient?gender=male&_count=50&_sort=family&_elements=gender,name
     @SuppressWarnings("rawtypes")
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
@@ -317,7 +317,7 @@ public class SortingTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("Patient").queryParam("gender", "male").queryParam("_count", "50")
-                .queryParam("_sort", "family").queryParam("_elements", "gender", "name")
+                .queryParam("_sort", "family").queryParam("_elements", "gender,name")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
@@ -473,14 +473,14 @@ public class SortingTest extends FHIRServerTestBase {
         assertTrueNaturalOrderingReverseInstant(list);
     }
 
-    // Patient?gender=male&_sort=family&_sort=birthdate
+    // Patient?_count=50&_sort=-family,birthdate
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
     public void testSortTwoParameters() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("_count", "50").queryParam("_sort", "-family")
-                .queryParam("_sort", "birthdate").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+                target.path("Patient").queryParam("_count", "50")
+                .queryParam("_sort", "-family,birthdate").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -527,14 +527,14 @@ public class SortingTest extends FHIRServerTestBase {
         assertTrueNaturalOrderingReverse(list);
     }
 
-    // Patient?gender=male&_sort=-family&_sort=-birthdate
+    // Patient?_count=50&_sort=-family,-birthdate
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
     public void testSortTwoParametersDescending() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("_count", "50").queryParam("_sort", "-family")
-                .queryParam("_sort", "-birthdate").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+                target.path("Patient").queryParam("_count", "50")
+                .queryParam("_sort", "-family,-birthdate").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -848,7 +848,7 @@ public class SortingTest extends FHIRServerTestBase {
 
 
 
-    // Patient?gender=male&_sort=family
+    // Patient?gender=male&_count=50&_sort=family&_elements=gender,name&_summary=true
     @SuppressWarnings("rawtypes")
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
@@ -857,7 +857,7 @@ public class SortingTest extends FHIRServerTestBase {
         // The _summary=true should be ignored.
         Response response =
                 target.path("Patient").queryParam("gender", "male").queryParam("_count", "50")
-                .queryParam("_sort", "family").queryParam("_elements", "gender", "name")
+                .queryParam("_sort", "family").queryParam("_elements", "gender,name")
                 .queryParam("_summary", "true")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/performance/SearchPerformanceTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/performance/SearchPerformanceTest.java
@@ -338,7 +338,7 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         Response response =
                 target.path("Observation").queryParam("subject", "Patient/"
                         + patientId).queryParam("_include", "Observation:subject")
-                .queryParam("_elements", "status", "category", "subject")
+                .queryParam("_elements", "status,category,subject")
                 .queryParam("_count", "100")
                 .queryParam("_page", "1")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
@@ -513,8 +513,8 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 1);
     }
-    
-    
+
+
     @Test(groups = { "server-search-performance" })
     public void testSearchObservationWithPatientName() {
         WebTarget target = getWebTarget();


### PR DESCRIPTION
Updated to return an error when the _type search parameter is used in a non-system search with strict parsing. Updated to have consistent behavior of the _type, _elements, _sort, _count, _page, and _summary search parameters with regards to when any of those parameters is specified multiple times; with strict parsing, an error is returned; with lenient parsing, the value of the first occurrence of the parameter is used.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>