### PR TITLE
fix touchstone conformance link

### DIFF
--- a/docs/src/data/nav-items.yaml
+++ b/docs/src/data/nav-items.yaml
@@ -1,6 +1,6 @@
-- title: Announcement
+- title: Overview
   pages:
-    - path: /announcement
+    - path: /
 - title: Conformance
   pages:
     - path: /Conformance
@@ -10,6 +10,8 @@
       path: /performance/performance450
     - title: FHIR Server on Raspberry Pi
       path: /blog/raspberrypi4howto
+    - title: Announcement
+      path: /announcement
 - title: Guides
   pages:
     - title: IBM FHIR Server User's Guide

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -5,7 +5,7 @@ export default HomepageTemplate;
 ## Conformance
 The IBM FHIR Server conforms to version 4.0.1 (R4) of the HL7 FHIR specification.
 
-We use [AEGIS Touchstone](https://touchstone.aegis.net/touchstone/analytics/publishedList)
+We use [AEGIS Touchstone](https://touchstone.aegis.net/touchstone/conformance/history)
 to test and publish our conformance results.
 
 For a detailed description of conformance, please see [Conformance](/Conformance).


### PR DESCRIPTION
and move the announcement under the blog header...its pretty old now and shouldn't be so prominent on the site.  i tried to preserve the URL though, so anything linking to it should be ok.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>