### PR TITLE
issue #1852 - remove requestProperties from all FHIRRestHelper methods

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIROperationContext.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIROperationContext.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,7 +27,7 @@ public class FHIROperationContext {
      * This property is of type String and represents the value of the Location header.
      */
     public static final String PROPNAME_LOCATION_URI = "LOCATION_URI";
-    
+
     /**
      * This property is of type FHIRPersistence and is the handle to the persistence layer implementation
      * being used by the FHIR Server while processing the current request.
@@ -35,41 +35,35 @@ public class FHIROperationContext {
      * this property unless you have been advised otherwise.
      */
     public static final String PROPNAME_PERSISTENCE_IMPL = "PERSISTENCE_IMPL";
-    
+
     /**
      * This property is of type javax.ws.rs.core.UriInfo and contains Application and Request
      * URI information associated with the REST API request for which the interceptor is being invoked.
      */
     public static final String PROPNAME_URI_INFO = "URI_INFO";
-    
+
     /**
      * This property is of type javax.ws.rs.core.HttpHeaders and contains the set of HTTP headers
      * associated with the REST API request.
      */
     public static final String PROPNAME_HTTP_HEADERS = "HTTP_HEADERS";
-    
-    /**
-     * This property is of type {@link java.util.Map<String,String>} and contains the
-     * set of additional request properties associated with the REST API request.
-     */
-    public static final String PROPNAME_REQUEST_PROPERTIES = "REQUEST_PROPERTIES";
 
     /**
      * This property is of type javax.ws.rs.core.SecurityContext and contains security-related information
      * associated with the REST API request for which the interceptor is being invoked.
      */
     public static final String PROPNAME_SECURITY_CONTEXT = "SECURITY_CONTEXT";
-    
+
     /**
-     *This property is of type HttpMethod 
+     *This property is of type HttpMethod
      */
     public static final String PROPNAME_METHOD_TYPE = "METHOD_TYPE";
-    
+
     /**
-     * The property is of Response.Status. 
+     * The property is of Response.Status.
      */
     public static final String PROPNAME_STATUS_TYPE = "STATUS";
-    
+
     /**
      * The property is of the Response
      */
@@ -77,7 +71,7 @@ public class FHIROperationContext {
 
     private Type type = null;
     private Map<String, Object> properties = null;
-    
+
     private FHIROperationContext(Type type) {
         if (type == null) {
             throw new IllegalArgumentException("Context type cannot be null");
@@ -85,19 +79,19 @@ public class FHIROperationContext {
         this.type = type;
         properties = new HashMap<String, Object>();
     }
-    
+
     public Type getType() {
         return type;
     }
-    
+
     public void setProperty(String name, Object value) {
         properties.put(name, value);
     }
-    
+
     public Object getProperty(String name) {
         return properties.get(name);
     }
-    
+
     /**
      * Returns the HttpHeaders instance associated with the request that triggered the operation.
      * Note that this HttpHeaders instance is only valid within the scope of a single request.
@@ -105,46 +99,32 @@ public class FHIROperationContext {
     public HttpHeaders getHttpHeaders() {
         return (HttpHeaders) getProperty(PROPNAME_HTTP_HEADERS);
     }
-    
-    /**
-     * Returns the Map containing additional request properties associated with the 
-     * FHIR REST API request that triggered the interceptor invocation.
-     */
-    @SuppressWarnings("unchecked")
-    public Map<String, String> getRequestProperties() {
-        return (Map<String, String>) getProperty(PROPNAME_REQUEST_PROPERTIES);
-    }
-    
+
     public static FHIROperationContext createSystemOperationContext() {
         return new FHIROperationContext(Type.SYSTEM);
     }
-    
+
     public static FHIROperationContext createResourceTypeOperationContext() {
         return new FHIROperationContext(Type.RESOURCE_TYPE);
     }
-    
+
     public static FHIROperationContext createInstanceOperationContext() {
         return new FHIROperationContext(Type.INSTANCE);
     }
-    
+
     /**
-     * Retrieves the specified header from the combined list of request headers
-     * and additional request properties associated with the request.
+     * Retrieves the specified header from the list of request headers.
      * @param headerName the name of the header to retrieve
      * @return the value of the request header or null if not present
      */
     public String getHeaderString(String headerName) {
         String value = null;
-        Map<String, String> props = getRequestProperties();
-        if (props != null) {
-            value = props.get(headerName);
-        }
-        if (value == null && getHttpHeaders() != null) {
+        if (getHttpHeaders() != null) {
             value = getHttpHeaders().getHeaderString(headerName);
         }
         return value;
     }
-    
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -152,7 +132,7 @@ public class FHIROperationContext {
         sb.append("type=" + type.name());
         sb.append(", properties={").append((properties != null ? properties.toString() : "<null>")).append("}");
         sb.append("]");
-        
+
         return sb.toString();
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
@@ -7,7 +7,6 @@
 package com.ibm.fhir.server.operation.spi;
 
 import java.time.Instant;
-import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -36,13 +35,11 @@ public interface FHIRResourceHelpers {
      *            the Resource to be stored.
      * @param ifNoneExist
      *            whether to create the resource if none exists
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
      * @return a FHIRRestOperationResponse object containing the results of the operation
      * @throws Exception
      */
-    default FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist, Map<String, String> requestProperties) throws Exception {
-        return doCreate(type, resource, ifNoneExist, requestProperties, DO_VALIDATION);
+    default FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist) throws Exception {
+        return doCreate(type, resource, ifNoneExist, DO_VALIDATION);
     }
 
     /**
@@ -54,14 +51,12 @@ public interface FHIRResourceHelpers {
      *            the Resource to be stored.
      * @param ifNoneExist
      *            whether to create the resource if none exists
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
      * @param doValidation
      *            if true, validate the resource; if false, assume the resource has already been validated
      * @return a FHIRRestOperationResponse object containing the results of the operation
      * @throws Exception
      */
-    public FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist, Map<String, String> requestProperties, boolean doValidation) throws Exception;
+    FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist, boolean doValidation) throws Exception;
 
     /**
      * Performs an update operation (a new version of the Resource will be stored). Validates the resource.
@@ -83,8 +78,8 @@ public interface FHIRResourceHelpers {
      * @throws Exception
      */
     default FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
-            String searchQueryString, Map<String, String> requestProperties, boolean skippableUpdate) throws Exception {
-        return doUpdate(type, id, newResource, ifMatchValue, searchQueryString, requestProperties, skippableUpdate, DO_VALIDATION);
+            String searchQueryString, boolean skippableUpdate) throws Exception {
+        return doUpdate(type, id, newResource, ifMatchValue, searchQueryString, skippableUpdate, DO_VALIDATION);
     }
 
     /**
@@ -108,8 +103,8 @@ public interface FHIRResourceHelpers {
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
      */
-    public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
-            String searchQueryString, Map<String, String> requestPropertie, boolean skippableUpdate, boolean doValidation) throws Exception;
+    FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
+            String searchQueryString, boolean skippableUpdate, boolean doValidation) throws Exception;
 
     /**
      * Performs a patch operation (a new version of the Resource will be stored).
@@ -130,8 +125,8 @@ public interface FHIRResourceHelpers {
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
      */
-    public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue,
-            String searchQueryString, Map<String, String> requestProperties, boolean skippableUpdate) throws Exception;
+    FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue,
+            String searchQueryString, boolean skippableUpdate) throws Exception;
 
 
     /**
@@ -144,7 +139,7 @@ public interface FHIRResourceHelpers {
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
      */
