### PR TITLE
issue #1983 - move verification methods into unit test

### DIFF
--- a/fhir-persistence-schema/pom.xml
+++ b/fhir-persistence-schema/pom.xml
@@ -24,11 +24,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-path</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbytools</artifactId>
         </dependency>
@@ -39,6 +34,12 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-registry</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateParameterNames.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateParameterNames.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,24 +13,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import com.ibm.fhir.database.utils.api.IDatabaseStatement;
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
-import com.ibm.fhir.model.resource.SearchParameter;
-import com.ibm.fhir.model.type.code.SearchParamType;
-import com.ibm.fhir.registry.FHIRRegistry;
 
 /**
  * Populates the Parameters Names Table
@@ -125,57 +115,6 @@ public class PopulateParameterNames implements IDatabaseStatement {
             }
         } catch (SQLException x) {
             throw translator.translate(x);
-        }
-    }
-
-    /**
-     * This method is very intentional to verify the parameter_names.properties on EVERY build.
-     * The mapping is intentionally managed, as these KEYS are inserted and used.
-     */
-    public static void verify() {
-        Properties props = new Properties();
-        boolean found = false;
-        try (InputStream fis =
-                PopulateParameterNames.class.getClassLoader().getResourceAsStream("parameter_names.properties")) {
-            props.load(fis);
-
-            Set<String> codes = new HashSet<>();
-            for (SearchParamType.ValueSet spt : SearchParamType.ValueSet.values()) {
-                Collection<SearchParameter> searchParametersForResourceType =
-                        FHIRRegistry.getInstance().getSearchParameters(spt.value());
-                for (SearchParameter searchParameter : searchParametersForResourceType) {
-                    codes.add(searchParameter.getCode().getValue());
-                }
-            }
-
-            // Sort Codes based on where system prefix '_' comes first.
-            List<String> codesList = new ArrayList<>(codes);
-            Collections.sort(codesList);
-
-            // Find the Highest Value to start from:
-            Integer highestValue = 1001;
-            Map<String, Integer> valueMap = new HashMap<>();
-            for (Entry<Object, Object> valueEntry : props.entrySet()) {
-                Integer curVal = Integer.parseInt((String) valueEntry.getValue());
-                String resource = (String) valueEntry.getKey();
-                valueMap.put(resource, curVal);
-                if (highestValue < curVal) {
-                    highestValue = curVal;
-                }
-                codes.remove(resource);
-            }
-
-            // Check to see if something is missing
-            for (String code : codes.stream().sorted().collect(Collectors.toList())) {
-                LOGGER.info(code + "=" + highestValue++);
-                found = true;
-            }
-        } catch (IOException e) {
-            throw new IllegalArgumentException("File access issue for parameter_names");
-        }
-
-        if (found) {
-            throw new IllegalArgumentException("Parameter Name/Code are missing from parameter_names");
         }
     }
 }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateResourceTypes.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateResourceTypes.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,16 +14,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.database.utils.api.IDatabaseStatement;
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
-import com.ibm.fhir.model.type.code.FHIRResourceType;
 
 /**
  * Populates the Resource Types Table
@@ -117,49 +114,6 @@ public class PopulateResourceTypes implements IDatabaseStatement {
             }
         } catch (SQLException x) {
             throw translator.translate(x);
-        }
-    }
-
-    /**
-     * This method is very intentional to verify the resource_types.properties on EVERY build.
-     * The mapping is intentionally managed, as these KEYS are inserted and used.
-     */
-    public static void verify() {
-        Properties props = new Properties();
-        boolean found = false;
-        try (InputStream fis =
-                PopulateResourceTypes.class.getClassLoader().getResourceAsStream("resource_types.properties")) {
-            props.load(fis);
-
-            Set<String> resources = new HashSet<>();
-            for (FHIRResourceType.ValueSet rt : FHIRResourceType.ValueSet.values()) {
-                resources.add(rt.value());
-            }
-
-            // Find the Highest Value to start from:
-            Integer highestValue = 0;
-            Map<String, Integer> valueMap = new HashMap<>();
-            for (Entry<Object, Object> valueEntry : props.entrySet()) {
-                Integer curVal = Integer.parseInt((String) valueEntry.getValue());
-                String resource = (String) valueEntry.getKey();
-                valueMap.put(resource, curVal);
-                if (highestValue < curVal) {
-                    highestValue = curVal;
-                }
-                resources.remove(resource);
-            }
-
-            // Check to see if something is missing
-            for (String resource : resources) {
-                LOGGER.info(resource + "=" + highestValue++);
-                found = true;
-            }
-        } catch (IOException e) {
-            throw new IllegalArgumentException("File access issue for resource_types");
-        }
-
-        if (found) {
-            throw new IllegalArgumentException("Resources are missing from resource_types");
         }
     }
 }

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/control/PopulateParameterNamesTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/control/PopulateParameterNamesTest.java
@@ -1,20 +1,79 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.schema.control;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.code.SearchParamType;
+import com.ibm.fhir.registry.FHIRRegistry;
+
 /**
- * Test to verify the resource_types.properties
+ * Test to verify the parameter_names.properties
  */
 public class PopulateParameterNamesTest {
+    private static final Logger LOGGER = Logger.getLogger(PopulateParameterNamesTest.class.getName());
+    /**
+     * This method is very intentional to verify the parameter_names.properties on EVERY build.
+     * The mapping is intentionally managed, as these KEYS are inserted and used.
+     */
     @Test
-    public void testVerify() {
-        PopulateParameterNames.verify();
-        assert true;
+    public static void verifyParameterNames() {
+        Properties props = new Properties();
+        boolean found = false;
+        try (InputStream fis =
+                PopulateParameterNames.class.getClassLoader().getResourceAsStream("parameter_names.properties")) {
+            props.load(fis);
+
+            Set<String> codes = new HashSet<>();
+            for (SearchParamType.ValueSet spt : SearchParamType.ValueSet.values()) {
+                Collection<SearchParameter> searchParametersForResourceType =
+                        FHIRRegistry.getInstance().getSearchParameters(spt.value());
+                for (SearchParameter searchParameter : searchParametersForResourceType) {
+                    codes.add(searchParameter.getCode().getValue());
+                }
+            }
+
+            // Find the Highest Value to start from:
+            Integer highestValue = 1001;
+            Map<String, Integer> valueMap = new HashMap<>();
+            for (Entry<Object, Object> valueEntry : props.entrySet()) {
+                Integer curVal = Integer.parseInt((String) valueEntry.getValue());
+                String resource = (String) valueEntry.getKey();
+                valueMap.put(resource, curVal);
+                if (highestValue < curVal) {
+                    highestValue = curVal;
+                }
+                codes.remove(resource);
+            }
+
+            // Check to see if something is missing
+            for (String code : codes.stream().sorted().collect(Collectors.toList())) {
+                LOGGER.info(code + "=" + highestValue++);
+                found = true;
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("File access issue for parameter_names");
+        }
+
+        if (found) {
+            throw new IllegalArgumentException("Parameter Name/Code are missing from parameter_names");
+        }
     }
 }

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/control/PopulateResourceTypesTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/control/PopulateResourceTypesTest.java
@@ -1,20 +1,72 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.schema.control;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.type.code.FHIRResourceType;
+
 /**
- * Test to verify the parameter_names.properties
+ * Test to verify the resource_types.properties
  */
 public class PopulateResourceTypesTest {
+    private static final Logger LOGGER = Logger.getLogger(PopulateResourceTypesTest.class.getName());
+
+    /**
+     * This method is very intentional to verify the resource_types.properties on EVERY build.
+     * The mapping is intentionally managed, as these KEYS are inserted and used.
+     */
     @Test
-    public void testVerify() {
-        PopulateParameterNames.verify();
-        assert true;
+    public static void verify() {
+        Properties props = new Properties();
+        boolean found = false;
+        try (InputStream fis =
+                PopulateResourceTypes.class.getClassLoader().getResourceAsStream("resource_types.properties")) {
+            props.load(fis);
+
+            Set<String> resources = new HashSet<>();
+            for (FHIRResourceType.ValueSet rt : FHIRResourceType.ValueSet.values()) {
+                resources.add(rt.value());
+            }
+
+            // Find the Highest Value to start from:
+            Integer highestValue = 0;
+            Map<String, Integer> valueMap = new HashMap<>();
+            for (Entry<Object, Object> valueEntry : props.entrySet()) {
+                Integer curVal = Integer.parseInt((String) valueEntry.getValue());
+                String resource = (String) valueEntry.getKey();
+                valueMap.put(resource, curVal);
+                if (highestValue < curVal) {
+                    highestValue = curVal;
+                }
+                resources.remove(resource);
+            }
+
+            // Check to see if something is missing
+            for (String resource : resources) {
+                LOGGER.info(resource + "=" + highestValue++);
+                found = true;
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("File access issue for resource_types");
+        }
+
+        if (found) {
+            throw new IllegalArgumentException("Resources are missing from resource_types");
+        }
     }
 }


### PR DESCRIPTION
Moved PopulateParameterNames.verify() to PopulateParameterNamesTest and
set the FHIRRegistry dependency to `test` scope.

Moved PopulateResourceTypes.verify() to PopulateResourceTypesTest just
for consistency.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>