### PR TITLE
reformat the acceptance criteria a tad

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -21,10 +21,11 @@ A clear and concise description of any alternative solutions or features you've 
 At least one acceptance criteria is included.
 
 1.  
-  GIVEN [a precondition]
-    AND [another precondition] WHEN [test step]
+   GIVEN [a precondition]
+    AND [another precondition]
+   WHEN [test step]
     AND [test step]
-    THEN [verification step]
+   THEN [verification step]
     AND [verification step]
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,10 +16,7 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
-
 **Acceptance Criteria**
-At least one acceptance criteria is included.
-
 1.  
    GIVEN [a precondition]
     AND [another precondition]


### PR DESCRIPTION
I always bugs me that `AND` and `WHEN` are on the same line, and we needed at least one more indent so that the text actually belongs to the numbered list item.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>