-    public FHIRRestOperationResponse doDelete(String type, String id, String searchQueryString, Map<String, String> requestProperties) throws Exception;
+    FHIRRestOperationResponse doDelete(String type, String id, String searchQueryString) throws Exception;
 
     /**
      * Performs a 'read' operation to retrieve a Resource.
@@ -153,26 +148,58 @@ public interface FHIRResourceHelpers {
      *            the resource type associated with the Resource to be retrieved
      * @param id
      *            the id of the Resource to be retrieved
+     * @param throwExcOnNull
+     *            whether to throw an exception on null
+     * @param includeDeleted
+     *            allow the read, even if the resource has been deleted
+     * @param contextResource
+     *            the resource
      * @param queryParameters
      *            for supporting _elements and _summary for resource read
      * @return the Resource
      * @throws Exception
      */
-    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted, Map<String, String> requestProperties,
-            Resource contextResource, MultivaluedMap<String, String> queryParameters) throws Exception;
+    default Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            Resource contextResource) throws Exception {
+        return doRead(type, id, throwExcOnNull, includeDeleted, contextResource, null);
+    }
 
     /**
-     * Performs a 'read' operation to retrieve a Resource.
+     * Performs a 'read' operation to retrieve a Resource with select query parameters.
      *
      * @param type
      *            the resource type associated with the Resource to be retrieved
      * @param id
      *            the id of the Resource to be retrieved
+     * @param throwExcOnNull
+     *            whether to throw an exception on null
+     * @param includeDeleted
+     *            allow the read, even if the resource has been deleted
+     * @param contextResource
+     *            the resource
+     * @param queryParameters
+     *            for supporting _elements and _summary for resource read
      * @return the Resource
      * @throws Exception
      */
