### PR TITLE
issue #2094 - add support for 'or' within inclusion criteria

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/patient/resource/PatientResourceHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/patient/resource/PatientResourceHandler.java
@@ -17,11 +17,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
 
 import com.ibm.fhir.bulkdata.audit.BulkAuditLogger;
-import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.format.Format;
@@ -71,7 +71,8 @@ public class PatientResourceHandler {
         // No Operation
     }
 
-    public void register(ExportTransientUserData chunkData, BulkDataContext ctx, FHIRPersistence fhirPersistence, int pageSize, Class<? extends Resource> resourceType, Map<Class<? extends Resource>,
+    public void register(ExportTransientUserData chunkData, BulkDataContext ctx, FHIRPersistence fhirPersistence,
+            int pageSize, Class<? extends Resource> resourceType, Map<Class<? extends Resource>,
             List<Map<String, List<String>>>> searchParametersForResoureTypes, String provider) {
         this.chunkData = chunkData;
         this.ctx = ctx;
@@ -82,16 +83,23 @@ public class PatientResourceHandler {
         this.provider = provider;
     }
 
-    public void fillChunkDataBuffer(List<String> patientIds, ReadResultDTO dto) throws Exception {
-        boolean isDoDuplicationCheck = adapter.shouldStorageProviderCheckDuplicate(ctx.getSource());
+    /**
+     * @param patientIds the patient ids to use to scope the search
+     * @throws Exception
+     */
+    public List<Resource> executeSearch(List<String> patientIds) throws Exception {
+        boolean isDoDuplicationCheck = searchParametersForResoureTypes.get(resourceType).size() > 1 ?
+                true : adapter.shouldStorageProviderCheckDuplicate(ctx.getSource());
         int indexOfCurrentTypeFilter = 0;
         int compartmentPageNum = 1;
-        int resSubTotal = 0;
         FHIRSearchContext searchContext;
 
+        List<Resource> results = new ArrayList<>();
+
         if (chunkData == null) {
-            logger.warning("fillChunkDataBuffer: chunkData is null, this should never happen!");
-            throw new Exception("fillChunkDataBuffer: chunkData is null, this should never happen!");
+            String msg = "fillChunkDataBuffer: chunkData is null, this should never happen!";
+            logger.warning(msg);
+            throw new Exception(msg);
         }
 
         do {
@@ -99,9 +107,6 @@ public class PatientResourceHandler {
             // Add the search parameters from the current typeFilter for current resource type.
             if (searchParametersForResoureTypes.get(resourceType) != null) {
                 queryParameters.putAll(searchParametersForResoureTypes.get(resourceType).get(indexOfCurrentTypeFilter));
-                if (searchParametersForResoureTypes.get(resourceType).size() > 1) {
-                    isDoDuplicationCheck = true;
-                }
             }
             List<String> searchCriteria = new ArrayList<>();
             if (ctx.getFhirSearchFromDate() != null) {
@@ -125,71 +130,42 @@ public class PatientResourceHandler {
                 QueryParameter inclusionCriteria = SearchUtil.buildInclusionCriteria("Patient", patientIds, resourceType.getSimpleName());
                 searchContext.getSearchParameters().add(0, inclusionCriteria);
             }
+            searchContext.setPageSize(pageSize);
 
             do {
-                searchContext.setPageSize(pageSize);
                 searchContext.setPageNumber(compartmentPageNum);
-
                 FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
 
                 Date startTime = new Date(System.currentTimeMillis());
                 List<Resource> resources = fhirPersistence.search(persistenceContext, resourceType).getResource();
-                compartmentPageNum++;
 
-                for (Resource res : resources) {
-                    if (res == null || (isDoDuplicationCheck && loadedResourceIds.contains(res.getId()))) {
-                        continue;
-                    }
-                    try {
-                        // No need to fill buffer for parquet because we're letting spark write to COS;
-                        // we don't need to control the Multi-part upload like in the NDJSON case
-                        if (!FHIRMediaType.APPLICATION_PARQUET.equals(ctx.getFhirExportFormat())) {
-                            if (dto != null) {
-                                dto.addResource(res);
-                            }
-                            FHIRGenerator.generator(Format.JSON).generate(res, chunkData.getBufferStream());
-                            chunkData.getBufferStream().write(ConfigurationFactory.getInstance().getEndOfFileDelimiter(ctx.getSource()));
-                        }
-                        resSubTotal++;
-                        if (isDoDuplicationCheck) {
-                            loadedResourceIds.add(res.getId());
-                        }
-                    } catch (FHIRGeneratorException e) {
-                        if (res.getId() != null) {
-                            logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with id '"
-                                    + res.getId() + "'", e);
-                        } else {
-                            logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with unknown id", e);
-                        }
-                    } catch (IOException e) {
-                        logger.warning("fillChunkDataBuffer: chunkDataBuffer written error!");
-                        throw e;
-                    }
+                if (isDoDuplicationCheck) {
+                    resources = resources.stream()
+                            // the add returns false if the id already exists, which filters it out of the collection
+                            .filter(r -> loadedResourceIds.add(r.getId()))
+                            .collect(Collectors.toList());
                 }
+                results.addAll(resources);
+
                 if (auditLogger.shouldLog() && resources != null) {
                     Date endTime = new Date(System.currentTimeMillis());
-                    auditLogger.logSearchOnExport(ctx.getPartitionResourceType(), queryParameters, resources.size(), startTime, endTime, Response.Status.OK, "StorageProvider@" + provider, "BulkDataOperator");
+                    auditLogger.logSearchOnExport(ctx.getPartitionResourceType(), queryParameters, resources.size(), startTime, endTime,
+                            Response.Status.OK, "StorageProvider@" + provider, "BulkDataOperator");
                 }
-            } while (searchContext.getLastPageNumber() >= compartmentPageNum);
+                compartmentPageNum++;
+            } while (compartmentPageNum <= searchContext.getLastPageNumber());
             compartmentPageNum = 1;
 
             indexOfCurrentTypeFilter++;
         } while (searchParametersForResoureTypes.get(resourceType) != null
                 && indexOfCurrentTypeFilter < searchParametersForResoureTypes.get(resourceType).size());
 
-        chunkData.addCurrentUploadResourceNum(resSubTotal);
-        chunkData.addCurrentUploadSize(chunkData.getBufferStream().size());
-        chunkData.addTotalResourcesNum(resSubTotal);
-
-        if (logger.isLoggable(Level.FINE)) {
-            logger.fine("fillChunkDataBuffer: Processed resources - " + resSubTotal + "; Bufferred data size - "
-                    + chunkData.getBufferStream().size());
-        }
+        return results;
     }
 
-    public void fillChunkPatientDataBuffer(List<Resource> patients) throws Exception {
+    public void fillChunkDataBuffer(List<Resource> resources) throws Exception {
         int resSubTotal = 0;
-        for (Resource res : patients) {
+        for (Resource res : resources) {
             try {
                 // No need to fill buffer for parquet because we're letting spark write to COS;
                 // we don't need to control the Multi-part upload like in the NDJSON case
@@ -200,10 +176,11 @@ public class PatientResourceHandler {
                 resSubTotal++;
             } catch (FHIRGeneratorException e) {
                 if (res.getId() != null) {
-                    logger.log(Level.WARNING, "fillChunkPatientDataBuffer: Error while writing resources with id '"
-                            + res.getId() + "'", e);
+                    logger.log(Level.WARNING, "fillChunkPatientDataBuffer: Error while writing " + resourceType +
+                            " with id '" + res.getId() + "'", e);
                 } else {
-                    logger.log(Level.WARNING, "fillChunkPatientDataBuffer: Error while writing resources with unknown id", e);
+                    logger.log(Level.WARNING, "fillChunkPatientDataBuffer: Error while writing "  + resourceType +
+                            " with unknown id", e);
                 }
             } catch (IOException e) {
                 logger.warning("fillChunkPatientDataBuffer: chunkDataBuffer written error!");
@@ -211,9 +188,11 @@ public class PatientResourceHandler {
             }
         }
         chunkData.addCurrentUploadResourceNum(resSubTotal);
+        chunkData.addCurrentUploadSize(chunkData.getBufferStream().size());
         chunkData.addTotalResourcesNum(resSubTotal);
         if (logger.isLoggable(Level.FINE)) {
-            logger.fine("fillChunkPatientDataBuffer: Processed resources - '" + resSubTotal + "' Bufferred data size - '" + chunkData.getBufferStream().size() + "'");
+            logger.fine("fillChunkPatientDataBuffer: Processed resources - '" + resSubTotal + "' "
+                    + "Bufferred data size - '" + chunkData.getBufferStream().size() + "'");
         }
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
@@ -46,8 +46,9 @@ public class SystemExportResourceHandler {
         boolean isDoDuplicationCheck = adapter.shouldStorageProviderCheckDuplicate(source);
         int resSubTotal = 0;
         if (chunkData == null) {
-            logger.warning("fillChunkDataBuffer: chunkData is null, this should never happen!");
-            throw new Exception("fillChunkDataBuffer: chunkData is null, this should never happen!");
+            String msg = "fillChunkDataBuffer: chunkData is null, this should never happen!";
+            logger.warning(msg);
+            throw new Exception(msg);
         }
 
         for (Resource res : dto.getResources()) {

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
@@ -6,12 +6,10 @@
 package com.ibm.fhir.bulkdata.export.system.resource;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.bulkdata.jbatch.export.system.ChunkReader;
 import com.ibm.fhir.core.FHIRMediaType;
@@ -29,21 +27,15 @@ public class SystemExportResourceHandler {
 
     private final static Logger logger = Logger.getLogger(ChunkReader.class.getName());
 
-    private ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
+    protected ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
 
-    boolean isSingleCosObject = false;
-
-    // Used to prevent the same resource from being exported multiple times when multiple _typeFilter for the same
-    // resource type are used, which leads to multiple search requests which can have overlaps of resources,
-    // loadedResourceIds and isDoDuplicationCheck are always reset when moving to the next resource type.
-    Set<String> loadedResourceIds = new HashSet<>();
+    protected Class<? extends Resource> resourceType;
 
     public SystemExportResourceHandler() {
         // No Operation
     }
 
-    public void fillChunkDataBuffer(String source, String exportFormat, ExportTransientUserData chunkData, ReadResultDTO dto) throws Exception {
-        boolean isDoDuplicationCheck = adapter.shouldStorageProviderCheckDuplicate(source);
+    public void fillChunkData(String exportFormat, ExportTransientUserData chunkData, List<Resource> resources) throws Exception {
         int resSubTotal = 0;
         if (chunkData == null) {
             String msg = "fillChunkDataBuffer: chunkData is null, this should never happen!";
@@ -51,29 +43,23 @@ public class SystemExportResourceHandler {
             throw new Exception(msg);
         }
 
-        for (Resource res : dto.getResources()) {
-            if (res == null || (isDoDuplicationCheck && loadedResourceIds.contains(res.getId()))) {
-                continue;
-            }
-
+        for (Resource res : resources) {
             try {
                 // No need to fill buffer for parquet because we're letting spark write to COS;
                 // we don't need to control the Multi-part upload like in the NDJSON case
                 if (!FHIRMediaType.APPLICATION_PARQUET.equals(exportFormat)) {
                     FHIRGenerator.generator(Format.JSON).generate(res, chunkData.getBufferStream());
-                    chunkData.getBufferStream().write(adapter.getEndOfFileDelimiter(source));
+                    chunkData.getBufferStream().write(adapter.getEndOfFileDelimiter(null));
                 }
                 resSubTotal++;
-                if (isDoDuplicationCheck && res.getId() != null) {
-                    loadedResourceIds.add(res.getId());
-                }
             } catch (FHIRGeneratorException e) {
                 // TODO write OperationOutcome to COS for these errors
                 if (res.getId() != null) {
-                    logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with id '"
-                            + res.getId() + "'", e);
+                    logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing " + res.getClass().getSimpleName() +
+                            " with id '" + res.getId() + "'", e);
                 } else {
-                    logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing resources with no id", e);
+                    logger.log(Level.WARNING, "fillChunkDataBuffer: Error while writing " + res.getClass().getSimpleName() +
+                            " with no id", e);
                 }
             } catch (IOException e) {
                 logger.warning("fillChunkDataBuffer: chunkDataBuffer written error!");

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
@@ -41,7 +41,7 @@ public class BatchContextAdapter {
         BulkDataContext ctx = new BulkDataContext();
         context(ctx);
         source(ctx);
-        ctx.setFhirResourceType(props.getProperty(OperationFields.FHIR_RESOURCE_TYPE));
+        ctx.setFhirResourceTypes(props.getProperty(OperationFields.FHIR_RESOURCE_TYPES));
         return ctx;
     }
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/group/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/group/ChunkReader.java
@@ -134,12 +134,12 @@ public class ChunkReader extends com.ibm.fhir.bulkdata.jbatch.export.patient.Chu
                 ReferenceValue refVal = ReferenceUtil.createReferenceValueFrom(member.getEntity(), baseUrl);
                 if (refVal.getType() != ReferenceType.LITERAL_RELATIVE ||
                         !"Patient".equals(refVal.getTargetResourceType())) {
-                    logger.warning("Skipping group member '" + refVal.getValue() + "'. "
+                    logger.info("Skipping group member '" + refVal.getValue() + "'. "
                             + "Only literal references to patients on this server will be exported.");
                     continue;
                 }
                 if (refVal.getVersion() != null) {
-                    logger.warning("Skipping group member '" + refVal.getValue() + "'. "
+                    logger.info("Skipping group member '" + refVal.getValue() + "'. "
                             + "Versioned references are not supported by Group export at this time.");
                     continue;
                 }
@@ -152,7 +152,7 @@ public class ChunkReader extends com.ibm.fhir.bulkdata.jbatch.export.patient.Chu
                 if (FHIRMediaType.APPLICATION_PARQUET.equals(ctx.getFhirExportFormat())) {
                     dto.setResources(resources);
                 }
-                patientHandler.fillChunkDataBuffer(resources);
+                patientHandler.fillChunkData(ctx.getFhirExportFormat(), chunkData, resources);
             }
         } else {
             logger.fine("readItem: End of reading!");

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
@@ -130,7 +130,7 @@ public class ChunkReader extends AbstractItemReader {
         adapter.registerRequestContext(ctx.getTenantId(), ctx.getDatastoreId(), ctx.getIncomingUrl());
 
         searchParametersForResoureTypes = BulkDataUtils.getSearchParametersFromTypeFilters(ctx.getFhirTypeFilters());
-        resourceType = ModelSupport.getResourceType(ctx.getFhirResourceType());
+        resourceType = ModelSupport.getResourceType(partResourceType);
 
         pageSize = adapter.getCorePageSize();
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
@@ -51,8 +51,8 @@ public class PatientExportPartitionMapper implements PartitionMapper {
         // By default we're in the Patient Compartment, if we have a valid context
         // which has a resourceType specified, it's valid as the operation has already checked.
         List<String> resourceTypes = CompartmentUtil.getCompartmentResourceTypes("Patient");
-        if (ctx.getFhirResourceType() != null ) {
-            resourceTypes = Arrays.asList(ctx.getFhirResourceType().split("\\s*,\\s*"));
+        if (ctx.getFhirResourceTypes() != null ) {
+            resourceTypes = Arrays.asList(ctx.getFhirResourceTypes().split("\\s*,\\s*"));
         }
 
         // Register the context to get the right configuration.

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
@@ -52,7 +52,7 @@ public class SystemExportPartitionMapper implements PartitionMapper {
         BulkDataContext ctx = ctxAdapter.getStepContextForPatientExportPartitionMapper();
 
         // We know these are real resource types.
-        List<String> resourceTypes = Arrays.asList(ctx.getFhirResourceType().split("\\s*,\\s*"));
+        List<String> resourceTypes = Arrays.asList(ctx.getFhirResourceTypes().split("\\s*,\\s*"));
 
         PartitionPlanImpl pp = new PartitionPlanImpl();
         pp.setPartitions(resourceTypes.size());

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -185,6 +185,7 @@ public class FileProvider implements Provider {
         }
 
         chunkData.getBufferStream().writeTo(out);
+        chunkData.getBufferStream().reset();
 
         StringBuilder output = new StringBuilder();
         output.append(fhirResourceType);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -24,9 +24,9 @@ import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
 import com.ibm.fhir.bulkdata.provider.Provider;
+import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.format.Format;
-import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.Resource;
@@ -40,9 +40,6 @@ public class FileProvider implements Provider {
 
     private static final Logger logger = Logger.getLogger(FileProvider.class.getName());
 
-    private static final long MAX_RES = ConfigurationFactory.getInstance().getCoreCosObjectResourceCountThreshold();
-    private static final long MAX_BUFFER = ConfigurationFactory.getInstance().getCoreCosObjectSizeThreshold();
-
     private String source = null;
     private long parseFailures = 0l;
     @SuppressWarnings("unused")
@@ -50,11 +47,9 @@ public class FileProvider implements Provider {
     private List<Resource> resources = new ArrayList<>();
     private String fhirResourceType = null;
     private String fileName = null;
-    private int total = 0;
-    private String cosBucketPathPrefix = null;
+    private String exportPathPrefix = null;
 
     private ExportTransientUserData chunkData = null;
-    private long bSize = 0;
 
     private OutputStream out = null;
     private BufferedReader br = null;
@@ -139,16 +134,17 @@ public class FileProvider implements Provider {
     }
 
     @Override
-    public void registerTransient(long executionId, ExportTransientUserData transientUserData, String cosBucketPathPrefix, String fhirResourceType,
-        boolean isExportPublic) throws Exception {
+    public void registerTransient(long executionId, ExportTransientUserData transientUserData, String exportPathPrefix, String fhirResourceType,
+            boolean isExportPublic) throws Exception {
         if (transientUserData == null) {
-            logger.warning("registerTransient: chunkData is null, this should never happen!");
-            throw new Exception("registerTransient: chunkData is null, this should never happen!");
+            String msg = "registerTransient: chunkData is null, this should never happen!";
+            logger.warning(msg);
+            throw new Exception(msg);
         }
 
         this.chunkData = transientUserData;
         this.fhirResourceType = fhirResourceType;
-        this.cosBucketPathPrefix = cosBucketPathPrefix;
+        this.exportPathPrefix = exportPathPrefix;
     }
 
     @Override
@@ -160,18 +156,14 @@ public class FileProvider implements Provider {
 
     @Override
     public void writeResources(String mediaType, List<ReadResultDTO> dtos) throws Exception {
+        if (!FHIRMediaType.APPLICATION_NDJSON.equals(mediaType)) {
+            throw new UnsupportedOperationException("FileProvider does not support writing files of type " + mediaType);
+        }
         if (out == null) {
-            boolean parquet = configuration.isStorageProviderParquetEnabled(source);
-            String ext;
-            if (parquet) {
-                ext = ".parquet";
-            } else {
-                ext = ".ndjson";
-            }
-            this.fileName = cosBucketPathPrefix + File.separator + fhirResourceType + "_" + chunkData.getUploadCount() + ext;
+            this.fileName = exportPathPrefix + File.separator + fhirResourceType + "_" + chunkData.getUploadCount() + ".ndjson";
             String base = configuration.getBaseFileLocation(source);
 
-            String folder = base + File.separator + cosBucketPathPrefix + File.separator;
+            String folder = base + File.separator + exportPathPrefix + File.separator;
             Path folderPath = Paths.get(folder);
             try {
                 Files.createDirectories(folderPath);
@@ -190,35 +182,22 @@ public class FileProvider implements Provider {
                 logger.warning("Error creating a file '" + fn + "'");
                 throw e;
             }
-            bSize = 0;
         }
 
-        for (ReadResultDTO dto : dtos) {
-            total += dto.size();
-            bSize += dto.size();
-            for (Resource r : dto.getResources()) {
-                FHIRGenerator.generator(Format.JSON).generate(r, out);
-                out.write(configuration.getEndOfFileDelimiter(source));
-            }
+        chunkData.getBufferStream().writeTo(out);
 
-            // This replaces the existing numbers each time.
-            chunkData.setCurrentUploadResourceNum(total);
-            StringBuilder output = new StringBuilder();
-            output.append(fhirResourceType);
-            output.append('[');
-            output.append(total);
-            output.append(']');
+        StringBuilder output = new StringBuilder();
+        output.append(fhirResourceType);
+        output.append('[');
+        output.append(chunkData.getCurrentUploadResourceNum());
+        output.append(']');
+        chunkData.setResourceTypeSummary(output.toString());
 
-            chunkData.setResourceTypeSummary(output.toString());
-        }
-
-        if (chunkData.isFinishCurrentUpload() && (bSize > MAX_RES
-                || chunkData.getBufferStream().size() > MAX_BUFFER)) {
+        if (chunkData.isFinishCurrentUpload()) {
             out.close();
             out = null;
             chunkData.setUploadCount(chunkData.getUploadCount() + 1);
             chunkData.getBufferStream().reset();
-            bSize = 0;
         }
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractSearchCompartmentTest extends AbstractPLSearchTest
         assertCompartmentSearchReturnsSavedResource(PATIENT, PATIENT_ID, "string", "testString,otherString");
         assertCompartmentSearchReturnsSavedResource(PRACTITIONER, PRACTITIONER_ID, "string", "testString,otherString");
         assertCompartmentSearchDoesntReturnSavedResource(PATIENT, OTHER_ID, "string", "testString,otherString");
-        assertCompartmentSearchDoesntReturnSavedResource(DEVICE, PATIENT_ID, "string", "testString,otherString");
+        assertCompartmentSearchDoesntReturnSavedResource(RELATED_PERSON, PATIENT_ID, "string", "testString,otherString");
     }
 
     @Test

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
@@ -12,7 +12,11 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -92,6 +96,14 @@ public abstract class AbstractSearchCompartmentTest extends AbstractPLSearchTest
         assertCompartmentSearchReturnsSavedResource(PRACTITIONER, PRACTITIONER_ID, "string", "testString");
         assertCompartmentSearchDoesntReturnSavedResource(PATIENT, OTHER_ID, "string", "testString");
         assertCompartmentSearchDoesntReturnSavedResource(RELATED_PERSON, PATIENT_ID, "string", "testString");
+    }
+
+    @Test
+    public void testSearchPatientCompartment_relativeReference_string_or() throws Exception {
+        assertCompartmentSearchReturnsSavedResource(PATIENT, PATIENT_ID, "string", "testString,otherString");
+        assertCompartmentSearchReturnsSavedResource(PRACTITIONER, PRACTITIONER_ID, "string", "testString,otherString");
+        assertCompartmentSearchDoesntReturnSavedResource(PATIENT, OTHER_ID, "string", "testString,otherString");
+        assertCompartmentSearchDoesntReturnSavedResource(DEVICE, PATIENT_ID, "string", "testString,otherString");
     }
 
     @Test
@@ -190,8 +202,48 @@ public abstract class AbstractSearchCompartmentTest extends AbstractPLSearchTest
      */
     protected boolean compartmentSearchReturnsResource(String compartmentType, String compartmentId,
             String searchParamCode, String queryValue, Resource expectedResource) throws Exception {
-        List<? extends Resource> resources = runQueryTest(compartmentType, compartmentId,
+        List<? extends Resource> resources = runCompartmentQueryTest(compartmentType, compartmentId,
                 expectedResource.getClass(), searchParamCode, queryValue, Integer.MAX_VALUE);
+        assertNotNull(resources);
+        return isResourceInResponse(expectedResource, resources);
+    }
+
+    @Test
+    public void testSearchPatientCompartment_relativeReference_multiCompartment_string() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<>(1);
+        queryParms.put("string", Collections.singletonList("testString"));
+        assertTrue("Expected resource was not returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PATIENT_ID, OTHER_ID}),
+                    queryParms, savedResource));
+        assertTrue("Expected resource was not returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{OTHER_ID, PATIENT_ID}),
+                    queryParms, savedResource));
+        assertFalse("Unexpected resource was returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID}),
+                    queryParms, savedResource));
+
+        queryParms.clear();
+        queryParms.put("subject:Basic.string", Collections.singletonList("testString"));
+        assertTrue("Expected resource was not returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PATIENT_ID, OTHER_ID}),
+                    queryParms, composition));
+        assertTrue("Expected resource was not returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{OTHER_ID, PATIENT_ID}),
+                    queryParms, composition));
+        assertFalse("Unexpected resource was returned from the search",
+            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID}),
+                    queryParms, composition));
+    }
+
+    /**
+     * Executes the compartment query and returns whether the expected resource was in the result set
+     * @throws Exception
+     */
+    protected boolean multiCompartmentSearchReturnsResource(String compartmentType, List<String> compartmentIds,
+            Map<String, List<String>> queryParms, Resource expectedResource) throws Exception {
+
+        List<? extends Resource> resources = runCompartmentQueryTest(compartmentType, compartmentIds,
+                expectedResource.getClass(), queryParms, Integer.MAX_VALUE);
         assertNotNull(resources);
         return isResourceInResponse(expectedResource, resources);
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
@@ -108,42 +108,42 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
 
     @Test
     public void testPatientCompartment() throws Exception {
-        List<Resource> results = runQueryTest("Patient", savedPatient.getId(),
+        List<Resource> results = runCompartmentQueryTest("Patient", savedPatient.getId(),
                                     Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testPatientCompartmentViaLogicalId() throws Exception {
-        List<Resource> results = runQueryTest("Patient", savedPatient.getId(),
+        List<Resource> results = runCompartmentQueryTest("Patient", savedPatient.getId(),
                                     Observation.class, "_id", savedObservation2.getId());
         assertEquals(0, results.size());
     }
 
     @Test
     public void testDeviceCompartment() throws Exception {
-        List<Resource> results = runQueryTest("Device", savedDevice.getId(),
+        List<Resource> results = runCompartmentQueryTest("Device", savedDevice.getId(),
                                     Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testEncounterCompartment() throws Exception {
-        List<Resource> results = runQueryTest("Encounter", savedEncounter.getId(),
+        List<Resource> results = runCompartmentQueryTest("Encounter", savedEncounter.getId(),
                                     Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testPractitionerCompartment() throws Exception {
-        List<Resource> results = runQueryTest("Practitioner", savedPractitioner.getId(),
+        List<Resource> results = runCompartmentQueryTest("Practitioner", savedPractitioner.getId(),
                                     Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testRelatedPersonCompartment() throws Exception {
-        List<Resource> results = runQueryTest("RelatedPerson", savedRelatedPerson.getId(),
+        List<Resource> results = runCompartmentQueryTest("RelatedPerson", savedRelatedPerson.getId(),
                                     Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1444,9 +1444,32 @@ public class SearchUtil {
     public static FHIRSearchContext parseCompartmentQueryParameters(String compartmentName, String compartmentLogicalId,
             Class<?> resourceType, Map<String, List<String>> queryParameters, boolean lenient) throws Exception {
 
+        List<String> compartmentLogicalIds = Collections.singletonList(compartmentLogicalId);
+        QueryParameter inclusionCriteria = buildInclusionCriteria(compartmentName, compartmentLogicalIds, resourceType.getSimpleName());
+        FHIRSearchContext context = parseQueryParameters(resourceType, queryParameters, lenient);
+
+        // Add the inclusion criteria to the front of the search parameter list
+        if (inclusionCriteria != null) {
+            context.getSearchParameters().add(0, inclusionCriteria);
+        }
+
+        return context;
+    }
+
+    /**
+     * Build a query parameter to encapsulate the inclusion criteria for a compartment query
+     *
+     * @param compartmentName
+     * @param compartmentLogicalIds
+     * @param resourceType
+     * @return
+     * @throws FHIRSearchException
+     */
+    public static QueryParameter buildInclusionCriteria(String compartmentName, List<String> compartmentLogicalIds, String resourceType)
+            throws FHIRSearchException {
         QueryParameter rootParameter = null;
 
-        if (compartmentName != null && compartmentLogicalId != null) {
+        if (compartmentName != null && compartmentLogicalIds != null && !compartmentLogicalIds.isEmpty()) {
             // The inclusion criteria are represented as a chain of parameters, each with a value of the
             // compartmentLogicalId.
             // The query parsers will OR these parameters to achieve the compartment search.
@@ -1456,18 +1479,21 @@ public class SearchUtil {
                 // issue #1708. When enabled, use the ibm-internal-... compartment parameter. This
                 // results in faster queries because only a single parameter is used to represent the
                 // compartment membership.
-                CompartmentUtil.checkValidCompartmentAndResource(compartmentName, resourceType.getSimpleName());
+                CompartmentUtil.checkValidCompartmentAndResource(compartmentName, resourceType);
                 inclusionCriteria = Collections.singletonList(CompartmentUtil.makeCompartmentParamName(compartmentName));
             } else {
                 // pre #1708 behavior
-                inclusionCriteria = CompartmentUtil.getCompartmentResourceTypeInclusionCriteria(compartmentName, resourceType.getSimpleName());
+                inclusionCriteria = CompartmentUtil.getCompartmentResourceTypeInclusionCriteria(compartmentName, resourceType);
             }
 
             for (String criteria : inclusionCriteria) {
                 QueryParameter parameter  = new QueryParameter(Type.REFERENCE, criteria, null, null, true);
-                QueryParameterValue value = new QueryParameterValue();
-                value.setValueString(compartmentName + "/" + compartmentLogicalId);
-                parameter.getValues().add(value);
+                for (String compartmentLogicalId : compartmentLogicalIds) {
+                    QueryParameterValue value = new QueryParameterValue();
+                    value.setValueString(compartmentName + "/" + compartmentLogicalId);
+                    parameter.getValues().add(value);
+                }
+
                 if (rootParameter == null) {
                     rootParameter = parameter;
                 } else {
@@ -1479,15 +1505,7 @@ public class SearchUtil {
                 }
             }
         }
-
-        FHIRSearchContext context = parseQueryParameters(resourceType, queryParameters, lenient);
-
-        // Add the inclusion criteria search parameters to the front of the search parameter list
-        if (rootParameter != null) {
-            context.getSearchParameters().add(0, rootParameter);
-        }
-
-        return context;
+        return rootParameter;
     }
 
     private static SearchConstants.Prefix getPrefix(String s) throws FHIRSearchException {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
@@ -261,7 +261,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
         // @formatter:on
     }
 
-    private void checkExportStatus(boolean isCheckPatient, boolean s3) throws Exception {
+    private void checkExportStatus(boolean isCheckPatient, boolean s3, List<String> types) throws Exception {
         Response response;
         do {
             response = doGet(exportStatusUrl, FHIRMediaType.APPLICATION_FHIR_JSON, "default", "default");
@@ -284,10 +284,11 @@ public class ExportOperationTest extends FHIRServerTestBase {
         }
 
         assertTrue(body.contains("output"));
-        verifyUrl(body, s3);
+        verifyUrl(body, s3, types);
     }
 
-    public void verifyUrl(String body, boolean s3) throws Exception {
+    public void verifyUrl(String body, boolean s3, List<String> types) throws Exception {
+        List<String> tmpTypes = new ArrayList<>();
         try (ByteArrayInputStream bais = new ByteArrayInputStream(body.getBytes());
                 JsonReader jsonReader = JSON_READER_FACTORY.createReader(bais, StandardCharsets.UTF_8)) {
             JsonObject object = jsonReader.readObject();
@@ -299,13 +300,29 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 String str = obj.getString("url");
                 assertNotNull(str);
                 assertTrue(str.contains(".ndjson"));
+                String resourceType = obj.getString("type").trim();
+                tmpTypes.add(resourceType);
                 if (!s3) {
-                    String resourceType = obj.getString("type");
                     verifyFileLines(str, obj.getInt("count"), resourceType);
                 } else {
                     verifyS3Lines(str, obj.getInt("count"));
                 }
             }
+        }
+        if (true) {
+            System.out.println("The list of resources is " + types);
+            System.out.println("The actual list of resources is " + tmpTypes);
+        }
+
+        // Check the Types that we retrieved are the ones we requested.
+        for (String type : tmpTypes) {
+            System.out.println(type + " | " + types.contains(type));
+            assertTrue(types.contains(type));
+        }
+
+        // Check the actual types that we retrieved are the ones we requested.
+        for (String type : types) {
+            assertTrue(tmpTypes.contains(type));
         }
     }
 
@@ -345,12 +362,10 @@ public class ExportOperationTest extends FHIRServerTestBase {
             SSLContext sslContext = sslContextBuilder.build();
 
             return new SSLConnectionSocketFactory(sslContext, verifier);
-        }catch(NoSuchAlgorithmException|KeyStoreException|
-
-    KeyManagementException e)
-    {
-        log.warning("Default Algorithm for Http Client not found " + e.getMessage());
-    }return SSLConnectionSocketFactory.getSocketFactory();
+        }catch(NoSuchAlgorithmException|KeyStoreException|KeyManagementException e){
+            log.warning("Default Algorithm for Http Client not found " + e.getMessage());
+        }
+        return SSLConnectionSocketFactory.getSocketFactory();
     }
 
     public CloseableHttpClient getHttpClient() {
@@ -621,11 +636,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testBaseExport() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Patient");
             Response response = doPost(
                     BASE_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Patient"),
+                    types,
                     null,
                     "default",
                     "default");
@@ -639,7 +655,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(false, false);
+            checkExportStatus(false, false, types);
         } else {
             System.out.println("Base Export Test Disabled, Skipping");
         }
@@ -679,12 +695,13 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = true)
     public void testBaseExportToS3() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Patient");
             Response response = doPost(
                     BASE_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON,
                     FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Patient"),
+                    types,
                     null,
                     "minio",
                     "minio");
@@ -698,7 +715,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(false, true);
+            checkExportStatus(false, true, types);
         } else {
             System.out.println("Base Export Test Disabled, Skipping");
         }
@@ -731,11 +748,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testBaseExportToParquet() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Patient");
             Response response = doPost(
                     BASE_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Patient"),
+                    types,
                     null,
                     "default",
                     "default");
@@ -749,7 +767,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(false, false);
+            checkExportStatus(false, false, types);
         } else {
             System.out.println("Base Export Test Disabled, Skipping");
         }
@@ -758,11 +776,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testPatientExport() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Observation", "Condition", "Patient");
             Response response = doPost(
                     PATIENT_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Observation,Condition,Patient"),
+                    types,
                     null,
                     "default",
                     "default");
@@ -776,7 +795,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(true, false);
+            checkExportStatus(true, false, types);
         } else {
             System.out.println("Patient Export Test Disabled, Skipping");
         }
@@ -785,11 +804,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testPatientExportToS3() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Observation", "Condition", "Patient");
             Response response = doPost(
                     PATIENT_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Observation,Condition,Patient"),
+                    types,
                     null,
                     "minio",
                     "minio");
@@ -803,7 +823,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(true, true);
+            checkExportStatus(true, true, types);
         } else {
             System.out.println("Patient Export Test Disabled, Skipping");
         }
@@ -816,11 +836,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testPatientExportToParquet() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Observation", "Condition", "Patient");
             Response response = doPost(
                     PATIENT_VALID_URL,
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Observation,Condition,Patient"),
+                    types,
                     null,
                     "default",
                     "default");
@@ -834,7 +855,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkExportStatus(true, false);
+            checkExportStatus(true, false, types);
         } else {
             System.out.println("Patient Export Test Disabled, Skipping");
         }
@@ -843,11 +864,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testGroupExport() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Patient", "Group", "Condition", "Observation");
             Response response = doPost(
                     GROUP_VALID_URL.replace("?", savedGroupId2),
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Patient", "Group", "Condition", "Observation"),
+                    types,
                     null,
                     "default",
                     "default");
@@ -861,7 +883,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkGroupExportStatus(false);
+            checkGroupExportStatus(false, types);
         } else {
             System.out.println("Group Export Test Disabled, Skipping");
         }
@@ -870,11 +892,12 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testGroupExportToS3() throws Exception {
         if (ON) {
+            List<String> types = Arrays.asList("Patient", "Group", "Condition", "Observation");
             Response response = doPost(
                     GROUP_VALID_URL.replace("?", savedGroupId2),
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_NDJSON,
                     Instant.of("2019-01-01T08:21:26.94-04:00"),
-                    Arrays.asList("Patient", "Group", "Condition", "Observation"),
+                    types,
                     null,
                     "minio",
                     "minio");
@@ -888,7 +911,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkGroupExportStatus(true);
+            checkGroupExportStatus(true, types);
         } else {
             System.out.println("Group Export Test Disabled, Skipping");
         }
@@ -901,6 +924,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" }, enabled = false)
     public void testGroupExportToParquet() throws Exception {
         if (ON) {
+            List<String> types = new ArrayList<>();
             Response response = doPost(
                     GROUP_VALID_URL.replace("?", savedGroupId2),
                     FHIRMediaType.APPLICATION_FHIR_JSON, FORMAT_PARQUET,
@@ -919,13 +943,13 @@ public class ExportOperationTest extends FHIRServerTestBase {
 
             assertTrue(contentLocation.contains(BASE_VALID_STATUS_URL));
             exportStatusUrl = contentLocation;
-            checkGroupExportStatus(false);
+            checkGroupExportStatus(false, types);
         } else {
             System.out.println("Group Export Test Disabled, Skipping");
         }
     }
 
-    private void checkGroupExportStatus(boolean s3) throws Exception {
+    private void checkGroupExportStatus(boolean s3, List<String> types) throws Exception {
         Response response;
         do {
             response = doGet(exportStatusUrl, FHIRMediaType.APPLICATION_FHIR_JSON, "default", "default");
@@ -942,6 +966,6 @@ public class ExportOperationTest extends FHIRServerTestBase {
         JsonObject jsonObject = JSON_READER_FACTORY.createReader(new StringReader(body)).readObject();
         assertTrue(jsonObject.containsKey("output"));
 
-        verifyUrl(body, s3);
+        verifyUrl(body, s3, types);
     }
 }

--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -138,15 +138,11 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                 }
                 try {
                     if (CompartmentUtil.getCompartmentResourceTypes("Patient").contains(event.getFhirResourceType())) {
-                        // Get Patient compartment inclusion criteria search parameters. It will actually be one QueryParameter object with each inclusion
-                        // criteria search parameter chained off the root.
-                        // NOTE: We currently do not support OR'd compartment searches, nor do we currently expect more than one patient ID to be
-                        // specified in the authorization token (see getPatientIdFromToken()). We will use the first ID specified for the compartment search.
-                        FHIRSearchContext compartmentSearchContext = SearchUtil.parseCompartmentQueryParameters("Patient", patientIdFromToken.get(0),
-                                ModelSupport.getResourceType(event.getFhirResourceType()), Collections.emptyMap(), searchContext.isLenient());
+                        // Build the Patient compartment inclusion criteria search parameter
+                        QueryParameter inclusionCriteria = SearchUtil.buildInclusionCriteria("Patient", patientIdFromToken, event.getFhirResourceType());
 
-                        // Add compartment search parameters to front of search parameter list
-                        searchContext.getSearchParameters().addAll(0, compartmentSearchContext.getSearchParameters());
+                        // Add the inclusion criteria parameter to the front of the search parameter list
+                        searchContext.getSearchParameters().add(0, inclusionCriteria);
                     }
                 } catch (Exception e) {
                     String msg = "Unexpected exception converting to Patient compartment search: " + e.getMessage();

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
@@ -95,7 +95,7 @@ public class ExportOperation extends AbstractOperation {
             }
 
             // Early detection of potential issues.
-            Preflight preflight =  PreflightFactory.getInstance(operationContext, null, exportType);
+            Preflight preflight =  PreflightFactory.getInstance(operationContext, null, exportType, outputFormat.toString());
             preflight.preflight();
 
             response = BulkDataFactory.getInstance(operationContext)

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
@@ -78,7 +78,7 @@ public class ImportOperation extends AbstractOperation {
         // Parameter: storageDetail
         StorageDetail storageDetail = util.retrieveStorageDetails();
 
-        Preflight preflight =  PreflightFactory.getInstance(operationContext, inputs, null);
+        Preflight preflight =  PreflightFactory.getInstance(operationContext, inputs, null, inputFormat);
         preflight.checkStorageAllowed(storageDetail);
         preflight.preflight();
         return BulkDataFactory.getInstance(operationContext)

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/PreflightFactory.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/PreflightFactory.java
@@ -36,7 +36,8 @@ public class PreflightFactory {
      * @param exportType
      * @return
      */
-    public static Preflight getInstance(FHIROperationContext operationContext, List<Input> inputs, OperationConstants.ExportType exportType) {
+    public static Preflight getInstance(FHIROperationContext operationContext, List<Input> inputs,
+            OperationConstants.ExportType exportType, String format) {
         // Get the Source
         OperationContextAdapter adapter = new OperationContextAdapter(operationContext);
         String source = adapter.getStorageProvider();
@@ -44,20 +45,20 @@ public class PreflightFactory {
 
         ConfigurationAdapter config = ConfigurationFactory.getInstance();
 
-        Preflight preflight = new NopPreflight(source, outcome, inputs, exportType);
+        Preflight preflight = new NopPreflight(source, outcome, inputs, exportType, format);
         if (!config.legacy()) {
             StorageType storageType = config.getStorageProviderStorageType(source);
 
             switch (storageType) {
             case HTTPS:
-                preflight = new HttpsPreflight(source, outcome, inputs, exportType);
+                preflight = new HttpsPreflight(source, outcome, inputs, exportType, format);
                 break;
             case FILE:
-                preflight = new FilePreflight(source, outcome, inputs, exportType);
+                preflight = new FilePreflight(source, outcome, inputs, exportType, format);
                 break;
             case AWSS3:
             case IBMCOS:
-                preflight = new S3Preflight(source, outcome, inputs, exportType);
+                preflight = new S3Preflight(source, outcome, inputs, exportType, format);
                 break;
             }
         }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/NopPreflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/NopPreflight.java
@@ -15,6 +15,7 @@ import com.ibm.fhir.operation.bulkdata.OperationConstants;
 import com.ibm.fhir.operation.bulkdata.config.preflight.Preflight;
 import com.ibm.fhir.operation.bulkdata.model.type.Input;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
+import com.ibm.fhir.operation.bulkdata.util.CommonUtil;
 
 /**
  * For the legacy configurations, we don't want to run the preflight checks.
@@ -29,12 +30,16 @@ public class NopPreflight implements Preflight {
     private String outcome = null;
     private List<Input> inputs = null;
     private OperationConstants.ExportType exportType = null;
+    private String format = null;
 
-    public NopPreflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType) {
+    protected CommonUtil util = new CommonUtil();
+
+    public NopPreflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType, String format) {
         this.source = source;
         this.outcome = outcome;
         this.inputs = inputs;
         this.exportType = exportType;
+        this.format = format;
     }
 
     @Override
@@ -66,6 +71,10 @@ public class NopPreflight implements Preflight {
 
     protected OperationConstants.ExportType getExportType(){
         return exportType;
+    }
+
+    protected String getFormat(){
+        return format;
     }
 
     @Override

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
@@ -29,7 +29,6 @@ import com.ibm.fhir.operation.bulkdata.model.type.Input;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
 import com.ibm.fhir.operation.bulkdata.util.BulkDataExportUtil;
-import com.ibm.fhir.operation.bulkdata.util.CommonUtil;
 
 /**
  * Checks the S3 Configuration.
@@ -38,8 +37,8 @@ public class S3Preflight extends NopPreflight {
 
     private static final BulkDataExportUtil export = new BulkDataExportUtil();
 
-    public S3Preflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType) {
-        super(source, outcome, inputs, exportType);
+    public S3Preflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType, String format) {
+        super(source, outcome, inputs, exportType, format);
     }
 
     @Override
@@ -152,7 +151,6 @@ public class S3Preflight extends NopPreflight {
     @Override
     public void checkStorageAllowed(StorageDetail storageDetail) throws FHIROperationException {
         if (storageDetail != null && !(StorageType.AWSS3.value().equals(storageDetail.getType()) || StorageType.IBMCOS.value().equals(storageDetail.getType()))){
-            CommonUtil util = new CommonUtil();
             throw util.buildExceptionWithIssue("S3: Configuration not set to import from storageDetail '" + getSource() + "'", IssueType.INVALID);
         }
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/BulkDataContext.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/BulkDataContext.java
@@ -60,7 +60,7 @@ public class BulkDataContext {
     String cosBucketPathPrefix;
 
     // BatchProperty(name = OperationFields.FHIR_RESOURCETYPES)
-    String fhirResourceType;
+    String fhirResourceTypes;
 
     // BatchProperty(name = OperationFields.EXPORT_FHIR_SEARCH_PATIENTGROUPID)
     String groupId;
@@ -310,18 +310,18 @@ public class BulkDataContext {
     }
 
     /**
-     * @return the fhirResourceType
+     * @return the comma-delimited list of FHIR resource types that were requested for export
      */
-    public String getFhirResourceType() {
-        return fhirResourceType;
+    public String getFhirResourceTypes() {
+        return fhirResourceTypes;
     }
 
     /**
      * @param fhirResourceType
-     *            the fhirResourceType to set
+     *            the comma-delimited list of FHIR resource types that were requested for export
      */
-    public void setFhirResourceType(String fhirResourceType) {
-        this.fhirResourceType = fhirResourceType;
+    public void setFhirResourceTypes(String fhirResourceType) {
+        this.fhirResourceTypes = fhirResourceType;
     }
 
     /**
@@ -346,7 +346,7 @@ public class BulkDataContext {
                 + ", partitionResourceType=" + partitionResourceType + ", users=" + users + ", dataSourcesInfo=" + dataSourcesInfo + ", fhirSearchPageSize="
                 + fhirSearchPageSize + ", fhirTypeFilters=" + fhirTypeFilters + ", fhirSearchToDate=" + fhirSearchToDate + ", fhirSearchFromDate="
                 + fhirSearchFromDate + ", fhirExportFormat=" + fhirExportFormat + ", cosBucketPathPrefix=" + cosBucketPathPrefix + ", fhirResourceType="
-                + fhirResourceType + ", groupId=" + groupId + "]";
+                + fhirResourceTypes + ", groupId=" + groupId + "]";
     }
 
 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/JobParameter.java
@@ -176,7 +176,7 @@ public class JobParameter {
                 throws IOException {
 
             if (parameter.getFhirResourceType() != null) {
-                generator.write(OperationFields.FHIR_RESOURCE_TYPE, parameter.getFhirResourceType());
+                generator.write(OperationFields.FHIR_RESOURCE_TYPES, parameter.getFhirResourceType());
             }
 
             if (parameter.getFhirSearchFromDate() != null) {
@@ -296,8 +296,8 @@ public class JobParameter {
         }
 
         public static void parse(Builder builder, JsonObject obj) throws FHIROperationException, IOException {
-            if (obj.containsKey(OperationFields.FHIR_RESOURCE_TYPE)) {
-                String fhirResourceType = obj.getString(OperationFields.FHIR_RESOURCE_TYPE);
+            if (obj.containsKey(OperationFields.FHIR_RESOURCE_TYPES)) {
+                String fhirResourceType = obj.getString(OperationFields.FHIR_RESOURCE_TYPES);
                 builder.fhirResourceType(fhirResourceType);
             }
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/OperationFields.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/type/OperationFields.java
@@ -30,7 +30,7 @@ public final class OperationFields {
     public static final String FHIR_SEARCH_TO_DATE = "fhir.search.todate";
     public static final String FHIR_SEARCH_TYPE_FILTERS = "fhir.typeFilters";
     public static final String FHIR_EXPORT_FORMAT = "fhir.exportFormat";
-    public static final String FHIR_RESOURCE_TYPE = "fhir.resourcetype";
+    public static final String FHIR_RESOURCE_TYPES = "fhir.resourcetype";
     public static final String FHIR_SEARCH_PATIENT_GROUP_ID = "fhir.search.patientgroupid";
 
     /**

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -100,8 +100,9 @@ public class BulkDataExportUtil {
          * the full content type of application/fhir+ndjson as well as the abbreviated representations
          * application/ndjson and ndjson.
          */
-        Optional<Parameter> parameter =
-                parameters.getParameter().stream().filter(p -> OperationConstants.PARAM_OUTPUT_FORMAT.equals(p.getName().getValue())).findFirst();
+        Optional<Parameter> parameter = parameters.getParameter().stream()
+                .filter(p -> OperationConstants.PARAM_OUTPUT_FORMAT.equals(p.getName().getValue()))
+                .findFirst();
 
         String mediaType = FHIRMediaType.APPLICATION_NDJSON;
         if (parameter.isPresent() && parameter.get().getValue().is(com.ibm.fhir.model.type.String.class)) {


### PR DESCRIPTION
1. Introduces SearchUtil.buildInclusionCriteria() for building the
inclusion criteria parameter with multiple compartmentId values (maybe
this should go in CompartmentUtil instead?)
2. Updates JDBCQueryBuilder.processInclusionCriteria to use all of the
inclusionCriteria values; previously it used `=` against the first value
but now it uses `IN (val1,val2,val3,...)` instead.

And update 3 places to use it:
1. A new test in AbstractSearchCompartmentTest
2. com.ibm.fhir.bulkdata.export.patient.resource.PatientResourceHandler.fillChunkDataBuffer()
    This should be much simpler now and also much more efficient.
Instead of searching with a value of `id1,id2,id3,...` on each and every
inclusion criteria, we can do a single query with a whole page of
patient ids.
3. com.ibm.fhir.smart.AuthzPolicyEnforcementPersistenceInterceptor.beforeSearch()
    This lays the groundwork for supporting `user` scopes. Instead of
converting the request to a compartment search for a single patient, we
can now scope the search to the union of all the patient compartments passed via the patient_id
claim in access token.

Also, some bulk data refactoring.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>