### PR TITLE
Bulk Data aborts when setting the ExitStatus #2018

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/fast/ExportJobListener.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/fast/ExportJobListener.java
@@ -44,9 +44,13 @@ public class ExportJobListener implements JobListener {
         int totalResourceCount = 0;
         List<String> resourceTypeSummaries = new ArrayList<>();
         for (PartitionSummary partitionSummary : partitionSummaries) {
-            resourceTypeSummaries.add(partitionSummary.getResourceTypeSummary());
+            // If we always send back 140+ resources we get a bit cramped on the ExitStatus.
+            // @see https://github.com/IBM/FHIR/issues/2018
             int partitionSum = partitionSummary.getResourceCounts().stream().reduce(0, Integer::sum);
-            totalResourceCount += partitionSum;
+            if (partitionSum > 0) {
+                totalResourceCount += partitionSum;
+                resourceTypeSummaries.add(partitionSummary.getResourceTypeSummary());
+            }
 
             logger.info(String.format("%s %32s %10d", logPrefix(), partitionSummary.getResourceType(), partitionSum));
         }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/ExportJobListener.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/ExportJobListener.java
@@ -131,8 +131,10 @@ public class ExportJobListener implements JobListener {
             for (ExportCheckpointUserData partitionSummary : partitionSummaries) {
                 logger.info(partitionSummary.getResourceTypeSummary() + "\t|"
                         + partitionSummary.getTotalResourcesNum());
-                resourceTypeSummaries.add(partitionSummary.getResourceTypeSummary());
-                totalExportedFhirResources += partitionSummary.getTotalResourcesNum();
+                if (partitionSummary.getTotalResourcesNum() > 0) {
+                    resourceTypeSummaries.add(partitionSummary.getResourceTypeSummary());
+                    totalExportedFhirResources += partitionSummary.getTotalResourcesNum();
+                }
             }
 
             logger.info(" ---- Total: " + totalExportedFhirResources


### PR DESCRIPTION
Note: this may not be ideal... since resources which are Zero'd out, are not returned in a list, back to the end user. 

So we may not want to do this... and may want to raise 2018 to a P2

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>