-    public Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted, Map<String, String> requestProperties,
-            Resource contextResource) throws Exception;
+    Resource doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            Resource contextResource, MultivaluedMap<String, String> queryParameters) throws Exception;
+
+    /**
+     * Performs a 'vread' operation by retrieving the specified version of a Resource with no query parameters
+     *
+     * @param type
+     *            the resource type associated with the Resource to be retrieved
+     * @param id
+     *            the id of the Resource to be retrieved
+     * @param versionId
+     *            the version id of the Resource to be retrieved
+     * @return the Resource
+     * @throws Exception
+     */
+    default Resource doVRead(String type, String id, String versionId) throws Exception {
+        return doVRead(type, id, versionId, null);
+    }
 
     /**
      * Performs a 'vread' operation by retrieving the specified version of a Resource.
@@ -183,31 +210,12 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param versionId
      *            the version id of the Resource to be retrieved
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
      * @param queryParameters
      *            for supporting _elements and _summary for resource vread
      * @return the Resource
      * @throws Exception
      */
-    public Resource doVRead(String type, String id, String versionId, Map<String, String> requestProperties,
-            MultivaluedMap<String, String> queryParameters) throws Exception;
-
-    /**
-     * Performs a 'vread' operation by retrieving the specified version of a Resource.
-     *
-     * @param type
-     *            the resource type associated with the Resource to be retrieved
-     * @param id
-     *            the id of the Resource to be retrieved
-     * @param versionId
-     *            the version id of the Resource to be retrieved
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
-     * @return the Resource
-     * @throws Exception
-     */
-    public Resource doVRead(String type, String id, String versionId, Map<String, String> requestProperties) throws Exception;
+    Resource doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception;
 
     /**
      * Performs the work of retrieving versions of a Resource.
@@ -219,12 +227,10 @@ public interface FHIRResourceHelpers {
      * @param queryParameters
      *            a Map containing the query parameters from the request URL
      * @param requestUri
-     * @param requestProperties
      * @return a Bundle containing the history of the specified Resource
      * @throws Exception
      */
-    public Bundle doHistory(String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri,
-            Map<String, String> requestProperties) throws Exception;
+    Bundle doHistory(String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri) throws Exception;
 
     /**
      * Implement the system level history operation to obtain a list of changes to resources
@@ -232,24 +238,32 @@ public interface FHIRResourceHelpers {
      * @param queryParameters
      *            a Map containing the query parameters from the request URL
      * @param requestUri
-     * @param requestProperties
+     *            the request URI
      * @return a Bundle containing the history of the specified Resource
      * @throws Exception
      */
-    public Bundle doHistory(MultivaluedMap<String, String> queryParameters, String requestUri, Map<String, String> requestProperties) throws Exception;
+    Bundle doHistory(MultivaluedMap<String, String> queryParameters, String requestUri) throws Exception;
 
     /**
      * Performs heavy lifting associated with a 'search' operation.
      *
      * @param type
      *            the resource type associated with the search
+     * @param compartment
+     *            the compartment type to search in, or null if not a compartment search
+     * @param compartmentId
+     *            the specific compartment to search in, or null if not a compartment search
      * @param queryParameters
      *            a Map containing the query parameters from the request URL
+     * @param requestUri
+     *            the request URI
+     * @param contextResource
+     *            the resource context
      * @return a Bundle containing the search result set
      * @throws Exception
      */
-    public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
-            String requestUri, Map<String, String> requestProperties, Resource contextResource) throws Exception;
+    Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
+            String requestUri, Resource contextResource) throws Exception;
 
 
     /**
@@ -270,13 +284,11 @@ public interface FHIRResourceHelpers {
      * @param queryParameters
      *            query parameters may be passed instead of a Parameters resource for certain custom operations invoked
      *            via GET
-     * @param requestProperties
-     *            additional request properties which supplement the HTTP headers associated with this request
      * @return a Resource that represents the response to the custom operation
      * @throws Exception
      */
