### PR TITLE
issue #1530 - javadoc updates

### DIFF
--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
@@ -379,7 +379,7 @@ public class FHIRTermService {
      * @param codingB
      *     the coding "B"
      * @return
-     *     the outcome of the subsumption test
+     *     the outcome of the subsumption test, or null if the relationship could not be tested
      */
     public ConceptSubsumptionOutcome subsumes(Coding codingA, Coding codingB) {
         Uri systemA = codingA.getSystem();

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -36,6 +36,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     public Concept getConcept(CodeSystem codeSystem, Code code) {
         Concept concept = CodeSystemSupport.findConcept(codeSystem, code);
         if (concept != null) {
+            // nested concepts are stripped for consistency with the other providers
             return concept.toBuilder()
                 .concept(Collections.emptyList())
                 .build();
@@ -45,6 +46,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem) {
+        // nested concepts are stripped for consistency with the other providers
         return CodeSystemSupport.getConcepts(codeSystem).stream()
             .map(concept -> Concept.builder()
                 .code(concept.getCode())
@@ -56,6 +58,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters) {
         try {
+            // nested concepts are stripped for consistency with the other providers
             return CodeSystemSupport.getConcepts(codeSystem, filters).stream()
                 .map(concept -> Concept.builder()
                     .code(concept.getCode())

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -36,7 +36,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     public Concept getConcept(CodeSystem codeSystem, Code code) {
         Concept concept = CodeSystemSupport.findConcept(codeSystem, code);
         if (concept != null) {
-            // nested concepts are stripped for consistency with the other providers
+            // child concepts are removed for consistency with the other providers
             return concept.toBuilder()
                 .concept(Collections.emptyList())
                 .build();
@@ -46,7 +46,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem) {
-        // nested concepts are stripped for consistency with the other providers
+        // child concepts are removed for consistency with the other providers
         return CodeSystemSupport.getConcepts(codeSystem).stream()
             .map(concept -> Concept.builder()
                 .code(concept.getCode())
@@ -58,7 +58,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters) {
         try {
-            // nested concepts are stripped for consistency with the other providers
+            // child concepts are removed for consistency with the other providers
             return CodeSystemSupport.getConcepts(codeSystem, filters).stream()
                 .map(concept -> Concept.builder()
                     .code(concept.getCode())

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
@@ -30,7 +30,7 @@ public interface FHIRTermServiceProvider {
 
     /**
      * Get the concept in the provided code system with the specified code.
-     * Consumers should not expect the returned Concept to contain nested concepts, even where
+     * Consumers should not expect the returned Concept to contain child concepts, even where
      * such concepts exist in the underlying CodeSystem.
      *
      * @param codeSystem

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
@@ -30,6 +30,8 @@ public interface FHIRTermServiceProvider {
 
     /**
      * Get the concept in the provided code system with the specified code.
+     * Consumers should not expect the returned Concept to contain nested concepts, even where
+     * such concepts exist in the underlying CodeSystem.
      *
      * @param codeSystem
      *     the code system
@@ -87,7 +89,8 @@ public interface FHIRTermServiceProvider {
     boolean isSupported(CodeSystem codeSystem);
 
     /**
-     * Find the concept in tree rooted by the provided concept that matches the specified code.
+     * Indicates whether the concept for {@code CodeA} subsumes the concept for {@code codeB}
+     * in the passed CodeSystem.
      *
      * @param codeSystem
      *     the code system
@@ -96,7 +99,8 @@ public interface FHIRTermServiceProvider {
      * @param codeB
      *     the code to match
      * @return
-     *     the code system concept that matches the specified code, or null if not such concept exists
+     *     true if the code system concept for {@code codeB} exists in the tree rooted by the concept for
+     *     {@code CodeA}, false otherwise
      */
     boolean subsumes(CodeSystem codeSystem, Code codeA, Code codeB);
 }


### PR DESCRIPTION
1. clarify the contract for FHIRTermServiceProvider.getConcept
2. update stale javadoc for FHIRTermServiceProvider.subsumes
3. clarify that ConceptSubsumptionOutcome can come back null

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>