### PR TITLE
Move FHIRUrlParser from fhir-provider to fhir-server

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/common/BulkDataUtils.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/common/BulkDataUtils.java
@@ -56,7 +56,7 @@ import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
-import com.ibm.fhir.provider.util.FHIRUrlParser;
+import com.ibm.fhir.server.util.FHIRUrlParser;
 import com.ibm.fhir.validation.FHIRValidator;
 import com.ibm.fhir.validation.exception.FHIRValidationException;
 

--- a/fhir-provider/pom.xml
+++ b/fhir-provider/pom.xml
@@ -28,18 +28,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -98,7 +98,6 @@ import com.ibm.fhir.persistence.interceptor.impl.FHIRPersistenceInterceptorMgr;
 import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessException;
 import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.profile.ProfileSupport;
-import com.ibm.fhir.provider.util.FHIRUrlParser;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.SummaryValueSet;
 import com.ibm.fhir.search.context.FHIRSearchContext;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRUrlParser.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRUrlParser.java
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.provider.util;
+package com.ibm.fhir.server.util;
 
 import java.nio.charset.StandardCharsets;
 

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRUrlParserTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRUrlParserTest.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2016,2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.provider.util;
+package com.ibm.fhir.server.util;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;


### PR DESCRIPTION
I actually like having this one in fhir-provider, but I was trying to
slim down `fhir-provider` and it was easier to move this than to remove
its unusual dependency on httpclient.

For those using just fhir-provider (and its runtime dependencies), its not a huge savings (9.6 MB to 8.1 MB) but its 4 fewer libs and it'll be nice not to pull in a whole http client for what should be a simple layer on top of fhir-model.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>