-    public Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName, String logicalId, String versionId, String operationName,
-            Resource resource, MultivaluedMap<String, String> queryParameters, Map<String, String> requestProperties) throws Exception;
+    Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName, String logicalId, String versionId, String operationName,
+            Resource resource, MultivaluedMap<String, String> queryParameters) throws Exception;
 
     /**
      * Processes a bundled request (batch or transaction type).
@@ -285,9 +297,9 @@ public interface FHIRResourceHelpers {
      *            the request Bundle
      * @return the response Bundle
      */
-    public Bundle doBundle(Bundle bundle, Map<String, String> requestProperties) throws Exception;
+    Bundle doBundle(Bundle bundle) throws Exception;
 
-    public FHIRPersistenceTransaction getTransaction() throws Exception;
+    FHIRPersistenceTransaction getTransaction() throws Exception;
 
     /**
      * Invoke the FHIR persistence reindex operation for a randomly chosen resource which was
@@ -299,5 +311,5 @@ public interface FHIRResourceHelpers {
      * @return number of resources reindexed (0 if no resources were found to reindex)
      * @throws Exception
      */
-    public int doReindex(FHIROperationContext operationContext, OperationOutcome.Builder operationOutcomeResult, Instant tstamp, String resourceLogicalId) throws Exception;
+    int doReindex(FHIROperationContext operationContext, OperationOutcome.Builder operationOutcomeResult, Instant tstamp, String resourceLogicalId) throws Exception;
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -74,7 +74,7 @@ public class Batch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            responseBundle = helper.doBundle(inputBundle, null);
+            responseBundle = helper.doBundle(inputBundle);
             status = Status.OK;
             return Response.ok(responseBundle).build();
         } catch (FHIRRestBundledRequestException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -22,8 +21,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -43,12 +40,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Batch extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Batch.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Batch() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -46,7 +46,7 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Create extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Create.class.getName());
-    
+
     // The JWT of the current caller. Since this is a request scoped resource, the
     // JWT will be injected for each JAX-RS request. The injection is performed by
     // the mpJwt feature.
