### PR TITLE
fhir-bucket: Allow clean exit when connection to FHIR server cannot be made

### DIFF
--- a/fhir-bucket/src/main/java/com/ibm/fhir/bucket/reindex/DriveReindexOperation.java
+++ b/fhir-bucket/src/main/java/com/ibm/fhir/bucket/reindex/DriveReindexOperation.java
@@ -27,7 +27,6 @@ import com.ibm.fhir.model.resource.Resource;
 
 import com.ibm.fhir.database.utils.api.DataAccessException;
 
-
 /**
  * Drives the $reindex custom operation in parallel. Each thread keeps running
  * until the OperationOutcome indicates that no work remains to be processed.


### PR DESCRIPTION
This addresses issue 2219.

The new behavior allows `callReindexOperation` to catch expected exceptions from `FHIRBucketClient.post` and allow the thread count to be decremented AND for running be set to false.  These two changes will allow `monitorLoop` to attempt to refill the request pool.  It is likely that will fail and the program will exit allowing the caller to fix the connection problem and restart the reindex program.

Log excerpt showing `monitorLoop` successfully exiting once a connection cannot be made to FHIR server:
```
java -jar "${JAR}" --tenant-name $MY_TENANT  --max-concurrent-fhir-requests 100 --no-scan --reindex-tstamp 2021-03-30T00:00:00Z --reindex-resource-count 100 --reindex-concurrent-requests 5 --fhir-properties $FHIR_PROPERTIES
Apr 08, 2021 11:58:36 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation init
INFO: Starting monitor thread
Apr 08, 2021 11:58:36 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation monitorLoop
INFO: monitor probe - checking reindex operation
Apr 08, 2021 11:58:46 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation callOnce
INFO: called $reindex: 200 OK [took 9.507 s]
Apr 08, 2021 11:58:46 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation monitorLoop
INFO: Test probe successful - filling worker pool
Apr 08, 2021 11:58:55 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation callOnce
INFO: called $reindex: 200 OK [took 9.318 s]
Apr 08, 2021 11:58:56 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation callOnce
INFO: called $reindex: 200 OK [took 8.756 s]
...
<< NOTE: kubectl port forward killed here >>
Apr 08, 2021 11:59:03 AM org.apache.http.impl.execchain.RetryExec execute
INFO: I/O exception (org.apache.http.NoHttpResponseException) caught when processing request to {s}->https://localhost:9442: The target server failed to respond
...
Apr 08, 2021 11:59:03 AM org.apache.http.impl.execchain.RetryExec execute
INFO: Retrying request to {s}->https://localhost:9442
...
Apr 08, 2021 11:59:04 AM com.ibm.fhir.bucket.client.FHIRBucketClient post
SEVERE: Error while executing the POST request. org.apache.http.conn.HttpHostConnectException: Connect to localhost:9442 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)
Apr 08, 2021 11:59:04 AM com.ibm.fhir.bucket.client.FHIRBucketClient post
WARNING: POST URL: https://localhost:9442/fhir-server/api/v4/$reindex
Request Body: {"resourceType":"Parameters","parameter":[{"name":"tstamp","valueString":"2021-03-30T00:00:00Z"},{"name":"resourceCount","valueInteger":100}]}
Apr 08, 2021 11:59:04 AM com.ibm.fhir.bucket.client.FHIRBucketClient post
...
Apr 08, 2021 11:59:04 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation callReindexOperation
SEVERE: DataAccessException caught when contacting FHIR server. FHIR client thread will exit.com.ibm.fhir.database.utils.api.DataAccessException: FHIR server connection failed
...
Apr 08, 2021 11:59:06 AM com.ibm.fhir.bucket.reindex.DriveReindexOperation monitorLoop
INFO: monitor probe - checking reindex operation
Apr 08, 2021 11:59:07 AM com.ibm.fhir.bucket.client.FHIRBucketClient post
SEVERE: Error while executing the POST request. org.apache.http.conn.HttpHostConnectException: Connect to localhost:9442 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)
Apr 08, 2021 11:59:07 AM com.ibm.fhir.bucket.client.FHIRBucketClient post
WARNING: POST URL: https://localhost:9442/fhir-server/api/v4/$reindex
Request Body: {"resourceType":"Parameters","parameter":[{"name":"tstamp","valueString":"2021-03-30T00:00:00Z"},{"name":"resourceCount","valueInteger":100}]}
Exception in thread "Thread-1" com.ibm.fhir.database.utils.api.DataAccessException: FHIR server connection failed
        at com.ibm.fhir.bucket.client.FHIRBucketClient.post(FHIRBucketClient.java:314)
        at com.ibm.fhir.bucket.reindex.DriveReindexOperation.callOnce(DriveReindexOperation.java:237)
        at com.ibm.fhir.bucket.reindex.DriveReindexOperation.monitorLoop(DriveReindexOperation.java:123)
        at com.ibm.fhir.bucket.reindex.DriveReindexOperation.lambda$init$0(DriveReindexOperation.java:107)
        at java.base/java.lang.Thread.run(Thread.java:834)

Apr 08, 2021 12:00:04 PM com.ibm.fhir.bucket.app.Main shutdown
INFO: Stopping all services
```