### PR TITLE
AuthzPolicyEnforcement changes

### DIFF
--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -8,13 +8,13 @@ package com.ibm.fhir.smart;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.Claim;
@@ -55,7 +55,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     private static final Logger log = Logger.getLogger(AuthzPolicyEnforcementPersistenceInterceptor.class.getName());
 
     private static final String BEARER_TOKEN_PREFIX = "Bearer";
-    private static final String PATIENT_REF_PREFIX = "Patient/";
+    private static final String PATIENT = "Patient";
 
     private static final String REQUEST_NOT_PERMITTED = "Requested interaction is not permitted by any of the passed scopes.";
 
@@ -75,7 +75,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     }
 
     private void enforceDirectPatientAccess(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
-        if ("Patient".equals(event.getFhirResourceType())) {
+        if (PATIENT.equals(event.getFhirResourceType())) {
             DecodedJWT jwt = JWT.decode(getAccessToken());
             List<String> patientIdFromToken = getPatientIdFromToken(jwt);
             if (!patientIdFromToken.contains(event.getFhirResourceId())) {
@@ -123,7 +123,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                     throw new FHIRPersistenceInterceptorException(msg).withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
                 }
                 try {
-                    if (!CompartmentUtil.getCompartmentResourceTypes("Patient").contains(event.getFhirResourceType())) {
+                    if (!CompartmentUtil.getCompartmentResourceTypes(PATIENT).contains(event.getFhirResourceType())) {
                         String msg = "Resource type '" + event.getFhirResourceType() + "' is not valid for Patient compartment search.";
                         throw new FHIRPersistenceInterceptorException(msg).withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.INVALID));
                     }
@@ -132,14 +132,10 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
                 }
             } else {
                 // Not compartment search - validate and convert to Patient compartment search if resource type is member of Patient compartment
-                if ("Patient".equals(event.getFhirResourceType())) {
-                    String msg = "Non-compartment Patient search is not permitted.";
-                    throw new FHIRPersistenceInterceptorException(msg).withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.FORBIDDEN));
-                }
                 try {
-                    if (CompartmentUtil.getCompartmentResourceTypes("Patient").contains(event.getFhirResourceType())) {
+                    if (CompartmentUtil.getCompartmentResourceTypes(PATIENT).contains(event.getFhirResourceType())) {
                         // Build the Patient compartment inclusion criteria search parameter
-                        QueryParameter inclusionCriteria = SearchUtil.buildInclusionCriteria("Patient", patientIdFromToken, event.getFhirResourceType());
+                        QueryParameter inclusionCriteria = SearchUtil.buildInclusionCriteria(PATIENT, patientIdFromToken, event.getFhirResourceType());
 
                         // Add the inclusion criteria parameter to the front of the search parameter list
                         searchContext.getSearchParameters().add(0, inclusionCriteria);
@@ -456,17 +452,19 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
      * @param node
      * @return the id to the Patient resource referenced by this node (assuming it is a Reference with a valid
      *         reference value); otherwise null
+     * @throws FHIRSearchException
      */
-    private String getPatientRefVal(FHIRPathNode node) {
+    private String getPatientRefVal(FHIRPathNode node) throws FHIRSearchException {
         if (!node.isElementNode() || !node.asElementNode().element().is(Reference.class)) {
             throw new IllegalStateException("Patient compartment inclusionCriteria expression has returned a non-Reference");
         }
+
         Reference reference = node.asElementNode().element().as(Reference.class);
-        if (reference.getReference() != null && reference.getReference().hasValue()) {
-            String refVal = reference.getReference().getValue();
-            if (refVal != null && refVal.startsWith(PATIENT_REF_PREFIX)) {
-                return refVal.substring(PATIENT_REF_PREFIX.length());
-            }
+        ReferenceValue refValue = ReferenceUtil.createReferenceValueFrom(reference, ReferenceUtil.getServiceBaseUrl());
+
+        if (refValue.getType() == com.ibm.fhir.search.util.ReferenceValue.ReferenceType.LITERAL_RELATIVE &&
+                PATIENT.equals(refValue.getTargetResourceType())) {
+            return refValue.getValue();
         } else if (log.isLoggable(Level.FINE)){
             log.fine("Skipping non-patient / non-relative reference: '" + reference + "'");
         }
@@ -539,10 +537,12 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
 
         String patientId = claim.asString();
         if (patientId == null) {
-            log.fine("Found patient_id claim was expected to be a string but is not; processing as a list");
             return claim.asList(String.class);
         }
 
-        return Collections.singletonList(patientId);
+        return Stream.of(patientId.split(" "))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
     }
 }

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.smart.test;
 
 import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.model.type.code.ResourceType.ValueSet.CONDITION;
 import static com.ibm.fhir.model.type.code.ResourceType.ValueSet.OBSERVATION;
 import static com.ibm.fhir.model.type.code.ResourceType.ValueSet.PATIENT;
 import static com.ibm.fhir.model.type.code.ResourceType.ValueSet.PROVENANCE;
@@ -34,6 +35,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Condition;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Practitioner;
@@ -55,6 +57,7 @@ import com.ibm.fhir.smart.Scope.Permission;
 public class AuthzPolicyEnforcementTest {
     private static final String PATIENT_ID =     "11111111-1111-1111-1111-111111111111";
     private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String CONDITION_ID =   "11111111-1111-1111-1111-111111111111";
 
     private static final List<Permission> READ_APPROVED = Arrays.asList(Permission.READ, Permission.ALL);
     private static final List<Permission> WRITE_APPROVED = Arrays.asList(Permission.WRITE, Permission.ALL);
@@ -62,6 +65,7 @@ public class AuthzPolicyEnforcementTest {
     private AuthzPolicyEnforcementPersistenceInterceptor interceptor;
     private Patient patient;
     private Observation observation;
+    private Condition condition;
     private Provenance patientProvenance;
     private Provenance observationProvenance;
     private Map<String, Object> properties;
@@ -78,7 +82,7 @@ public class AuthzPolicyEnforcementTest {
 
         Provenance provenanceBase = TestUtil.getMinimalResource(ResourceType.PROVENANCE);
 
-        patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
         patient = patient.toBuilder()
                 .id(PATIENT_ID)
                 .build();
@@ -89,7 +93,7 @@ public class AuthzPolicyEnforcementTest {
                     .build())
                 .build();
 
-        observation = TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json");
+        observation = TestUtil.getMinimalResource(ResourceType.OBSERVATION);
         observation = observation.toBuilder()
                 .id(OBSERVATION_ID)
                 .subject(Reference.builder().reference(string("Patient/" + PATIENT_ID)).build())
@@ -98,6 +102,13 @@ public class AuthzPolicyEnforcementTest {
         observationProvenance = provenanceBase.toBuilder()
                 .target(Reference.builder()
                     .reference(string("Observation/" + OBSERVATION_ID))
+                    .build())
+                .build();
+
+        condition = TestUtil.getMinimalResource(ResourceType.CONDITION);
+        condition = condition.toBuilder()
+                .subject(Reference.builder()
+                    .reference(string("Patient/" + PATIENT_ID + "/_history/1"))
                     .build())
                 .build();
 
@@ -128,6 +139,15 @@ public class AuthzPolicyEnforcementTest {
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, WRITE_APPROVED, permission));
         }
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(condition, properties);
+            interceptor.beforeCreate(event);
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
+        }
     }
 
     @Test(dataProvider = "scopeStringProvider")
@@ -157,6 +177,18 @@ public class AuthzPolicyEnforcementTest {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission) &&
                         shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, WRITE_APPROVED, permission));
         }
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(condition, properties);
+            event.setPrevFhirResource(condition);
+            interceptor.beforeUpdate(event);
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission) &&
+                        shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission) &&
+                        shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
+        }
     }
 
     @Test(dataProvider = "scopeStringProvider")
