### PR TITLE
Issue #2092, Issue #1733, Issue #1980 - miscellaneous updates

### DIFF
--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/URLSupport.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/URLSupport.java
@@ -28,6 +28,14 @@ public class URLSupport {
 
     private URLSupport() { }
 
+    /**
+     * URL decode the input string
+     *
+     * @param s
+     *     the string to URL decode
+     * @return
+     *     the URL decoded string
+     */
     public static String decode(String s) {
         try {
             return URLDecoder.decode(s, "UTF-8");
@@ -36,43 +44,149 @@ public class URLSupport {
         }
     }
 
-    public static String getFirst(Map<String, List<String>> queryParameters, String key) {
-        List<String> values = queryParameters.get(key);
+    /**
+     * Get the first value of the list for the specified key from the provided multivalued map
+     *
+     * @param map
+     *     the multivalued map
+     * @param key
+     *     the key
+     * @return
+     *     the first value of the list for the specified key from the provided multivalued map or null if not exists
+     */
+    public static String getFirst(Map<String, List<String>> map, String key) {
+        List<String> values = map.get(key);
         return (values != null && !values.isEmpty()) ? values.get(0) : null;
     }
 
+    /**
+     * Get the path part of the provided URL
+     *
+     * @param url
+     *     the url
+     * @return
+     *     the path part or empty if not exists
+     * @see
+     *     URL#getPath()
+     */
     public static String getPath(String url) {
         return getURL(url).getPath();
     }
 
+    /**
+     * Get a list containing the path segments from the provided URL
+     *
+     * <p>The path segments are URL decoded
+     *
+     * @param url
+     *     the url
+     * @return
+     *     a list containing the path segments from the provided URL
+     */
     public static List<String> getPathSegments(String url) {
         return getPathSegments(url, true);
     }
 
+    /**
+     * Get a list containing the path segments from the provided URL
+     *
+     * <p>The path segments are URL decoded according to the specified parameter
+     *
+     * @param url
+     *     the url
+     * @param decode
+     *     indicates whether to decode the path segments
+     * @return
+     *     a list containing the path segments from the provided URL
+     */
     public static List<String> getPathSegments(String url, boolean decode) {
         return parsePath(getPath(url), decode);
     }
 
+    /**
+     * Get the query part of the provided URL
+     *
+     * @param url
+     *     the URL
+     * @return
+     *     the query part of the provided URL or empty if not exists
+     * @see
+     *     URL#getQuery()
+     */
     public static String getQuery(String url) {
         return getURL(url).getQuery();
     }
 
+    /**
+     * Get a multivalued map containing the query parameters for the provided URL
+     *
+     * <p>The keys and values of the multivalued map are URL decoded
+     *
+     * @param url
+     *     the URL
+     * @return
+     *     a multivalued map containing the query parameters for the provided URL
+     */
     public static Map<String, List<String>> getQueryParameters(String url) {
         return getQueryParameters(url, true);
     }
 
+    /**
+     * Get a multivalued map containing the query parameters for the provided URL
+     *
+     * <p>The keys and values of the multivalued map are URL decoded according the specified parameter
+     *
+     * @param url
+     *     the URL
+     * @param decode
+     *     indicates whether to decode the keys and values of the multivalued map should be decoded
+     * @return
+     *     a multivalued map containing the query parameters for the provided URL
+     */
     public static Map<String, List<String>> getQueryParameters(String url, boolean decode) {
         return parseQuery(getQuery(url), decode);
     }
 
+    /**
+     * Get a {@link URL} instance that represents the specified parameter
+     *
+     * @param url
+     *     the url
+     * @return
+     *     a {@link URL} instance that represents the specified parameter
+     * @see
+     *     URL
+     */
     public static URL getURL(String url) {
         return URL_CACHE.computeIfAbsent(url, k -> computeURL(url));
     }
 
+    /**
+     * Parse the provided path part into a List of path segments
+     *
+     * <p>The path segments are URL decoded
+     *
+     * @param path
+     *     the path part
+     * @return
+     *     a list of path segments
+     */
     public static List<String> parsePath(String path) {
         return parsePath(path, true);
     }
 
+    /**
+     * Parse the provided path part into a list of path segments
+     *
+     * <p>The path segments are decoded according to the specified parameter
+     *
+     * @param path
+     *     the path part
+     * @param decode
+     *     indicates whether the path segments should be URL decoded
+     * @return
+     *     a list of path segments
+     */
     public static List<String> parsePath(String path, boolean decode) {
         return Arrays.stream(path.split("/"))
             .skip(1)
@@ -80,10 +194,34 @@ public class URLSupport {
             .collect(Collectors.toList());
     }
 
+    /**
+     * Parse the provided query part into a multivalued map of query parameters
+     *
+     * <p>The keys and values of the multivalued map are URL decoded
+     *
+     * @param query
+     *     the query part
+     * @return
+     *     a multivalued map containing the query parameters for the provided URL
+     *
+     */
     public static Map<String, List<String>> parseQuery(String query) {
         return parseQuery(query, true);
     }
 
+    /**
+     * Parse the provided query part into a multivalued map of query parameters
+     *
+     * <p>The keys and values of the multivalued map are URL decoded according to the specified parameter
+     *
+     * @param query
+     *     the query part
+     * @param decode
+     *     indicates whether to decode the keys and values of the multivalued map should be decoded
+     * @return
+     *     a multivalued map containing the query parameters for the provided URL
+     *
+     */
     public static Map<String, List<String>> parseQuery(String query, boolean decode) {
         if (query == null || query.isEmpty()) {
             return Collections.emptyMap();

--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/URLSupport.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/URLSupport.java
@@ -1,0 +1,119 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.core.util;
+
+import static com.ibm.fhir.core.util.LRUCache.createLRUCache;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class for working with URLs
+ */
+public class URLSupport {
+    private static final Map<String, URL> URL_CACHE = createLRUCache(128);
+
+    private URLSupport() { }
+
+    public static String decode(String s) {
+        try {
+            return URLDecoder.decode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getFirst(Map<String, List<String>> queryParameters, String key) {
+        List<String> values = queryParameters.get(key);
+        return (values != null && !values.isEmpty()) ? values.get(0) : null;
+    }
+
+    public static String getPath(String url) {
+        return getURL(url).getPath();
+    }
+
+    public static List<String> getPathSegments(String url) {
+        return getPathSegments(url, true);
+    }
+
+    public static List<String> getPathSegments(String url, boolean decode) {
+        return parsePath(getPath(url), decode);
+    }
+
+    public static String getQuery(String url) {
+        return getURL(url).getQuery();
+    }
+
+    public static Map<String, List<String>> getQueryParameters(String url) {
+        return getQueryParameters(url, true);
+    }
+
+    public static Map<String, List<String>> getQueryParameters(String url, boolean decode) {
+        return parseQuery(getQuery(url), decode);
+    }
+
+    public static URL getURL(String url) {
+        return URL_CACHE.computeIfAbsent(url, k -> computeURL(url));
+    }
+
+    public static List<String> parsePath(String path) {
+        return parsePath(path, true);
+    }
+
+    public static List<String> parsePath(String path, boolean decode) {
+        return Arrays.stream(path.split("/"))
+            .skip(1)
+            .map(s -> decode ? decode(s) : s)
+            .collect(Collectors.toList());
+    }
+
+    public static Map<String, List<String>> parseQuery(String query) {
+        return parseQuery(query, true);
+    }
+
+    public static Map<String, List<String>> parseQuery(String query, boolean decode) {
+        if (query == null || query.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Arrays.stream(query.split("&"))
+            .map(pair -> Arrays.asList(pair.split("=", 2)))
+            .collect(Collectors.collectingAndThen(
+                Collectors.toMap(
+                    // key mapping function
+                    pair -> decode ? decode(pair.get(0)) : pair.get(0),
+                    // value mapping function
+                    pair -> (pair.size() > 1) ? Collections.unmodifiableList(Arrays.stream(pair.get(1).split(","))
+                        .map(s -> decode ? decode(s) : s)
+                        .collect(Collectors.toList())) : Collections.<String>emptyList(),
+                    // merge function
+                    (u, v) -> {
+                        List<String> merged = new ArrayList<>(u);
+                        merged.addAll(v);
+                        return Collections.unmodifiableList(merged);
+                    },
+                    // map supplier
+                    LinkedHashMap::new),
+                Collections::unmodifiableMap));
+    }
+
+    private static URL computeURL(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException (e);
+        }
+    }
+}

--- a/fhir-core/src/test/java/com/ibm/fhir/core/util/test/URLSupportTest.java
+++ b/fhir-core/src/test/java/com/ibm/fhir/core/util/test/URLSupportTest.java
@@ -30,9 +30,9 @@ public class URLSupportTest {
     @Test
     public void testGetPathSegments() {
         String url = "http://ibm.com/fhir/ValueSet/generalizes?system=http://ibm.com/fhir/CodeSystem/cs5&code=r";
-        List<String> pathSegments = getPathSegments(url);
+        List<String> actual = getPathSegments(url);
         List<String> expected = Arrays.asList("fhir", "ValueSet", "generalizes");
-        Assert.assertEquals(pathSegments, expected);
+        Assert.assertEquals(actual, expected);
     }
 
     @Test

--- a/fhir-core/src/test/java/com/ibm/fhir/core/util/test/URLSupportTest.java
+++ b/fhir-core/src/test/java/com/ibm/fhir/core/util/test/URLSupportTest.java
@@ -1,0 +1,46 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.core.util.test;
+
+import static com.ibm.fhir.core.util.URLSupport.getFirst;
+import static com.ibm.fhir.core.util.URLSupport.getPathSegments;
+import static com.ibm.fhir.core.util.URLSupport.getQueryParameters;
+import static com.ibm.fhir.core.util.URLSupport.parseQuery;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class URLSupportTest {
+    @Test
+    public void testGetQueryParameters() {
+        String url = "http://ibm.com/fhir/ValueSet/generalizes?system=http://ibm.com/fhir/CodeSystem/cs5&code=r";
+        Map<String, List<String>> queryParameters = getQueryParameters(url);
+        Assert.assertEquals(getFirst(queryParameters, "system"), "http://ibm.com/fhir/CodeSystem/cs5");
+        Assert.assertEquals(getFirst(queryParameters, "code"), "r");
+    }
+
+    @Test
+    public void testGetPathSegments() {
+        String url = "http://ibm.com/fhir/ValueSet/generalizes?system=http://ibm.com/fhir/CodeSystem/cs5&code=r";
+        List<String> pathSegments = getPathSegments(url);
+        List<String> expected = Arrays.asList("fhir", "ValueSet", "generalizes");
+        Assert.assertEquals(pathSegments, expected);
+    }
+
+    @Test
+    public void testParseQuery() throws Exception {
+        String query = "name1=value1%7Cvalue2%7Cvalue3";
+        Map<String, List<String>> queryParameters = parseQuery(query);
+        Assert.assertEquals(getFirst(queryParameters, "name1"), "value1|value2|value3");
+        queryParameters = parseQuery(query, false);
+        Assert.assertEquals(getFirst(queryParameters, "name1"), "value1%7Cvalue2%7Cvalue3");
+    }
+}

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractTermFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractTermFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractTermFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractTermFunction.java
@@ -1,11 +1,12 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.path.function;
 
+import static com.ibm.fhir.core.util.URLSupport.parseQuery;
 import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
 import static com.ibm.fhir.path.util.FHIRPathUtil.getElementNode;
@@ -17,13 +18,9 @@ import static com.ibm.fhir.path.util.FHIRPathUtil.isResourceNode;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isSingleton;
 import static com.ibm.fhir.path.util.FHIRPathUtil.isStringValue;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -123,7 +120,7 @@ public abstract class FHIRPathAbstractTermFunction extends FHIRPathAbstractFunct
     protected Parameters getParameters(List<Collection<FHIRPathNode>> arguments) {
         if (arguments.size() == getMaxArity()) {
             String params = getString(arguments.get(arguments.size() - 1));
-            Map<String, List<String>> queryParameters = parse(params);
+            Map<String, List<String>> queryParameters = parseQuery(params);
             return buildParameters(queryParameters);
         }
         return EMPTY_PARAMETERS;
@@ -182,35 +179,5 @@ public abstract class FHIRPathAbstractTermFunction extends FHIRPathAbstractFunct
                     .value(elementFactory.apply(value))
                     .build())
                 .collect(Collectors.toList());
-    }
-
-    private Map<String, List<String>> parse(String params) {
-        return Arrays.stream(params.split("&"))
-                .map(pair -> Arrays.asList(pair.split("=", 2)))
-                .collect(Collectors.collectingAndThen(
-                    Collectors.toMap(
-                        // key mapping function
-                        pair -> decode(pair.get(0)),
-                        // value mapping function
-                        pair -> Collections.unmodifiableList(Arrays.stream(pair.get(1).split(","))
-                            .map(s -> decode(s))
-                            .collect(Collectors.toList())),
-                        // merge function
-                        (u, v) -> {
-                            List<String> merged = new ArrayList<>(u);
-                            merged.addAll(v);
-                            return Collections.unmodifiableList(merged);
-                        },
-                        // map supplier
-                        LinkedHashMap::new),
-                    Collections::unmodifiableMap));
-    }
-
-    private String decode(String s) {
-        try {
-            return URLDecoder.decode(s, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/resource/FHIRRegistryResource.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/resource/FHIRRegistryResource.java
@@ -230,7 +230,9 @@ public class FHIRRegistryResource implements Comparable<FHIRRegistryResource> {
     }
 
     public static FHIRRegistryResource from(Resource resource) {
-        Objects.requireNonNull(resource, "resource");
+        if (resource == null) {
+            return null;
+        }
 
         Class<? extends Resource> resourceType = resource.getClass();
         requireDefinitionalResourceType(resourceType);

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
@@ -189,6 +189,10 @@ public class GraphTermServiceProvider implements FHIRTermServiceProvider {
             first = false;
         }
 
+        if (filters.isEmpty()) {
+            g = g.hasLabel("Concept");
+        }
+
         g = g.timeLimit(timeLimit);
         TimeLimitStep<?> timeLimitStep = getTimeLimitStep(g);
 

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
@@ -6,14 +6,13 @@
 
 package com.ibm.fhir.term.graph.registry;
 
-import static com.ibm.fhir.core.util.LRUCache.createLRUCache;
+import static com.ibm.fhir.core.util.URLSupport.getFirst;
+import static com.ibm.fhir.core.util.URLSupport.getQueryParameters;
 import static com.ibm.fhir.model.type.String.string;
 
 import java.io.InputStream;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.ibm.fhir.model.format.Format;
@@ -34,11 +33,11 @@ import com.ibm.fhir.model.type.code.FilterOperator;
 import com.ibm.fhir.model.type.code.NarrativeStatus;
 import com.ibm.fhir.model.type.code.PublicationStatus;
 import com.ibm.fhir.registry.resource.FHIRRegistryResource;
-import com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider;
+import com.ibm.fhir.term.registry.ImplicitValueSetRegistryResourceProvider;
 import com.ibm.fhir.term.service.FHIRTermService;
 import com.ibm.fhir.term.spi.ValidationOutcome;
 
-public class SnomedRegistryResourceProvider implements FHIRRegistryResourceProvider {
+public class SnomedRegistryResourceProvider extends ImplicitValueSetRegistryResourceProvider {
     private static final Logger log = Logger.getLogger(SnomedRegistryResourceProvider.class.getName());
 
     private static final String SNOMED_URL = "http://snomed.info/sct";
@@ -47,53 +46,14 @@ public class SnomedRegistryResourceProvider implements FHIRRegistryResourceProvi
 
     public static final CodeSystem SNOMED_CODE_SYSTEM = loadCodeSystem();
     private static final FHIRRegistryResource SNOMED_CODE_SYSTEM_REGISTRY_RESOURCE = FHIRRegistryResource.from(SNOMED_CODE_SYSTEM);
-    private static final FHIRRegistryResource SNOMED_ALL_CONCEPTS_IMPLICIT_VALUE_SET_REGISTRY_RESOURCE = FHIRRegistryResource.from(buildAllConceptsImplicitValueSet());
-    private static final Map<String, FHIRRegistryResource> SNOMED_SUBSUMED_BY_IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE = createLRUCache(128);
+    private static final ValueSet ALL_CONCEPTS_IMPLICIT_VALUE_SET = buildAllConceptsImplicitValueSet();
 
     @Override
     public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
-        if (url == null) {
-            return null;
-        }
-        if (ValueSet.class.equals(resourceType) && url.startsWith(SNOMED_IMPLICIT_VALUE_SET_PREFIX)) {
-            if (SNOMED_IMPLICIT_VALUE_SET_PREFIX.equals(url)) {
-                return SNOMED_ALL_CONCEPTS_IMPLICIT_VALUE_SET_REGISTRY_RESOURCE;
-            } else {
-                String[] tokens = url.split("=isa\\/");
-                if (tokens.length == 2) {
-                    String sctid = tokens[1];
-                    ValidationOutcome outcome = FHIRTermService.getInstance().validateCode(SNOMED_CODE_SYSTEM, Code.of(sctid), null);
-                    if (outcome == null || Boolean.FALSE.equals(outcome.getResult())) {
-                        log.log(Level.WARNING, "Code: " + sctid + " is invalid or SNOMED CT is not supported");
-                        return null;
-                    }
-                    return SNOMED_SUBSUMED_BY_IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.computeIfAbsent(sctid, k -> FHIRRegistryResource.from(buildSubsumedByImplicitValueSet(sctid)));
-                }
-            }
-        } else if (CodeSystem.class.equals(resourceType) && SNOMED_URL.equals(url)) {
+        if (CodeSystem.class.equals(resourceType) && SNOMED_URL.equals(url)) {
             return SNOMED_CODE_SYSTEM_REGISTRY_RESOURCE;
         }
-        return null;
-    }
-
-    @Override
-    public Collection<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType) {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public Collection<FHIRRegistryResource> getRegistryResources() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public Collection<FHIRRegistryResource> getProfileResources(String type) {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public Collection<FHIRRegistryResource> getSearchParameterResources(String type) {
-        return Collections.emptyList();
+        return super.getRegistryResource(resourceType, url, version);
     }
 
     private static ValueSet buildAllConceptsImplicitValueSet() {
@@ -145,5 +105,34 @@ public class SnomedRegistryResourceProvider implements FHIRRegistryResourceProvi
         } catch (Exception e) {
             throw new Error(e);
         }
+    }
+
+    @Override
+    protected ValueSet buildImplicitValueSet(String url) {
+        if (SNOMED_IMPLICIT_VALUE_SET_PREFIX.equals(url)) {
+            return ALL_CONCEPTS_IMPLICIT_VALUE_SET;
+        }
+        Map<String, List<String>> queryParameters = getQueryParameters(url);
+        String value = getFirst(queryParameters, "fhir_vs");
+        if (value == null || value.isEmpty()) {
+            log.warning("The 'fhir_vs' parameter value is null or empty");
+            return null;
+        }
+        String[] tokens = value.split("/");
+        if (tokens.length == 2) {
+            String sctid = tokens[1];
+            ValidationOutcome outcome = FHIRTermService.getInstance().validateCode(SNOMED_CODE_SYSTEM, Code.of(sctid), null);
+            if (outcome == null || Boolean.FALSE.equals(outcome.getResult())) {
+                log.warning("The code '" + sctid + "' is invalid or SNOMED CT is not supported");
+                return null;
+            }
+            return buildSubsumedByImplicitValueSet(sctid);
+        }
+        return null;
+    }
+
+    @Override
+    protected boolean isSupported(String url) {
+        return (url != null && url.startsWith(SNOMED_IMPLICIT_VALUE_SET_PREFIX));
     }
 }

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
@@ -40,13 +40,13 @@ import com.ibm.fhir.term.spi.ValidationOutcome;
 public class SnomedRegistryResourceProvider extends ImplicitValueSetRegistryResourceProvider {
     private static final Logger log = Logger.getLogger(SnomedRegistryResourceProvider.class.getName());
 
+    public static final CodeSystem SNOMED_CODE_SYSTEM = loadCodeSystem();
+
     private static final String SNOMED_URL = "http://snomed.info/sct";
     private static final String SNOMED_IMPLICIT_VALUE_SET_PREFIX = SNOMED_URL + "?fhir_vs";
     private static final String SNOMED_COPYRIGHT = "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (SNOMED International), and distributed by agreement between SNOMED International and HL7. Implementer use of SNOMED CT is not covered by this agreement";
-
-    public static final CodeSystem SNOMED_CODE_SYSTEM = loadCodeSystem();
     private static final FHIRRegistryResource SNOMED_CODE_SYSTEM_REGISTRY_RESOURCE = FHIRRegistryResource.from(SNOMED_CODE_SYSTEM);
-    private static final ValueSet ALL_CONCEPTS_IMPLICIT_VALUE_SET = buildAllConceptsImplicitValueSet();
+    private static final ValueSet SNOMED_ALL_CONCEPTS_IMPLICIT_VALUE_SET = buildAllConceptsImplicitValueSet();
 
     @Override
     public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
@@ -110,7 +110,7 @@ public class SnomedRegistryResourceProvider extends ImplicitValueSetRegistryReso
     @Override
     protected ValueSet buildImplicitValueSet(String url) {
         if (SNOMED_IMPLICIT_VALUE_SET_PREFIX.equals(url)) {
-            return ALL_CONCEPTS_IMPLICIT_VALUE_SET;
+            return SNOMED_ALL_CONCEPTS_IMPLICIT_VALUE_SET;
         }
         Map<String, List<String>> queryParameters = getQueryParameters(url);
         String value = getFirst(queryParameters, "fhir_vs");

--- a/fhir-term/src/main/java/com/ibm/fhir/term/registry/ImplicitValueSetRegistryResourceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/registry/ImplicitValueSetRegistryResourceProvider.java
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.registry;
+
+import static com.ibm.fhir.core.util.LRUCache.createLRUCache;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.ValueSet;
+import com.ibm.fhir.registry.resource.FHIRRegistryResource;
+import com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider;
+
+/**
+ * An abstract base class for implicit registry resource provider implementations (e.g. SNOMED, LOINC, etc.)
+ */
+public abstract class ImplicitValueSetRegistryResourceProvider implements FHIRRegistryResourceProvider {
+    private static final Map<String, FHIRRegistryResource> IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE = createLRUCache(1024);
+
+    @Override
+    public Collection<FHIRRegistryResource> getProfileResources(String type) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
+        if (url == null) {
+            return null;
+        }
+        if (ValueSet.class.equals(resourceType) && isSupported(url)) {
+            return IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.computeIfAbsent(url, k -> FHIRRegistryResource.from(buildImplicitValueSet(url)));
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources() {
+        return IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.values();
+    }
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType) {
+        return ValueSet.class.equals(resourceType) ? IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.values() : Collections.emptyList();
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getSearchParameterResources(String type) {
+        return Collections.emptyList();
+    }
+
+    protected abstract ValueSet buildImplicitValueSet(String url);
+    protected abstract boolean isSupported(String url);
+}

--- a/fhir-term/src/main/java/com/ibm/fhir/term/registry/ImplicitValueSetRegistryResourceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/registry/ImplicitValueSetRegistryResourceProvider.java
@@ -41,11 +41,11 @@ public abstract class ImplicitValueSetRegistryResourceProvider implements FHIRRe
 
     @Override
     public Collection<FHIRRegistryResource> getRegistryResources() {
-        return IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.values();
+        return Collections.emptyList();
     }
     @Override
     public Collection<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType) {
-        return ValueSet.class.equals(resourceType) ? IMPLICIT_VALUE_SET_REGISTRY_RESOURCE_CACHE.values() : Collections.emptyList();
+        return Collections.emptyList();
     }
 
     @Override

--- a/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
@@ -742,6 +742,17 @@ public final class CodeSystemSupport {
         }
     }
 
+    private static class NotInFilter extends InFilter {
+        public NotInFilter(Code property, Set<Code> set) {
+            super(property, set);
+        }
+
+        @Override
+        public boolean accept(Concept concept) {
+            return !super.accept(concept);
+        }
+    }
+
     private static class RegexFilter implements ConceptFilter {
         private final Code property;
         private final Pattern pattern;
@@ -760,17 +771,6 @@ public final class CodeSystemSupport {
                 }
             }
             return false;
-        }
-    }
-
-    static class NotInFilter extends InFilter {
-        public NotInFilter(Code property, Set<Code> set) {
-            super(property, set);
-        }
-
-        @Override
-        public boolean accept(Concept concept) {
-            return !super.accept(concept);
         }
     }
 }

--- a/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
+++ b/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
@@ -1,0 +1,36 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.term.service.test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.CodeSystem;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.term.util.CodeSystemSupport;
+
+public class CodeSystemSupportTest {
+    @Test
+    public void testGetAncestorsAndSelf() {
+        CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/cs5|1.0.0");
+        Set<String> actual = CodeSystemSupport.getAncestorsAndSelf(codeSystem, Code.of("r"));
+        Set<String> expected = new HashSet<>(Arrays.asList("r", "p", "m"));
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testGetDescendantsAndSelf() {
+        CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/cs5|1.0.0");
+        Set<String> actual = CodeSystemSupport.getDescendantsAndSelf(codeSystem, Code.of("m"));
+        Set<String> expected = new HashSet<>(Arrays.asList("m", "p", "q", "r"));
+        Assert.assertEquals(actual, expected);
+    }
+}


### PR DESCRIPTION
Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>

1. Refactored common code for working with URLs into a utility class called `URLSupport`
2. Created abstract base class for implicit value set registry resource providers
3. Added `getAncestorsAndSelf` and `getDescedantsAndSelf` methods to `CodeSystemSupport` (for #1733)
4. Added unit tests for 1. and 3.
5. Added `hasLabel("Concept")` when `ValueSet` include filters list is empty

NOTE: I "sorted members" on `CodeSystemSupport`, therefore, it looks like more changes than are actually there. The only substantive changes are the addition of the new methods mentioned in 3. above.