@@ -80,7 +80,7 @@ public class Create extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doCreate(type, resource, ifNoneExist, null);
+            ior = helper.doCreate(type, resource, ifNoneExist);
 
             ResponseBuilder response =
                     Response.created(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -25,8 +24,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRMediaType;
@@ -46,12 +43,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Create extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Create.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     /**
      * This HL7-defined extension header supports "conditional create", allowing a client to create a new resource only if some equivalent

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
@@ -24,8 +23,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -44,12 +41,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Delete extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Delete.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Delete() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -67,7 +67,7 @@ public class Delete extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doDelete(type, id, null, null);
+            ior = helper.doDelete(type, id, null);
             status = ior.getStatus();
             return buildResponse(ior);
         } catch (FHIRPersistenceNotSupportedException e) {
@@ -111,7 +111,7 @@ public class Delete extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doDelete(type, null, searchQueryString, null);
+            ior = helper.doDelete(type, null, searchQueryString);
             status = ior.getStatus();
             return buildResponse(ior);
         } catch (FHIRPersistenceNotSupportedException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -64,7 +64,7 @@ public class History extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri(), null);
+            bundle = helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri());
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
@@ -97,7 +97,7 @@ public class History extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doHistory(uriInfo.getQueryParameters(), getRequestUri(), null);
+            bundle = helper.doHistory(uriInfo.getQueryParameters(), getRequestUri());
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -23,8 +22,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -41,12 +38,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class History extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(History.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public History() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -84,7 +84,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
+                    null, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, null, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -125,7 +125,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, null, null, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
+                    resource, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, null, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -167,8 +167,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result =
-                    helper.doInvoke(operationContext, null, null, null, operationName, null,
-                            uriInfo.getQueryParameters(), null);
+                    helper.doInvoke(operationContext, null, null, null, operationName, null, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, null, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -210,7 +209,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
+                    null, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -252,7 +251,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
+                    resource, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -308,7 +307,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
-                    null, uriInfo.getQueryParameters(), null);
+                    null, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -351,7 +350,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
+                    resource, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -395,7 +394,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,
-                    null, uriInfo.getQueryParameters(), null);
+                    null, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
@@ -439,7 +438,7 @@ public class Operation extends FHIRResource {
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,
-                    resource, uriInfo.getQueryParameters(), null);
+                    resource, uriInfo.getQueryParameters());
             Response response = buildResponse(operationContext, resourceTypeName, result);
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -16,7 +16,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -30,8 +29,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -51,12 +48,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Operation extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Operation.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Operation() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.json.JsonArray;
 import javax.json.JsonPatch;
 import javax.json.JsonValue;
@@ -28,8 +27,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRConstants;
@@ -58,12 +55,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Patch extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Patch.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Patch() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -86,7 +86,7 @@ public class Patch extends FHIRResource {
             FHIRPatch patch = createPatch(array);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, ifMatch, null, null, onlyIfModified);
+            ior = helper.doPatch(type, id, patch, ifMatch, null, onlyIfModified);
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)
@@ -143,7 +143,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, id, patch, ifMatch, null, null, onlyIfModified);
+            ior = helper.doPatch(type, id, patch, ifMatch, null, onlyIfModified);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -206,7 +206,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, null, onlyIfModified);
+            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, onlyIfModified);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -274,7 +274,7 @@ public class Patch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, null, onlyIfModified);
+            ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, onlyIfModified);
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -15,7 +15,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -28,8 +27,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -47,12 +44,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Read extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Read.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Read() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -73,7 +73,7 @@ public class Read extends FHIRResource {
             long modifiedSince = parseIfModifiedSince();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource resource = helper.doRead(type, id, true, false, null, null, queryParameters);
+            Resource resource = helper.doRead(type, id, true, false, null, queryParameters);
             int version2Match = -1;
             // Support ETag value with or without " (and W/)
             // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -25,8 +24,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -43,12 +40,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Search extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Search.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Search() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -79,7 +79,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null, null);
+            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null);
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
@@ -127,7 +127,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null, null);
+            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null);
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
@@ -173,7 +173,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null, null);
+            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null);
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
@@ -26,8 +25,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.core.FHIRConstants;
@@ -50,12 +47,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class Update extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(Update.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public Update() throws Exception {
         super();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -74,7 +74,7 @@ public class Update extends FHIRResource {
             checkInitComplete();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, id, resource, ifMatch, null, null, onlyIfModified);
+            ior = helper.doUpdate(type, id, resource, ifMatch, null, onlyIfModified);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
@@ -134,7 +134,7 @@ public class Update extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            ior = helper.doUpdate(type, null, resource, ifMatch, searchQueryString, null, onlyIfModified);
+            ior = helper.doUpdate(type, null, resource, ifMatch, searchQueryString, onlyIfModified);
 
             ResponseBuilder response =
                     Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -68,7 +68,7 @@ public class VRead extends FHIRResource {
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            Resource resource = helper.doVRead(type, id, vid, null, queryParameters);
+            Resource resource = helper.doVRead(type, id, vid, queryParameters);
             status = Status.OK;
             ResponseBuilder response = Response.ok().entity(resource);
             response = addHeaders(response, resource);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -14,7 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -25,8 +24,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
-
-import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -44,12 +41,6 @@ import com.ibm.fhir.server.util.RestAuditLogger;
 @RequestScoped
 public class VRead extends FHIRResource {
     private static final Logger log = java.util.logging.Logger.getLogger(VRead.class.getName());
-
-    // The JWT of the current caller. Since this is a request scoped resource, the
-    // JWT will be injected for each JAX-RS request. The injection is performed by
-    // the mpJwt feature.
-    @Inject
-    private JsonWebToken jwt;
 
     public VRead() throws Exception {
         super();

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -100,7 +100,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doCreate("Patient", patient, null, null, false);
+            FHIRRestOperationResponse response = helper.doCreate("Patient", patient, null, false);
             assertEquals(ALL_OK, response.getOperationOutcome());
         } catch (FHIROperationException e) {
             fail();
@@ -127,7 +127,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, null, false);
+            FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, false);
             assertEquals(ALL_OK, response.getOperationOutcome());
         } catch (FHIROperationException e) {
             fail();
@@ -154,7 +154,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, null, false);
+            FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, false);
             assertEquals(ALL_OK, response.getOperationOutcome());
         } catch (FHIROperationException e) {
             fail();
@@ -181,7 +181,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, false);
+            helper.doCreate("Patient", patient, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -214,7 +214,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Encounter", encounter, null, null, false);
+            helper.doCreate("Encounter", encounter, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -254,7 +254,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Procedure", procedure, null, null, false);
+            helper.doCreate("Procedure", procedure, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -294,7 +294,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Procedure", procedure, null, null, false);
+            helper.doCreate("Procedure", procedure, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -321,7 +321,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Practitioner", practitioner, null, null, false);
+            helper.doCreate("Practitioner", practitioner, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -693,7 +693,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doHistory("Patient", "1", new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doHistory("Patient", "1", new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -711,7 +711,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -729,7 +729,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -747,7 +747,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doHistory("Patient", "1", new MultivaluedHashMap<>(), null, null);
+            helper.doHistory("Patient", "1", new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -771,7 +771,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), null, null);
+            helper.doHistory("Encounter", "1", new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -795,7 +795,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doHistory("Procedure", "1", new MultivaluedHashMap<>(), null, null);
+            helper.doHistory("Procedure", "1", new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -819,7 +819,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doHistory("Procedure", "1", new MultivaluedHashMap<>(), null, null);
+            helper.doHistory("Procedure", "1", new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -843,7 +843,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doHistory("Practitioner", "1", new MultivaluedHashMap<>(), null, null);
+            helper.doHistory("Practitioner", "1", new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -867,7 +867,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), "test", null, null);
+            Bundle bundle = helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), "test", null);
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -885,7 +885,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null, null);
+            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null);
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -903,7 +903,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null, null);
+            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null);
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -921,7 +921,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), null, null, null);
+            helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -945,7 +945,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), null, null, null);
+            helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -969,7 +969,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null, null);
+            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -993,7 +993,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null, null);
+            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1017,7 +1017,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Practitioner", null, null, new MultivaluedHashMap<>(), null, null, null);
+            helper.doSearch("Practitioner", null, null, new MultivaluedHashMap<>(), null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1051,7 +1051,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doUpdate("Patient", "1", patient, null, null, null, false, false);
+            FHIRRestOperationResponse response = helper.doUpdate("Patient", "1", patient, null, null, false, false);
             assertEquals(ALL_OK, response.getOperationOutcome());
         } catch (FHIROperationException e) {
             fail();
@@ -1079,7 +1079,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doUpdate("Encounter", "1", encounter, null, null, null, false, false);
+            FHIRRestOperationResponse response = helper.doUpdate("Encounter", "1", encounter, null, null, false, false);
             assertEquals(response.getOperationOutcome(), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
@@ -1107,7 +1107,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doUpdate("Encounter", "1", encounter, null, null, null, false, false);
+            FHIRRestOperationResponse response = helper.doUpdate("Encounter", "1", encounter, null, null, false, false);
             assertEquals(response.getOperationOutcome(), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
@@ -1134,7 +1134,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Patient", "1", patient, null, null, null, false, false);
+            helper.doUpdate("Patient", "1", patient, null, null, false, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1167,7 +1167,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Encounter", "1", encounter, null, null, null, false, false);
+            helper.doUpdate("Encounter", "1", encounter, null, null, false, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1200,7 +1200,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Encounter", "1", encounter, null, null, null, false, false);
+            helper.doUpdate("Encounter", "1", encounter, null, null, false, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1240,7 +1240,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Procedure", "1", procedure, null, null, null, false, false);
+            helper.doUpdate("Procedure", "1", procedure, null, null, false, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1267,7 +1267,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Practitioner", "1", practitioner, null, null, null, false, false);
+            helper.doUpdate("Practitioner", "1", practitioner, null, null, false, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1291,7 +1291,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doPatch("Patient", "1", null, null, null, null, false);
+            helper.doPatch("Patient", "1", null, null, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1315,7 +1315,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doPatch("Encounter", "1", null, null, null, null, false);
+            helper.doPatch("Encounter", "1", null, null, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1339,7 +1339,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doPatch("Procedure", "1", null, null, null, null, false);
+            helper.doPatch("Procedure", "1", null, null, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1363,7 +1363,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doPatch("Encounter", "1", null, null, null, null, false);
+            helper.doPatch("Encounter", "1", null, null, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1382,15 +1382,12 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
-        Practitioner practitioner = Practitioner.builder()
-                .active(com.ibm.fhir.model.type.Boolean.TRUE)
-                .build();
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doPatch("Practitioner", "1", null, null, null, null, false);
+            helper.doPatch("Practitioner", "1", null, null, null, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1414,7 +1411,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doDelete("Patient", "1", null, null);
+            FHIRRestOperationResponse response = helper.doDelete("Patient", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
             assertEquals(1, issues.size());
             assertEquals("Deleted 1 Patient resource(s) with the following id(s): 1",
@@ -1437,7 +1434,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null, null);
+            FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
             assertEquals(1, issues.size());
             assertEquals("Deleted 1 Encounter resource(s) with the following id(s): 1",
@@ -1460,7 +1457,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null, null);
+            FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
             assertEquals(1, issues.size());
             assertEquals("Deleted 1 Encounter resource(s) with the following id(s): 1",
@@ -1483,7 +1480,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doDelete("Patient", "1", null, null);
+            helper.doDelete("Patient", "1", null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1507,7 +1504,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doDelete("Encounter", "1", null, null);
+            helper.doDelete("Encounter", "1", null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1531,7 +1528,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doDelete("Procedure", "1", null, null);
+            helper.doDelete("Procedure", "1", null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1555,7 +1552,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doDelete("Procedure", "1", null, null);
+            helper.doDelete("Procedure", "1", null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1579,7 +1576,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doDelete("Practitioner", "1", null, null);
+            helper.doDelete("Practitioner", "1", null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1650,7 +1647,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle, null);
+            Bundle bundle = helper.doBundle(requestBundle);
             assertEquals(2, bundle.getEntry().size());
             for (Entry bundleEntry : bundle.getEntry()) {
                 assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
@@ -1718,7 +1715,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle, null);
+            helper.doBundle(requestBundle);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1789,7 +1786,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle, null);
+            Bundle bundle = helper.doBundle(requestBundle);
             assertEquals(2, bundle.getEntry().size());
             for (Entry bundleEntry : bundle.getEntry()) {
                 assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
@@ -1857,7 +1854,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle, null);
+            Bundle bundle = helper.doBundle(requestBundle);
             assertEquals(2, bundle.getEntry().size());
             assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Patient'",
                 bundle.getEntry().get(0).getResource().as(OperationOutcome.class).getIssue().get(0).getDetails().getText().getValue());

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/ProfileValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/ProfileValidationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -97,7 +97,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -132,7 +132,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -167,7 +167,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -202,7 +202,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -236,7 +236,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.
@@ -268,7 +268,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.
@@ -300,7 +300,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Patient", patient, null, null, true);
+            helper.doCreate("Patient", patient, null, true);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.
@@ -329,7 +329,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Encounter", encounter, null, null, true);
+            helper.doCreate("Encounter", encounter, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -364,7 +364,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Encounter", encounter, null, null, true);
+            helper.doCreate("Encounter", encounter, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -399,7 +399,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Encounter", encounter, null, null, true);
+            helper.doCreate("Encounter", encounter, null, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -433,7 +433,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doCreate("Encounter", encounter, null, null, true);
+            helper.doCreate("Encounter", encounter, null, true);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.
@@ -469,7 +469,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            FHIRRestOperationResponse response = helper.doCreate("Procedure", procedure, null, null, true);
+            FHIRRestOperationResponse response = helper.doCreate("Procedure", procedure, null, true);
             assertEquals(ALL_OK, response.getOperationOutcome());
         } catch (Exception e) {
             fail();
@@ -496,7 +496,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Patient", "1", patient, null, null, null, false, true);
+            helper.doUpdate("Patient", "1", patient, null, null, false, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -532,7 +532,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Patient", "1", patient, null, null, null, true, true);
+            helper.doUpdate("Patient", "1", patient, null, null, true, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -568,7 +568,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Patient", "1", patient, null, null, null, false, true);
+            helper.doUpdate("Patient", "1", patient, null, null, false, true);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -603,7 +603,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doUpdate("Patient", "1", patient, null, null, null, false, true);
+            helper.doUpdate("Patient", "1", patient, null, null, false, true);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.
@@ -647,7 +647,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle, null);
+            helper.doBundle(requestBundle);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -700,7 +700,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle, null);
+            helper.doBundle(requestBundle);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -754,7 +754,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle, null);
+            helper.doBundle(requestBundle);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -807,7 +807,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle, null);
+            helper.doBundle(requestBundle);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -135,7 +135,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -179,7 +179,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -228,7 +228,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -273,7 +273,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -331,7 +331,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -398,7 +398,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -475,7 +475,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -545,7 +545,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -614,7 +614,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -753,7 +753,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -840,7 +840,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -894,7 +894,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -935,7 +935,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -981,7 +981,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1023,7 +1023,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1082,7 +1082,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1150,7 +1150,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1229,7 +1229,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1299,7 +1299,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1367,7 +1367,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1435,7 +1435,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1579,7 +1579,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1667,7 +1667,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1746,7 +1746,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1917,7 +1917,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle, null);
+        Bundle responseBundle = helper.doBundle(requestBundle);
 
         // Validate results
         assertNotNull(responseBundle);

--- a/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
+++ b/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
@@ -426,7 +426,7 @@ public class ApplyOperation extends AbstractOperation {
     private PlanDefinition checkAndRetrievePlanDefinition(FHIRResourceHelpers resourceHelper,
         String planDefinitionId) throws Exception {
         Resource resource =
-                resourceHelper.doRead("PlanDefinition", planDefinitionId, false, false, null, null);
+                resourceHelper.doRead("PlanDefinition", planDefinitionId, false, false, null);
         if (resource == null) {
             throw buildOperationExceptionNotFound("Could not find 'PlanDefinition' with id: ["
                     + planDefinitionId + "]");

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -49,7 +49,7 @@ public class DocumentOperation extends AbstractOperation {
         try {
             Composition composition = null;
 
-            Resource resource = resourceHelper.doRead("Composition", logicalId, false, false, null, null);
+            Resource resource = resourceHelper.doRead("Composition", logicalId, false, false, null);
             if (resource == null) {
                 throw new FHIROperationException("Could not find composition with id: " + logicalId);
             }
@@ -71,7 +71,7 @@ public class DocumentOperation extends AbstractOperation {
 
                     if (persist) {
                         // FHIRResourceHelper resourceHelper = (FHIRResourceHelper) operationContext.getProperty(FHIROperationContext.PROPNAME_RESOURCE_HELPER;
-                        FHIRRestOperationResponse response = resourceHelper.doCreate("Bundle", bundle, null, null, false);
+                        FHIRRestOperationResponse response = resourceHelper.doCreate("Bundle", bundle, null, false);
                         // Use the responded bundle to create response to client.
                         bundle = (Bundle)response.getResource();
                         URI locationURI = response.getLocationURI();
@@ -178,7 +178,7 @@ public class DocumentOperation extends AbstractOperation {
             String resourceTypeName = referenceTokens[0];
             String logicalId = referenceTokens[1];
 
-            resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null, null);
+            resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null);
 
             if (resource == null) {
                 throw new FHIROperationException("Could not find resource for reference value: " + referenceValue);

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -151,7 +151,7 @@ public class EverythingOperation extends AbstractOperation {
 
         Patient patient = null;
         try {
-            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false, false, null, null);
+            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false, false, null);
         } catch (FHIRPersistenceResourceDeletedException fde) {
             FHIROperationException exceptionWithIssue = buildExceptionWithIssue("Patient with ID '" + logicalId + "' does not exist.", IssueType.NOT_FOUND);
             throw exceptionWithIssue;
@@ -189,7 +189,7 @@ public class EverythingOperation extends AbstractOperation {
             Bundle results = null;
             int currentResourceCount = 0;
             try {
-                results = resourceHelper.doSearch(compartmentType, PATIENT, logicalId, searchParameters, null, null, null);
+                results = resourceHelper.doSearch(compartmentType, PATIENT, logicalId, searchParameters, null, null);
                 currentResourceCount = results.getTotal().getValue();
                 totalResourceCount += currentResourceCount;
                 LOG.finest("Got " + compartmentType + " resources " + currentResourceCount + " for a total of " + totalResourceCount);
@@ -214,7 +214,7 @@ public class EverythingOperation extends AbstractOperation {
                     LOG.finest("Retrieving page " + page + " of the " + compartmentType + " resources for patient " + logicalId);
                     try {
                         searchParameters.putSingle(SearchConstants.PAGE, page++ + "");
-                        results = resourceHelper.doSearch(compartmentType, PATIENT, logicalId, searchParameters, null, null, null);
+                        results = resourceHelper.doSearch(compartmentType, PATIENT, logicalId, searchParameters, null, null);
                     } catch (Exception e) {
                         FHIROperationException exceptionWithIssue = buildExceptionWithIssue("Error retrieving $everything resources page '" + page + "' of type '" + compartmentType + "' for patient " + logicalId, IssueType.EXCEPTION);
                         LOG.throwing(this.getClass().getName(), "doInvoke", exceptionWithIssue);

--- a/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -54,7 +54,7 @@ public abstract class AbstractTermOperation extends AbstractOperation {
         String resourceParameterName = resourceTypeName.substring(0, 1).toLowerCase() + resourceTypeName.substring(1);
         String resourceVersionParameterName = resourceParameterName + "Version";
         if (FHIROperationContext.Type.INSTANCE.equals(operationContext.getType())) {
-            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null, null);
+            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null);
             if (resource == null) {
                 throw buildExceptionWithIssue(resourceTypeName + " with id '" + logicalId + "' was not found", IssueType.NOT_FOUND);
             }


### PR DESCRIPTION
And also from the OperationContext.

Also updated javadoc in FHIRResourceHelpers (lots of missing params).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>