### PR TITLE
ch.qos.logback:logback-core is vulnerable to CVE-2017-5929 #2216

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -489,6 +489,16 @@
                 <artifactId>jaxb-impl</artifactId>
                 <version>2.3.0</version>
             </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.3</version>
+            </dependency>
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>