### PR TITLE
Add causedBy to caught exceptions.

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
@@ -101,6 +101,7 @@ public class BatchContextAdapter {
         context(ctx);
         source(ctx);
         audit(ctx);
+        systemWrite(ctx);
         search(ctx);
         format(ctx);
         return ctx;

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
@@ -71,9 +71,9 @@ public class S3Preflight extends NopPreflight {
                 }
             }
         } catch (ExecutionException ee) {
-            throw export.buildOperationException("Failed to execute the s3 access, check the s3 configuration", IssueType.NO_STORE);
+            throw export.buildOperationException("Failed to execute the s3 access, check the s3 configuration", IssueType.NO_STORE, ee);
         } catch (InterruptedException e) {
-            throw export.buildOperationException("Timeout hit trying to access s3, check the s3 configuration", IssueType.NO_STORE);
+            throw export.buildOperationException("Timeout hit trying to access s3, check the s3 configuration", IssueType.NO_STORE, e);
         }
         executor.shutdown();
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -132,13 +132,16 @@ public class BulkDataExportUtil {
     }
 
     public FHIROperationException buildOperationException(String errMsg, IssueType issueType) {
-        FHIROperationException operationException = new FHIROperationException(errMsg);
+        return buildOperationException(errMsg, issueType, null);
+    }
 
-        List<Issue> issues = new ArrayList<>();
-        issues.add(Issue.builder().code(issueType).diagnostics(string(errMsg)).severity(IssueSeverity.ERROR).build());
-
-        operationException.setIssues(issues);
-        return operationException;
+    public FHIROperationException buildOperationException(String errMsg, IssueType issueType, Exception e) {
+        return new FHIROperationException(errMsg, e)
+                .withIssue(Issue.builder()
+                    .code(issueType)
+                    .diagnostics(string(errMsg))
+                    .severity(IssueSeverity.ERROR)
+                    .build());
     }
 
     /**


### PR DESCRIPTION
By overloading BulkDataExportUtil.buildOperationException with a variant
that accepts the cause.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>