### PR TITLE
WHFFHIR-108

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -226,7 +226,7 @@ public class FHIRUtil {
         String causedBy = "";
         while (e != null) {
             msgs.append(causedBy + e.getClass().getSimpleName() + ": "
-                    + (e.getMessage() != null ? e.getMessage().replaceAll("<", "&lt;").replaceAll(">", "&gt;") : "<null message>"));
+                    + (e.getMessage() != null ? e.getMessage().replaceAll("<", "&lt;").replaceAll(">", "&gt;") : "&lt;null message&gt;"));
             e = e.getCause();
             causedBy = System.lineSeparator() + "Caused by: ";
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/FHIRUtil.java
@@ -225,7 +225,8 @@ public class FHIRUtil {
         Throwable e = exception;
         String causedBy = "";
         while (e != null) {
-            msgs.append(causedBy + e.getClass().getSimpleName() + ": " + (e.getMessage() != null ? e.getMessage() : "<null message>"));
+            msgs.append(causedBy + e.getClass().getSimpleName() + ": "
+                    + (e.getMessage() != null ? e.getMessage().replaceAll("<", "&lt;").replaceAll(">", "&gt;") : "<null message>"));
             e = e.getCause();
             causedBy = System.lineSeparator() + "Caused by: ";
 

--- a/fhir-provider/pom.xml
+++ b/fhir-provider/pom.xml
@@ -56,5 +56,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
@@ -93,11 +93,12 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
         } catch (FHIRParserException e) {
             if (RuntimeType.SERVER.equals(runtimeType)) {
                 String acceptHeader = httpHeaders.getFirst(HttpHeaders.ACCEPT);
+                String encMsg = Encode.forHtml(e.getMessage());
                 Response response =
                         buildResponse(
                                 buildOperationOutcome(Collections.singletonList(
                                         buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.INVALID,
-                                                "FHIRProvider: " + e.getMessage(), e.getPath()))),
+                                                "FHIRProvider: " + encMsg, e.getPath()))),
                                 getMediaType(acceptHeader));
                 throw new WebApplicationException(response);
             } else {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -639,7 +639,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle historyBundle = response.getResource(Bundle.class);
         assertNotNull(historyBundle);
-        assertEquals(2, historyBundle.getTotal().getValue());
+        assertEquals(2, historyBundle.getTotal().getValue() * 1); // Testng complained about ambiguity.
 
         // A search that results in multiple matches should result in a 412 status code.
         FHIRParameters multipleMatches = new FHIRParameters().searchParam("status", "final");

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
@@ -323,13 +323,10 @@ public class ServerSpecTest extends FHIRServerTestBase {
         savedObservation = responseObs;
     }
 
-
-
     // Test: create an invalid observation
     @Test(groups = { "server-spec" })
     public void testCreateObservationErrorInvalidResource() throws Exception {
         WebTarget target = getWebTarget();
-
 
         JsonObject observation = BUILDER_FACTORY.createObjectBuilder().add("resourceType", "Observation")
                 .build();
@@ -337,7 +334,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         Entity<JsonObject> entity = Entity.entity(observation, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Observation").request().post(entity, Response.class);
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
-        assertValidationOperationOutcome(response.readEntity(OperationOutcome.class), "Missing required element: 'status'");
+        assertValidationOperationOutcome(response.readEntity(OperationOutcome.class), "Missing required element: &#39;status&#39;");
     }
 
     // Test: include incorrect resource type in request body.
@@ -642,7 +639,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
         Bundle historyBundle = response.getResource(Bundle.class);
         assertNotNull(historyBundle);
-        assertEquals(2, historyBundle.getTotal().getValue().intValue());
+        assertEquals(2, historyBundle.getTotal().getValue());
 
         // A search that results in multiple matches should result in a 412 status code.
         FHIRParameters multipleMatches = new FHIRParameters().searchParam("status", "final");


### PR DESCRIPTION
- Updated fhir-provider/pom.xml to include OWASP Encoder
- Added FHIRProvider encoding for OperationOutcome Messages
- Add defensive code to FHIRUtil, FHIRResource to escape simple HTML

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>