### PR TITLE
issue #2040 - cleanup in S3Provider.writeResources

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/group/resource/GroupHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/group/resource/GroupHandler.java
@@ -62,17 +62,11 @@ public class GroupHandler {
     }
 
     /**
-     * get page of members
+     * resolve the groupId into a set of patients and add them to this handler
      *
-     * @param pageNum
-     * @param pageSize
-     * @return
+     * @param groupId
+     * @throws Exception
      */
-    public List<Member> getPageOfMembers(int pageNum, int pageSize){
-        return patientMembers.subList((pageNum - 1) * pageSize,
-            pageNum * pageSize <= patientMembers.size() ? pageNum * pageSize : patientMembers.size());
-    }
-
     public void process(String groupId) throws Exception {
         if (patientMembers == null) {
             Group group = findGroupByID(groupId);
@@ -83,10 +77,20 @@ public class GroupHandler {
         }
     }
 
-    /*
+    /**
+     * get a page of members from this handler
+     *
+     * @param pageNum
+     * @param pageSize
+     * @return
+     * @implNote {@link GroupHandler#process(String)} must be called first
+     */
+    public List<Member> getPageOfMembers(int pageNum, int pageSize){
+        return patientMembers.subList((pageNum - 1) * pageSize, Math.min(pageNum * pageSize, patientMembers.size()));
+    }
+
+    /**
      * recursively expands a group into a set of members
-     * @param fhirTenant
-     * @param fhirDatastoreId
      * @param group
      * @param patients
      * @param groupsInPath empty, or prior Groups scanned

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.bulkdata.jbatch.export.checkpoint;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.api.chunk.CheckpointAlgorithm;
@@ -38,13 +39,36 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
 
     @Override
     public void beginCheckpoint() {
-        logger.finer("begin checkpoint");
+        if (logger.isLoggable(Level.FINE)) {
+            ExportTransientUserData chunkData = (ExportTransientUserData) stepCtx.getTransientUserData();
+            if (chunkData != null) {
+                logger.fine("begin checkpoint [" +
+                        "page " + chunkData.getPageNum() + " of " + chunkData.getLastPageNum() + ", " +
+                        "bufferSize=" + chunkData.getBufferStream().size() + ", " +
+                        "uploadPart=" + chunkData.getPartNum() + ", " +
+                        "currentUploadSize=" + chunkData.getCurrentUploadSize() + ", " +
+                        "currentUploadResourceNum=" + chunkData.getCurrentUploadResourceNum() +
+                        "]");
+            }
+        }
     }
 
     @Override
     public void endCheckpoint() {
-        // Nothing to do here at present
-        logger.finer("end checkpoint");
+        if (logger.isLoggable(Level.FINE)) {
+            ExportTransientUserData chunkData = (ExportTransientUserData) stepCtx.getTransientUserData();
+            if (chunkData == null) {
+                logger.warning("end checkpoint [no chunkData]");
+            } else {
+                logger.fine("end checkpoint [" +
+                        "page " + chunkData.getPageNum() + " of " + chunkData.getLastPageNum() + ", " +
+                        "bufferSize=" + chunkData.getBufferStream().size() + ", " +
+                        "uploadPart=" + chunkData.getPartNum() + ", " +
+                        "currentUploadSize=" + chunkData.getCurrentUploadSize() + ", " +
+                        "currentUploadResourceNum=" + chunkData.getCurrentUploadResourceNum() +
+                        "]");
+            }
+        }
     }
 
     @Override
@@ -61,13 +85,13 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
         // Stop writing to the current COS object
         boolean overFileSizeThreshold = cosFileThresholdSize != 0 && chunkData.getBufferStream().size() >= cosFileThresholdSize;
         boolean overMaxResourceCountThreshold = cosFileMaxResources != 0 && chunkData.getCurrentUploadResourceNum() >= cosFileMaxResources;
-        boolean end = chunkData.getPageNum() > chunkData.getLastPageNum();
+        boolean end = chunkData.getPageNum() >= chunkData.getLastPageNum();
         chunkData.setFinishCurrentUpload(overFileSizeThreshold || overMaxResourceCountThreshold || end);
 
         // Indicates a multipart read.
         boolean multiPartChunkMinimum = chunkData.getBufferStream().size() > cosMultiPartMinSize;
 
-        // At this point, there are three conditions that trigger a checkpoint:
+        // At this point, there are two conditions that trigger a checkpoint:
         // 1 - Multipart Chunk
         // 2 - Or the end of a write
         return multiPartChunkMinimum || chunkData.isFinishCurrentUpload();

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/data/ExportCheckpointUserData.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/data/ExportCheckpointUserData.java
@@ -31,7 +31,7 @@ public class ExportCheckpointUserData implements java.io.Serializable {
     protected String resourceTypeSummary = null;
     // Used to mark the complete of the partition.
     private boolean isMoreToExport = true;
-    protected int lastWritePageNum;
+    protected int lastWrittenPageNum;
 
     protected ExportCheckpointUserData() {
         super();
@@ -50,7 +50,7 @@ public class ExportCheckpointUserData implements java.io.Serializable {
             .currentUploadSize(userData.currentUploadSize)
             .uploadCount(userData.uploadCount)
             .lastPageNum(userData.lastPageNum)
-            .lastWritePageNum(userData.lastWritePageNum)
+            .lastWrittenPageNum(userData.lastWrittenPageNum)
             .build();
     }
 
@@ -131,7 +131,7 @@ public class ExportCheckpointUserData implements java.io.Serializable {
             return this;
         }
 
-        public Builder lastWritePageNum(int lastWritePageNum) {
+        public Builder lastWrittenPageNum(int lastWritePageNum) {
             this.lastWritePageNum = lastWritePageNum;
             return this;
         }
@@ -149,7 +149,7 @@ public class ExportCheckpointUserData implements java.io.Serializable {
             checkPointUserData.totalResourcesNum = this.totalResourcesNum;
             checkPointUserData.indexOfCurrentTypeFilter = this.indexOfCurrentTypeFilter;
             checkPointUserData.resourceTypeSummary = this.resourceTypeSummary;
-            checkPointUserData.lastWritePageNum = this.lastWritePageNum;
+            checkPointUserData.lastWrittenPageNum = this.lastWritePageNum;
 
             return checkPointUserData;
         }
@@ -268,15 +268,15 @@ public class ExportCheckpointUserData implements java.io.Serializable {
         this.uploadCount = uploadCount;
     }
 
-    public int getLastWritePageNum() {
-        return lastWritePageNum;
+    public int getLastWrittenPageNum() {
+        return lastWrittenPageNum;
     }
 
     /**
      * @param lastWritePageNum the last page of search results that was exported
      */
-    public void setLastWritePageNum(int lastWritePageNum) {
-        this.lastWritePageNum = lastWritePageNum;
+    public void setLastWrittenPageNum(int lastWritePageNum) {
+        this.lastWrittenPageNum = lastWritePageNum;
     }
 
     @Override
@@ -285,7 +285,7 @@ public class ExportCheckpointUserData implements java.io.Serializable {
                 + uploadCount + ", cosDataPacks=" + cosDataPacks + ", currentUploadResourceNum=" + currentUploadResourceNum + ", currentUploadSize="
                 + currentUploadSize + ", isFinishCurrentUpload=" + isFinishCurrentUpload + ", totalResourcesNum=" + totalResourcesNum
                 + ", indexOfCurrentTypeFilter=" + indexOfCurrentTypeFilter + ", resourceTypeSummary=" + resourceTypeSummary + ", isMoreToExport="
-                + isMoreToExport + ", lastWritePageNum=" + lastWritePageNum + "]";
+                + isMoreToExport + ", lastWritePageNum=" + lastWrittenPageNum + "]";
     }
 
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/data/ExportTransientUserData.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/data/ExportTransientUserData.java
@@ -7,6 +7,9 @@
 package com.ibm.fhir.bulkdata.jbatch.export.data;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 
 /**
  * Bulk Export Job Transient data
@@ -22,7 +25,7 @@ public class ExportTransientUserData extends ExportCheckpointUserData {
     }
 
     public static ExportTransientUserData fromCheckPointUserData(ExportCheckpointUserData checkPointData) {
-        return (ExportTransientUserData)ExportTransientUserData.Builder.builder()
+        return ExportTransientUserData.Builder.builder()
             .pageNum(checkPointData.pageNum)
             .uploadId(checkPointData.uploadId)
             .cosDataPacks(checkPointData.cosDataPacks)
@@ -34,7 +37,7 @@ public class ExportTransientUserData extends ExportCheckpointUserData {
             .currentUploadSize(checkPointData.currentUploadSize)
             .uploadCount(checkPointData.uploadCount)
             .lastPageNum(checkPointData.lastPageNum)
-            .lastWritePageNum(checkPointData.lastWritePageNum)
+            .lastWrittenPageNum(checkPointData.lastWrittenPageNum)
             .build();
     }
 
@@ -49,7 +52,67 @@ public class ExportTransientUserData extends ExportCheckpointUserData {
         }
 
         @Override
-        public ExportCheckpointUserData build(){
+        public Builder pageNum(int pageNum) {
+            return (Builder) super.pageNum(pageNum);
+        }
+
+        @Override
+        public Builder lastPageNum(int lastPageNum) {
+            return (Builder) super.lastPageNum(lastPageNum);
+        }
+
+        @Override
+        public Builder partNum(int partNum) {
+            return (Builder) super.partNum(partNum);
+        }
+
+        @Override
+        public Builder uploadId(String uploadId) {
+            return (Builder) super.uploadId(uploadId);
+        }
+
+        @Override
+        public Builder uploadCount(long uploadCount) {
+            return (Builder) super.uploadCount(uploadCount);
+        }
+
+        @Override
+        public Builder cosDataPacks(List<PartETag> cosDataPacks) {
+            return (Builder) super.cosDataPacks(cosDataPacks);
+        }
+
+        @Override
+        public Builder currentUploadResourceNum(long currentUploadResourceNum) {
+            return (Builder) super.currentUploadResourceNum(currentUploadResourceNum);
+        }
+
+        @Override
+        public Builder currentUploadSize(long currentUploadSize) {
+            return (Builder) super.currentUploadSize(currentUploadSize);
+        }
+
+        @Override
+        public Builder totalResourcesNum(long totalResourcesNum) {
+            return (Builder) super.totalResourcesNum(totalResourcesNum);
+        }
+
+        @Override
+        public Builder indexOfCurrentTypeFilter(int indexOfCurrentTypeFilter) {
+            return (Builder) super.indexOfCurrentTypeFilter(indexOfCurrentTypeFilter);
+        }
+
+        @Override
+        public Builder resourceTypeSummary(String resourceTypeSummary) {
+            return (Builder) super.resourceTypeSummary(resourceTypeSummary);
+        }
+
+        @Override
+        public Builder lastWrittenPageNum(int lastWritePageNum) {
+            return (Builder) super.lastWrittenPageNum(lastWritePageNum);
+        }
+
+        @Override
+        public ExportTransientUserData build(){
             ExportTransientUserData transientUserData = new ExportTransientUserData();
             transientUserData.pageNum  = this.pageNum;
             transientUserData.lastPageNum = this.lastPageNum;
@@ -62,7 +125,7 @@ public class ExportTransientUserData extends ExportCheckpointUserData {
             transientUserData.totalResourcesNum = this.totalResourcesNum;
             transientUserData.indexOfCurrentTypeFilter = this.indexOfCurrentTypeFilter;
             transientUserData.resourceTypeSummary = this.resourceTypeSummary;
-            transientUserData.lastWritePageNum = this.lastWritePageNum;
+            transientUserData.lastWrittenPageNum = this.lastWritePageNum;
             return transientUserData;
         }
     }
@@ -73,6 +136,6 @@ public class ExportTransientUserData extends ExportCheckpointUserData {
                 + ", uploadId=" + uploadId + ", uploadCount=" + uploadCount + ", cosDataPacks=" + cosDataPacks + ", currentUploadResourceNum="
                 + currentUploadResourceNum + ", currentUploadSize=" + currentUploadSize + ", totalResourcesNum=" + totalResourcesNum
                 + ", indexOfCurrentTypeFilter=" + indexOfCurrentTypeFilter + ", resourceTypeSummary=" + resourceTypeSummary + ", lastWritePageNum="
-                + lastWritePageNum + "]";
+                + lastWrittenPageNum + "]";
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
@@ -67,8 +67,10 @@ public class ChunkReader extends AbstractItemReader {
 
     private PatientResourceHandler handler = new PatientResourceHandler();
 
-    // Maintains the pointer to the current resources by pageNum,pageSize
-    protected int pageNum = 1;
+    // Initialized to zero so we can increment it on every call to readItem (including the first one).
+    protected int pageNum = 0;
+
+    // Control the number of records to read in each "item".
     protected int pageSize;
 
     protected Class<? extends Resource> resourceType;
@@ -107,7 +109,7 @@ public class ChunkReader extends AbstractItemReader {
 
         if (checkpoint != null) {
             ExportCheckpointUserData checkPointData = (ExportCheckpointUserData) checkpoint;
-            pageNum = checkPointData.getLastWritePageNum();
+            pageNum = checkPointData.getLastWrittenPageNum();
             stepCtx.setTransientUserData(ExportTransientUserData.fromCheckPointUserData(checkPointData));
         }
 
@@ -141,6 +143,9 @@ public class ChunkReader extends AbstractItemReader {
             // short-circuit
             return null;
         }
+
+        // Move the page number forward. On the first readItem call, this will increment from 0 to 1.
+        pageNum++;
 
         ExportTransientUserData chunkData = (ExportTransientUserData) stepCtx.getTransientUserData();
         if (chunkData != null && pageNum > chunkData.getLastPageNum()) {
@@ -188,27 +193,22 @@ public class ChunkReader extends AbstractItemReader {
             }
 
             dto = new ReadResultDTO(resources);
-            pageNum++;
 
             if (chunkData == null) {
-                // @formatter:off
-                chunkData =
-                        (ExportTransientUserData) ExportTransientUserData.Builder.builder()
-                            .pageNum(pageNum)
-                            .uploadId(null)
-                            .cosDataPacks(new ArrayList<PartETag>())
-                            .partNum(1)
-                            .indexOfCurrentTypeFilter(0)
-                            .resourceTypeSummary(null)
-                            .totalResourcesNum(0)
-                            .currentUploadResourceNum(0)
-                            .currentUploadSize(0)
-                            .uploadCount(1)
-                            .lastPageNum(searchContext.getLastPageNumber())
-                            .lastWritePageNum(1)
-                            .build();
-                // @formatter:on
-
+                chunkData = ExportTransientUserData.Builder.builder()
+                        .pageNum(pageNum)
+                        .uploadId(null)
+                        .cosDataPacks(new ArrayList<PartETag>())
+                        .partNum(1)
+                        .indexOfCurrentTypeFilter(0)
+                        .resourceTypeSummary(null)
+                        .totalResourcesNum(0)
+                        .currentUploadResourceNum(0)
+                        .currentUploadSize(0)
+                        .uploadCount(1)
+                        .lastPageNum(searchContext.getLastPageNumber())
+                        .lastWrittenPageNum(1)
+                        .build();
             } else {
                 chunkData.setPageNum(pageNum);
                 chunkData.setLastPageNum(searchContext.getLastPageNumber());

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/ChunkReader.java
@@ -65,16 +65,18 @@ public class ChunkReader extends AbstractItemReader {
 
     private SystemExportResourceHandler handler = new SystemExportResourceHandler();
 
-    // The handle to the persistence instance used to fetch the resources we want to export
+    // The handle to the persistence instance used to fetch the resources we want to export.
     FHIRPersistence fhirPersistence;
 
     // The resource type class of the resources being exported by this instance (derived from the injected
-    // fhirResourceType value
+    // fhirResourceType value).
     Class<? extends Resource> resourceType;
 
     private BulkDataContext ctx = null;
 
-    int pageNum = 1;
+    // Initialized to zero so we can increment it on every call to readItem (including the first one).
+    int pageNum = 0;
+
     // Control the number of records to read in each "item".
     int pageSize = ConfigurationFactory.getInstance().getCorePageSize();
 
@@ -114,7 +116,7 @@ public class ChunkReader extends AbstractItemReader {
 
         if (checkpoint != null) {
             ExportCheckpointUserData checkPointData = (ExportCheckpointUserData) checkpoint;
-            pageNum = checkPointData.getLastWritePageNum();
+            pageNum = checkPointData.getLastWrittenPageNum();
             indexOfCurrentTypeFilter = checkPointData.getIndexOfCurrentTypeFilter();
 
             // We use setTransient from checkpoint when we have just uploaded to COS.
@@ -149,6 +151,9 @@ public class ChunkReader extends AbstractItemReader {
             // short-circuit
             return null;
         }
+
+        // Move the page number forward. On the first readItem call, this will increment from 0 to 1.
+        pageNum++;
 
         ExportTransientUserData chunkData = (ExportTransientUserData) stepCtx.getTransientUserData();
         // If the search already reaches the last page, then check if need to move to the next typeFilter.
@@ -216,26 +221,22 @@ public class ChunkReader extends AbstractItemReader {
                 auditLogger.logSearchOnExport(queryParameters, dto.size(), startTime, endTime, Response.Status.OK, "@source:" + ctx.getSource(), "BulkDataOperator");
             }
         }
-        pageNum++;
 
         if (chunkData == null) {
-            // @formatter:off
-                chunkData =
-                        (ExportTransientUserData) ExportTransientUserData.Builder.builder()
-                            .pageNum(pageNum)
-                            .uploadId(null)
-                            .cosDataPacks(new ArrayList<PartETag>())
-                            .partNum(1)
-                            .indexOfCurrentTypeFilter(0)
-                            .resourceTypeSummary(null)
-                            .totalResourcesNum(0)
-                            .currentUploadResourceNum(0)
-                            .currentUploadSize(0)
-                            .uploadCount(1)
-                            .lastPageNum(searchContext.getLastPageNumber())
-                            .lastWritePageNum(1)
-                            .build();
-                // @formatter:on
+            chunkData = ExportTransientUserData.Builder.builder()
+                    .pageNum(pageNum)
+                    .uploadId(null)
+                    .cosDataPacks(new ArrayList<PartETag>())
+                    .partNum(1)
+                    .indexOfCurrentTypeFilter(0)
+                    .resourceTypeSummary(null)
+                    .totalResourcesNum(0)
+                    .currentUploadResourceNum(0)
+                    .currentUploadSize(0)
+                    .uploadCount(1)
+                    .lastPageNum(searchContext.getLastPageNumber())
+                    .lastWrittenPageNum(1)
+                    .build();
             stepCtx.setTransientUserData(chunkData);
         } else {
             chunkData.setPageNum(pageNum);

--- a/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
+++ b/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportGroupChunkJob.xml
@@ -15,7 +15,7 @@
         <listeners>
             <listener ref="com.ibm.fhir.bulkdata.jbatch.listener.StepChunkListener"></listener>
         </listeners>
-        <chunk checkpoint-policy="item" item-count="1">
+        <chunk checkpoint-policy="custom">
             <reader ref="com.ibm.fhir.bulkdata.jbatch.export.group.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>

--- a/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
+++ b/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportPatientChunkJob.xml
@@ -15,7 +15,7 @@
         <listeners>
             <listener ref="com.ibm.fhir.bulkdata.jbatch.listener.StepChunkListener"></listener>
         </listeners>
-        <chunk checkpoint-policy="item" item-count="1">
+        <chunk checkpoint-policy="custom">
             <reader ref="com.ibm.fhir.bulkdata.jbatch.export.patient.ChunkReader">
                 <properties >
                     <property name="fhir.tenant" value="#{jobParameters['fhir.tenant']}"/>

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -84,11 +85,18 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
     private static final int TIMEOUT = 10000;
 
-    private static final SSLConnectionSocketFactory sf = generateSSF();
-    private static final HttpRequestRetryHandler rh=new HttpRequestRetryHandler(){@Override public boolean retryRequest(IOException exception,int executionCount,HttpContext context){return executionCount<2;}};
+    private static final HttpRequestRetryHandler rh = new HttpRequestRetryHandler(){
+        @Override
+        public boolean retryRequest(IOException exception, int executionCount,HttpContext context){
+            return executionCount<2;
+        }
+    };
 
-    private static final RequestConfig config =
-            RequestConfig.custom().setConnectTimeout(TIMEOUT).setConnectionRequestTimeout(TIMEOUT).setSocketTimeout(TIMEOUT).build();
+    private static final RequestConfig config = RequestConfig.custom()
+            .setConnectTimeout(TIMEOUT)
+            .setConnectionRequestTimeout(TIMEOUT)
+            .setSocketTimeout(TIMEOUT)
+            .build();
     public static final String TEST_GROUP_NAME = "export-operation";
     public static final String PATIENT_VALID_URL = "Patient/$export";
     public static final String GROUP_VALID_URL = "Group/?/$export";
@@ -281,6 +289,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 JsonReader jsonReader = JSON_READER_FACTORY.createReader(bais, StandardCharsets.UTF_8)) {
             JsonObject object = jsonReader.readObject();
             JsonArray arr = object.getJsonArray("output");
+            assertNotNull(arr);
             assertTrue(arr.size() > 0);
             for (int i = 0; i < arr.size(); i++) {
                 JsonObject obj = arr.get(i).asJsonObject();
@@ -598,8 +607,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testBaseExport() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null, "default", "default");
+            Response response = doPost(
+                    BASE_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -619,8 +634,15 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = true)
     public void testBaseExportToS3() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null, "minio", "minio");
+            Response response = doPost(
+                    BASE_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON,
+                    FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient"),
+                    null,
+                    "minio",
+                    "minio");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -643,8 +665,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = true)
     public void testExportToParquetResponse() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null, "default", "default");
+            Response response = doPost(
+                    BASE_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode(), "Response status");
         } else {
             System.out.println("Base Export Test Disabled, Skipping");
@@ -658,8 +686,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testBaseExportToParquet() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(BASE_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient"), null, "default", "default");
+            Response response = doPost(
+                    BASE_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -679,8 +713,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testPatientExport() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null, "default", "default");
+            Response response = doPost(
+                    PATIENT_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Observation,Condition,Patient"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -700,8 +740,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testPatientExportToS3() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null, "minio", "minio");
+            Response response = doPost(
+                    PATIENT_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Observation,Condition,Patient"),
+                    null,
+                    "minio",
+                    "minio");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -725,8 +771,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testPatientExportToParquet() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(PATIENT_VALID_URL, FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Observation,Condition,Patient"), null, "default", "default");
+            Response response = doPost(
+                    PATIENT_VALID_URL,
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Observation,Condition,Patient"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -746,8 +798,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testGroupExport() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient", "Group", "Condition", "Observation"), null, "default", "default");
+            Response response = doPost(
+                    GROUP_VALID_URL.replace("?", savedGroupId2),
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient", "Group", "Condition", "Observation"),
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -767,8 +825,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testGroupExportToS3() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON, Instant.of("2019-01-01T08:21:26.94-04:00"), Arrays.asList("Patient", "Group", "Condition", "Observation"), null, "minio", "minio");
+            Response response = doPost(
+                    GROUP_VALID_URL.replace("?", savedGroupId2),
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    Arrays.asList("Patient", "Group", "Condition", "Observation"),
+                    null,
+                    "minio",
+                    "minio");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -792,8 +856,14 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testGroupExportToParquet() throws Exception {
         if (ON) {
-            Response response =
-                    doPost(GROUP_VALID_URL.replace("?", savedGroupId2), FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET, Instant.of("2019-01-01T08:21:26.94-04:00"), null, null, "default", "default");
+            Response response = doPost(
+                    GROUP_VALID_URL.replace("?", savedGroupId2),
+                    FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
+                    Instant.of("2019-01-01T08:21:26.94-04:00"),
+                    null,
+                    null,
+                    "default",
+                    "default");
             assertEquals(response.getStatus(), Response.Status.ACCEPTED.getStatusCode());
 
             // check the content-location that's returned.
@@ -824,7 +894,8 @@ public class ExportOperationTest extends FHIRServerTestBase {
         // Export finished successfully, we should be about to find the "output" part in the message body
         // which includes all the COS objects download urls.
         String body = response.readEntity(String.class);
-        assertTrue(body.contains("output"));
+        JsonObject jsonObject = JSON_READER_FACTORY.createReader(new StringReader(body)).readObject();
+        assertTrue(jsonObject.containsKey("output"));
 
         verifyUrl(body, s3);
     }


### PR DESCRIPTION
1. Previously we were looping through all of the ReadResultDTOs
(presumably 1 per page of search results), and entering our logic for
each page.  However, the chunkData buffer stream constains the content
from all the results, so this doesn't make much sense to me.

2. Renamed lastWritePageNum to lastWrittenPageNum to make its purpose
more clear (more distinct from lastPageNum)

3. Update ExportOperationTest to properly look for an 'output' key in
the response json, not just anywhere in the response body

4. Add logging to ExportCheckpointAlgorithm

5. ExportTransientUserData.Builder methods now return
ExportTransientUserData instead of the super type (same change was made
to ImportTransientUserData previously)

6. Page number now matches the actual page number read; previously it
was always 1 higher

7. Set the checkpoint-policy of Group and Patient export to 'custom' to
indicate that the ExportCheckpointAlgorithm will be used to control
checkpointing

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>