### PR TITLE
issue #1971 - handle duplicate entries in version_history with grace

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/version/GetLatestVersionDAO.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/version/GetLatestVersionDAO.java
@@ -70,7 +70,7 @@ public class GetLatestVersionDAO implements IDatabaseSupplier<Map<String,Integer
                     if (currentValue != null) {
                         // version can't be null due to NOT NULL db constraint
                         newValue = Integer.max(currentValue, version);
-                        logger.warning("Version history entry " + schemaTypeName + " exists with multiple values [" + currentValue
+                        logger.fine("Version history entry " + schemaTypeName + " exists with multiple values [" + currentValue
                                 + ", " + version + "]; using " + newValue + ". Check schema name casing.");
                     }
                     return newValue;

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/version/GetLatestVersionDAO.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/version/GetLatestVersionDAO.java
@@ -71,7 +71,7 @@ public class GetLatestVersionDAO implements IDatabaseSupplier<Map<String,Integer
                         // version can't be null due to NOT NULL db constraint
                         newValue = Integer.max(currentValue, version);
                         logger.warning("Version history entry " + schemaTypeName + " exists with multiple values [" + currentValue
-                                + ", " + version + "]; using " + newValue);
+                                + ", " + version + "]; using " + newValue + ". Check schema name casing.");
                     }
                     return newValue;
                 });


### PR DESCRIPTION
This should workaround the root cause of issue #1971 and prevent
`--update-schema` from trying to apply updates that have already been
applied.

The root cause will need to be addressed in a separate PR.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>