### PR TITLE
update the Resource type discriminator for OpenAPI 3

### DIFF
--- a/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
+++ b/fhir-swagger-generator/src/main/java/com/ibm/fhir/openapi/generator/FHIROpenApiGenerator.java
@@ -1387,7 +1387,8 @@ public class FHIROpenApiGenerator {
             } else {
                 definition.add("type", "object");
                 if (Resource.class.equals(modelClass)) {
-                    definition.add("discriminator", "resourceType");
+                    JsonObject discriminator = factory.createObjectBuilder().add("propertyName", "resourceType").build();
+                    definition.add("discriminator", discriminator);
                 }
                 definition.add("properties", properties);
                 if (!requiredArray.isEmpty()) {


### PR DESCRIPTION
In swagger 2.0, this was a simple string.
However, in OpenAPI 3.0, this became an object (as documented at
https://swagger.io/specification#discriminator-object ) and we just
never noticed til now.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>