### PR TITLE
Relative path enables malicious content to be imported or /dev/null

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -161,10 +161,27 @@ public class FileProvider implements Provider {
     @Override
     public void writeResources(String mediaType, List<ReadResultDTO> dtos) throws Exception {
         if (out == null) {
-            this.fileName = cosBucketPathPrefix + "_" + fhirResourceType + "_" + chunkData.getUploadCount() + ".ndjson";
+            boolean parquet = configuration.isStorageProviderParquetEnabled(source);
+            String ext;
+            if (parquet) {
+                ext = ".parquet";
+            } else {
+                ext = ".ndjson";
+            }
+            this.fileName = cosBucketPathPrefix + File.separator + fhirResourceType + "_" + chunkData.getUploadCount() + ext;
             String base = configuration.getBaseFileLocation(source);
 
-            String fn = base + "/" + fileName;
+            String folder = base + File.separator + cosBucketPathPrefix + File.separator;
+            Path folderPath = Paths.get(folder);
+            try {
+                Files.createDirectories(folderPath);
+            } catch(IOException ioe) {
+                if (!Files.exists(folderPath)) {
+                    throw ioe;
+                }
+            }
+
+            String fn = base + File.separator + fileName;
             Path p1 = Paths.get(fn);
             try {
                 // This is a trap. Be sure to mark CREATE and APPEND.

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
@@ -273,6 +273,22 @@ public class ImportOperationTest extends FHIRServerTestBase {
         }
     }
 
+    @Test(groups = { TEST_GROUP_NAME })
+    public void testImportFromFileWithRelativePath() throws Exception {
+        if (ON) {
+            String path = BASE_VALID_URL;
+            String inputFormat = FORMAT;
+            String inputSource = "https://localhost:9443/source-fhir-server";
+            String resourceType = "Patient";
+            String url = "../../test-import.ndjson";
+
+            Response response = doPost(path, inputFormat, inputSource, resourceType, url, "default");
+            assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+        } else {
+            System.out.println("Import Test Disabled, Skipping");
+        }
+    }
+
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testImport" })
     public void testImportCheckQuery() throws Exception {
         if (ON) {

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.operation.bulkdata.client;
 
+import java.io.File;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -721,7 +722,7 @@ public class BulkDataClient {
                             ext = ".ndjson";
                         }
                         // Originally we set i to resourceCounts[i], however we don't always know the count when create the file.
-                        sUrl = cosBucketPathPrefix + "_" + resourceType + "_" + (i + 1) + ext;
+                        sUrl = cosBucketPathPrefix + File.separator + resourceType + "_" + (i + 1) + ext;
                     }
                     outputList.add(new PollingLocationResponse.Output(resourceType, sUrl, resourceCounts[i]));
                 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/FilePreflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/FilePreflight.java
@@ -6,7 +6,6 @@
 
 package com.ibm.fhir.operation.bulkdata.config.preflight.impl;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,9 +53,13 @@ public class FilePreflight extends NopPreflight {
             } else {
                 // This is an import
                 for (Input input : getInputs()) {
-                    File f = new File(input.getUrl());
+
                     // We want to append the input path on the base, we don't want to allow everything.
-                    Path p1 = Paths.get(base, f.getAbsolutePath());
+                    Path p1 = Paths.get(base, input.getUrl()).normalize();
+                    if (!p1.startsWith(p)) {
+                        throw util.buildExceptionWithIssue("The path is outside the accepted base path", IssueType.INVALID);
+                    }
+
                     accessible = Files.isReadable(p1);
                     if (!accessible) {
                         // Skip out of the for loop


### PR DESCRIPTION
#2103

File-based exports should be organized by subdirectory #2087

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>