### PR TITLE
issue #2121 - skip file creation when the buffer is empty

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/audit/BulkAuditLogger.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/audit/BulkAuditLogger.java
@@ -54,8 +54,8 @@ public class BulkAuditLogger {
 
     public boolean shouldLog() {
         // Wraps common code for logging
-        if (log.isLoggable(Level.FINE)) {
-            log.fine("Bulk Data Audit Log is '" + svc.isEnabled() + "'");
+        if (log.isLoggable(Level.FINER)) {
+            log.finer("Bulk Data Audit Log is '" + svc.isEnabled() + "'");
         }
         return svc.isEnabled();
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
@@ -173,7 +173,7 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     }
 
     private static final int defaultCoreFileWriteTriggerSize() {
-        return 1024 * 1024 * FHIRConfigHelper.getIntProperty("fhirServer/bulkdata/core/cos/partUploadTriggerSizeMB", DEFAULT_FILE_WRITE_TRIGGER_SIZE_MB);
+        return 1024 * 1024 * FHIRConfigHelper.getIntProperty("fhirServer/bulkdata/core/file/writeTriggerSizeMB", DEFAULT_FILE_WRITE_TRIGGER_SIZE_MB);
     }
 
     @Override
@@ -182,7 +182,7 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     }
 
     private static final long defaultCoreFileSizeThreshold() {
-        final String PATH = "fhirServer/bulkdata/core/cos/objectSizeThresholdMB";
+        final String PATH = "fhirServer/bulkdata/core/file/sizeThresholdMB";
         return 1024l * 1024l * FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_SIZE_MB);
     }
 
@@ -192,7 +192,7 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
     }
 
     private static final int defaultCoreFileResourceCountThreshold() {
-        final String PATH = "fhirServer/bulkdata/core/cos/objectResourceCountThreshold";
+        final String PATH = "fhirServer/bulkdata/core/file/resourceCountThreshold";
         return FHIRConfigHelper.getIntProperty(PATH, DEFAULT_FILE_MAX_RESOURCE_COUNT);
     }
 


### PR DESCRIPTION
Also, set more status fields in transient user data (chunkData) to
facilitate logging / debug.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>