@@ -180,6 +212,15 @@ public class AuthzPolicyEnforcementTest {
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, WRITE_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, WRITE_APPROVED, permission));
+        }
+
+        try {properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent();
+            event.setPrevFhirResource(condition);
+            interceptor.beforeDelete(event);
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
         }
     }
 
@@ -311,7 +352,7 @@ public class AuthzPolicyEnforcementTest {
             fail("Patient interaction was not allowed but should have been");
         }
 
-        // Valid non-compartment search: converted to Patient compartment search and compartment search parms first in list
+        // Valid non-compartment search: converted to Patient compartment search and compartment search parm is first in list
         try {
             searchContext = new FHIRSearchContextImpl();
             QueryParameterValue queryParm1Value = new QueryParameterValue();
@@ -338,6 +379,22 @@ public class AuthzPolicyEnforcementTest {
             fail("Patient interaction was not allowed but should have been");
         }
 
+        // Valid non-compartment search: Patient search is now allowed, but converted to a compartment search
+        try {
+            searchContext = new FHIRSearchContextImpl();
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            assertEquals(1, searchContext.getSearchParameters().size());
+            for (QueryParameter searchParameter : searchContext.getSearchParameters()) {
+                assertTrue(searchParameter.isInclusionCriteria());
+                assertEquals("Patient/" + PATIENT_ID, searchParameter.getValues().get(0).getValueString());
+            }
+        } catch (FHIRPersistenceInterceptorException e) {
+            fail("Patient interaction was not allowed but should have been");
+        }
+
         // Valid non-compartment search: resource type not in Patient compartment so not converted to compartment search
         try {
             searchContext = new FHIRSearchContextImpl();
@@ -345,24 +402,9 @@ public class AuthzPolicyEnforcementTest {
             properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
             FHIRPersistenceEvent event = new FHIRPersistenceEvent(practitioner, properties);
             interceptor.beforeSearch(event);
-            assertEquals(0, searchContext.getSearchParameters().size());
+            assertEquals(searchContext.getSearchParameters().size(), 0);
         } catch (FHIRPersistenceInterceptorException e) {
             fail("Patient interaction was not allowed but should have been");
-        }
-
-        // Invalid non-compartment search: resource type is Patient
-        try {
-            searchContext = new FHIRSearchContextImpl();
-            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
-            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
-            FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-            interceptor.beforeSearch(event);
-            fail("Patient interaction was allowed but should not be");
-        } catch (FHIRPersistenceInterceptorException e) {
-            // success
-            assertEquals(1, e.getIssues().size());
-            assertEquals(IssueType.FORBIDDEN, e.getIssues().get(0).getCode());
-            assertEquals("Non-compartment Patient search is not permitted.", e.getIssues().get(0).getDetails().getText().getValue());
         }
     }
 
@@ -386,6 +428,15 @@ public class AuthzPolicyEnforcementTest {
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission));
+        }
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(condition, properties);
+            interceptor.afterRead(event);
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
         }
 
         try {
@@ -428,6 +479,15 @@ public class AuthzPolicyEnforcementTest {
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(typesPermittedByScopes, OBSERVATION, READ_APPROVED, permission));
         }
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(condition, properties);
+            interceptor.afterVread(event);
+            assertTrue(shouldSucceed(typesPermittedByScopes, CONDITION, READ_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(typesPermittedByScopes, CONDITION, READ_APPROVED, permission));
+        }
     }
 
     @Test(dataProvider = "scopeStringProvider")
