### PR TITLE
Failure acquiring local host IP address results in 400 #2243

### DIFF
--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
@@ -43,13 +43,10 @@ public class IPHandler {
         String ip = null;
         try {
             ip = Inet4Address.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e) {
+        } catch (UnknownHostException | NumberFormatException e) {
             // Defaulting to the localhost, as the machine's name is not registered in the local lookup/dns.
             log.log(Level.SEVERE, "Failure acquiring local host IP address - be sure the name is registered in the name resolution service", e);
             ip = "127.0.0.1";
-        } catch (NumberFormatException e) {
-            // Defaulting to the localhost, as the machine's name is not registered in the local lookup/dns.
-            log.log(Level.SEVERE, "Failure parsing local host IP address '" + ip + "' - be sure the name is registered in the name resolution service" , e);
             ip = "127.0.0.1";
         }
         return ip;

--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
@@ -47,7 +47,6 @@ public class IPHandler {
             // Defaulting to the localhost, as the machine's name is not registered in the local lookup/dns.
             log.log(Level.SEVERE, "Failure acquiring local host IP address - be sure the name is registered in the name resolution service", e);
             ip = "127.0.0.1";
-            ip = "127.0.0.1";
         }
         return ip;
     }

--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/handler/IPHandler.java
@@ -44,9 +44,13 @@ public class IPHandler {
         try {
             ip = Inet4Address.getLocalHost().getHostAddress();
         } catch (UnknownHostException e) {
-            log.log(Level.SEVERE, "Failure acquiring local host IP address", e);
+            // Defaulting to the localhost, as the machine's name is not registered in the local lookup/dns.
+            log.log(Level.SEVERE, "Failure acquiring local host IP address - be sure the name is registered in the name resolution service", e);
+            ip = "127.0.0.1";
         } catch (NumberFormatException e) {
-            log.log(Level.SEVERE, "Failure parsing local host IP address '" + ip + "'", e);
+            // Defaulting to the localhost, as the machine's name is not registered in the local lookup/dns.
+            log.log(Level.SEVERE, "Failure parsing local host IP address '" + ip + "' - be sure the name is registered in the name resolution service" , e);
+            ip = "127.0.0.1";
         }
         return ip;
     }


### PR DESCRIPTION
- Specific to some setups where the name lookup fails.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>