### PR TITLE
Issue #2162 - miscellaneous updates

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ExpandFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ExpandFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,7 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.term.spi.ExpansionParameters;
+import com.ibm.fhir.term.service.ExpansionParameters;
 
 public class ExpandFunction extends FHIRPathAbstractTermFunction {
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/LookupFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/LookupFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,8 +29,8 @@ import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.term.spi.LookupOutcome;
-import com.ibm.fhir.term.spi.LookupParameters;
+import com.ibm.fhir.term.service.LookupOutcome;
+import com.ibm.fhir.term.service.LookupParameters;
 
 public class LookupFunction extends FHIRPathAbstractTermFunction {
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,7 +40,7 @@ import com.ibm.fhir.path.FHIRPathTree;
 import com.ibm.fhir.path.FHIRPathType;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.term.service.FHIRTermService;
-import com.ibm.fhir.term.spi.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationOutcome;
 
 /**
  * Implementation of the 'memberOf' FHIRPath function per: <a href="http://hl7.org/fhir/fhirpath.html#functions">http://hl7.org/fhir/fhirpath.html#functions</a>

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/TranslateFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/TranslateFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,8 +31,8 @@ import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.term.spi.TranslationOutcome;
-import com.ibm.fhir.term.spi.TranslationParameters;
+import com.ibm.fhir.term.service.TranslationOutcome;
+import com.ibm.fhir.term.service.TranslationParameters;
 
 public class TranslateFunction extends FHIRPathAbstractTermFunction {
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateCSFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateCSFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,8 +33,8 @@ import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.term.spi.ValidationOutcome;
-import com.ibm.fhir.term.spi.ValidationParameters;
+import com.ibm.fhir.term.service.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationParameters;
 
 public class ValidateCSFunction extends FHIRPathAbstractTermFunction {
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateVSFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ValidateVSFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,8 +33,8 @@ import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.term.spi.ValidationOutcome;
-import com.ibm.fhir.term.spi.ValidationParameters;
+import com.ibm.fhir.term.service.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationParameters;
 
 public class ValidateVSFunction extends FHIRPathAbstractTermFunction {
     @Override

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
@@ -128,7 +128,7 @@ public class GraphTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> function) {
         checkArgument(codeSystem);
 
         Set<R> concepts = new LinkedHashSet<>(getCount(codeSystem));
@@ -138,7 +138,7 @@ public class GraphTermServiceProvider implements FHIRTermServiceProvider {
             .timeLimit(timeLimit);
         TimeLimitStep<?> timeLimitStep = getTimeLimitStep(g);
 
-        g.elementMap().toStream().forEach(elementMap -> concepts.add(mapper.apply(createConcept(elementMap))));
+        g.elementMap().toStream().forEach(elementMap -> concepts.add(function.apply(createConcept(elementMap))));
 
         checkTimeLimit(timeLimitStep);
 
@@ -151,7 +151,7 @@ public class GraphTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> function) {
         checkArguments(codeSystem, filters);
 
         Set<R> concepts = new LinkedHashSet<>();
@@ -203,7 +203,7 @@ public class GraphTermServiceProvider implements FHIRTermServiceProvider {
         g = g.timeLimit(timeLimit);
         TimeLimitStep<?> timeLimitStep = getTimeLimitStep(g);
 
-        g.elementMap().toStream().forEach(elementMap -> concepts.add(mapper.apply(createConcept(elementMap))));
+        g.elementMap().toStream().forEach(elementMap -> concepts.add(function.apply(createConcept(elementMap))));
 
         checkTimeLimit(timeLimitStep);
 

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/registry/SnomedRegistryResourceProvider.java
@@ -35,7 +35,7 @@ import com.ibm.fhir.model.type.code.PublicationStatus;
 import com.ibm.fhir.registry.resource.FHIRRegistryResource;
 import com.ibm.fhir.term.registry.ImplicitValueSetRegistryResourceProvider;
 import com.ibm.fhir.term.service.FHIRTermService;
-import com.ibm.fhir.term.spi.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationOutcome;
 
 public class SnomedRegistryResourceProvider extends ImplicitValueSetRegistryResourceProvider {
     private static final Logger log = Logger.getLogger(SnomedRegistryResourceProvider.class.getName());

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/ExpansionParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/ExpansionParameters.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.ibm.fhir.model.resource.CodeSystem;
@@ -39,18 +40,11 @@ import com.ibm.fhir.model.type.String;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.CodeSystemHierarchyMeaning;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
+import com.ibm.fhir.term.service.LookupOutcome.Designation;
+import com.ibm.fhir.term.service.LookupOutcome.Property;
+import com.ibm.fhir.term.service.TranslationOutcome.Match;
 import com.ibm.fhir.term.service.provider.RegistryTermServiceProvider;
-import com.ibm.fhir.term.spi.ExpansionParameters;
 import com.ibm.fhir.term.spi.FHIRTermServiceProvider;
-import com.ibm.fhir.term.spi.LookupOutcome;
-import com.ibm.fhir.term.spi.LookupOutcome.Designation;
-import com.ibm.fhir.term.spi.LookupOutcome.Property;
-import com.ibm.fhir.term.spi.LookupParameters;
-import com.ibm.fhir.term.spi.TranslationOutcome;
-import com.ibm.fhir.term.spi.TranslationOutcome.Match;
-import com.ibm.fhir.term.spi.TranslationParameters;
-import com.ibm.fhir.term.spi.ValidationOutcome;
-import com.ibm.fhir.term.spi.ValidationParameters;
 import com.ibm.fhir.term.util.CodeSystemSupport;
 import com.ibm.fhir.term.util.ValueSetSupport;
 
@@ -267,12 +261,29 @@ public class FHIRTermService {
      * hierarchies have been flattened.
      *
      * @param codeSystem
-     *     the code system
+     *     the code system containing the set of Concept instances to be flattened
      * @return
-     *     flattened list of Concept instances for the given code system
+     *     flattened set of Concept instances for the given code system
      */
     public Set<Concept> getConcepts(CodeSystem codeSystem) {
         return findProvider(codeSystem).getConcepts(codeSystem);
+    }
+
+    /**
+     * Get a set containing {@link R} instances mapped from concepts where all structural
+     * hierarchies have been flattened.
+     *
+     * @param <R>
+     *     the element type of the result set
+     * @param codeSystem
+     *     the code system containing the set of Concept instances to be flattened
+     * @param mapper
+     *     the function to be applied
+     * @return
+     *     flattened set of {@link R} instances mapped from concepts for the given code system
+     */
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
+        return findProvider(codeSystem).getConcepts(codeSystem, mapper);
     }
 
     /**
@@ -288,6 +299,25 @@ public class FHIRTermService {
      */
     public Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters) {
         return findProvider(codeSystem).getConcepts(codeSystem, filters);
+    }
+
+    /**
+     * Get a set containing {@link R} instances mapped from concepts where all structural
+     * hierarchies have been flattened and filtered by the given set of value set include filters.
+     *
+     * @param <R>
+     *     the element type of the result set
+     * @param codeSystem
+     *     the code system containing the set of Concept instances to be flattened / filtered
+     * @param filters
+     *     the value set include filters
+     * @param mapper
+     *     the function to be applied
+     * @return
+     *     flattened / filtered set of {@link R} instances mapped from concepts for the given code system
+     */
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
+        return findProvider(codeSystem).getConcepts(codeSystem, filters, mapper);
     }
 
     /**

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/FHIRTermService.java
@@ -57,11 +57,6 @@ public class FHIRTermService {
         }
 
         @Override
-        public Map<Code, Set<Concept>> closure(CodeSystem codeSystem, Set<Code> codes) {
-            return Collections.emptyMap();
-        }
-
-        @Override
         public Concept getConcept(CodeSystem codeSystem, Code code) {
             return null;
         }
@@ -277,13 +272,13 @@ public class FHIRTermService {
      *     the element type of the result set
      * @param codeSystem
      *     the code system containing the set of Concept instances to be flattened
-     * @param mapper
-     *     the function to be applied
+     * @param function
+     *     the function to apply to each element of the result set
      * @return
      *     flattened set of {@link R} instances mapped from concepts for the given code system
      */
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
-        return findProvider(codeSystem).getConcepts(codeSystem, mapper);
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> function) {
+        return findProvider(codeSystem).getConcepts(codeSystem, function);
     }
 
     /**
@@ -311,13 +306,13 @@ public class FHIRTermService {
      *     the code system containing the set of Concept instances to be flattened / filtered
      * @param filters
      *     the value set include filters
-     * @param mapper
-     *     the function to be applied
+     * @param function
+     *     the function to apply to each element of the result set
      * @return
      *     flattened / filtered set of {@link R} instances mapped from concepts for the given code system
      */
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
-        return findProvider(codeSystem).getConcepts(codeSystem, filters, mapper);
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> function) {
+        return findProvider(codeSystem).getConcepts(codeSystem, filters, function);
     }
 
     /**

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/LookupOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/LookupOutcome.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.model.type.String.string;
 

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/LookupParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/LookupParameters.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/TranslationOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/TranslationOutcome.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.model.type.String.string;
 
@@ -21,7 +21,7 @@ import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.String;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.ConceptMapEquivalence;
-import com.ibm.fhir.term.spi.TranslationOutcome.Match.Product;
+import com.ibm.fhir.term.service.TranslationOutcome.Match.Product;
 
 /**
  * This class is used to represent the outcome of the translate operation:

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/TranslationParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/TranslationParameters.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameters;

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationOutcome.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationOutcome.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.model.type.String.string;
 

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationParameters.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationParameters.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.term.spi;
+package com.ibm.fhir.term.service;
 
 import static com.ibm.fhir.term.service.util.FHIRTermServiceUtil.getParameter;
 

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -35,14 +35,14 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
         Concept concept = CodeSystemSupport.findConcept(codeSystem, code);
         if (concept != null) {
             // child concepts are removed for consistency with the other providers
-            return CodeSystemSupport.NO_CHILDREN_MAPPER.apply(concept);
+            return CodeSystemSupport.CONCEPT_NO_CHILDREN_FUNCTION.apply(concept);
         }
         return null;
     }
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem) {
-        return getConcepts(codeSystem, CodeSystemSupport.SIMPLE_CONCEPT_MAPPER);
+        return getConcepts(codeSystem, CodeSystemSupport.SIMPLE_CONCEPT_FUNCTION);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters) {
-        return getConcepts(codeSystem, filters, CodeSystemSupport.SIMPLE_CONCEPT_MAPPER);
+        return getConcepts(codeSystem, filters, CodeSystemSupport.SIMPLE_CONCEPT_FUNCTION);
     }
 
     @Override

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -6,13 +6,9 @@
 
 package com.ibm.fhir.term.service.provider;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
 import com.ibm.fhir.model.resource.CodeSystem;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;
@@ -35,48 +31,34 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public Map<Code, Set<Concept>> closure(CodeSystem codeSystem, Set<Code> codes) {
-        Map<Code, Set<Concept>> result = new LinkedHashMap<>();
-        for (Code code : codes) {
-            Set<Concept> closure = closure(codeSystem, code);
-            result.put(code, closure);
-        }
-        return result;
-    }
-
-    @Override
     public Concept getConcept(CodeSystem codeSystem, Code code) {
         Concept concept = CodeSystemSupport.findConcept(codeSystem, code);
         if (concept != null) {
             // child concepts are removed for consistency with the other providers
-            return concept.toBuilder()
-                .concept(Collections.emptyList())
-                .build();
+            return CodeSystemSupport.NO_CHILDREN_MAPPER.apply(concept);
         }
         return null;
     }
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem) {
-        // child concepts are removed for consistency with the other providers
-        return CodeSystemSupport.getConcepts(codeSystem).stream()
-            .map(concept -> Concept.builder()
-                .code(concept.getCode())
-                .display(concept.getDisplay())
-                .build())
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+        return getConcepts(codeSystem, CodeSystemSupport.SIMPLE_CONCEPT_MAPPER);
+    }
+
+    @Override
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
+        return CodeSystemSupport.getConcepts(codeSystem, mapper);
     }
 
     @Override
     public Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters) {
+        return getConcepts(codeSystem, filters, CodeSystemSupport.SIMPLE_CONCEPT_MAPPER);
+    }
+
+    @Override
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
         try {
-            // child concepts are removed for consistency with the other providers
-            return CodeSystemSupport.getConcepts(codeSystem, filters).stream()
-                .map(concept -> Concept.builder()
-                    .code(concept.getCode())
-                    .display(concept.getDisplay())
-                    .build())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+            return CodeSystemSupport.getConcepts(codeSystem, filters, mapper);
         } catch (FHIRTermException e) {
             throw new FHIRTermServiceException(e.getMessage(), e, e.getIssues());
         }

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -46,8 +46,8 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
-        return CodeSystemSupport.getConcepts(codeSystem, mapper);
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> function) {
+        return CodeSystemSupport.getConcepts(codeSystem, function);
     }
 
     @Override
@@ -56,9 +56,9 @@ public class RegistryTermServiceProvider implements FHIRTermServiceProvider {
     }
 
     @Override
-    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
+    public <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> function) {
         try {
-            return CodeSystemSupport.getConcepts(codeSystem, filters, mapper);
+            return CodeSystemSupport.getConcepts(codeSystem, filters, function);
         } catch (FHIRTermException e) {
             throw new FHIRTermServiceException(e.getMessage(), e, e.getIssues());
         }

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
@@ -86,14 +86,14 @@ public interface FHIRTermServiceProvider {
      *     the element type of the result set
      * @param codeSystem
      *     the code system containing the set of Concept instances to be flattened
-     * @param mapper
-     *     the function to be applied
+     * @param function
+     *     the function to apply to each element of the result set
      * @return
      *     flattened set of {@link R} instances mapped from concepts for the given code system
      */
