### PR TITLE
Avoid use of injected httpHeaders and uriInfo when in client mode

### DIFF
--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRJsonProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRJsonProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,16 +45,19 @@ import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 
+/**
+ * Maps entity streams to/from javax.json objects
+ */
 @Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON })
 public class FHIRJsonProvider implements MessageBodyReader<JsonObject>, MessageBodyWriter<JsonObject> {
     private static final Logger log = Logger.getLogger(FHIRJsonProvider.class.getName());
-    
+
     private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
     private static final JsonWriterFactory JSON_WRITER_FACTORY = Json.createWriterFactory(null);
-    
+
     private final RuntimeType runtimeType;
-    
+
     public FHIRJsonProvider(RuntimeType runtimeType) {
         this.runtimeType = Objects.requireNonNull(runtimeType);
     }
@@ -66,7 +69,7 @@ public class FHIRJsonProvider implements MessageBodyReader<JsonObject>, MessageB
 
     @Override
     public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType,
-        MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         log.entering(this.getClass().getName(), "readFrom");
         try (JsonReader reader = JSON_READER_FACTORY.createReader(nonClosingInputStream(entityStream))) {
             return reader.readObject();
@@ -92,7 +95,7 @@ public class FHIRJsonProvider implements MessageBodyReader<JsonObject>, MessageB
 
     @Override
     public void writeTo(JsonObject t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
-        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         log.entering(this.getClass().getName(), "writeTo");
         try (JsonWriter writer = JSON_WRITER_FACTORY.createWriter(nonClosingOutputStream(entityStream))) {
             writer.writeObject(t);

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -50,6 +50,9 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 
+/**
+ * Maps entity streams to/from fhir-model objects
+ */
 @Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON, FHIRMediaType.APPLICATION_FHIR_XML,
         MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON, FHIRMediaType.APPLICATION_FHIR_XML,
@@ -134,23 +137,25 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
         }
     }
 
-    protected static boolean isPretty(HttpHeaders httpHeaders, UriInfo uriInfo) {
-        // Header evaluation
-        String value = httpHeaders.getHeaderString(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME);
+    protected boolean isPretty(HttpHeaders httpHeaders, UriInfo uriInfo) {
+        if (RuntimeType.SERVER.equals(runtimeType)) {
+            // Header evaluation
+            String value = httpHeaders.getHeaderString(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME);
 
-        // IFF not Header set, then grab the Query Parameter.
-        // and use the FIRST value for _pretty.
-        if (value == null) {
-            value = uriInfo.getQueryParameters().getFirst("_pretty");
-        }
+            // IFF not Header set, then grab the Query Parameter.
+            // and use the FIRST value for _pretty.
+            if (value == null) {
+                value = uriInfo.getQueryParameters().getFirst("_pretty");
+            }
 
-        if (value != null) {
-            if (Boolean.parseBoolean(value)) {
-                //explicitly on in the header
-                return true;
-            } else if ("false".equalsIgnoreCase(value)) {
-                //explicitly off in the header.  ignore header value if it doesn't specify "true" or false"
-                return false;
+            if (value != null) {
+                if (Boolean.parseBoolean(value)) {
+                    //explicitly on in the header
+                    return true;
+                } else if ("false".equalsIgnoreCase(value)) {
+                    //explicitly off in the header.  ignore header value if it doesn't specify "true" or false"
+                    return false;
+                }
             }
         }
 

--- a/fhir-provider/src/test/java/com/ibm/fhir/provider/FHIRProviderTest.java
+++ b/fhir-provider/src/test/java/com/ibm/fhir/provider/FHIRProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.RuntimeType;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -32,7 +33,7 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.config.FHIRConfiguration;
 
 public class FHIRProviderTest {
-    
+
     /*
      * generate multivalued map
      * @param value
@@ -246,29 +247,35 @@ public class FHIRProviderTest {
 
     @Test
     public void isPrettyDefaultsFalse() {
-
         HttpHeaders headers = createHeaders();
+        FHIRProvider fhirProvider = new FHIRProvider(RuntimeType.SERVER);
 
         // when empty
-        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
+        assertFalse(fhirProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
+
         // when populated but misspelled
         headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "nottrue");
-        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
+        assertFalse(fhirProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     @Test
     public void isPrettyTrueForTrue() {
         HttpHeaders headers = createHeaders();
+        FHIRProvider fhirProvider = new FHIRProvider(RuntimeType.SERVER);
+
+        // when populated to true
         headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "true");
-        assertTrue(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
+        assertTrue(fhirProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     @Test
     public void isPrettyFalseForFalse() {
         HttpHeaders headers = createHeaders();
-        headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "false");
+        FHIRProvider fhirProvider = new FHIRProvider(RuntimeType.SERVER);
 
-        assertFalse(FHIRProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
+        // when populated to true
+        headers.getRequestHeaders().putSingle(FHIRConfiguration.DEFAULT_PRETTY_RESPONSE_HEADER_NAME, "false");
+        assertFalse(fhirProvider.isPretty(headers, generatePrettyParameterUriInfo("false")));
     }
 
     private static HttpHeaders createHeaders() {


### PR DESCRIPTION
This change is needed to allow fhir-provider to execute in other
environments such as from within a standalone RestEasy client.

I also converted the static 'isPretty' helper to a member function to
allow access to the instance-level RuntimeType.

I also added javadoc to help distinguish FHIRProvider from
FHIRJsonProvider.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>