### PR TITLE
CVE-2020-28491: com.fasterxml.jackson.dataformat:jackson-dataformat-c…

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -238,6 +238,12 @@
                 <version>2.12.1</version>
             </dependency>
             <dependency>
+                <!--  Used by COS in fhir-bucket and bulkdata -->
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>2.12.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>2.7.0</version>


### PR DESCRIPTION
…bor:jar:2.10.0:compile is used in fhir-bucket and fhir-bulkimportexport-webapp #1973

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>