### PR TITLE
set x_RESOURCE_TOKEN_REFS to V0009

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Migration.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Migration.java
@@ -24,5 +24,5 @@ public interface Migration {
      * @implSpec this method should only be executed when the current version > priorVersion and so the steps need not be
      *         idempotent
      */
-    public List<IDatabaseStatement> migrateFrom(Integer priorVersion);
+    public List<IDatabaseStatement> migrateFrom(int priorVersion);
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Migration.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Migration.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -113,16 +113,6 @@ public class FhirResourceTableGroup {
 
     private static final String ROW_ID = "ROW_ID";
 
-    // suffix for the token view
-    private static final String _TOKEN_VALUES_V = "_TOKEN_VALUES_V";
-
-    private static final String _STR = "_STR";
-    private static final String _NUMBER = "_NUMBER";
-    private static final String _DATE = "_DATE";
-    private static final String _TOKEN = "_TOKEN";
-    private static final String _QUANTITY = "_QUANTITY";
-    private static final String _LATLNG = "_LATLNG";
-
     /**
      * Public constructor
      */
@@ -440,7 +430,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         // logical_resources (1) ---- (*) patient_resource_token_refs (*) ---- (0|1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0008.vid())
+                .setVersion(FhirSchemaVersion.V0009.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(       PARAMETER_NAME_ID,    false)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,     true)


### PR DESCRIPTION
We missed this as part of #1996, so anyone that has applied these updates to a DB since that change now has the wrong
version of that object.  Since that change was never released, I think we're OK just to fix it now (and help anyone
riding the bleeding edge to manually fix their VERSION_HISTORY table).

I also made an unrelated tweak to the Migration interface:  priorVersion should never be null and this makes that more clear

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>