### PR TITLE
Issue #2198 - getConcept should return null for responses other than 200

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/RemoteTermServiceProviderTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/RemoteTermServiceProviderTest.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.server.test;
 import static com.ibm.fhir.model.type.String.string;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Collections;
@@ -84,6 +85,12 @@ public class RemoteTermServiceProviderTest extends FHIRServerTestBase {
         Concept concept = provider.getConcept(codeSystem, Code.of("a"));
         assertNotNull(concept);
         assertEquals(concept.getCode(), Code.of("a"));
+    }
+
+    @Test(dependsOnMethods = { "testCreateCodeSystem", "testCreateRemoteTermServiceProvider" })
+    public void testRemoteTermServiceProviderGetConceptNotFound() {
+        Concept concept = provider.getConcept(codeSystem, Code.of("zzz"));
+        assertNull(concept);
     }
 
     @Test(dependsOnMethods = { "testCreateCodeSystem", "testCreateRemoteTermServiceProvider" })

--- a/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
+++ b/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
@@ -185,7 +185,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                 return toConcept(code, parameters);
             }
 
-            throw errorOccurred(response, "CodeSystem $lookup");
+            return null;
         } finally {
             if (response != null) {
                 response.close();


### PR DESCRIPTION
Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>

`RemoteTermServiceProvider.getConcept` throws an Exception for responses other than OK (200). However, in order to be aligned with the `getConcept` contract, we should return null instead.