### PR TITLE
issue #1951 - add OperationOutcomeIssue to exceptions thrown from interceptor

### DIFF
--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -494,21 +494,27 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     private String getAccessToken() throws FHIRPersistenceInterceptorException {
         List<String> list = FHIRRequestContext.get().getHttpHeaders().get("Authorization");
         if (list.size() != 1) {
-            throw new FHIRPersistenceInterceptorException("Request must contain exactly one Authorization header.");
+            String msg = "Request must contain exactly one Authorization header.";
+            throw new FHIRPersistenceInterceptorException(msg)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }
         String header = list.get(0);
 
         if (!header.startsWith(BEARER_TOKEN_PREFIX)) {
-            throw new FHIRPersistenceInterceptorException("Authorization header must carry a Bearer token");
+            String msg = "Authorization header must carry a Bearer token";
+            throw new FHIRPersistenceInterceptorException(msg)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }
 
         return header.substring(BEARER_TOKEN_PREFIX.length()).trim();
     }
 
-    private List<Scope> getScopesFromToken(DecodedJWT jwt) {
+    private List<Scope> getScopesFromToken(DecodedJWT jwt) throws FHIRPersistenceInterceptorException {
         Claim claim = jwt.getClaim("scope");
         if (claim.isNull()) {
-            throw new IllegalArgumentException("Authorization token is missing 'scope' claim");
+            String msg = "Authorization token is missing 'scope' claim";
+            throw new FHIRPersistenceInterceptorException(msg)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }
 
         List<String> scopeStrings;
@@ -527,10 +533,12 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                 .collect(Collectors.toList());
     }
 
-    private List<String> getPatientIdFromToken(DecodedJWT jwt) {
+    private List<String> getPatientIdFromToken(DecodedJWT jwt) throws FHIRPersistenceInterceptorException {
         Claim claim = jwt.getClaim("patient_id");
         if (claim.isNull()) {
-            throw new IllegalArgumentException("Authorization token is missing 'patient_id' claim");
+            String msg = "Authorization token is missing 'patient_id' claim";
+            throw new FHIRPersistenceInterceptorException(msg)
+                    .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
         }
 
         String patientId = claim.asString();


### PR DESCRIPTION
Instead of throwing IllegalArgumentException errors, the various helpers in this class
now throw FHIRPersistenceInterceptorException with OperationOutcomeIssues of type FORBIDDEN.

These issues then get mapped into the desired HTTP status codes on their way out of the server.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>