### PR TITLE
Issue #1731 - Add support for ':not' modifier

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -165,9 +165,9 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, the `:missing` and `:not` modifiers are not supported for whole-system search nor for chained parameter search. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
+At present, the `:missing` and `:not` modifiers are not supported for whole-system search nor for chained parameter search. For example, a search with a query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
 
-The :text, :above, :below, :in, :not-in, and :of-type modifiers are not supported in this version of the IBM FHIR server and use of this modifier will results in an HTTP 400 error with an OperationOutcome that describes the failure.
+The :text, :above, :below, :in, :not-in, and :of-type modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
 
 ### Search prefixes
 FHIR search prefixes are described at https://www.hl7.org/fhir/R4/search.html#prefix.

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-05 12:00:00 -0400
+date:   2021-02-09 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -141,8 +141,6 @@ The `_include` and `_revinclude` parameters can be used to return resources rela
 
 The `:iterate` modifier is not supported for the `_include` parameter (or any other).
 
-The `:missing` modifier is not supported for whole-system search.
-
 The `_total`, `_contained`, and `_containedType` parameters are not supported at this time.
 
 ### Custom search parameters
@@ -158,7 +156,7 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 |String                    |`:exact`,`:contains`,`:missing` |"starts with" search that is case-insensitive and accent-insensitive|
 |Reference                 |`:[type]`,`:missing`            |exact match search and targets are implicitly added|
 |URI                       |`:below`,`:above`,`:missing`    |exact match search|
