### PR TITLE
Issue #2112 - checkpoint after each item for file-based export

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2029,6 +2029,9 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/core/cos/requestTimeout`|number|The request timeout in second for the COS client|
 |`fhirServer/bulkdata/core/cos/socketTimeout`|number|The socket timeout in second for the COS client|
 |`fhirServer/bulkdata/core/cos/useServerTruststore`|boolean|If the COS Client should use the IBM FHIR Server's TrustStore to access S3/IBMCOS service |
+|`fhirServer/bulkdata/core/file/writeTriggerSizeMB`|number|The size, in megabytes, at which to write the buffer to file.|
+|`fhirServer/bulkdata/core/file/sizeThresholdMB`|number|The size, in megabytes, at which to finish writing a given file. Use `0` to indicate that all resources of a given type should be written to a single file.|
+|`fhirServer/bulkdata/core/file/resourceCountThreshold`|number|The number of resources at which to finish writing a given file. The actual number of resources written to a single file may be slightly above this number, dependent on the configured page size. Use `0` to indicate that there is no limit to the number of resources to be written to a single file.|
 |`fhirServer/bulkdata/core/batchIdEncryptionKey`|string|Encoding key for JavaBatch job id |
 |`fhirServer/bulkdata/core/pageSize`|number|The search page size for patient/group export and the legacy export, the default value is 1000 |
 |`fhirServer/bulkdata/core/maxPartitions`|number| The maximum number of simultaneous partitions that are processed per Export and Import |

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
 import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 
@@ -39,6 +40,8 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
 
     Boolean isFileExport;
 
+    ConfigurationAdapter config = ConfigurationFactory.getInstance();
+
     public ExportCheckpointAlgorithm() {
         // No Operation
     }
@@ -55,7 +58,7 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
             JobExecution jobExecution = jobOperator.getJobExecution(jobCtx.getExecutionId());
             BatchContextAdapter contextAdapter = new BatchContextAdapter(jobExecution.getJobParameters());
             BulkDataContext ctx = contextAdapter.getStepContextForSystemChunkWriter();
-            isFileExport = "file".equals(ConfigurationFactory.getInstance().getStorageProviderType(ctx.getSource()));
+            isFileExport = "file".equals(config.getStorageProviderType(ctx.getSource()));
         }
 
         if (logger.isLoggable(Level.FINE)) {
@@ -97,16 +100,19 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
             return false;
         }
 
-        long cosFileMaxResources = ConfigurationFactory.getInstance().getCoreCosObjectResourceCountThreshold();
-        long cosFileThresholdSize = ConfigurationFactory.getInstance().getCoreCosObjectSizeThreshold();
-        long cosMultiPartMinSize = ConfigurationFactory.getInstance().getCoreCosPartUploadTriggerSize();
+        long resourceCountThreshold = isFileExport ? config.getCoreFileResourceCountThreshold()
+                : config.getCoreCosObjectResourceCountThreshold();
+        long sizeThreshold = isFileExport ? config.getCoreFileSizeThreshold()
+                : config.getCoreCosObjectSizeThreshold();
+        long writeTrigger = isFileExport ? config.getCoreFileWriteTriggerSize()
+                : config.getCoreCosPartUploadTriggerSize();
 
         // Set to true if we have enough bytes to write a part
-        boolean readyToWrite = isFileExport || (chunkData.getBufferStream().size() > cosMultiPartMinSize);
+        boolean readyToWrite = chunkData.getBufferStream().size() >= writeTrigger;
 
         // Check if we should finish writing the current object/file
-        boolean overFileSizeThreshold = cosFileThresholdSize != 0 && chunkData.getBufferStream().size() >= cosFileThresholdSize;
-        boolean overMaxResourceCountThreshold = cosFileMaxResources != 0 && chunkData.getCurrentUploadResourceNum() >= cosFileMaxResources;
+        boolean overFileSizeThreshold = sizeThreshold != 0 && chunkData.getBufferStream().size() >= sizeThreshold;
+        boolean overMaxResourceCountThreshold = resourceCountThreshold != 0 && chunkData.getCurrentUploadResourceNum() >= resourceCountThreshold;
         boolean end = chunkData.getPageNum() >= chunkData.getLastPageNum();
         chunkData.setFinishCurrentUpload(overFileSizeThreshold || overMaxResourceCountThreshold || end);
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/checkpoint/ExportCheckpointAlgorithm.java
@@ -10,12 +10,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.batch.api.chunk.CheckpointAlgorithm;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.context.JobContext;
 import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
+import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 
 /**
  * BulkData Export Custom CheckpointAlgorithm which considers COS size requirements while checkpointing.
@@ -26,7 +32,12 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
     private final static Logger logger = Logger.getLogger(ExportCheckpointAlgorithm.class.getName());
 
     @Inject
+    JobContext jobCtx;
+
+    @Inject
     StepContext stepCtx;
+
+    Boolean isFileExport;
 
     public ExportCheckpointAlgorithm() {
         // No Operation
@@ -39,6 +50,14 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
 
     @Override
     public void beginCheckpoint() {
+        if (isFileExport == null) {
+            JobOperator jobOperator = BatchRuntime.getJobOperator();
+            JobExecution jobExecution = jobOperator.getJobExecution(jobCtx.getExecutionId());
+            BatchContextAdapter contextAdapter = new BatchContextAdapter(jobExecution.getJobParameters());
+            BulkDataContext ctx = contextAdapter.getStepContextForSystemChunkWriter();
+            isFileExport = "file".equals(ConfigurationFactory.getInstance().getStorageProviderType(ctx.getSource()));
+        }
+
         if (logger.isLoggable(Level.FINE)) {
             ExportTransientUserData chunkData = (ExportTransientUserData) stepCtx.getTransientUserData();
             if (chunkData != null) {
@@ -82,18 +101,18 @@ public class ExportCheckpointAlgorithm implements CheckpointAlgorithm {
         long cosFileThresholdSize = ConfigurationFactory.getInstance().getCoreCosObjectSizeThreshold();
         long cosMultiPartMinSize = ConfigurationFactory.getInstance().getCoreCosPartUploadTriggerSize();
 
-        // Stop writing to the current COS object
+        // Set to true if we have enough bytes to write a part
+        boolean readyToWrite = isFileExport || (chunkData.getBufferStream().size() > cosMultiPartMinSize);
+
+        // Check if we should finish writing the current object/file
         boolean overFileSizeThreshold = cosFileThresholdSize != 0 && chunkData.getBufferStream().size() >= cosFileThresholdSize;
         boolean overMaxResourceCountThreshold = cosFileMaxResources != 0 && chunkData.getCurrentUploadResourceNum() >= cosFileMaxResources;
         boolean end = chunkData.getPageNum() >= chunkData.getLastPageNum();
         chunkData.setFinishCurrentUpload(overFileSizeThreshold || overMaxResourceCountThreshold || end);
 
-        // Indicates a multipart read.
-        boolean multiPartChunkMinimum = chunkData.getBufferStream().size() > cosMultiPartMinSize;
-
-        // At this point, there are two conditions that trigger a checkpoint:
-        // 1 - Multipart Chunk
-        // 2 - Or the end of a write
-        return multiPartChunkMinimum || chunkData.isFinishCurrentUpload();
+        // There are two conditions that trigger a checkpoint:
+        // 1 - We have enough bytes to start writing a part; or
+        // 2 - We're ready to finish writing the current object/file
+        return readyToWrite || chunkData.isFinishCurrentUpload();
     }
 }

--- a/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config-db2.json
@@ -133,6 +133,11 @@
                     "objectResourceCountThreshold": 200000,
                     "useServerTruststore": true
                 },
+                "file" : { 
+                    "writeTriggerSizeMB": 1,
+                    "sizeThresholdMB": 200,
+                    "resourceCountThreshold": 200000
+                },
                 "pageSize": 100,
                 "batchIdEncryptionKey": "change-password",
                 "maxPartitions": 3, 

--- a/fhir-server/liberty-config/config/default/fhir-server-config.json
+++ b/fhir-server/liberty-config/config/default/fhir-server-config.json
@@ -10,6 +10,9 @@
             "serverRegistryResourceProviderEnabled": true,
             "disabledOperations": ""
         },
+        "search": {
+            "useStoredCompartmentParam": false
+        },
         "security": {
             "cors": true,
             "basic": {
@@ -146,6 +149,11 @@
                     "objectSizeThresholdMB": 200,
                     "objectResourceCountThreshold": 200000,
                     "useServerTruststore": true
+                },
+                "file" : { 
+                    "writeTriggerSizeMB": 1,
+                    "sizeThresholdMB": 200,
+                    "resourceCountThreshold": 200000
                 },
                 "pageSize": 100,
                 "batchIdEncryptionKey": "change-password",

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/ConfigurationAdapter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/ConfigurationAdapter.java
@@ -153,6 +153,35 @@ public interface ConfigurationAdapter {
     int getCoreCosSocketTimeout();
 
     /**
+     * The size (in bytes) to buffer before writing to file.
+     *
+     * @implNote System value.
+     *
+     * @return
+     */
+    int getCoreFileWriteTriggerSize();
+
+    /**
+     * The size (in bytes) at which to finish writing to a given file,
+     * or 0 to indicate that there is no file size threshold.
+     *
+     * @implNote System value.
+     *
+     * @return
+     */
+    long getCoreFileSizeThreshold();
+
+    /**
+     * The number of resources at which to finish writing to a given file,
+     * or 0 to indicate that there is no resource count threshold.
+     *
+     * @implNote System value.
+     *
+     * @return
+     */
+    int getCoreFileResourceCountThreshold();
+
+    /**
      * get the core page size used in Search.
      *
      * @return

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
@@ -47,6 +47,16 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     // 200,000 at 1 KB/file would lead to roughly 200 MB files; similar to the DEFAULT_COS_OBJ_MAX_SIZE_MB.
     protected static final int DEFAULT_COS_OBJ_MAX_RESOURCE_COUNT = 200000;
 
+    // The default size (1MiB) at which to write to file (NDJSON-only).
+    private static final int DEFAULT_FILE_WRITE_TRIGGER_SIZE_MB = 1;
+
+    // The default size (200MiB) at which to finish writing a given file (NDJSON-only).
+    protected static final int DEFAULT_FILE_MAX_SIZE_MB = 200;
+
+    // The number of resources at which to finish writing a given file (NDJSON and Parquet).
+    // 200,000 at 1 KB/file would lead to roughly 200 MB files; similar to the DEFAULT_COS_OBJ_MAX_SIZE_MB.
+    protected static final int DEFAULT_FILE_MAX_RESOURCE_COUNT = 200000;
+
     private static final String FHIR_BULKDATA_ALLOWED_TYPES = "FHIR_BULKDATA_ALLOWED_TYPES";
     private static final Set<String> ALLOWED_STORAGE_TYPES = determineAllowedStorageType();
 
@@ -62,6 +72,9 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     private static final boolean coreCosUseServerTruststore = defaultCoreCosUseServerTruststore();
     private static final int coreCosRequestTimeout = defaultCoreCosRequestTimeout();
     private static final int coreCosSocketTimeout = defaultCoreCosSocketTimeout();
+    private static final int coreFileResourceCountThreshold = defaultCoreFileResourceCountThreshold();
+    private static final int coreFileWriteTriggerSize = defaultCoreFileWriteTriggerSize();
+    private static final long coreFileSizeThreshold = defaultCoreFileSizeThreshold();
     private static final String coreBatchIdEncryptionKey = defaultCoreBatchIdEncryptionKey();
     private static final int coreMaxParititions = defaultCoreMaxParititions();
     private static final int inputLimits = defaultInputLimits();
@@ -152,6 +165,35 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     private static final int defaultCoreCosObjectResourceCountThreshold() {
         final String PATH = "fhirServer/bulkdata/core/cos/objectResourceCountThreshold";
         return FHIRConfigHelper.getIntProperty(PATH, DEFAULT_COS_OBJ_MAX_RESOURCE_COUNT);
+    }
+
+    @Override
+    public int getCoreFileWriteTriggerSize() {
+        return coreFileWriteTriggerSize;
+    }
+
+    private static final int defaultCoreFileWriteTriggerSize() {
+        return 1024 * 1024 * FHIRConfigHelper.getIntProperty("fhirServer/bulkdata/core/cos/partUploadTriggerSizeMB", DEFAULT_FILE_WRITE_TRIGGER_SIZE_MB);
+    }
+
+    @Override
+    public long getCoreFileSizeThreshold() {
+        return coreFileSizeThreshold;
+    }
+
+    private static final long defaultCoreFileSizeThreshold() {
+        final String PATH = "fhirServer/bulkdata/core/cos/objectSizeThresholdMB";
+        return 1024l * 1024l * FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_SIZE_MB);
+    }
+
+    @Override
+    public int getCoreFileResourceCountThreshold() {
+        return coreFileResourceCountThreshold;
+    }
+
+    private static final int defaultCoreFileResourceCountThreshold() {
+        final String PATH = "fhirServer/bulkdata/core/cos/objectResourceCountThreshold";
+        return FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_RESOURCE_COUNT);
     }
 
     @Override

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/LegacyConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/LegacyConfigurationImpl.java
@@ -61,6 +61,18 @@ public class LegacyConfigurationImpl extends AbstractSystemConfigurationImpl {
     }
 
     @Override
+    public int getCoreFileResourceCountThreshold() {
+        final String PATH = "fhirServer/bulkdata/cosFileMaxResources";
+        return FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_RESOURCE_COUNT);
+    }
+
+    @Override
+    public long getCoreFileSizeThreshold() {
+        final String PATH = "fhirServer/bulkdata/cosFileMaxSize";
+        return FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_SIZE_MB * 1024 * 1024);
+    }
+
+    @Override
     public int getCorePageSize() {
         int pageSize = FHIRConfigHelper.getIntProperty("fhirServer/bulkdata/patientExportPageSize", SearchConstants.MAX_PAGE_SIZE);
         return Math.min(SearchConstants.MAX_PAGE_SIZE, pageSize);


### PR DESCRIPTION
Previously, the file-based export would use the COS properties for
checkpointing. This is a bit confusing and, additionally, I think we'd
want a different default for "when to start writing" (in COS there are
constraints on the size and count of the parts, while writing to local
disk has different concerns).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>