### PR TITLE
Issue #1926 - Add support for ':not' modifier within chained search and whole-system search

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-11 12:00:00 -0400
+date:   2021-02-12 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -165,7 +165,7 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
 
-At present, the `:not` modifier is not supported for whole-system search nor for chained parameter search. Use of this modifier in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
+At present, the `:not` modifier is not supported for chained parameter search. Use of this modifier in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
 
 The `:text`, `:above`, `:below`, `:in`, `:not-in`, and `:of-type` modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
 

--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -2,7 +2,7 @@
 layout: post
 title:  Conformance
 description: Notes on the Conformance of the IBM FHIR Server
-date:   2021-02-12 12:00:00 -0400
+date:   2021-02-16 12:00:00 -0400
 permalink: /conformance/
 ---
 
@@ -164,8 +164,6 @@ FHIR search modifiers are described at https://www.hl7.org/fhir/R4/search.html#m
 |Special (near)            | none                           |searches a bounding area according to the value of the `fhirServer/search/useBoundingRadius` property|
 
 Due to performance implications, the `:exact` modifier should be used for String searches where possible.
-
-At present, the `:not` modifier is not supported for chained parameter search. Use of this modifier in an unsupported manner will result in an HTTP 400 error with an OperationOutcome explaining that the search parameter could not be processed.
 
 The `:text`, `:above`, `:below`, `:in`, `:not-in`, and `:of-type` modifiers are not supported in this version of the IBM FHIR server and use of these modifiers will result in an HTTP 400 error with an OperationOutcome that describes the failure.
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -752,14 +752,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
      */
     private void checkModifiers(FHIRSearchContext searchContext, boolean isSystemLevelSearch) throws FHIRPersistenceNotSupportedException {
         for (QueryParameter param : searchContext.getSearchParameters()) {
-            if (isSystemLevelSearch) {
-                if (param.getModifier() == Modifier.NOT) {
-                    // ':not' modifier is not yet supported for whole-system searches
-                    throw buildNotSupportedException("Modifier ':" + param.getModifier().value() + "' is not yet supported "
-                            + "for whole-system search [code=" + param.getCode() + "]");
-                }
-            }
-
             if (!param.getChain().isEmpty()) {
                 if (param.getChain().getLast().getModifier() == Modifier.NOT) {
                     // ':not' modifier on the last parameter in the chain is not yet supported

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -143,7 +143,6 @@ import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.persistence.util.LogicalIdentityProvider;
 import com.ibm.fhir.schema.control.FhirSchemaConstants;
 import com.ibm.fhir.search.SearchConstants;
-import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.SummaryValueSet;
 import com.ibm.fhir.search.compartment.CompartmentUtil;
 import com.ibm.fhir.search.context.FHIRSearchContext;
@@ -752,14 +751,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
      */
     private void checkModifiers(FHIRSearchContext searchContext, boolean isSystemLevelSearch) throws FHIRPersistenceNotSupportedException {
         for (QueryParameter param : searchContext.getSearchParameters()) {
-            if (!param.getChain().isEmpty()) {
-                if (param.getChain().getLast().getModifier() == Modifier.NOT) {
-                    // ':not' modifier on the last parameter in the chain is not yet supported
-                    throw buildNotSupportedException("Modifier ':" + param.getChain().getLast().getModifier().value() + "' is not yet supported "
-                            + "for chained parameters [code=" + param.getCode() + "]");
-                }
-            }
-
             do {
                 if (param.getModifier() != null &&
                         !JDBCConstants.supportedModifiersMap.get(param.getType()).contains(param.getModifier())) {

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/AbstractQueryBuilder.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/AbstractQueryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -109,7 +109,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
                     databaseQueryParm = this.processDateParm(resourceType, queryParm);
                     break;
                 case TOKEN:
-                    databaseQueryParm = this.processTokenParm(queryParm);
+                    databaseQueryParm = this.processTokenParm(resourceType, queryParm);
                     break;
                 case NUMBER:
                     databaseQueryParm = this.processNumberParm(resourceType, queryParm);
@@ -145,6 +145,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
     /**
      * Creates a query segment for a Reference type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter.
      * @return T1 - An object containing query segment.
      * @throws Exception
@@ -185,6 +186,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
     /**
      * Creates a query segment for a Date type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter.
      * @return T1 - An object containing query segment.
      * @throws Exception
@@ -194,14 +196,16 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
     /**
      * Creates a query segment for a Token type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter.
      * @return T1 - An object containing query segment.
      */
-    protected abstract T1 processTokenParm(QueryParameter queryParm) throws FHIRPersistenceException;
+    protected abstract T1 processTokenParm(Class<?> resourceType, QueryParameter queryParm) throws FHIRPersistenceException;
 
     /**
      * Creates a query segment for a Number type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter.
      * @return T1 - An object containing query segment.
      * @throws FHIRPersistenceException
@@ -211,6 +215,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
     /**
      * Creates a query segment for a Quantity type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter.
      * @return T1 - An object containing query segment.
      * @throws Exception
@@ -230,6 +235,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
     /**
      * Creates a query segment for a Composite type parameter.
      *
+     * @param resourceType - The resource type.
      * @param queryParm - The query parameter
      * @return T1 - An object containing query segment
      * @throws FHIRPersistenceException
@@ -241,6 +247,7 @@ public abstract class AbstractQueryBuilder<T1> implements QueryBuilder<T1> {
      * LocationPosition data type.
      *
      * @param queryParameters The entire collection of query input parameters
+     * @param paramTableAlias the alias name of the parameter table
      * @return T1 - A query segment related to a LocationPosition
      * @throws FHIRPersistenceException
      */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchTokenTest.java
@@ -40,6 +40,7 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     public void testSearchToken_string() throws Exception {
         assertSearchReturnsSavedResource("string", "testString");
         assertSearchReturnsSavedResource("string", "|testString");
+        assertSearchDoesntReturnSavedResource("string", "other");
     }
 
     @Test
@@ -67,7 +68,6 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertTrue(searchReturnsResource(Basic.class, queryParms, composition));
     }
 
-
     @Test
     public void testSearchToken_boolean_missing() throws Exception {
         assertSearchReturnsSavedResource("boolean:missing", "false");
@@ -81,12 +81,32 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     public void testSearchToken_code() throws Exception {
         assertSearchReturnsSavedResource("code", "code");
         assertSearchReturnsSavedResource("code", "|code");
+        assertSearchDoesntReturnSavedResource("code", "other");
     }
 
     @Test
     public void testSearchToken_code_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.code", "code");
         assertSearchReturnsComposition("subject:Basic.code", "|code");
+        assertSearchDoesntReturnComposition("subject:Basic.code", "other");
+    }
+
+    @Test
+    public void testSearchToken_code_not() throws Exception {
+        assertSearchDoesntReturnSavedResource("code:not", "code");
+        assertSearchDoesntReturnSavedResource("code:not", "|code");
+        assertSearchReturnsSavedResource("code:not", "other");
+
+        assertSearchReturnsSavedResource("missing-code:not", "code");
+    }
+
+    @Test
+    public void testSearchToken_code_chained_not() throws Exception {
+        assertSearchDoesntReturnComposition("subject:Basic.code:not", "code");
+        assertSearchDoesntReturnComposition("subject:Basic.code:not", "|code");
+        assertSearchReturnsComposition("subject:Basic.code:not", "other");
+
+        assertSearchReturnsComposition("subject:Basic.missing-code:not", "code");
     }
 
     @Test
@@ -138,15 +158,6 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 
         assertSearchReturnsComposition("subject:Basic.missing-code:missing", "true");
         assertSearchDoesntReturnComposition("subject:Basic.missing-code:missing", "false");
-    }
-
-    @Test
-    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
-        assertSearchReturnsComposition("subject:Basic.CodeableConcept:missing", "false");
-        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:missing", "true");
-
-        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:missing", "true");
-        assertSearchDoesntReturnComposition("subject:Basic.missing-CodeableConcept:missing", "false");
     }
 
     @Test
@@ -204,14 +215,16 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-CodeableConcept:not", "http://example.org/codesystem|code");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support the ':not'
-     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
-     */
-//    @Test
-//    public void testSearchToken_CodeableConcept_chained_not() throws Exception {
-//    }
+    @Test
+    public void testSearchToken_CodeableConcept_chained_not() throws Exception {
+        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:not", "code");
+        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:not", "http://example.org/codesystem|code");
+        assertSearchReturnsComposition("subject:Basic.CodeableConcept:not", "other");
+        assertSearchReturnsComposition("subject:Basic.CodeableConcept:not", "http://example.org/other|code");
+
+        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:not", "code");
+        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:not", "http://example.org/codesystem|code");
+    }
 
     @Test
     public void testSearchToken_CodeableConcept_missing() throws Exception {
@@ -220,6 +233,15 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
 
         assertSearchReturnsSavedResource("missing-CodeableConcept:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-CodeableConcept:missing", "false");
+    }
+
+    @Test
+    public void testSearchToken_CodeableConcept_chained_missing() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.CodeableConcept:missing", "false");
+        assertSearchDoesntReturnComposition("subject:Basic.CodeableConcept:missing", "true");
+
+        assertSearchReturnsComposition("subject:Basic.missing-CodeableConcept:missing", "true");
+        assertSearchDoesntReturnComposition("subject:Basic.missing-CodeableConcept:missing", "false");
     }
 
     @Test
@@ -277,15 +299,16 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-Coding:not", "http://example.org/codesystem|code");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support the ':not'
-     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
-     */
+    @Test
+    public void testSearchToken_Coding_chained_not() throws Exception {
+        assertSearchDoesntReturnComposition("subject:Basic.Coding:not", "code");
+        assertSearchDoesntReturnComposition("subject:Basic.Coding:not", "http://example.org/codesystem|code");
+        assertSearchReturnsComposition("subject:Basic.Coding:not", "other");
+        assertSearchReturnsComposition("subject:Basic.Coding:not", "http://example.org/other|code");
 
-//    @Test
-//    public void testSearchToken_Coding_chained_not() throws Exception {
-//    }
+        assertSearchReturnsComposition("subject:Basic.missing-Coding:not", "code");
+        assertSearchReturnsComposition("subject:Basic.missing-Coding:not", "http://example.org/codesystem|code");
+    }
 
     @Test
     public void testSearchToken_Coding_missing() throws Exception {
@@ -343,19 +366,21 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchDoesntReturnSavedResource("Identifier:not", "http://example.org/identifiersystem|code");
         assertSearchReturnsSavedResource("Identifier:not", "other");
         assertSearchReturnsSavedResource("Identifier:not", "http://example.org/other|code");
+
         assertSearchReturnsSavedResource("missing-Identifier:not", "code");
-        assertSearchReturnsSavedResource("missing-Identifier:not", "http://example.org/codesystem|code");
+        assertSearchReturnsSavedResource("missing-Identifier:not", "http://example.org/identifiersystem|code");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support the ':not'
-     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
-     */
+    @Test
+    public void testSearchToken_Identifier_chained_not() throws Exception {
+        assertSearchDoesntReturnComposition("subject:Basic.Identifier:not", "code");
+        assertSearchDoesntReturnComposition("subject:Basic.Identifier:not", "http://example.org/identifiersystem|code");
+        assertSearchReturnsComposition("subject:Basic.Identifier:not", "other");
+        assertSearchReturnsComposition("subject:Basic.Identifier:not", "http://example.org/other|code");
 
-//    @Test
-//    public void testSearchToken_Identifier_chained_not() throws Exception {
-//    }
+        assertSearchReturnsComposition("subject:Basic.missing-Identifier:not", "code");
+        assertSearchReturnsComposition("subject:Basic.missing-Identifier:not", "http://example.org/identifiersystem|code");
+    }
 
     @Test
     public void testSearchToken_Identifier_missing() throws Exception {
@@ -379,42 +404,47 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
     public void testSearchToken_ContactPoint() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint", "(555) 675 5745");
     }
+
     @Test
     public void testSearchToken_ContactPoint_chained() throws Exception {
         assertSearchReturnsComposition("subject:Basic.ContactPoint", "(555) 675 5745");
     }
+
     @Test
     public void testSearchToken_ContactPoint_URI() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-uri", "tel:+15556755745");
     }
+
     @Test
     public void testSearchToken_ContactPoint_HomeFax() throws Exception {
+
         assertSearchReturnsSavedResource("ContactPoint-homeFax", "(555) 675 5745");
     }
+
     @Test
     public void testSearchToken_ContactPoint_NoUse() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-noUse", "test@example.com");
     }
+
     @Test
     public void testSearchToken_ContactPoint_NoSystem() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint-noSystem", "test@example.com");
         assertSearchReturnsSavedResource("ContactPoint-noSystem", "|test@example.com");
     }
+
     @Test
     public void testSearchToken_ContactPoint_not() throws Exception {
         assertSearchReturnsSavedResource("ContactPoint:not", "(555) 555 5555");
         assertSearchDoesntReturnSavedResource("ContactPoint:not", "(555) 675 5745");
+        assertSearchReturnsSavedResource("missing-ContactPoint:not", "(555) 555 5555");
     }
 
-    /*
-     * Currently, documented in our conformance statement. We do not support the ':not'
-     * modifier on chained parameters. https://ibm.github.io/FHIR/Conformance#search-modifiers
-     * Refer to https://github.com/IBM/FHIR/issues/1926 to track the issue.
-     */
-
-//    @Test
-//    public void testSearchToken_ContactPoint_chained_not() throws Exception {
-//    }
+    @Test
+    public void testSearchToken_ContactPoint_chained_not() throws Exception {
+        assertSearchReturnsComposition("subject:Basic.ContactPoint:not", "(555) 555 5555");
+        assertSearchDoesntReturnComposition("subject:Basic.ContactPoint:not", "(555) 675 5745");
+        assertSearchReturnsComposition("subject:Basic.missing-ContactPoint:not", "(555) 555 5555");
+    }
 
     @Test
     public void testSearchToken_ContactPoint_missing() throws Exception {
@@ -424,6 +454,7 @@ public abstract class AbstractSearchTokenTest extends AbstractPLSearchTest {
         assertSearchReturnsSavedResource("missing-ContactPoint:missing", "true");
         assertSearchDoesntReturnSavedResource("missing-ContactPoint:missing", "false");
     }
+
     @Test
     public void testSearchToken_ContactPoint_chained_missing() throws Exception {
         assertSearchReturnsComposition("subject:Basic.ContactPoint:missing", "false");

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,6 +40,7 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
     protected final String TAG_SYSTEM = "http://ibm.com/fhir/tag";
     protected final String TAG = UUID.randomUUID().toString();
     protected final String TAG2 = UUID.randomUUID().toString();
+    protected final String TAG3 = UUID.randomUUID().toString();
     protected final String SECURITY_SYSTEM = "http://ibm.com/fhir/security";
     protected final String SECURITY = UUID.randomUUID().toString();
     protected final String PROFILE = "http://ibm.com/fhir/profile/" + UUID.randomUUID().toString();
@@ -286,4 +287,26 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
         assertEquals(resources.size(), 1, "Number of resources returned");
         assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
     }
+
+    @Test
+    public void testSearchAllUsingTagNot_Results() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        queryParms.put("_id", Collections.singletonList(savedResource.getId()));
+        queryParms.put("_tag:not", Collections.singletonList(TAG_SYSTEM + "|" + TAG3));
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 1, "Number of resources returned");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+    }
+
+    @Test
+    public void testSearchAllUsingTagNot_NoResults() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        queryParms.put("_id", Collections.singletonList(savedResource.getId()));
+        queryParms.put("_tag:not", Collections.singletonList(TAG_SYSTEM + "|" + TAG));
+        List<Resource> resources = runQueryTest(Resource.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(resources.size(), 0, "Number of resources returned");
+    }
+
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1117,7 +1117,7 @@ public class SearchUtil {
         List<QueryParameterValue> queryParameterValues;
         if (Modifier.MISSING.equals(modifier)) {
             // FHIR search considers booleans a special case of token for some reason...
-            queryParameterValues = parseQueryParameterValuesString(searchParameter, Type.TOKEN, modifierResourceTypeName, queryParameterValueString);
+            queryParameterValues = parseQueryParameterValuesString(searchParameter, Type.TOKEN, modifier, modifierResourceTypeName, queryParameterValueString);
         } else {
             if (Type.COMPOSITE == type) {
                 List<Component> components = searchParameter.getComponent();
@@ -1132,7 +1132,7 @@ public class SearchUtil {
                 }
                 queryParameterValues = parseCompositeQueryParameterValuesString(searchParameter, parameterCode, compTypes, queryParameterValueString);
             } else {
-                queryParameterValues = parseQueryParameterValuesString(searchParameter, type, modifierResourceTypeName, queryParameterValueString);
+                queryParameterValues = parseQueryParameterValuesString(searchParameter, type, modifier, modifierResourceTypeName, queryParameterValueString);
             }
         }
         return queryParameterValues;
@@ -1151,7 +1151,7 @@ public class SearchUtil {
             }
             QueryParameterValue parameterValue = new QueryParameterValue();
             for (int i = 0; i < compTypes.size(); i++) {
-                List<QueryParameterValue> values = parseQueryParameterValuesString(searchParameter, compTypes.get(i), null, componentValueStrings[i]);
+                List<QueryParameterValue> values = parseQueryParameterValuesString(searchParameter, compTypes.get(i), null, null, componentValueStrings[i]);
                 if (values.isEmpty()) {
                     throw new FHIRSearchException("Component values cannot be empty");
                 } else if (values.size() > 1) {
@@ -1169,7 +1169,7 @@ public class SearchUtil {
     }
 
     private static List<QueryParameterValue> parseQueryParameterValuesString(SearchParameter searchParameter, Type type,
-        String modifierResourceTypeName, String queryParameterValuesString) throws FHIRSearchException {
+        Modifier modifier, String modifierResourceTypeName, String queryParameterValuesString) throws FHIRSearchException {
         List<QueryParameterValue> parameterValues = new ArrayList<>();
 
         // BACKSLASH_NEGATIVE_LOOKBEHIND means it won't split on ',' that are preceded by a '\'
@@ -1255,19 +1255,20 @@ public class SearchUtil {
                     parameterValue.setValueCode(unescapeSearchParm(parts[1]));
                 } else {
                     // Optimization for search parameters that always reference the same system, added under #1929
-                    try {
-                        String implicitSystem = searchParameter.getExtension().stream()
-                                .filter(e -> SearchConstants.IMPLICIT_SYSTEM_EXT_URL.equals(e.getUrl()) && e.getValue() != null)
-                                .findFirst()
-                                .map(e -> e.getValue().as(Uri.class).getValue())
-                                .orElse(null);
-                        if (implicitSystem != null) {
-                            parameterValue.setValueSystem(implicitSystem);
+                    if (!Modifier.MISSING.equals(modifier)) {
+                        try {
+                            String implicitSystem = searchParameter.getExtension().stream()
+                                    .filter(e -> SearchConstants.IMPLICIT_SYSTEM_EXT_URL.equals(e.getUrl()) && e.getValue() != null)
+                                    .findFirst()
+                                    .map(e -> e.getValue().as(Uri.class).getValue())
+                                    .orElse(null);
+                            if (implicitSystem != null) {
+                                parameterValue.setValueSystem(implicitSystem);
+                            }
+                        } catch (ClassCastException e) {
+                            log.log(Level.INFO, "Found " + SearchConstants.IMPLICIT_SYSTEM_EXT_URL + " extension with unexpected value type", e);
                         }
-                    } catch (ClassCastException e) {
-                        log.log(Level.INFO, "Found " + SearchConstants.IMPLICIT_SYSTEM_EXT_URL + " extension with unexpected value type", e);
                     }
-
                     parameterValue.setValueCode(unescapeSearchParm(v));
                 }
                 break;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -339,6 +339,29 @@ public class SearchAllTest extends FHIRServerTestBase {
         assertTrue(bundle.getEntry().isEmpty());
     }
 
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllWithTagNot_Results() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_tag:not", "tag3");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreateObservation" })
+    public void testSearchAllWithTagNot_NoResults() throws Exception {
+        FHIRParameters parameters = new FHIRParameters();
+        parameters.searchParam("_id", patientId);
+        parameters.searchParam("_tag:not", "tag2");
+        FHIRResponse response = client.searchAll(parameters, false, headerTenant, headerDataStore);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle bundle = response.getResource(Bundle.class);
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
     /*
      * generates the output into a resource.
      */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
@@ -218,6 +218,8 @@ public class SearchChainTest extends FHIRServerTestBase {
 
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
+        assertTrue(bundle.getLink().size() == 1);
+        assertTrue(bundle.getLink().get(0).getUrl().getValue().contains("active:missing=true"));
     }
 
     @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
@@ -259,6 +261,56 @@ public class SearchChainTest extends FHIRServerTestBase {
                 target.path("Procedure")
                 .queryParam("_id", procedureId)
                 .queryParam("subject:Patient.gender:missing", "false")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+        assertTrue(bundle.getLink().size() == 1);
+        assertTrue(bundle.getLink().get(0).getUrl().getValue().contains("gender:missing=false"));
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithActiveNot() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.active:not", "true")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().size() >= 1);
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithGenderNot_NoResults() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.gender:not", "male")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertTrue(bundle.getEntry().isEmpty());
+    }
+
+    @Test(groups = { "server-search-chain" }, dependsOnMethods = {"testCreatePatient" , "testCreateProcedure"})
+    public void testSearchProcedureForPatientWithGenderNot_Results() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Procedure")
+                .queryParam("_id", procedureId)
+                .queryParam("subject:Patient.gender:not", "female")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .get();
         assertResponse(response, Response.Status.OK.getStatusCode());

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
@@ -1153,6 +1153,41 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertEquals(1, bundle.getEntry().size());
         assertEquals(patient1Id, bundle.getEntry().get(0).getResource().getId());
+        assertTrue(bundle.getLink().size() == 1);
+        assertTrue(bundle.getLink().get(0).getUrl().getValue().contains("status:missing=false"));
+    }
+
+    @Test(groups = { "server-search-reverse-chain" }, dependsOnMethods = {"testCreateProcedure1", "testCreateProcedure2"})
+    public void testSearchSingleReverseChainWithStringParmNot_NoResults() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient")
+                .queryParam("given", "1" + tag)
+                .queryParam("_has:Procedure:subject:status:not", "completed")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertEquals(0, bundle.getEntry().size());
+    }
+
+    @Test(groups = { "server-search-reverse-chain" }, dependsOnMethods = {"testCreateProcedure1", "testCreateProcedure2"})
+    public void testSearchSingleReverseChainWithStringParmNot_Results() {
+        WebTarget target = getWebTarget();
+        Response response =
+                target.path("Patient")
+                .queryParam("given", "1" + tag)
+                .queryParam("_has:Procedure:subject:status:not", "in-progress")
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Bundle bundle = response.readEntity(Bundle.class);
+
+        assertNotNull(bundle);
+        assertEquals(1, bundle.getEntry().size());
+        assertEquals(patient1Id, bundle.getEntry().get(0).getResource().getId());
     }
 
 }


### PR DESCRIPTION
Issue #1926 - Adds support for the ':not' modifier to be used in chained search and whole-system search.

Signed-off-by: Troy Biesterfeld tbieste@us.ibm.com