-|Token                     |`:missing`                      |exact match search|
+|Token                     |`:missing`,`:not`               |exact match search|
 |Number                    |`:missing`                      |implicit range search (see http://hl7.org/fhir/R4/search.html#number)|
 |Date                      |`:missing`                      |implicit range search (see https://www.hl7.org/fhir/search.html#date)|
 |Quantity                  |`:missing`                      |implicit range search (see http://hl7.org/fhir/R4/search.html#quantity)|
@@ -167,9 +165,9 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, the `:missing` modifier is not supported for whole-system search nor for chained parameter search. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
+At present, the `:missing` and `:not` modifiers are not supported for whole-system search nor for chained parameter search. For example, a search with query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
 
-The :text, :not, :above, :below, :in, :not-in, and :of-type modifiers are not supported in this version of the IBM FHIR server and use of this modifier will results in an HTTP 400 error with an OperationOutcome that describes the failure.
+The :text, :above, :below, :in, :not-in, and :of-type modifiers are not supported in this version of the IBM FHIR server and use of this modifier will results in an HTTP 400 error with an OperationOutcome that describes the failure.
 
 ### Search prefixes
 FHIR search prefixes are described at https://www.hl7.org/fhir/R4/search.html#prefix.
@@ -280,9 +278,6 @@ Positional Search uses [UCUM units](https://unitsofmeasure.org/ucum.html) of dis
 |FEET|ft, fts, foot|
 
 Note, the use of the surrounding bracket, such as `[mi_us]` is optional; `mi_us` is also valid.
-
-### Search parameters
-
 
 ## HL7 FHIR R4 (v4.0.1) errata
 We add information here as we find issues with the artifacts provided with this version of the specification.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -132,7 +132,7 @@ public class JDBCConstants {
         supportedModifiersMap.put(Type.STRING, Arrays.asList(Modifier.EXACT, Modifier.CONTAINS, Modifier.MISSING));
         supportedModifiersMap.put(Type.REFERENCE, Arrays.asList(Modifier.TYPE, Modifier.MISSING));
         supportedModifiersMap.put(Type.URI, Arrays.asList(Modifier.BELOW, Modifier.ABOVE, Modifier.MISSING));
-        supportedModifiersMap.put(Type.TOKEN, Arrays.asList(Modifier.MISSING));
+        supportedModifiersMap.put(Type.TOKEN, Arrays.asList(Modifier.MISSING, Modifier.NOT));
         supportedModifiersMap.put(Type.NUMBER, Arrays.asList(Modifier.MISSING));
         supportedModifiersMap.put(Type.DATE, Arrays.asList(Modifier.MISSING));
         supportedModifiersMap.put(Type.QUANTITY, Arrays.asList(Modifier.MISSING));
@@ -144,7 +144,7 @@ public class JDBCConstants {
         modifierOperatorMap.put(Modifier.BELOW, LT);
         modifierOperatorMap.put(Modifier.CONTAINS, LIKE);
         modifierOperatorMap.put(Modifier.EXACT, EQ);
-        modifierOperatorMap.put(Modifier.NOT, NE);
+        modifierOperatorMap.put(Modifier.NOT, EQ); // EQ since it will be within a "WHERE NOT EXISTS" subquery
     }
 
     private JDBCConstants() {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -771,7 +771,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 if (param.getModifier() != null &&
                         !JDBCConstants.supportedModifiersMap.get(param.getType()).contains(param.getModifier())) {
                     throw buildNotSupportedException("Found unsupported modifier ':" + param.getModifier().value() + "'"
-                            + " for search parameter '" + param.getCode() + "' of type " + param.getType());
+                            + " for search parameter '" + param.getCode() + "' of type '" + param.getType() + "'");
                 }
                 param = param.getNextParameter();
             } while (param != null);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -753,15 +753,16 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
     private void checkModifiers(FHIRSearchContext searchContext, boolean isSystemLevelSearch) throws FHIRPersistenceNotSupportedException {
         for (QueryParameter param : searchContext.getSearchParameters()) {
             if (param.getChain().isEmpty()) {
-                if (isSystemLevelSearch && param.getModifier() == Modifier.MISSING) {
+                if (isSystemLevelSearch &&
+                        (param.getModifier() == Modifier.MISSING || param.getModifier() == Modifier.NOT)) {
                     // modifiers are not supported for whole-system searches
-                    throw buildNotSupportedException("Modifier '" + param.getModifier() + "' is not yet supported "
+                    throw buildNotSupportedException("Modifier ':" + param.getModifier().value() + "' is not yet supported "
                             + "for whole-system search [code=" + param.getCode() + "]");
                 }
             } else {
-                if (param.getChain().getLast().getModifier() == Modifier.MISSING) {
+                if (param.getChain().getLast().getModifier() == Modifier.MISSING || param.getChain().getLast().getModifier() == Modifier.NOT) {
                     // modifiers on the last parameter in the chain are not yet supported
-                    throw buildNotSupportedException("Modifier '" + Modifier.MISSING.value() + "' is not yet supported "
+                    throw buildNotSupportedException("Modifier ':" + param.getChain().getLast().getModifier().value() + "' is not yet supported "
                             + "for chained parameters [code=" + param.getCode() + "]");
                 }
             }
@@ -769,7 +770,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             do {
                 if (param.getModifier() != null &&
                         !JDBCConstants.supportedModifiersMap.get(param.getType()).contains(param.getModifier())) {
-                    throw buildNotSupportedException("Found unsupported modifier '" + param.getModifier() + "'"
+                    throw buildNotSupportedException("Found unsupported modifier ':" + param.getModifier().value() + "'"
                             + " for search parameter '" + param.getCode() + "' of type " + param.getType());
                 }
                 param = param.getNextParameter();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCQueryBuilder.java
@@ -1366,7 +1366,7 @@ public class JDBCQueryBuilder extends AbstractQueryBuilder<SqlQueryData> {
 
     private SqlQueryData processMissingParm(Class<?> resourceType, QueryParameter queryParm, String tableAlias)
             throws FHIRPersistenceException {
-        final String METHODNAME = "processStringParm";
+        final String METHODNAME = "processMissingParm";
         log.entering(CLASSNAME, METHODNAME, queryParm.toString());
 
         // boolean to track whether the user has requested the resources missing this parameter (true) or not missing it

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -195,6 +195,25 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 //    }
 
     @Test
+    public void testSearchToken_CodeableConcept_not() throws Exception {
+        assertSearchDoesntReturnSavedResource("CodeableConcept:not", "code");
+        assertSearchDoesntReturnSavedResource("CodeableConcept:not", "http://example.org/codesystem|code");
+        assertSearchReturnsSavedResource("CodeableConcept:not", "other");
+        assertSearchReturnsSavedResource("CodeableConcept:not", "http://example.org/other|code");
+        assertSearchReturnsSavedResource("missing-CodeableConcept:not", "code");
+        assertSearchReturnsSavedResource("missing-CodeableConcept:not", "http://example.org/codesystem|code");
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
+     */
+//    @Test
+//    public void testSearchToken_CodeableConcept_chained_not() throws Exception {
+//    }
+
+    @Test
     public void testSearchToken_CodeableConcept_missing() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept:missing", "false");
         assertSearchDoesntReturnSavedResource("CodeableConcept:missing", "true");
@@ -246,6 +265,26 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 //    @Test
 //    public void testSearchDate_Coding_NoCode() throws Exception {
 //        assertSearchReturnsSavedResource("Coding-noCode", "http://example.org/codesystem|");
+//    }
+
+    @Test
+    public void testSearchToken_Coding_not() throws Exception {
+        assertSearchDoesntReturnSavedResource("Coding:not", "code");
+        assertSearchDoesntReturnSavedResource("Coding:not", "http://example.org/codesystem|code");
+        assertSearchReturnsSavedResource("Coding:not", "other");
+        assertSearchReturnsSavedResource("Coding:not", "http://example.org/other|code");
+        assertSearchReturnsSavedResource("missing-Coding:not", "code");
+        assertSearchReturnsSavedResource("missing-Coding:not", "http://example.org/codesystem|code");
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
+     */
+
+//    @Test
+//    public void testSearchToken_Coding_chained_not() throws Exception {
 //    }
 
     @Test
@@ -303,6 +342,27 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 //    public void testSearchDate_Identifier_NoValue() throws Exception {
 //        assertSearchReturnsSavedResource("Identifier-noValue", "http://example.org/identifiersystem|");
 //    }
+
+    @Test
+    public void testSearchToken_Identifier_not() throws Exception {
+        assertSearchDoesntReturnSavedResource("Identifier:not", "code");
+        assertSearchDoesntReturnSavedResource("Identifier:not", "http://example.org/identifiersystem|code");
+        assertSearchReturnsSavedResource("Identifier:not", "other");
+        assertSearchReturnsSavedResource("Identifier:not", "http://example.org/other|code");
+        assertSearchReturnsSavedResource("missing-Identifier:not", "code");
+        assertSearchReturnsSavedResource("missing-Identifier:not", "http://example.org/codesystem|code");
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support
+     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
+     */
+
+//    @Test
+//    public void testSearchToken_Identifier_chained_not() throws Exception {
+//    }
+
 
     @Test
     public void testSearchToken_Identifier_missing() throws Exception {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -420,6 +420,20 @@ public class SearchTest extends FHIRServerTestBase {
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
+    @Test(groups = { "server-search" }, dependsOnMethods = {"testCreatePatient" })
+    public void testSearchPatientWithGenderNot() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient").queryParam("gender:not", "female").request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                    .header("X-FHIR-TENANT-ID", tenantName)
+                    .header("X-FHIR-DSID", dataStoreId)
+                    .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
     @Test(groups = { "server-search" })
     public void testCreateObservationWithRange() throws Exception {
         WebTarget target = getWebTarget();


### PR DESCRIPTION
Added support for the search parameter ':not' modifier.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>