### PR TITLE
issues #1907 and #1964 - strip the query from originalRequestUri before parsing and fix baseUrl for whole-system queries

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -129,7 +129,7 @@ The IBM FHIR Server includes a Docker image [ibmcom/ibm-fhir-server](https://hub
 
 Note, logging for the IBM FHIR Server docker image is to stderr and stdout, and is picked up by Logging agents.
 
-The IBM FHIR Server is configured using Environment variables using: 
+The IBM FHIR Server is configured using Environment variables using:
 
 | Environment Variable | Description |
 |----------------------|-------------|
@@ -1671,7 +1671,7 @@ Note: The batch-user referenced in the `fhir-server-config.json` must have a rol
 
 By default, in-memory Derby database is used for persistence of the JavaBatch Jobs as configured in `fhir-server/configDropins/defaults/bulkdata.xml`. This database is destroyed on the restart of the IBM FHIR Server, and does not support load balancing.
 
-To support IBM Db2 on IBM Cloud, copy `fhir-server/configDropins/disabled/db2-cloud/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables: 
+To support IBM Db2 on IBM Cloud, copy `fhir-server/configDropins/disabled/db2-cloud/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables:
 
 | Variable          | Default     | Description                                                    |
 |-------------------|-------------|----------------------------------------------------------------|
@@ -1683,7 +1683,7 @@ To support IBM Db2 on IBM Cloud, copy `fhir-server/configDropins/disabled/db2-cl
 
 Instruction is also provided in 'Configuring a Liberty Datasource with API Key' section of the DB2OnCloudSetup guide to configure DB2 service in IBM Clouds as JavaBatch persistence store. The JavaBatch schema is created using the `fhir-persistence-schema` command line interface jar.
 
-To support IBM Db2 with a user-name and password , copy `fhir-server/configDropins/disabled/db2/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables: 
+To support IBM Db2 with a user-name and password , copy `fhir-server/configDropins/disabled/db2/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables:
 
 | Variable          | Default         | Description                                                    |
 |-------------------|-----------------|----------------------------------------------------------------|
@@ -1695,7 +1695,7 @@ To support IBM Db2 with a user-name and password , copy `fhir-server/configDropi
 | BATCH_DB_PASSWORD | `blank`         | The password for the Db2 database                              |
 | BATCH_DB_SSL      | true            | The ssl connection is either true or false                     |
 
-If one wants to support Postgres with a user-name and password , one should copy `fhir-server/configDropins/disabled/postgres/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables: 
+If one wants to support Postgres with a user-name and password , one should copy `fhir-server/configDropins/disabled/postgres/bulkdata.xml` to `fhir-server/configDropins/defaults/bulkdata.xml` replacing the existing bulkdata.xml. One can configure the Datasource by setting the following environment variables:
 
 | Variable               | Default         | Description                                                    |
 |------------------------|-----------------|----------------------------------------------------------------|
@@ -1797,7 +1797,7 @@ Please refer to the property names that start with `fhirServer/audit/` in [5.1 C
 
 There are two types of configuration for the Audit Logging Service. The first type is using the environment variable, and the second is the configuration driven from the fhir-server-config.json.
 
-For example, the following uses the 'config' in order to config the Kafka publisher as part of the audit logging service. 
+For example, the following uses the 'config' in order to config the Kafka publisher as part of the audit logging service.
 
 ```
 "audit": {
@@ -1807,7 +1807,7 @@ For example, the following uses the 'config' in order to config the Kafka publis
     }
 ```
 
-Or, you could load from an environment, note, this is the default behavior. 
+Or, you could load from an environment, note, this is the default behavior.
 
 ```
 "audit": {
@@ -1884,7 +1884,7 @@ Please refer to https://cloud.ibm.com/docs/containers?topic=containers-service-b
     }
 ```
 
-The service can map to the CADF format or the FHIR AuditEvent resource format by declaring a mapper type - 'cadf' or 'auditevent'. 
+The service can map to the CADF format or the FHIR AuditEvent resource format by declaring a mapper type - 'cadf' or 'auditevent'.
 
 - *CADF* Example
 ```
@@ -2150,6 +2150,17 @@ In this case, since the `fhirServer/resources/open` property is set to `false`, 
 Whole-system search is a special case of this resource type validation, since no resource type is specified on a whole-system search request. In this case, validation will be done against the `Resource` resource type. In the above configuration example, a whole-system search request such as `GET [base]?_lastUpdated=gt2020-01-01` will fail because the `Resource` resource type is not specified. If the configuration were to have the `fhirServer/resources/open` property set to `true`, or if the `Resource` resource type were specified in the `fhirServer/resources` property group, then the whole-system search request would be allowed, assuming the `search` interaction was valid for the `Resource` resource type.
 
 In addition to interaction configuration, the `fhirServer/resources` property group also provides the ability to configure search parameter filtering and profile validation. See [Search configuration](https://ibm.github.io/FHIR/guides/FHIRSearchConfiguration#12-filtering) and [Resource validation](#44-resource-validation) respectively for details.
+
+## 4.12.1 Using the IBM FHIR Server behind a proxy
+It is possible to run the IBM FHIR Server behind a reverse proxy such as Kubernetes Ingress or an API Gateway.
+
+Because the FHIR API relies on links and references between resources (both absolute and relative), operators must ensure that the IBM FHIR Server is configured appropriately for the front-end URL being used by the FHIR clients.
+
+This can be accomplished by configuring the `fhirServer/core/originalRequestUriHeaderName` property in the default fhir-server-config.json. When this parameter is configured, the IBM FHIR Server will use the value of the corresponding header to set the "originalRequestUri" for the scope of the request.
+
+For example, consider a FHIR Server that is listening at https://fhir:9443/fhir-server/api/v4 and is configured with an  originalRequestUriHeaderName of `X-FHIR-Forwarded-Uri`. If this server is proxied by a server at https://example.com/fhir, then the proxy must set the `X-FHIR-Forwarded-Uri` header to the value of the front-end request URL (e.g. https://example.com/fhir/Patient/abc-123).
+
+The originalRequestUriHeader is expected to contain the full path of the original request. Values with no scheme (e.g. `https://`) will be handled like relative URLs, but full URL values (including scheme, hostname, optional port, and path) are recommended. Query string values can be included in the header value but will be ignored by the server; the server will use the query string of the actual request to process the request.
 
 # 5 Appendix
 

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2158,7 +2158,7 @@ Because the FHIR API relies on links and references between resources (both abso
 
 This can be accomplished by configuring the `fhirServer/core/originalRequestUriHeaderName` property in the default fhir-server-config.json. When this parameter is configured, the IBM FHIR Server will use the value of the corresponding header to set the "originalRequestUri" for the scope of the request.
 
-For example, consider a FHIR Server that is listening at https://fhir:9443/fhir-server/api/v4 and is configured with an  originalRequestUriHeaderName of `X-FHIR-Forwarded-Uri`. If this server is proxied by a server at https://example.com/fhir, then the proxy must set the `X-FHIR-Forwarded-Uri` header to the value of the front-end request URL (e.g. https://example.com/fhir/Patient/abc-123).
+For example, consider a FHIR Server that is listening at https://fhir:9443/fhir-server/api/v4 and is configured with an  originalRequestUriHeaderName of `X-FHIR-FORWARDED-URL`. If this server is proxied by a server at https://example.com/fhir, then the proxy must set the `X-FHIR-FORWARDED-URL` header to the value of the front-end request URL (e.g. https://example.com/fhir/Patient/abc-123).
 
 The originalRequestUriHeader is expected to contain the full path of the original request. Values with no scheme (e.g. `https://`) will be handled like relative URLs, but full URL values (including scheme, hostname, optional port, and path) are recommended. Query string values can be included in the header value but will be ignored by the server; the server will use the query string of the actual request to process the request.
 
@@ -2722,8 +2722,9 @@ IBM FHIR Server Supports the following custom HTTP Headers:
 
 | Header Name      | Description                |
 |------------------|----------------------------|
-|`X-FHIR-TENANT-ID`|Specifies which tenant config should be used for the request. Default is `default`. Header name can be overridden via config property `fhirServer/core/tenantIdHeaderName`.|
-|`X-FHIR-DSID`|Specifies which datastore config should be used for the request. Default is `default`. Header name can be overridden via config property `fhirServer/core/dataSourceIdHeaderName`.|
+|`X-FHIR-TENANT-ID`|Specifies which tenant config should be used for the request. Default is `default`. The header name can be overridden via config property `fhirServer/core/tenantIdHeaderName`.|
+|`X-FHIR-DSID`|Specifies which datastore config should be used for the request. Default is `default`. The header name can be overridden via config property `fhirServer/core/dataSourceIdHeaderName`.|
+|`X-FHIR-FORWARDED-URL`|The original (user-facing) request URL; used for constructing absolute URLs within the server response. Only enabled when explicitly configured in the default fhir-server-config.json. If either the config property or the header itself is missing, the server will use the actual request URL. The header name can be overridden via config property `fhirServer/core/originalRequestUriHeaderName`.|
 
 # 6 Related topics
 For more information about topics related to configuring a FHIR server, see the following documentation:

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/OriginalRequestRewriteServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/OriginalRequestRewriteServerTest.java
@@ -1,0 +1,100 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static com.ibm.fhir.model.type.Code.code;
+import static com.ibm.fhir.model.type.Uri.uri;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Coding;
+import com.ibm.fhir.model.type.Meta;
+
+/**
+ * Basic sniff test of the FHIR Server.
+ */
+public class OriginalRequestRewriteServerTest extends FHIRServerTestBase {
+    private static final String TAG = "OriginalRequestRewriteServerTest";
+    private static final String ORIGINAL_URI = "https://frontend-url/base";
+
+    /**
+     * Create a Patient and ensure the Location header reflects the OriginalRequestUri
+     */
+    @Test
+    public void testCreatePatient_LocationRewrite() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
+        Meta.Builder meta = patient.getMeta() == null ? Meta.builder() : patient.getMeta().toBuilder();
+        meta.tag(Coding.builder().system(uri("http://ibm.com/fhir/tag")).code(code(TAG)).build());
+        patient = patient.toBuilder()
+                .meta(meta.build())
+                .build();
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient").request()
+                .header("X-FHIR-Forwarded-URL", ORIGINAL_URI + "/Patient")
+                .post(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+        assertTrue(response.getLocation().toString().startsWith(ORIGINAL_URI),
+                response.getLocation().toString() + " should begin with " + ORIGINAL_URI);
+    }
+
+    /**
+     * Search for the Patient and ensure that both the search links and the search response bundle entries
+     * reflect the OriginalRequestUri
+     */
+    @Test(dependsOnMethods = "testCreatePatient_LocationRewrite")
+    public void testPatientSearch_BaseUrlRewrite() throws Exception {
+        WebTarget target = getWebTarget();
+
+        Response response = target.path("Patient").queryParam("_tag", TAG).request()
+                .header("X-FHIR-Forwarded-URL", ORIGINAL_URI + "/Patient?_tag=" + TAG)
+                .get(Response.class);
+        assertResponse(response, Response.Status.OK.getStatusCode());
+
+        Bundle responseBundle = response.readEntity(Bundle.class);
+        assertFalse(responseBundle.getLink().isEmpty());
+        assertTrue(responseBundle.getLink().stream().allMatch(l -> l.getUrl().getValue().startsWith(ORIGINAL_URI)),
+                "All search response bundle links start with the passed in uri");
+        assertFalse(responseBundle.getEntry().isEmpty());
+        assertTrue(responseBundle.getEntry().stream().allMatch(e -> e.getFullUrl().getValue().startsWith(ORIGINAL_URI)),
+                "All search response bundle entry fullUrls start with the passed in uri");
+    }
+
+    /**
+     * Search for the Patient via a whole-system search and ensure that both the search links
+     * and the search response bundle entries reflect the OriginalRequestUri
+     */
+    @Test(dependsOnMethods = "testCreatePatient_LocationRewrite")
+    public void testWholeSystemSearch_BaseUrlRewrite() throws Exception {
+        WebTarget target = getWebTarget();
+
+        Response response = target.queryParam("_tag", TAG).request()
+                .header("X-FHIR-Forwarded-URL", ORIGINAL_URI + "?_tag=" + TAG)
+                .get(Response.class);
+        assertResponse(response, Response.Status.OK.getStatusCode());
+
+        Bundle responseBundle = response.readEntity(Bundle.class);
+        assertFalse(responseBundle.getLink().isEmpty());
+        assertTrue(responseBundle.getLink().stream().allMatch(l -> l.getUrl().getValue().startsWith(ORIGINAL_URI)),
+                "All search response bundle links start with the passed in uri");
+        assertFalse(responseBundle.getEntry().isEmpty());
+        assertTrue(responseBundle.getEntry().stream().allMatch(e -> e.getFullUrl().getValue().startsWith(ORIGINAL_URI + "/Patient")),
+                "All search response bundle entry fullUrls start with the passed in uri");
+    }
+}

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -736,6 +736,17 @@ public class SearchAllTest extends FHIRServerTestBase {
 
         assertTrue(validSelf);
         assertTrue(validRel);
+
+        /*
+         * Runs through the fullUrl of the entries and checks for appropriate values
+         */
+        for (Entry entry : bundle.getEntry()) {
+            Resource resource = entry.getResource();
+            // The client always ensures that the baseUrl ends with a '/'
+            String expectedBase = client.getWebTarget().getUri() + resource.getClass().getSimpleName();
+            assertTrue(entry.getFullUrl().getValue().startsWith(expectedBase),
+                    "fullUrl " + entry.getFullUrl().getValue() + " should start with " + expectedBase);
+        }
     }
 
     /*

--- a/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
@@ -4,6 +4,7 @@
         "core": {
             "tenantIdHeaderName": "X-FHIR-TENANT-ID",
             "datastoreIdHeaderName": "X-FHIR-DSID",
+            "originalRequestUriHeaderName": "X-FHIR-FORWARDED-URL",
             "checkReferenceTypes": true,
             "conditionalDeleteMaxNumber": 10,
             "capabilityStatementCacheTimeout": 60,

--- a/fhir-server/liberty-config/config/default/fhir-server-config-postgresql.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-postgresql.json
@@ -4,6 +4,7 @@
         "core": {
             "tenantIdHeaderName": "X-FHIR-TENANT-ID",
             "datastoreIdHeaderName": "X-FHIR-DSID",
+            "originalRequestUriHeaderName": "X-FHIR-FORWARDED-URL",
             "checkReferenceTypes": true,
             "conditionalDeleteMaxNumber": 10,
             "disabledOperations": ""

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -4,6 +4,7 @@
         "core": {
             "tenantIdHeaderName": "X-FHIR-TENANT-ID",
             "datastoreIdHeaderName": "X-FHIR-DSID",
+            "originalRequestUriHeaderName": "X-FHIR-FORWARDED-URL",
             "checkReferenceTypes": true,
             "conditionalDeleteMaxNumber": 10,
             "serverRegistryResourceProviderEnabled": true,

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -997,8 +997,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 throw buildUnsupportedResourceTypeException(type);
             }
 
-            Class<? extends Resource> resourceType =
-                    getResourceType(resourceTypeName);
+            Class<? extends Resource> resourceType = getResourceType(resourceTypeName);
 
             FHIRSearchContext searchContext = SearchUtil.parseQueryParameters(compartment, compartmentId, resourceType, queryParameters,
                 HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
@@ -1205,8 +1204,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     /**
-     * Performs validation of a request Bundle and returns a Bundle containing response entries corresponding to the
-     * request entries in the request Bundle. holding the responses for the requests contained in the request Bundle.
+     * Performs validation of a request Bundle and returns a Bundle containing response entries that correspond
+     * to the request entries in the request Bundle.
      *
      * @param bundle
      *            the bundle to be validated
@@ -1257,7 +1256,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             List<OperationOutcome.Issue> issueList = new ArrayList<OperationOutcome.Issue>();
 
             List<Bundle.Entry> responseList = new ArrayList<Bundle.Entry>();
-
             Set<String> localIdentifiers = new HashSet<>();
 
             for (Bundle.Entry requestEntry : bundle.getEntry()) {
@@ -1634,9 +1632,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @throws Exception
      */
     private Bundle processEntriesForMethod(Bundle requestBundle, Bundle responseBundle,
-        HTTPVerb httpMethod, boolean failFast, Map<String, String> localRefMap,
-        Map<String, String> bundleRequestProperties, String bundleRequestCorrelationId)
-        throws Exception {
+            HTTPVerb httpMethod, boolean failFast, Map<String, String> localRefMap,
+            Map<String, String> bundleRequestProperties, String bundleRequestCorrelationId)
+            throws Exception {
         log.entering(this.getClass().getName(), "processEntriesForMethod", new Object[] {"httpMethod", httpMethod });
 
         try {
@@ -1771,23 +1769,18 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            the response bundle entry
      * @param responseIndexAndEntries
      *            the hashmap containing bundle entry indexes and their associated response entries
-     * @param requestURL 
-     * @param entryIndex
-     *            the bundle entry index of the bundle entry being processed
-     * @param localRefMap
-     *            the map of local references to external references
      * @param requestURL
      *            the request URL
-     * @param absoluteUri
-     *            the absolute URI
+     * @param entryIndex
+     *            the bundle entry index of the bundle entry being processed
      * @param requestDescription
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
      * @throws Exception
      */
-    private void processEntryforPatch(Entry requestEntry, Entry responseEntry, Map<Integer, Entry> responseIndexAndEntries, FHIRUrlParser requestURL, Integer entryIndex, String requestDescription, long initialTime)
-        throws Exception {
+    private void processEntryforPatch(Entry requestEntry, Entry responseEntry, Map<Integer, Entry> responseIndexAndEntries,
+            FHIRUrlParser requestURL, Integer entryIndex, String requestDescription, long initialTime) throws Exception {
         FHIRRestOperationResponse ior = null;
         String[] pathTokens = requestURL.getPathTokens();
         String resourceType = null;
@@ -1808,11 +1801,11 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             String msg = "Request URL for bundled PATCH request should have path part with two tokens (<resourceType>/<id>).";
             throw buildRestException(msg, IssueType.INVALID);
         }
-       
+
                 if (requestEntry.getResource().is(Parameters.class)) {
 
                     Parameters parameters = requestEntry.getResource().as(Parameters.class);
-                  
+
 
                     FHIRPatch patch = FHIRPathPatch.from(parameters);
 
@@ -1825,7 +1818,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     String msg="Request resource type for PATCH request must be type 'Parameters'";
                     throw buildRestException(msg, IssueType.INVALID);
                 }
-       
+
 
     }
 
@@ -2749,10 +2742,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 String nextLinkUrl = selfUri;
 
                 // remove existing _page parameters from the query string
-                nextLinkUrl =
-                        nextLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
-                                + context.getPageNumber() + "&", "").replace("_page="
-                                        + context.getPageNumber(), "");
+                nextLinkUrl = nextLinkUrl.replace("&_page=" + context.getPageNumber(), "").replace("_page="
+                        + context.getPageNumber() + "&", "").replace("_page=" + context.getPageNumber(), "");
 
                 if (nextLinkUrl.contains("?")) {
                     if (!nextLinkUrl.endsWith("?")) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -2841,14 +2841,16 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             if (resourceNamePathLocation != -1) {
                 baseUri = requestUri.substring(0, resourceNamePathLocation);
             } else {
-                // Assume the request was a batch/transaction and just use the requestUri as the base
-                baseUri = requestUri;
+                // Assume the request was a batch/transaction; nothing to strip
             }
-        } else {
-            if (baseUri.endsWith("/_history")) {
-                baseUri = baseUri.substring(0, baseUri.length() - "/_history".length());
-            } else if (baseUri.endsWith("/_search")) {
+        }
+
+        // Strip any path segments for whole-system interactions (in case of whole-system search, "Resource" is passed as the type)
+        if (type == null || type.isEmpty() || "Resource".equals(type)) {
+            if (baseUri.endsWith("/_search")) {
                 baseUri = baseUri.substring(0, baseUri.length() - "/_search".length());
+            } else if (baseUri.endsWith("/_history")) {
+                baseUri = baseUri.substring(0, baseUri.length() - "/_history".length());
             } else if (baseUri.contains("/$")) {
                 baseUri = baseUri.substring(0, baseUri.lastIndexOf("/$"));
             }


### PR DESCRIPTION
1. Previously I updated our UriBuilder for this case (and introduced tests
to ensure it is properly functioning). However, I missed the fact that
FHIRRestServletFilter parses the originalRequestUri header value into a
URI and, when this fails, it simply reverts to the actual URL of the
request. Therefor, when the request contained a character like `|`, this
header value was never being used in downstream processing like
UriBuilder.buildSelfUri.toSearchSelfUri().

2. Set originalRequestUriHeaderName to "X-FHIR-FORWARDED-URL" in our
default fhir-server-config (so that this can get tested by our default
CI without flags)
3. Added OriginalRequestRewriteServerTest to ensure this feature is
working as expected
4. Expanded SearchAllTest to include a check for the fullUrl entries in the
response bundle
5. Fix FHIRRestHelper.getRequestBaseUri(type) in two cases:
  * for certain cases we were setting the baseUri to requestUri (losing our strip of the query string)
  * strip the `/_search` from the end of the whole-system search URL

6. Also performed some minor cleanup.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>