@@ -459,6 +519,19 @@ public class AuthzPolicyEnforcementTest {
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission));
         }
+
+        try {
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
+            Bundle historyBundle = Bundle.builder()
+                    .type(BundleType.HISTORY)
+                    .entry(Bundle.Entry.builder().resource(condition).build())
+                    .build();
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(historyBundle, properties);
+            interceptor.afterHistory(event);
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
+        }
     }
 
     @Test(dataProvider = "scopeStringProvider")
@@ -488,6 +561,19 @@ public class AuthzPolicyEnforcementTest {
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {
             assertFalse(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, READ_APPROVED, permission));
+        }
+
+        try {
+            Bundle searchBundle = Bundle.builder()
+                    .type(BundleType.SEARCHSET)
+                    .entry(Bundle.Entry.builder().resource(condition).build())
+                    .build();
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(searchBundle, properties);
+            interceptor.afterSearch(event);
+
+            assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
+        } catch (FHIRPersistenceInterceptorException e) {
+            assertFalse(shouldSucceed(resourceTypesPermittedByScope, CONDITION, READ_APPROVED, permission));
         }
 
         try {


### PR DESCRIPTION
1. getPatientRefValue now uses ReferenceUtil to obtain the id of the
target Patient being referenced. This technique matches what we do
during the extraction of the compartment membership param and is more
robust to special reference values like versioned references or absolute
references that match the base server url.

2. getPatientIdFromToken will now split the patient_id claim on spaces.
This sets us up for scenarios where a single token can grant access to
multiple patient records. Additionally, I removed the log statement
about expecting patient_id to be a string and not a list.

3. Patient search is now allowed. Because we convert all searches into
compartment searches, there is no longer a risk of exposing whether a
given Patient resource by a given id exists or not. Therefore, we don't
need to prevent such searches any longer. That said, because a Patient
is not in its own compartment (unless it has a corresponding
Patient.link), Patient search behavior will likely to be confusing to
clients and so operators may want to continue to disallow Patient search 
from the REST layer in select deployments.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>