-    default <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
+    default <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> function) {
         return getConcepts(codeSystem).stream()
-            .map(mapper)
+            .map(function)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
@@ -120,14 +120,14 @@ public interface FHIRTermServiceProvider {
      *     the code system containing the set of Concept instances to be flattened / filtered
      * @param filters
      *     the value set include filters
-     * @param mapper
-     *     the function to be applied
+     * @param function
+     *     the function to apply to each element of the result set
      * @return
      *     flattened / filtered set of {@link R} instances mapped from concepts for the given code system
      */
-    default <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
+    default <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> function) {
         return getConcepts(codeSystem, filters).stream()
-            .map(mapper)
+            .map(function)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/spi/FHIRTermServiceProvider.java
@@ -6,9 +6,13 @@
 
 package com.ibm.fhir.term.spi;
 
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.ibm.fhir.model.resource.CodeSystem;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;
@@ -40,7 +44,14 @@ public interface FHIRTermServiceProvider {
      * @return
      *     a map containing flattened sets of Concept instances for the given trees
      */
-    Map<Code, Set<Concept>> closure(CodeSystem codeSystem, Set<Code> codes);
+    default Map<Code, Set<Concept>> closure(CodeSystem codeSystem, Set<Code> codes) {
+        Map<Code, Set<Concept>> result = new LinkedHashMap<>();
+        for (Code code : codes) {
+            Set<Concept> closure = closure(codeSystem, code);
+            result.put(code, closure);
+        }
+        return result;
+    }
 
     /**
      * Get the concept in the provided code system with the specified code.
@@ -61,24 +72,64 @@ public interface FHIRTermServiceProvider {
      * hierarchies have been flattened.
      *
      * @param codeSystem
-     *     the code system
+     *     the code system containing the set of Concept instances to be flattened
      * @return
-     *     flattened list of Concept instances for the given code system
+     *     flattened set of Concept instances for the given code system
      */
     Set<Concept> getConcepts(CodeSystem codeSystem);
+
+    /**
+     * Get a set containing {@link R} instances mapped from concepts where all structural
+     * hierarchies have been flattened.
+     *
+     * @param <R>
+     *     the element type of the result set
+     * @param codeSystem
+     *     the code system containing the set of Concept instances to be flattened
+     * @param mapper
+     *     the function to be applied
+     * @return
+     *     flattened set of {@link R} instances mapped from concepts for the given code system
+     */
+    default <R> Set<R> getConcepts(CodeSystem codeSystem, Function<Concept, ? extends R> mapper) {
+        return getConcepts(codeSystem).stream()
+            .map(mapper)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 
     /**
      * Get a set containing {@link CodeSystem.Concept} instances where all structural
      * hierarchies have been flattened and filtered by the given set of value set include filters.
      *
      * @param codeSystem
-     *     the code system
+     *     the code system containing the set of Concept instances to be flattened / filtered
      * @param filters
      *     the value set include filters
      * @return
-     *     flattened / filtered list of Concept instances for the given code system
+     *     flattened / filtered set of Concept instances for the given code system
      */
     Set<Concept> getConcepts(CodeSystem codeSystem, List<Filter> filters);
+
+    /**
+     * Get a set containing {@link R} instances mapped from concepts where all structural
+     * hierarchies have been flattened and filtered by the given set of value set include filters.
+     *
+     * @param <R>
+     *     the element type of the result set
+     * @param codeSystem
+     *     the code system containing the set of Concept instances to be flattened / filtered
+     * @param filters
+     *     the value set include filters
+     * @param mapper
+     *     the function to be applied
+     * @return
+     *     flattened / filtered set of {@link R} instances mapped from concepts for the given code system
+     */
+    default <R> Set<R> getConcepts(CodeSystem codeSystem, List<Filter> filters, Function<Concept, ? extends R> mapper) {
+        return getConcepts(codeSystem, filters).stream()
+            .map(mapper)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
 
     /**
      * Indicates whether the given code system contains a concept with the specified code.

--- a/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
+++ b/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
@@ -62,7 +62,7 @@ public class CodeSystemSupportTest {
     public void testGetConceptsWithMapper() {
         CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/test");
 
-        Function<Concept, String> mapper = CodeSystemSupport.getStringMapper(codeSystem);
+        Function<Concept, String> mapper = CodeSystemSupport.getCodeValueFunction(codeSystem);
         Set<String> actual = CodeSystemSupport.getConcepts(codeSystem, mapper);
 
         Set<Concept> concepts = CodeSystemSupport.getConcepts(codeSystem);

--- a/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
+++ b/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
@@ -59,11 +59,11 @@ public class CodeSystemSupportTest {
     }
 
     @Test
-    public void testGetConceptsWithMapper() {
+    public void testGetConceptsWithCodeValueFunction() {
         CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/test");
 
-        Function<Concept, String> mapper = CodeSystemSupport.getCodeValueFunction(codeSystem);
-        Set<String> actual = CodeSystemSupport.getConcepts(codeSystem, mapper);
+        Function<Concept, String> function = CodeSystemSupport.getCodeValueFunction(codeSystem);
+        Set<String> actual = CodeSystemSupport.getConcepts(codeSystem, function);
 
         Set<Concept> concepts = CodeSystemSupport.getConcepts(codeSystem);
         Set<String> expected = concepts.stream()

--- a/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
+++ b/fhir-term/src/test/java/com/ibm/fhir/term/service/test/CodeSystemSupportTest.java
@@ -6,14 +6,20 @@
 
 package com.ibm.fhir.term.service.test;
 
+import static com.ibm.fhir.term.util.CodeSystemSupport.isCaseSensitive;
+import static com.ibm.fhir.term.util.CodeSystemSupport.normalize;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.resource.CodeSystem;
+import com.ibm.fhir.model.resource.CodeSystem.Concept;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.term.util.CodeSystemSupport;
 
@@ -49,6 +55,23 @@ public class CodeSystemSupportTest {
         CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://terminology.hl7.org/CodeSystem/condition-clinical");
         Set<String> actual = CodeSystemSupport.getDescendantsAndSelf(codeSystem, Code.of("active"));
         Set<String> expected = new HashSet<>(Arrays.asList("active", "recurrence", "relapse"));
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testGetConceptsWithMapper() {
+        CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/test");
+
+        Function<Concept, String> mapper = CodeSystemSupport.getStringMapper(codeSystem);
+        Set<String> actual = CodeSystemSupport.getConcepts(codeSystem, mapper);
+
+        Set<Concept> concepts = CodeSystemSupport.getConcepts(codeSystem);
+        Set<String> expected = concepts.stream()
+                .map(concept -> isCaseSensitive(codeSystem) ?
+                        concept.getCode().getValue() :
+                        normalize(concept.getCode().getValue()))
+                .collect(Collectors.toSet());
+
         Assert.assertEquals(actual, expected);
     }
 }

--- a/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
+++ b/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
@@ -38,10 +38,10 @@ import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.ConceptMapEquivalence;
 import com.ibm.fhir.model.type.code.ConceptSubsumptionOutcome;
 import com.ibm.fhir.term.service.FHIRTermService;
-import com.ibm.fhir.term.spi.LookupOutcome;
-import com.ibm.fhir.term.spi.TranslationOutcome;
-import com.ibm.fhir.term.spi.TranslationOutcome.Match;
-import com.ibm.fhir.term.spi.ValidationOutcome;
+import com.ibm.fhir.term.service.LookupOutcome;
+import com.ibm.fhir.term.service.TranslationOutcome;
+import com.ibm.fhir.term.service.ValidationOutcome;
+import com.ibm.fhir.term.service.TranslationOutcome.Match;
 
 public class FHIRTermServiceTest {
     @Test

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/CodeSystemValidateCodeOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/CodeSystemValidateCodeOperation.java
@@ -18,9 +18,9 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
+import com.ibm.fhir.term.service.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationParameters;
 import com.ibm.fhir.term.service.exception.FHIRTermServiceException;
-import com.ibm.fhir.term.spi.ValidationOutcome;
-import com.ibm.fhir.term.spi.ValidationParameters;
 
 public class CodeSystemValidateCodeOperation extends AbstractTermOperation {
     @Override

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/ExpandOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/ExpandOperation.java
@@ -18,8 +18,8 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
+import com.ibm.fhir.term.service.ExpansionParameters;
 import com.ibm.fhir.term.service.exception.FHIRTermServiceException;
-import com.ibm.fhir.term.spi.ExpansionParameters;
 
 public class ExpandOperation extends AbstractTermOperation {
     @Override

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/LookupOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/LookupOperation.java
@@ -23,9 +23,9 @@ import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
 import com.ibm.fhir.server.util.FHIRRestHelper;
+import com.ibm.fhir.term.service.LookupOutcome;
+import com.ibm.fhir.term.service.LookupParameters;
 import com.ibm.fhir.term.service.exception.FHIRTermServiceException;
-import com.ibm.fhir.term.spi.LookupOutcome;
-import com.ibm.fhir.term.spi.LookupParameters;
 
 public class LookupOperation extends AbstractTermOperation {
     @Override

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/TranslateOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/TranslateOperation.java
@@ -17,9 +17,9 @@ import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
+import com.ibm.fhir.term.service.TranslationOutcome;
+import com.ibm.fhir.term.service.TranslationParameters;
 import com.ibm.fhir.term.service.exception.FHIRTermServiceException;
-import com.ibm.fhir.term.spi.TranslationOutcome;
-import com.ibm.fhir.term.spi.TranslationParameters;
 
 public class TranslateOperation extends AbstractTermOperation {
     @Override

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/ValueSetValidateCodeOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/ValueSetValidateCodeOperation.java
@@ -17,9 +17,9 @@ import com.ibm.fhir.model.type.Element;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
 import com.ibm.fhir.server.operation.spi.FHIRResourceHelpers;
+import com.ibm.fhir.term.service.ValidationOutcome;
+import com.ibm.fhir.term.service.ValidationParameters;
 import com.ibm.fhir.term.service.exception.FHIRTermServiceException;
-import com.ibm.fhir.term.spi.ValidationOutcome;
-import com.ibm.fhir.term.spi.ValidationParameters;
 
 public class ValueSetValidateCodeOperation extends AbstractTermOperation {
     @Override


### PR DESCRIPTION
Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>

Updates include:
1. Added the following methods to `CodeSystemSupport`
`getConcepts(CodeSystem, Function)`
`getConcepts(CodeSystem, List<Filter>, Function)`
`getConcepts(Concept, Function)`
2. Added the following methods to the `FHIRTermServiceProvider` interface:
`getConcepts(CodeSystem, Function)`
`getConcepts(CodeSystem, List<Filter>, Function)`
NOTE: included default implementation of these methods in the `FHIRTermServiceProvider` interface
3. Added the following methods to `FHIRTermService`:
`getConcepts(CodeSystem, Function)`
`getConcepts(CodeSystem, List<Filter>, Function)`
4. Moved all `Parameters` and `Outcome` classes from the `com.ibm.fhir.term.spi` package to the `com.ibm.fhir.term.service` package which is where they are actually used.
5. Added commonly used `Function` implementations to `CodeSystemSupport` including:
`CODE_VALUE_FUNCTION`
`NORMALIZED_CODE_VALUE_FUNCTION`
`DISPLAY_VALUE_FUNCTION`
`NORMALIZED_DISPLAY_VALUE_FUNCTION`
`CONCEPT_NO_CHILDREN_FUNCTION`
`SIMPLE_CONCEPT_FUNCTION`
6. Added `getCodeValueFunction(CodeSystem)` method to `CodeSystemSupport`
7. Refactored `CodeSystemSupport` to use new `getConcepts` methods
8. Removed `toSet` method from `CodeSystemSupport`
9. Added a unit test
