### PR TITLE
take 2: use an ibm.biz link

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -5,8 +5,7 @@ export default HomepageTemplate;
 ## Conformance
 The IBM FHIR Server conforms to version 4.0.1 (R4) of the HL7 FHIR specification.
 
-We use [AEGIS Touchstone](https://touchstone.aegis.net/touchstone/conformance/history)
-to test and publish our conformance results.
+We use AEGIS Touchstone to test and publish our [conformance results](http://ibm.biz/ibm-fhir-server-touchstone-results).
 
 For a detailed description of conformance, please see [Conformance](/Conformance).
 


### PR DESCRIPTION
This way we can control the exact results that we link to without committing to this repo every time we want to change it.
Currently, I'm the owner of the vanity URL.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>