### PR TITLE
issue #923 - run features.sh earlier to enable layer caching

### DIFF
--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -7,13 +7,10 @@
 
 FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java8-openj9-ubi as base
 
-ENV LICENSE accept
-
 USER root
-
 RUN yum install -y unzip
-
-RUN mkdir -p /opt/ibm-fhir-server
+RUN install -d -o 1001 /opt/ibm-fhir-server
+USER 1001
 
 COPY target/fhir-server-distribution.zip /tmp/
 RUN unzip -qq /tmp/fhir-server-distribution.zip -d /tmp && \
@@ -22,13 +19,12 @@ RUN unzip -qq /tmp/fhir-server-distribution.zip -d /tmp && \
 COPY src/main/docker/ibm-fhir-server/bootstrap.properties /opt/ol/wlp/usr/servers/defaultServer/
 COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 
-USER 1001
-
 # ----------------------------------------------------------------------------
 # Stage: Runnable
 
 FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java8-openj9-ubi
 
+ARG VERBOSE=true
 ARG FHIR_VERSION=4.7.0-SNAPSHOT
 
 # The following labels are required: 
@@ -37,11 +33,6 @@ LABEL vendor='IBM'
 LABEL version="$FHIR_VERSION"
 LABEL summary="Image for IBM FHIR Server with OpenJ9 and UBI 8"
 LABEL description="The IBM FHIR Server is a modular Java implementation of version 4 of the HL7 FHIR specification with a focus on performance and configurability."
-
-COPY --chown=1001:0 --from=base /opt/ol/wlp/usr /opt/ol/wlp/usr
-COPY --chown=1001:0 --from=base /opt/ibm-fhir-server /opt/ibm-fhir-server
-
-COPY target/LICENSE /licenses/
 
 ENV FHIR_CONFIG_HOME=/opt/ol/wlp/usr/servers/defaultServer \
     WLP_LOGGING_CONSOLE_SOURCE=message,trace,accessLog,ffdc,audit \
@@ -52,11 +43,21 @@ ENV FHIR_CONFIG_HOME=/opt/ol/wlp/usr/servers/defaultServer \
     TRACE_FILE=stdout \
     TRACE_FORMAT=BASIC
 
+COPY target/LICENSE /licenses/
+
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/server.xml /opt/ol/wlp/usr/servers/defaultServer/
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins /opt/ol/wlp/usr/servers/defaultServer/configDropins
+
+RUN features.sh
+
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr /opt/ol/wlp/usr
+
+RUN configure.sh
+
+COPY --chown=1001:0 --from=base /opt/ibm-fhir-server /opt/ibm-fhir-server
+
 # Set the working directory to the liberty defaultServer
 WORKDIR ${FHIR_CONFIG_HOME}
-
-RUN features.sh && \
-    VERBOSE=true configure.sh
 
 ENTRYPOINT ["/opt/ibm-fhir-server/bootstrap.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/fhir-install/src/main/resources/scripts/install-fhir.sh
+++ b/fhir-install/src/main/resources/scripts/install-fhir.sh
@@ -10,7 +10,6 @@ Executing $0 to deploy the fhir-server web application...
 "
 
 # Determine the location of this script.
-# basedir=`dirname "$0"`
 cd $(dirname $0); basedir="$(pwd)/"
 
 # Default liberty install location


### PR DESCRIPTION
this change splits the COPY /opt/ol/wlp/usr /opt/ol/wlp/usr into two
steps:
* first we move just the server.xml and configDropins
* then, after installing the liberty features, we add the application
* finally, we add the bootstrap.sh script and related tools

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>