### PR TITLE
Remove deprecated commit() and rollback() methods from

### DIFF
--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
@@ -56,7 +56,7 @@ import com.ibm.fhir.search.util.SearchUtil;
  * Specification: Positional Searching for Location Resource</a>
  * <br>
  * Original LONG/LAT
- * 
+ *
  * <pre>
  *  "position": {
  *      "longitude": -83.6945691,
@@ -113,13 +113,13 @@ public class JDBCSearchNearTest {
             if (persistence.isTransactional()) {
                 persistence.getTransaction().begin();
             }
-            
+
             FHIRSearchContext ctx = SearchUtil.parseQueryParameters(Location.class, Collections.emptyMap(), true);
             FHIRPersistenceContext persistenceContext =
                     FHIRPersistenceContextFactory.createPersistenceContext(null, ctx);
             persistence.delete(persistenceContext, Location.class, savedResource.getId());
             if (persistence.isTransactional()) {
-                persistence.getTransaction().commit();
+                persistence.getTransaction().end();
             }
         }
         FHIRRequestContext.get().setTenantId("default");
@@ -162,7 +162,7 @@ public class JDBCSearchNearTest {
     @AfterMethod(alwaysRun = true)
     public void commitTrx() throws Exception {
         if (persistence != null && persistence.isTransactional()) {
-            persistence.getTransaction().commit();
+            persistence.getTransaction().end();
         }
     }
 

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceTransaction.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistenceTransaction.java
@@ -24,7 +24,7 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
  *           }
  */
 public interface FHIRPersistenceTransaction {
-    
+
     /**
      * Does the underlying implementation actually support transactions? A persistence
      * layer must always return a FHIRPersistenceTransaction even if it doesn't support
@@ -55,23 +55,4 @@ public interface FHIRPersistenceTransaction {
      * @throws FHIRPersistenceException
      */
     void setRollbackOnly() throws FHIRPersistenceException;
-    
-
-    /**
-     * Commit the transaction (if we started it).
-     * Use {@link #end()} instead.
-     * @throws FHIRPersistenceException
-     */
-    @Deprecated
-    default void commit() throws FHIRPersistenceException { end(); }
-
-    /**
-     * Request rollback. Will only perform the rollback if this
-     * instance actually started the transaction
-     * Use {@link #setRollbackOnly()} and {@link #end()} instead.
-     * @throws FHIRPersistenceException
-     */
-    @Deprecated
-    default void rollback() throws FHIRPersistenceException { setRollbackOnly(); end(); }
-
 }

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockTransactionAdapter.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockTransactionAdapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,13 +23,5 @@ public class MockTransactionAdapter implements FHIRPersistenceTransaction {
 
     @Override
     public void setRollbackOnly() throws FHIRPersistenceException {
-    }
-
-    @Override
-    public void commit() throws FHIRPersistenceException {
-    }
-
-    @Override
-    public void rollback() throws FHIRPersistenceException {
     }
 }


### PR DESCRIPTION
FHIRPersistenceTransaction #1304

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>