### PR TITLE
Issue #473 - Add support for ':missing' modifier within chained search and whole-system search

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -165,9 +165,9 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, the `:missing` and `:not` modifiers are not supported for whole-system search nor for chained parameter search. For example, a search with a query string like `subject:Basic.date:missing` will result in an `OperationOutcome` explaining that the search parameter could not be processed.
+At present, the `:missing` and `:not` modifiers are not supported for whole-system search. The `:not` modifier is also not supported for chained parameter search. Use of these modifiers in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
 
-The :text, :above, :below, :in, :not-in, and :of-type modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
+The `:text`, `:above`, `:below`, `:in`, `:not-in`, and `:of-type` modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
 
 ### Search prefixes
 FHIR search prefixes are described at https://www.hl7.org/fhir/R4/search.html#prefix.

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-09 12:00:00 -0400
+date:   2021-02-11 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -165,7 +165,7 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, the `:missing` and `:not` modifiers are not supported for whole-system search. The `:not` modifier is also not supported for chained parameter search. Use of these modifiers in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
+At present, the `:not` modifier is not supported for whole-system search nor for chained parameter search. Use of this modifier in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
 
 The `:text`, `:above`, `:below`, `:in`, `:not-in`, and `:of-type` modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -50,6 +50,7 @@ public class JDBCConstants {
     public static final char DOT_CHAR = '.';
     public static final String WHERE = " WHERE ";
     public static final String PARAMETER_TABLE_ALIAS = "pX";
+    public static final String RESOURCE_TABLE_ALIAS = "R";
     public static final String LEFT_PAREN = "(";
     public static final String RIGHT_PAREN = ")";
     public static final String BIND_VAR = "?";

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -50,7 +50,6 @@ public class JDBCConstants {
     public static final char DOT_CHAR = '.';
     public static final String WHERE = " WHERE ";
     public static final String PARAMETER_TABLE_ALIAS = "pX";
-    public static final String RESOURCE_TABLE_ALIAS = "R";
     public static final String LEFT_PAREN = "(";
     public static final String RIGHT_PAREN = ")";
     public static final String BIND_VAR = "?";

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -50,6 +50,7 @@ public class JDBCConstants {
     public static final char DOT_CHAR = '.';
     public static final String WHERE = " WHERE ";
     public static final String PARAMETER_TABLE_ALIAS = "pX";
+    public static final String PARAMETER_TABLE_NAME_PLACEHOLDER = "pX_TABLE_NAME";
     public static final String LEFT_PAREN = "(";
     public static final String RIGHT_PAREN = ")";
     public static final String BIND_VAR = "?";

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -752,16 +752,17 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
      */
     private void checkModifiers(FHIRSearchContext searchContext, boolean isSystemLevelSearch) throws FHIRPersistenceNotSupportedException {
         for (QueryParameter param : searchContext.getSearchParameters()) {
-            if (param.getChain().isEmpty()) {
-                if (isSystemLevelSearch &&
-                        (param.getModifier() == Modifier.MISSING || param.getModifier() == Modifier.NOT)) {
-                    // modifiers are not supported for whole-system searches
+            if (isSystemLevelSearch) {
+                if (param.getModifier() == Modifier.NOT) {
+                    // ':not' modifier is not yet supported for whole-system searches
                     throw buildNotSupportedException("Modifier ':" + param.getModifier().value() + "' is not yet supported "
                             + "for whole-system search [code=" + param.getCode() + "]");
                 }
-            } else {
+            }
+
+            if (!param.getChain().isEmpty()) {
                 if (param.getChain().getLast().getModifier() == Modifier.NOT) {
-                    // modifiers on the last parameter in the chain are not yet supported
+                    // ':not' modifier on the last parameter in the chain is not yet supported
                     throw buildNotSupportedException("Modifier ':" + param.getChain().getLast().getModifier().value() + "' is not yet supported "
                             + "for chained parameters [code=" + param.getCode() + "]");
                 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -760,7 +760,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                             + "for whole-system search [code=" + param.getCode() + "]");
                 }
             } else {
-                if (param.getChain().getLast().getModifier() == Modifier.MISSING || param.getChain().getLast().getModifier() == Modifier.NOT) {
+                if (param.getChain().getLast().getModifier() == Modifier.NOT) {
                     // modifiers on the last parameter in the chain are not yet supported
                     throw buildNotSupportedException("Modifier ':" + param.getChain().getLast().getModifier().value() + "' is not yet supported "
                             + "for chained parameters [code=" + param.getCode() + "]");

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/QuerySegmentAggregator.java
@@ -559,12 +559,20 @@ public class QuerySegmentAggregator {
             if (!SKIP_WHERE.contains(code)) {
 
                 if (Modifier.MISSING.equals(param.getModifier())) {
+                    // The param table alias needs to be replaced by the table name, since for a whole-system
+                    // search the JDBCQueryBuilder.processMissingParm() put the param table alias in the query string
+                    // because each resource type has its own table name
+                    String valuesTable = tableName(overrideType, param);
+                    final String querySegmentString = querySegment.getQueryString()
+                            .replaceAll(PARAMETER_TABLE_ALIAS + "\\.", valuesTable + ".")
+                            .replaceAll(PARAMETER_TABLE_ALIAS + " ", valuesTable + " ");
+
                     // Append queryString to a separate StringBuilder which will get appended to the where clause last.
                     if (missingModifierWhereClause.length() == 0) {
-                        missingModifierWhereClause.append(querySegment.getQueryString());
+                        missingModifierWhereClause.append(querySegmentString);
                     } else {
                         // If not the first param with a :missing modifier, replace the WHERE with an AND
-                        missingModifierWhereClause.append(querySegment.getQueryString().replaceFirst(WHERE, AND));
+                        missingModifierWhereClause.append(querySegmentString.replaceFirst(WHERE, AND));
                     }
                 } else {
                     if (!Type.COMPOSITE.equals(param.getType())) {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchDateTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -28,7 +25,7 @@ public class JDBCSearchDateTest extends AbstractSearchDateTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchDateTest() throws Exception {
@@ -43,7 +40,7 @@ public class JDBCSearchDateTest extends AbstractSearchDateTest {
             derbyInit = new DerbyInitializer(this.testProps);
             IConnectionProvider cp = derbyInit.getConnectionProvider(false);
             this.connectionPool = new PoolConnectionProvider(cp, 1);
-            
+
             ICommonTokenValuesCache rrc = new CommonTokenValuesCacheImpl(100, 100);
             cache = new FHIRPersistenceJDBCCacheImpl(new NameIdCache<Integer>(), new NameIdCache<Integer>(), rrc);
         }
@@ -63,32 +60,5 @@ public class JDBCSearchDateTest extends AbstractSearchDateTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchDate_instant_chained_missing() throws Exception {
-        super.testSearchDate_instant_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchDate_Period_chained_missing() throws Exception {
-        super.testSearchDate_Period_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchDate_date_chained_missing() throws Exception {
-        super.testSearchDate_date_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchDate_dateTime_chained_missing() throws Exception {
-        super.testSearchDate_dateTime_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNumberTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNumberTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -28,7 +25,7 @@ public class JDBCSearchNumberTest extends AbstractSearchNumberTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchNumberTest() throws Exception {
@@ -63,23 +60,5 @@ public class JDBCSearchNumberTest extends AbstractSearchNumberTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchNumber_integer_chained_missing() throws Exception {
-        super.testSearchNumber_integer_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchNumber_decimal_chained_missing() throws Exception {
-        super.testSearchNumber_decimal_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchQuantityTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchQuantityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019,2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -29,7 +26,7 @@ public class JDBCSearchQuantityTest extends AbstractSearchQuantityTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchQuantityTest() throws Exception {
@@ -64,18 +61,5 @@ public class JDBCSearchQuantityTest extends AbstractSearchQuantityTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchQuantity_Quantity_chained_missing() throws Exception {
-        super.testSearchQuantity_Quantity_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchReferenceTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2019, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -29,7 +26,7 @@ public class JDBCSearchReferenceTest extends AbstractSearchReferenceTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchReferenceTest() throws Exception {
@@ -64,23 +61,5 @@ public class JDBCSearchReferenceTest extends AbstractSearchReferenceTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchReference_Reference_chained_missing() throws Exception {
-        super.testSearchReference_Reference_chained_missing();
-    }
-
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchReference_uri_chained_missing() throws Exception {
-        super.testSearchReference_uri_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchStringTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchStringTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2019, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -30,7 +27,7 @@ public class JDBCSearchStringTest extends AbstractSearchStringTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchStringTest() throws Exception {
@@ -65,22 +62,5 @@ public class JDBCSearchStringTest extends AbstractSearchStringTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchString_string_chained_missing() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.string:missing", "false");
-        assertSearchDoesntReturnComposition("subject:Basic.string:missing", "true");
-
-        assertSearchReturnsComposition("subject:Basic.missing-string:missing", "true");
-        assertSearchDoesntReturnComposition("subject:Basic.missing-string:missing", "false");
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchTokenTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchTokenTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2019, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -30,7 +27,7 @@ public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchTokenTest() throws Exception {
@@ -65,28 +62,5 @@ public class JDBCSearchTokenTest extends AbstractSearchTokenTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchToken_boolean_chained_missing() throws Exception {
-        super.testSearchToken_boolean_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchToken_code_chained_missing() throws Exception {
-        super.testSearchToken_code_chained_missing();
-    }
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
-        super.testSearchToken_CodeableConcept_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchURITest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchURITest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2019, 2020
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -28,7 +25,7 @@ public class JDBCSearchURITest extends AbstractSearchURITest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCSearchURITest() throws Exception {
@@ -63,18 +60,5 @@ public class JDBCSearchURITest extends AbstractSearchURITest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters.
-     * https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchURI_uri_chained_missing() throws Exception {
-        super.testSearchURI_uri_chained_missing();
     }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCWholeSystemSearchTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCWholeSystemSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,13 +8,10 @@ package com.ibm.fhir.persistence.jdbc.search.test;
 
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.cache.CommonTokenValuesCacheImpl;
 import com.ibm.fhir.persistence.jdbc.cache.FHIRPersistenceJDBCCacheImpl;
@@ -29,7 +26,7 @@ public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
     private Properties testProps;
 
     private PoolConnectionProvider connectionPool;
-    
+
     private FHIRPersistenceJDBCCache cache;
 
     public JDBCWholeSystemSearchTest() throws Exception {
@@ -64,12 +61,5 @@ public class JDBCWholeSystemSearchTest extends AbstractWholeSystemSearchTest {
         if (this.connectionPool != null) {
             this.connectionPool.close();
         }
-    }
-
-
-    @Override
-    @Test(expectedExceptions = FHIRPersistenceNotSupportedException.class)
-    public void testSearchAllUsingIdAndLastUpdatedAndAnyTagOrProfile() throws Exception {
-        super.testSearchAllUsingIdAndLastUpdatedAndAnyTagOrProfile();
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchDateTest.java
@@ -959,7 +959,7 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
         // "dateTime" is 2019-12-31T20:00:00-04:00
 
         assertSearchReturnsComposition("subject:Basic.dateTime", "2019-12-31T20:00:00-04:00");
-        assertSearchDoesntReturnSavedResource("subject:Basic.dateTime", "2025-10-29");
+        assertSearchDoesntReturnComposition("subject:Basic.dateTime", "2025-10-29");
     }
     @Test
     public void testSearchDate_dateTime_missing() throws Exception {
@@ -1936,11 +1936,11 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
 
     @Test
     public void testSearchDate_instant_chained_missing() throws Exception {
-        assertSearchReturnsSavedResource("subject:Basic.instant:missing", "false");
-        assertSearchDoesntReturnSavedResource("subject:Basic.instant:missing", "true");
+        assertSearchReturnsComposition("subject:Basic.instant:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.instant:missing", "true");
 
-        assertSearchReturnsSavedResource("subject:Basic.missing-instant:missing", "true");
-        assertSearchDoesntReturnSavedResource("subject:Basic.missing-instant:missing", "false");
+        assertSearchReturnsComposition("subject:Basic.missing-instant:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-instant:missing", "false");
     }
     @Test
     public void testSearchDate_Period_chained_missing() throws Exception {
@@ -1953,10 +1953,10 @@ public abstract class AbstractSearchDateTest extends AbstractPLSearchTest {
     @Test
     public void testSearchDate_date_chained_missing() throws Exception {
         assertSearchReturnsComposition("subject:Basic.date:missing", "false");
-        assertSearchDoesntReturnSavedResource("subject:Basic.date:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.date:missing", "true");
 
         assertSearchReturnsComposition("subject:Basic.missing-date:missing", "true");
-        assertSearchDoesntReturnSavedResource("subject:Basic.missing-date:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-date:missing", "false");
     }
     @Test
     public void testSearchDate_dateTime_chained_missing() throws Exception {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchReferenceTest.java
@@ -21,6 +21,7 @@ import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.search.exception.FHIRSearchException;
 
 /**
  * @see https://hl7.org/fhir/r4/search.html#reference
@@ -65,13 +66,12 @@ public abstract class AbstractSearchReferenceTest extends AbstractPLSearchTest {
     @Test
     public void testSearchReference_Reference_relative_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.Reference-relative", "Patient/123");
-        /*
-         * Currently, as documented in our conformance doc, we do not support modifiers on chained parameters.
-         * See https://ibm.github.io/FHIR/Conformance#search-modifiers and
-         * refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-         */
-        // assertSearchReturnsComposition("subject:Basic.Reference-relative:Patient", "123");
-        // assertSearchReturnsComposition("subject:Basic.Reference-relative:Basic", "123");
+        assertSearchReturnsComposition("subject:Basic.Reference-relative:Patient", "123");
+    }
+
+    @Test(expectedExceptions = { FHIRSearchException.class })
+    public void testSearchReference_Reference_relative_chained_invalid_type() throws Exception {
+        assertSearchDoesntReturnComposition("subject:Basic.Reference-relative:Basic", "123");
     }
 
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -183,14 +183,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     @Test
-    public void testSearchDate_CodeableConcept_multiCoded() throws Exception {
+    public void testSearchToken_CodeableConcept_multiCoded() throws Exception {
         assertSearchReturnsSavedResource("CodeableConcept-multiCoded", "http://example.org/codesystem|code");
         assertSearchReturnsSavedResource("CodeableConcept-multiCoded", "http://example.org/othersystem|code");
     }
 
     // Currently CodeableConcepts with no code are skipped
 //    @Test
-//    public void testSearchDate_CodeableConcept_NoCode() throws Exception {
+//    public void testSearchToken_CodeableConcept_NoCode() throws Exception {
 //        assertSearchReturnsSavedResource("CodeableConcept-noCode", "http://example.org/codesystem|");
 //    }
 
@@ -205,8 +205,8 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Currently, documented in our conformance statement. We do not support the ':not'
+     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
      */
 //    @Test
@@ -256,14 +256,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     @Test
-    public void testSearchDate_Coding_NoSystem() throws Exception {
+    public void testSearchToken_Coding_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("Coding-noSystem", "code");
         assertSearchReturnsSavedResource("Coding-noSystem", "|code");
     }
 
     // Currently codings with no code are skipped
 //    @Test
-//    public void testSearchDate_Coding_NoCode() throws Exception {
+//    public void testSearchToken_Coding_NoCode() throws Exception {
 //        assertSearchReturnsSavedResource("Coding-noCode", "http://example.org/codesystem|");
 //    }
 
@@ -278,8 +278,8 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Currently, documented in our conformance statement. We do not support the ':not'
+     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
      */
 
@@ -296,20 +296,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-Coding:missing", "false");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
+    @Test
+    public void testSearchToken_Coding_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.Coding:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.Coding:missing", "true");
 
-//    @Test
-//    public void testSearchToken_Coding_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.Coding:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.Coding:missing", "true");
-//
-//        assertSearchReturnsComposition("subject:Basic.missing-Coding:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-Coding:missing", "false");
-//    }
+        assertSearchReturnsComposition("subject:Basic.missing-Coding:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-Coding:missing", "false");
+    }
 
     @Test
     public void testSearchToken_Identifier() throws Exception {
@@ -332,14 +326,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     @Test
-    public void testSearchDate_Identifier_NoSystem() throws Exception {
+    public void testSearchToken_Identifier_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("Identifier-noSystem", "code");
         assertSearchReturnsSavedResource("Identifier-noSystem", "|code");
     }
 
     // Currently identifiers with no value are skipped
 //    @Test
-//    public void testSearchDate_Identifier_NoValue() throws Exception {
+//    public void testSearchToken_Identifier_NoValue() throws Exception {
 //        assertSearchReturnsSavedResource("Identifier-noValue", "http://example.org/identifiersystem|");
 //    }
 
@@ -354,15 +348,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     }
 
     /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Currently, documented in our conformance statement. We do not support the ':not'
+     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
      * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
      */
 
 //    @Test
 //    public void testSearchToken_Identifier_chained_not() throws Exception {
 //    }
-
 
     @Test
     public void testSearchToken_Identifier_missing() throws Exception {
@@ -373,20 +366,14 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("missing-Identifier:missing", "false");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support
-     * modifiers on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/473 to track the issue.
-     */
+    @Test
+    public void testSearchToken_Identifier_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.Identifier:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.Identifier:missing", "true");
 
-//    @Test
-//    public void testSearchToken_Identifier_chained_missing() throws Exception {
-//        assertSearchReturnsComposition("subject:Basic.Identifier:missing", "false");
-//        assertSearchDoesntReturnComposition("subject:Basic.Identifier:missing", "true");
-//
-//        assertSearchReturnsComposition("subject:Basic.missing-Identifier:missing", "true");
-//        assertSearchDoesntReturnComposition("subject:Basic.missing-Identifier:missing", "false");
-//    }
+        assertSearchReturnsComposition("subject:Basic.missing-Identifier:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-Identifier:missing", "false");
+    }
 
     @Test
     public void testSearchToken_ContactPoint() throws Exception {
@@ -401,16 +388,49 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("ContactPoint-uri", "tel:+15556755745");
     }
     @Test
-    public void testSearchDate_ContactPoint_HomeFax() throws Exception {
+    public void testSearchToken_ContactPoint_HomeFax() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-homeFax", "(555) 675 5745");
     }
     @Test
-    public void testSearchDate_ContactPoint_NoUse() throws Exception {
+    public void testSearchToken_ContactPoint_NoUse() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-noUse", "test@example.com");
     }
     @Test
-    public void testSearchDate_ContactPoint_NoSystem() throws Exception {
+    public void testSearchToken_ContactPoint_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-noSystem", "test@example.com");
         assertSearchReturnsSavedResource("ContactPoint-noSystem", "|test@example.com");
     }
+    @Test
+    public void testSearchToken_ContactPoint_not() throws Exception {
+        assertSearchReturnsSavedResource("ContactPoint:not", "(555) 555 5555");
+        assertSearchDoesntReturnSavedResource("ContactPoint:not", "(555) 675 5745");
+    }
+
+    /*
+     * Currently, documented in our conformance statement. We do not support the ':not'
+     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
+     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
+     */
+
+//    @Test
+//    public void testSearchToken_ContactPoint_chained_not() throws Exception {
+//    }
+
+    @Test
+    public void testSearchToken_ContactPoint_missing() throws Exception {
+        assertSearchReturnsSavedResource("ContactPoint:missing", "false");
+        assertSearchDoesntReturnSavedResource("ContactPoint:missing", "true");
+
+        assertSearchReturnsSavedResource("missing-ContactPoint:missing", "true");
+        assertSearchDoesntReturnSavedResource("missing-ContactPoint:missing", "false");
+    }
+    @Test
+    public void testSearchToken_ContactPoint_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.ContactPoint:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.ContactPoint:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-ContactPoint:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-ContactPoint:missing", "false");
+    }
+
 }

--- a/fhir-persistence/src/test/resources/config/token/extension-search-parameters.json
+++ b/fhir-persistence/src/test/resources/config/token/extension-search-parameters.json
@@ -549,5 +549,21 @@
             "xpath": "f:Basic/f:extension[@url='http://example.org/missing-CodeableConcept']/f:valueCodeableConcept",
             "xpathUsage": "normal"
         }
+    },{
+        "fullUrl": "http://ibm.com/watsonhealth/fhir/SearchParameter/Basic-missing-ContactPoint",
+        "resource": {
+            "resourceType": "SearchParameter",
+            "id": "Basic-missing-ContactPoint",
+            "url": "http://ibm.com/fhir/SearchParameter/Basic-missing-ContactPoint",
+            "name": "missing-ContactPoint",
+            "status": "active",
+            "description": "test param",
+            "code": "missing-ContactPoint",
+            "base": ["Basic"],
+            "type": "token",
+            "expression": "Basic.extension.where(url='http://example.org/missing-ContactPoint').value",
+            "xpath": "f:Basic/f:extension[@url='http://example.org/missing-ContactPoint']/f:valueContactPoint",
+            "xpathUsage": "normal"
+        }
     }]
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -55,7 +55,7 @@ public class SearchAllTest extends FHIRServerTestBase {
 
     private static final boolean DEBUG_SEARCH = false;
 
-    private String patientId, patientId2;
+    private String patientId, patientId2, observationId;
     private Instant lastUpdated;
     private Patient patient4DuplicationTest = null;
     private String strUniqueTag = UUID.randomUUID().toString();
@@ -132,6 +132,18 @@ public class SearchAllTest extends FHIRServerTestBase {
                         .header("X-FHIR-DSID", dataStoreId)
                         .post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // Get the patient's logical id value.
+        observationId = getLocationLogicalId(response);
+
+        // Next, call the 'read' API to retrieve the new observation and verify it.
+        response  = target.path("Observation/" + observationId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .header("X-FHIR-TENANT-ID", tenantName)
+                .header("X-FHIR-DSID", dataStoreId)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Observation createdObservation = response.readEntity(Observation.class);
+        TestUtil.assertResourceEquals(observation, createdObservation);
     }
 
     @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreatePatient" })
@@ -252,6 +264,79 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllWithTagMissing_Results() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_tag:missing", "true");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllWithTagMissing_NoResults() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_id", observationId);
+        parameters.searchParam("_tag:missing", "false");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreatePatient" })
+    public void testSearchAllWithTagNotMissing_Results() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_id", patientId);
+        parameters.searchParam("_tag:missing", "false");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertEquals(bundle.getEntry().size(), 1);
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreatePatient" })
+    public void testSearchAllWithTagNotMissing_NoResults() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_id", patientId);
+        parameters.searchParam("_tag:missing", "true");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllChainWithTagNotMissing_Results() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_type", "Observation");
+        parameters.searchParam("_id", observationId);
+        parameters.searchParam("subject:Patient._tag:missing", "false");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertEquals(bundle.getEntry().size(), 1);
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllChainWithTagMissing_NoResults() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_type", "Observation");
+        parameters.searchParam("_id", observationId);
+        parameters.searchParam("subject:Patient._tag:missing", "true");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
     }
 
     /*

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
@@ -204,4 +204,68 @@ public class SearchChainTest extends FHIRServerTestBase {
         assertEquals(oo.getIssue().get(0).getExpression().get(0).getValue(), "Encounter.subject");
     }
 
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithActiveMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.active:missing", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithActiveNotMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.active:missing", "false")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithGenderMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.gender:missing", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithGenderNotMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.gender:missing", "false")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
@@ -1122,4 +1122,37 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         assertEquals(0, bundle.getEntry().size());
     }
 
+    @Test(groups = { "server-search-reverse-chain" }, dependsOnMethods = {"testCreateProcedure1", "testCreateProcedure2"})
+    public void testSearchSingleReverseChainWithStringParmMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient")
+                .queryParam("given", "1" + tag)
+                .queryParam("_has:Procedure:subject:status:missing", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertEquals(0, bundle.getEntry().size());
+    }
+
+    @Test(groups = { "server-search-reverse-chain" }, dependsOnMethods = {"testCreateProcedure1", "testCreateProcedure2"})
+    public void testSearchSingleReverseChainWithStringParmNotMissing() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient")
+                .queryParam("given", "1" + tag)
+                .queryParam("_has:Procedure:subject:status:missing", "false")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertEquals(1, bundle.getEntry().size());
+        assertEquals(patient1Id, bundle.getEntry().get(0).getResource().getId());
+    }
+
 }


### PR DESCRIPTION
Issue #473 - Adds support for the ':missing' modifier to be used in chained search and whole-system search.

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>