### PR TITLE
change to java 11 in the docker image

### DIFF
--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -5,7 +5,7 @@
 # ----------------------------------------------------------------------------
 # Stage: Base
 
-FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java8-openj9-ubi as base
+FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java11-openj9-ubi as base
 
 USER root
 RUN yum install -y unzip
@@ -22,7 +22,7 @@ COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 # ----------------------------------------------------------------------------
 # Stage: Runnable
 
-FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java8-openj9-ubi
+FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java11-openj9-ubi
 
 ARG VERBOSE=true
 ARG FHIR_VERSION=4.7.0-SNAPSHOT


### PR DESCRIPTION
Image size and startup time are comparable (java 11 was ~400 MB larger and starts about 1 second slower).

Image build time was significantly slower on the first build, but then comparable on every build after that, even with `--no-cache` (not sure why).

first java 11 build:
```
$ docker build fhir-install -t ibmcom/ibm-fhir-server 
...
=> [stage-1 5/9] RUN features.sh                                                     144.2s 
=> [stage-1 6/9] COPY --chown=1001:0 --from=base /opt/ol/wlp/usr /opt/ol/wlp/usr       1.1s 
=> [stage-1 7/9] RUN configure.sh                                                    193.5s
...
```

second build with java 11 (with no-cache):
```
$ docker build fhir-install -t ibmcom/ibm-fhir-server --no-cache   
...
=> [stage-1 5/9] RUN features.sh                                                     102.7s 
=> [stage-1 6/9] COPY --chown=1001:0 --from=base /opt/ol/wlp/usr /opt/ol/wlp/usr       0.6s 
=> [stage-1 7/9] RUN configure.sh                                                     95.9s
...
```

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>