### PR TITLE
add missing definitions to the metatadata swagger

### DIFF
--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -558,6 +558,8 @@ public class FHIROpenApiGenerator {
 
 
         generateDefinition(CapabilityStatement.class, definitions);
+        generateDefinition(Resource.class, definitions);
+        generateDefinition(DomainResource.class, definitions);
 
         // generate definition for all inner classes inside the top level resources.
         for (String innerClassName : getAllResourceInnerClasses()) {

--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/swagger/generator/FHIRSwaggerGenerator.java
@@ -316,6 +316,8 @@ public class FHIRSwaggerGenerator {
 
 
         generateDefinition(CapabilityStatement.class, definitions);
+        generateDefinition(Resource.class, definitions);
+        generateDefinition(DomainResource.class, definitions);
 
         // generate definition for all inner classes inside the top level resources.
         for (String innerClassName : FHIROpenApiGenerator.getAllResourceInnerClasses()) {


### PR DESCRIPTION
specifically, we were missing the definitions for Resource and
DomainResource, which are referenced from the CapabilityStatement
definition

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>