### PR TITLE
issues #2281 and #864 - batch/transaction bundle processing changes

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -7,7 +7,6 @@
 package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.test.TestUtil.isResourceInResponse;
-
 import static com.ibm.fhir.model.type.String.string;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertEquals;
@@ -2242,17 +2241,7 @@ public class BundleTest extends FHIRServerTestBase {
 
         Bundle bundle = buildBundle(BundleType.BATCH);
 
-        // Commented out because $hello operation isn't installed by default
-        // 1. GET request at global level
-        //bundle = addRequestToBundle(null, bundle, HTTPVerb.GET, "$hello?input=" + message, null, null);
-
-        // 2. POST request at global level
-        //Parameters hellowWorldParameters = Parameters.builder()
-        //        .parameter(Parameter.builder().name(string("input")).value(string(message)).build()).build();
-
-        //bundle = addRequestToBundle(null, bundle, HTTPVerb.POST, "$hello", null, hellowWorldParameters);
-
-        // 3. POST request with resource at resource level
+        // 1. POST request with resource at resource level
         Patient patient = TestUtil.readLocalResource("Patient_JohnDoe.json");
 
         Parameters validateOperationParameters = Parameters.builder()
@@ -2261,9 +2250,20 @@ public class BundleTest extends FHIRServerTestBase {
         bundle = addRequestToBundle(null, bundle, HTTPVerb.POST, "Patient/$validate", null,
                 validateOperationParameters);
 
-        // 4. POST request with resource at resource instance level
+        // 2. POST request with resource at resource instance level
         bundle = addRequestToBundle(null, bundle, HTTPVerb.POST,
                 "Patient/" + patientB1.getId() + "/$validate", null, validateOperationParameters);
+
+        //////
+        // Commented out because $hello operation isn't installed by default
+        //////
+        // 3. GET request at global level
+        //bundle = addRequestToBundle(null, bundle, HTTPVerb.GET, "$hello?input=" + message, null, null);
+
+        // 4. POST request at global level
+        //Parameters hellowWorldParameters = Parameters.builder()
+        //        .parameter(Parameter.builder().name(string("input")).value(string(message)).build()).build();
+        //bundle = addRequestToBundle(null, bundle, HTTPVerb.POST, "$hello", null, hellowWorldParameters);
 
         printBundle(method, "request", bundle);
 
@@ -2273,17 +2273,11 @@ public class BundleTest extends FHIRServerTestBase {
         Bundle responseBundle = getEntityWithExtraWork(response,method);
 
         assertResponseBundle(responseBundle, BundleType.BATCH_RESPONSE, 2);
-        // Commented out because $hello operation isn't installed by default
-//        assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
-//        assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode());
 
-        // Commented out because $hello operation isn't installed by default
-//        assertNotNull(responseBundle.getEntry().get(0).getResource().getParameters());
-//        assertNotNull(responseBundle.getEntry().get(1).getResource().getParameters());
-        assertNotNull(responseBundle.getEntry().get(0).getResponse().getOutcome());
-        assertNotNull(responseBundle.getEntry().get(1).getResponse().getOutcome());
+        assertNotNull(responseBundle.getEntry().get(0).getResource());
+        assertNotNull(responseBundle.getEntry().get(1).getResource());
     }
 
     @Test(groups = { "transaction" })

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1183,7 +1183,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         FHIRRequestContext requestContext = FHIRRequestContext.get();
 
         try {
-            // First, validate the bundle and create the response bundle.
+            // First, validate the bundle and save the error / warning responses by index entry.
             Map<Integer, Entry> validationResponseEntries = validateBundle(inputBundle);
 
             // Next, process each of the entries in the bundle.
@@ -1621,7 +1621,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     + bundleRequestCorrelationId);
             }
 
-            // Clear both correlation id fields since we're done processing the bundle.
+            // Clear the request correlation id field since we're done processing the bundle.
             bundleRequestCorrelationId = null;
 
             if (txn != null) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.server.util;
 
 import static com.ibm.fhir.model.type.String.string;
 import static com.ibm.fhir.model.util.ModelSupport.getResourceType;
+import static javax.servlet.http.HttpServletResponse.SC_ACCEPTED;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_GONE;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
@@ -19,11 +20,13 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -132,6 +135,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     private static final com.ibm.fhir.model.type.String SC_BAD_REQUEST_STRING = string(Integer.toString(SC_BAD_REQUEST));
     private static final com.ibm.fhir.model.type.String SC_GONE_STRING = string(Integer.toString(SC_GONE));
     private static final com.ibm.fhir.model.type.String SC_NOT_FOUND_STRING = string(Integer.toString(SC_NOT_FOUND));
+    private static final com.ibm.fhir.model.type.String SC_ACCEPTED_STRING = string(Integer.toString(SC_ACCEPTED));
     private static final com.ibm.fhir.model.type.String SC_OK_STRING = string(Integer.toString(SC_OK));
     private static final String TOO_MANY_INCLUDE_RESOURCES = "Number of returned 'include' resources exceeds allowable limit of " + SearchConstants.MAX_PAGE_SIZE;
     private static final ZoneId UTC = ZoneId.of("UTC");
@@ -155,8 +159,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
     private FHIRPersistence persistence = null;
 
-    // These values are used for correlating requests within a bundle.
-    private String bundleTransactionCorrelationId = null;
+    // Used for correlating requests within a bundle.
     private String bundleRequestCorrelationId = null;
 
     public FHIRRestHelper(FHIRPersistence persistence) {
@@ -1181,12 +1184,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         try {
             // First, validate the bundle and create the response bundle.
-            Bundle responseBundle = validateBundle(inputBundle);
+            Map<Integer, Entry> validationResponseEntries = validateBundle(inputBundle);
 
             // Next, process each of the entries in the bundle.
-            responseBundle = processBundleEntries(inputBundle, responseBundle);
-
-            return responseBundle;
+            return processBundleEntries(inputBundle, validationResponseEntries);
         } finally {
             // Restore the original request context.
             FHIRRequestContext.set(requestContext);
@@ -1245,16 +1246,17 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     /**
-     * Performs validation of a request Bundle and returns a Bundle containing response entries that correspond
-     * to the request entries in the request Bundle.
+     * Performs validation of a request Bundle and returns a Map of entry indices to error / warning
+     * response entries that correspond to the entries in the request Bundle.
      *
      * @param bundle
      *            the bundle to be validated
-     * @return a response Bundle
+     * @return a map of entry indices to error responses / warnings; empty if there are no validation warnings or errors
      * @throws Exception
      */
-    private Bundle validateBundle(Bundle bundle) throws Exception {
+    private Map<Integer, Entry> validateBundle(Bundle bundle) throws Exception {
         log.entering(this.getClass().getName(), "validateBundle");
+        Map<Integer, Entry> validationResponseEntries = new HashMap<>();
 
         try {
             // Make sure the bundle isn't empty
@@ -1264,49 +1266,39 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
 
             BundleType.ValueSet requestType = bundle.getType().getValueAsEnumConstant();
-
-            // Determine the bundle type of the response bundle.
-            BundleType responseBundleType = null;
-
-            if (requestType == BundleType.ValueSet.BATCH) {
-                // For 'batch' interactions, return a 'batch-response'
-                responseBundleType = BundleType.BATCH_RESPONSE;
-            } else if (requestType == BundleType.ValueSet.TRANSACTION) {
-                responseBundleType = BundleType.TRANSACTION_RESPONSE;
-                // For a 'transaction' interaction, if the underlying persistence layer doesn't support
-                // transactions, then throw an error.
-                if (!persistence.isTransactional()) {
-                    String msg = "Bundled 'transaction' request cannot be processed because "
-                            + "the configured persistence layer does not support transactions.";
-                    IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
-                            .extension(Extension.builder()
-                                .url(EXTENSION_URL +  "/not-supported-detail")
-                                .value(Code.of("interaction"))
-                                .build())
-                            .build();
-                    throw buildRestException(msg, extendedIssueType);
-                }
-            } else {
-                // For any other bundle type, throw an error.
+            if (requestType != BundleType.ValueSet.BATCH && requestType != BundleType.ValueSet.TRANSACTION) {
                 // TODO add support for posting history bundles
                 String msg = "Bundle.type must be either 'batch' or 'transaction'.";
                 throw buildRestException(msg, IssueType.VALUE);
+            }
+            if (requestType == BundleType.ValueSet.TRANSACTION && !persistence.isTransactional()) {
+                // For a 'transaction' interaction, if the underlying persistence layer doesn't support
+                // transactions, then throw an error.
+                String msg = "Bundled 'transaction' request cannot be processed because "
+                        + "the configured persistence layer does not support transactions.";
+                IssueType extendedIssueType = IssueType.NOT_SUPPORTED.toBuilder()
+                        .extension(Extension.builder()
+                            .url(EXTENSION_URL +  "/not-supported-detail")
+                            .value(Code.of("interaction"))
+                            .build())
+                        .build();
+                throw buildRestException(msg, extendedIssueType);
             }
 
             // For 'transaction' bundle requests, keep a list of issues in case of failure
             List<OperationOutcome.Issue> issueList = new ArrayList<OperationOutcome.Issue>();
 
-            List<Bundle.Entry> responseList = new ArrayList<Bundle.Entry>();
             Set<String> localIdentifiers = new HashSet<>();
 
-            for (Bundle.Entry requestEntry : bundle.getEntry()) {
+            for (int i = 0; i < bundle.getEntry().size(); i++) {
                 // Create a corresponding response entry and add it to the response bundle.
-                Bundle.Entry.Response response;
+                Bundle.Entry requestEntry = bundle.getEntry().get(i);
                 Bundle.Entry responseEntry = null;
 
                 // Validate 'requestEntry' and update 'responseEntry' with any errors.
                 try {
                     Bundle.Entry.Request request = requestEntry.getRequest();
+
                     // Verify that the request field is present.
                     if (request == null) {
                         String msg = "Bundle.Entry is missing the 'request' field.";
@@ -1348,37 +1340,28 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     if (resource != null) {
                         List<Issue> issues = validateResource(resource);
                         if (!issues.isEmpty()) {
+                            OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
                             if (anyFailureInIssues(issues)) {
                                 if (requestType == BundleType.ValueSet.TRANSACTION) {
                                     issueList.addAll(issues);
                                 } else {
-                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
-                                    response = Bundle.Entry.Response.builder()
-                                                .status(SC_BAD_REQUEST_STRING)
-                                                .build();
-                                    responseEntry = Bundle.Entry.builder()
-                                                .response(response)
+                                    responseEntry = Entry.builder()
+                                                .response(Entry.Response.builder()
+                                                    .status(SC_BAD_REQUEST_STRING)
+                                                    .build())
                                                 .resource(oo)
                                                 .build();
                                 }
                             } else {
-                                response = Bundle.Entry.Response.builder()
-                                            .status(SC_OK_STRING)
-                                            .build();
-                                Bundle.Entry.Builder responseEntryBuilder = Bundle.Entry.builder().response(response);
-                                // Only add hints/warnings if the return preference was "OperationOutcome"
-                                if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
-                                    OperationOutcome oo = FHIRUtil.buildOperationOutcome(issues);
-                                    responseEntryBuilder.resource(oo);
-                                }
-                                responseEntry = responseEntryBuilder.build();
+                                responseEntry = Entry.builder()
+                                        .response(Entry.Response.builder()
+                                            .status(SC_ACCEPTED_STRING)
+                                            .outcome(oo)
+                                            .build())
+                                        .build();
                             }
-                            continue;
                         }
                     }
-                    response =
-                            Bundle.Entry.Response.builder().status(SC_OK_STRING).build();
-                    responseEntry = Bundle.Entry.builder().response(response).build();
                 } catch (FHIROperationException e) {
                     if (log.isLoggable(Level.FINE)) {
                         log.log(Level.FINE, "Failed to process BundleEntry ["
@@ -1387,17 +1370,17 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     if (requestType == BundleType.ValueSet.TRANSACTION) {
                         issueList.addAll(e.getIssues());
                     } else {
-                        response = Bundle.Entry.Response.builder()
+                        Entry.Response response = Entry.Response.builder()
                                 .status(SC_BAD_REQUEST_STRING)
                                 .build();
-                        responseEntry = Bundle.Entry.builder()
+                        responseEntry = Entry.builder()
                                 .response(response)
                                 .resource(FHIRUtil.buildOperationOutcome(e, false))
                                 .build();
                     }
                 } finally {
                     if (responseEntry != null) {
-                        responseList.add(responseEntry);
+                        validationResponseEntries.put(i, responseEntry);
                     }
                 }
             } // End foreach requestEntry
@@ -1411,10 +1394,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 throw buildRestException(msg, IssueType.INVALID).withIssue(issueList);
             }
 
-            // Create the response bundle with the appropriate type.
-            Bundle responseBundle = Bundle.builder().type(responseBundleType).entry(responseList).build();
-
-            return responseBundle;
+            return validationResponseEntries;
         } finally {
             log.exiting(this.getClass().getName(), "validateBundle");
         }
@@ -1472,8 +1452,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @param currentResource
      *            the current latest version of the resource
      */
-    private void performVersionAwareUpdateCheck(Resource currentResource, String ifMatchValue)
-            throws FHIROperationException {
+    private void performVersionAwareUpdateCheck(Resource currentResource, String ifMatchValue) throws FHIROperationException {
         if (ifMatchValue != null) {
             if (log.isLoggable(Level.FINE)) {
                 log.fine("Performing a version aware update. ETag value =  " + ifMatchValue);
@@ -1579,10 +1558,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @param requestBundle
      *            the bundle containing the requests
-     * @param responseBundle
-     *            the bundle containing the responses
+     * @param validationResponseEntries
+     *            a map from entry indices to the corresponding response entries created during validation
      */
-    private Bundle processBundleEntries(Bundle requestBundle, Bundle responseBundle) throws Exception {
+    private Bundle processBundleEntries(Bundle requestBundle, Map<Integer, Entry> validationResponseEntries) throws Exception {
         log.entering(this.getClass().getName(), "processBundleEntries");
 
         FHIRTransactionHelper txn = null;
@@ -1594,37 +1573,42 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         }
 
         try {
+            BundleType.ValueSet bundleType = requestBundle.getType().getValueAsEnumConstant();
             // If we're working on a 'transaction' type interaction, then start a new transaction now
-            if (responseBundle.getType() == BundleType.TRANSACTION_RESPONSE) {
-                bundleTransactionCorrelationId = bundleRequestCorrelationId;
+            if (bundleType == BundleType.ValueSet.TRANSACTION) {
                 txn = new FHIRTransactionHelper(getTransaction());
                 txn.begin();
                 if (log.isLoggable(Level.FINE)) {
-                    log.fine("Started new transaction for transaction bundle, txn-correlation-id="
-                        + bundleTransactionCorrelationId);
+                    log.fine("Started new transaction for transaction bundle, request-correlation-id="
+                        + bundleRequestCorrelationId);
                 }
             }
 
             // Build a mapping of local identifiers to external identifiers for local reference resolution.
-            Map<String, String> localRefMap = buildLocalRefMap(requestBundle, responseBundle);
+            Map<String, String> localRefMap = buildLocalRefMap(requestBundle, validationResponseEntries);
 
             // Process entries.
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.DELETE,
+            List<Entry> responseEntries = processEntriesByMethod(requestBundle, validationResponseEntries,
                     txn != null, localRefMap, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.POST,
-                    txn != null, localRefMap, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.PUT,
-                    txn != null, localRefMap, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.GET,
-                    txn != null, localRefMap, bundleRequestCorrelationId);
-            responseBundle = processEntriesForMethod(requestBundle, responseBundle, HTTPVerb.PATCH,
-                    txn != null, localRefMap, bundleRequestCorrelationId);
+
+            // Build the response bundle.
+            Bundle.Builder bundleResponseBuilder = Bundle.builder().entry(responseEntries);
+            if (bundleType == BundleType.ValueSet.BATCH) {
+                bundleResponseBuilder.type(BundleType.BATCH_RESPONSE);
+            } else if (bundleType == BundleType.ValueSet.TRANSACTION) {
+                bundleResponseBuilder.type(BundleType.TRANSACTION_RESPONSE);
+            } else {
+                // TODO add support for posting history bundles
+                String msg = "Bundle.type must be either 'batch' or 'transaction'.";
+                throw buildRestException(msg, IssueType.VALUE);
+            }
+            Bundle responseBundle = bundleResponseBuilder.build();
 
             // Commit transaction if started
             if (txn != null) {
                 if (log.isLoggable(Level.FINE)) {
-                    log.fine("Committing transaction for transaction bundle, txn-correlation-id="
-                        + bundleTransactionCorrelationId);
+                    log.fine("Committing transaction for transaction bundle, request-correlation-id="
+                        + bundleRequestCorrelationId);
                 }
                 txn.commit();
                 txn = null;
@@ -1639,7 +1623,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             // Clear both correlation id fields since we're done processing the bundle.
             bundleRequestCorrelationId = null;
-            bundleTransactionCorrelationId = null;
 
             if (txn != null) {
                 txn.rollback();
@@ -1654,10 +1637,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @param requestBundle
      *            the bundle containing the request entries
-     * @param responseBundle
-     *            the bundle containing the corresponding response entries
-     * @param httpMethod
-     *            the HTTP method (GET, POST, PUT, etc.) to be processed
+     * @param validationResponseEntries
+     *            the response entries with errors/warnings constructed during validation
      * @param failFast
      *            a boolean value indicating if processing should stop on first failure
      * @param localRefMap
@@ -1670,52 +1651,72 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            the response bundle
      * @throws Exception
      */
-    private Bundle processEntriesForMethod(Bundle requestBundle, Bundle responseBundle, HTTPVerb httpMethod,
+    private List<Entry> processEntriesByMethod(Bundle requestBundle, Map<Integer, Entry> validationResponseEntries,
             boolean failFast, Map<String, String> localRefMap, String bundleRequestCorrelationId) throws Exception {
-        log.entering(this.getClass().getName(), "processEntriesForMethod", new Object[] {"httpMethod", httpMethod });
+        log.entering(this.getClass().getName(), "processEntriesByMethod");
 
         try {
-            // First, obtain a list of request entry indices for the entries that we'll process.
-            // This list will contain the indices associated with only the entries for the specified http method.
-            List<Integer> entryIndices =
-                    getBundleRequestIndicesForMethod(requestBundle, responseBundle, httpMethod);
-            if (log.isLoggable(Level.FINER)) {
-                log.finer("Bundle request indices to be processed: " + entryIndices.toString());
-            }
+            // Placeholder for response entries
+            Entry[] responseEntries = new Entry[requestBundle.getEntry().size()];
 
-            // Next, for PUT and DELETE requests, we need to sort the indices by the request url path value.
-            if (httpMethod.equals(HTTPVerb.PUT) || httpMethod.equals(HTTPVerb.DELETE)) {
-                sortBundleRequestEntries(requestBundle, entryIndices);
-                if (log.isLoggable(Level.FINER)) {
-                    log.finer("Sorted bundle request indices to be processed: "
-                            + entryIndices.toString());
+            // Group the request entries by request method; LinkedHashMap because order is important
+            Map<HTTPVerb.ValueSet, List<Integer>> requestEntriesByMethod = new LinkedHashMap<>(6);
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.DELETE, new ArrayList<>());
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.POST, new ArrayList<>());
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.PUT, new ArrayList<>());
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.GET, new ArrayList<>());
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.PATCH, new ArrayList<>());
+            requestEntriesByMethod.put(HTTPVerb.ValueSet.HEAD, new ArrayList<>());
+            for (int i = 0; i < requestBundle.getEntry().size(); i++) {
+                if (validationResponseEntries.containsKey(i) &&
+                        !validationResponseEntries.get(i).getResponse().getStatus().equals(SC_ACCEPTED_STRING)) {
+                    // validation marked this entry as invalid, so write the validation response entry and skip it
+                    responseEntries[i] = validationResponseEntries.get(i);
+                    continue;
                 }
+                Entry entry = requestBundle.getEntry().get(i);
+                requestEntriesByMethod.get(entry.getRequest().getMethod().getValueAsEnumConstant()).add(i);
             }
 
-            // Now visit each of the request entries using the list of indices obtained above.
-            // Use hashmap to store both the index and the accordingly updated response bundle entry.
-            Map<Integer, Bundle.Entry> responseIndexAndEntries = new HashMap<Integer, Bundle.Entry>();
-            for (Integer entryIndex : entryIndices) {
-                Bundle.Entry requestEntry = requestBundle.getEntry().get(entryIndex);
-                Bundle.Entry.Request request = requestEntry.getRequest();
-                Bundle.Entry responseEntry = responseBundle.getEntry().get(entryIndex);
-                Bundle.Entry.Response response = responseEntry.getResponse();
-                if (response.getStatus().equals(SC_OK_STRING) && request.getMethod().equals(httpMethod)) {
-                    // Process request entry.
-                    Bundle.Entry.Builder responseEntryBuilder = responseEntry.toBuilder();
-                    StringBuffer requestDescription = new StringBuffer();
+            if (log.isLoggable(Level.FINE)) {
+                log.fine("Bundle request indices to be processed: " +
+                        "DELETE" + requestEntriesByMethod.get(HTTPVerb.ValueSet.DELETE) + ", " +
+                        "POST" + requestEntriesByMethod.get(HTTPVerb.ValueSet.POST) + ", " +
+                        "PUT" + requestEntriesByMethod.get(HTTPVerb.ValueSet.PUT) + ", " +
+                        "GET" + requestEntriesByMethod.get(HTTPVerb.ValueSet.GET) + ", " +
+                        "PATCH" + requestEntriesByMethod.get(HTTPVerb.ValueSet.PATCH) + ", " +
+                        "HEAD" + requestEntriesByMethod.get(HTTPVerb.ValueSet.HEAD));
+            }
+
+            for (Map.Entry<HTTPVerb.ValueSet, List<Integer>> methodIndices : requestEntriesByMethod.entrySet()) {
+                HTTPVerb.ValueSet httpMethod = methodIndices.getKey();
+                List<Integer> entryIndices = methodIndices.getValue();
+
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Beginning processing for method: " + httpMethod);
+                }
+
+                // For PUT and DELETE requests, we need to sort the indices by the request url path value.
+                if (httpMethod == HTTPVerb.ValueSet.PUT || httpMethod == HTTPVerb.ValueSet.DELETE) {
+                    sortBundleRequestEntries(requestBundle, entryIndices);
+                    if (log.isLoggable(Level.FINER)) {
+                        log.finer("Sorted bundle request indices to be processed: "
+                                + entryIndices.toString());
+                    }
+                }
+
+                // Now visit each of the request entries using the list of indices obtained above.
+                // Use hashmap to store both the index and the accordingly updated response bundle entry.
+                Map<Integer, Entry> responseIndexAndEntries = new HashMap<Integer, Entry>();
+                for (Integer entryIndex : entryIndices) {
+                    Entry requestEntry = requestBundle.getEntry().get(entryIndex);
+                    Entry.Request request = requestEntry.getRequest();
+
+                    StringBuilder requestDescription = new StringBuilder();
                     long initialTime = System.currentTimeMillis();
 
                     try {
                         FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
-
-                        if (log.isLoggable(Level.FINER)) {
-                            log.finer("Processing bundle request entry " + entryIndex + "; method="
-                                    + request.getMethod().getValue() + ", url="
-                                    + request.getUrl().getValue());
-                            log.finer("--> path: '" + requestURL.getPath() + "'");
-                            log.finer("--> query: '" + requestURL.getQuery() + "'");
-                        }
 
                         // Log our initial info message for this request.
                         requestDescription.append("entryIndex:[");
@@ -1727,22 +1728,34 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                         requestDescription.append("] uri:[");
                         requestDescription.append(request.getUrl().getValue());
                         requestDescription.append("]");
-                        log.info("Received bundle request: " + requestDescription.toString());
+                        if (log.isLoggable(Level.FINE)) {
+                            log.fine("Processing bundled request: " + requestDescription.toString());
+                            if (log.isLoggable(Level.FINER)) {
+                                log.finer("--> path: '" + requestURL.getPath() + "'");
+                                log.finer("--> query: '" + requestURL.getQuery() + "'");
+                            }
+                        }
 
                         // Construct the absolute requestUri to be used for any response bundles associated
                         // with history and search requests.
                         String absoluteUri = getAbsoluteUri(getRequestUri(), request.getUrl().getValue());
 
                         if (request.getMethod().equals(HTTPVerb.GET)) {
-                            processEntryForGet(responseEntry, responseIndexAndEntries, entryIndex, requestURL, absoluteUri, requestDescription.toString(), initialTime);
+                            responseEntries[entryIndex] = processEntryForGet(request, requestURL, absoluteUri,
+                                    requestDescription.toString(), initialTime);
                         } else if (request.getMethod().equals(HTTPVerb.POST)) {
-                            processEntryForPost(requestEntry, responseEntry, responseIndexAndEntries, entryIndex, localRefMap, requestURL, absoluteUri, requestDescription.toString(), initialTime);
+                            Entry validationResponseEntry = validationResponseEntries.get(entryIndex);
+                            responseEntries[entryIndex] = processEntryForPost(requestEntry, validationResponseEntry, responseIndexAndEntries,
+                                    entryIndex, localRefMap, requestURL, absoluteUri, requestDescription.toString(), initialTime);
                         } else if (request.getMethod().equals(HTTPVerb.PUT)) {
-                            processEntryForPut(requestEntry, responseEntry, responseIndexAndEntries, entryIndex, localRefMap, requestURL, absoluteUri, requestDescription.toString(), initialTime);
-                        } else if (request.getMethod().equals(HTTPVerb.DELETE)) {
-                            processEntryForDelete(responseEntry, responseIndexAndEntries, entryIndex, requestURL, requestDescription.toString(), initialTime);
+                            Entry validationResponseEntry = validationResponseEntries.get(entryIndex);
+                            responseEntries[entryIndex] = processEntryForPut(requestEntry, validationResponseEntry, responseIndexAndEntries,
+                                    entryIndex, localRefMap, requestURL, absoluteUri, requestDescription.toString(), initialTime);
                         } else if (request.getMethod().equals(HTTPVerb.PATCH)) {
-                            processEntryforPatch(requestEntry, responseEntry, responseIndexAndEntries, requestURL,entryIndex, requestDescription.toString(), initialTime);
+                            responseEntries[entryIndex] = processEntryforPatch(requestEntry, requestURL,entryIndex,
+                                    requestDescription.toString(), initialTime);
+                        } else if (request.getMethod().equals(HTTPVerb.DELETE)) {
+                            responseEntries[entryIndex] = processEntryForDelete(requestURL, requestDescription.toString(), initialTime);
                         } else {
                             // Internal error, should not get here!
                             throw new IllegalStateException("Internal Server Error: reached an unexpected code location.");
@@ -1753,9 +1766,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                             throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
                         }
 
-                        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                        responseBuilder.status(SC_NOT_FOUND_STRING);
-                        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(FHIRUtil.buildOperationOutcome(e, false)).response(responseBuilder.build()).build());
+                        responseEntries[entryIndex] = Entry.builder()
+                                .resource(FHIRUtil.buildOperationOutcome(e, false))
+                                .response(Entry.Response.builder()
+                                    .status(SC_NOT_FOUND_STRING)
+                                    .build())
+                                .build();
                         logBundleRequestCompletedMsg(requestDescription.toString(), initialTime, SC_NOT_FOUND);
                     } catch (FHIRPersistenceResourceDeletedException e) {
                         if (failFast) {
@@ -1763,9 +1779,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                             throw new FHIRRestBundledRequestException(msg).withIssue(e.getIssues());
                         }
 
-                        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                        responseBuilder.status(SC_GONE_STRING);
-                        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(FHIRUtil.buildOperationOutcome(e, false)).response(responseBuilder.build()).build());
+                        responseEntries[entryIndex] = Entry.builder()
+                                .resource(FHIRUtil.buildOperationOutcome(e, false))
+                                .response(Entry.Response.builder()
+                                    .status(SC_GONE_STRING)
+                                    .build())
+                                .build();
                         logBundleRequestCompletedMsg(requestDescription.toString(), initialTime, SC_GONE);
                     } catch (FHIROperationException e) {
                         if (failFast) {
@@ -1780,17 +1799,21 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                             status = IssueTypeToHttpStatusMapper.issueListToStatus(e.getIssues());
                         }
 
-                        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-                        responseBuilder.status(string(Integer.toString(status.getStatusCode())));
-                        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(FHIRUtil.buildOperationOutcome(e, false)).response(responseBuilder.build()).build());
+                        responseEntries[entryIndex] = Entry.builder()
+                                .resource(FHIRUtil.buildOperationOutcome(e, false))
+                                .response(Entry.Response.builder()
+                                    .status(string(Integer.toString(status.getStatusCode())))
+                                    .build())
+                                .build();
                         logBundleRequestCompletedMsg(requestDescription.toString(), initialTime, status.getStatusCode());
                     }
+                } // end foreach method entry
+                if (log.isLoggable(Level.FINER)) {
+                    log.finer("Finished processing for method: " + httpMethod);
                 }
-            }
+            } // end foreach method
 
-            // Now, let's re-construct the responseBundle
-            responseBundle = reconstructResponseBundle(responseBundle, responseIndexAndEntries);
-            return responseBundle;
+            return Arrays.asList(responseEntries);
 
         } finally {
             log.exiting(this.getClass().getName(), "processEntriesForMethod");
@@ -1802,10 +1825,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @param requestEntry
      *            the request bundle entry
-     * @param responseEntry
-     *            the response bundle entry
-     * @param responseIndexAndEntries
-     *            the hashmap containing bundle entry indexes and their associated response entries
      * @param requestURL
      *            the request URL
      * @param entryIndex
@@ -1814,10 +1833,11 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
+     * @return the bundle entry response
      * @throws Exception
      */
-    private void processEntryforPatch(Entry requestEntry, Entry responseEntry, Map<Integer, Entry> responseIndexAndEntries,
-            FHIRUrlParser requestURL, Integer entryIndex, String requestDescription, long initialTime) throws Exception {
+    private Entry processEntryforPatch(Entry requestEntry, FHIRUrlParser requestURL, Integer entryIndex, String requestDescription, long initialTime)
+            throws Exception {
         FHIRRestOperationResponse ior = null;
         String[] pathTokens = requestURL.getPathTokens();
         String resourceType = null;
@@ -1839,30 +1859,23 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             throw buildRestException(msg, IssueType.INVALID);
         }
 
-        if (requestEntry.getResource().is(Parameters.class)) {
-            Parameters parameters = requestEntry.getResource().as(Parameters.class);
-            FHIRPatch patch = FHIRPathPatch.from(parameters);
-            ior = doPatch(resourceType, resourceId, patch, null, null, !SKIPPABLE_UPDATE);
-
-            // Process and replace bundle entry.
-            Bundle.Entry resultEntry =
-                    setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription, initialTime);
-            responseIndexAndEntries.put(entryIndex, resultEntry);
-        } else {
+        if (!requestEntry.getResource().is(Parameters.class)) {
             String msg="Request resource type for PATCH request must be type 'Parameters'";
             throw buildRestException(msg, IssueType.INVALID);
         }
+
+        Parameters parameters = requestEntry.getResource().as(Parameters.class);
+        FHIRPatch patch = FHIRPathPatch.from(parameters);
+        ior = doPatch(resourceType, resourceId, patch, null, null, !SKIPPABLE_UPDATE);
+
+        return buildResponseBundleEntry(ior, null, requestDescription, initialTime);
     }
 
     /**
      * Processes a request entry with a request method of GET.
      *
-     * @param responseEntry
-     *            the response bundle entry
-     * @param responseIndexAndEntries
-     *            the hashmap containing bundle entry indexes and their associated response entries
-     * @param entryIndex
-     *            the bundle entry index of the bundle entry being processed
+     * @param entryRequest
+     *            the request portion of the corresponding request bundle entry
      * @param requestURL
      *            the request URL
      * @param absoluteUri
@@ -1871,10 +1884,11 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
+     * @return the bundle entry response
      * @throws Exception
      */
-    private void processEntryForGet(Bundle.Entry responseEntry, Map<Integer, Bundle.Entry> responseIndexAndEntries, Integer entryIndex,
-        FHIRUrlParser requestURL, String absoluteUri, String requestDescription, long initialTime) throws Exception {
+    private Entry processEntryForGet(Entry.Request entryRequest, FHIRUrlParser requestURL, String absoluteUri,
+            String requestDescription, long initialTime) throws Exception {
 
         String[] pathTokens = requestURL.getPathTokens();
         MultivaluedMap<String, String> queryParams = requestURL.getQueryParameters();
@@ -1933,13 +1947,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         }
 
         // Save the results of the operation in the bundle response field.
-        Bundle.Entry.Builder responseEntryBuilder = responseEntry.toBuilder();
-        Bundle.Entry.Response response = responseEntry.getResponse();
-        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
-        responseBuilder.status(SC_OK_STRING);
         logBundleRequestCompletedMsg(requestDescription, initialTime, SC_OK);
 
-        responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(resource).response(responseBuilder.build()).build());
+        return Entry.builder()
+                .response(Entry.Response.builder()
+                    .status(SC_OK_STRING)
+                    .build())
+                .resource(resource)
+                .build();
     }
 
     /**
@@ -1947,8 +1962,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @param requestEntry
      *            the request bundle entry
-     * @param responseEntry
-     *            the response bundle entry
+     * @param validationResponseEntry
+     *            the response bundle entry created during validation, possibly null
      * @param responseIndexAndEntries
      *            the hashmap containing bundle entry indexes and their associated response entries
      * @param entryIndex
@@ -1963,15 +1978,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
+     * @return the bundle entry response
      * @throws Exception
      */
-    private void processEntryForPost(Bundle.Entry requestEntry, Bundle.Entry responseEntry, Map<Integer, Bundle.Entry> responseIndexAndEntries,
-        Integer entryIndex, Map<String, String> localRefMap, FHIRUrlParser requestURL, String absoluteUri, String requestDescription, long initialTime)
-        throws Exception {
-
-        Bundle.Entry.Builder responseEntryBuilder = responseEntry.toBuilder();
-        Bundle.Entry.Response response = responseEntry.getResponse();
-        Bundle.Entry.Response.Builder responseBuilder = response.toBuilder();
+    private Entry processEntryForPost(Entry requestEntry, Entry validationResponseEntry, Map<Integer, Entry> responseIndexAndEntries,
+            Integer entryIndex, Map<String, String> localRefMap, FHIRUrlParser requestURL, String absoluteUri, String requestDescription, long initialTime)
+            throws Exception {
 
         String[] pathTokens = requestURL.getPathTokens();
         MultivaluedMap<String, String> queryParams = requestURL.getQueryParameters();
@@ -1979,9 +1991,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         // Process a POST (create or search, or custom operation).
         if (pathTokens.length > 0 && pathTokens[pathTokens.length - 1].startsWith("$")) {
-            // This is a custom operation request
+            // This is a custom operation request.
 
-            // Chop off the '$' and save the name
+            // Chop off the '$' and save the name.
             String operationName = pathTokens[pathTokens.length - 1].substring(1);
 
             // Retrieve the resource from the request entry.
@@ -2007,24 +2019,25 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 throw buildRestException(msg, IssueType.NOT_FOUND);
             }
 
-            // Add warning and hint issues to response outcome if any.
-            if (result instanceof OperationOutcome && ((OperationOutcome) result).getIssue() != null) {
-                responseBuilder.outcome(result);
-            }
-
-            // Save the results of the operation in the bundle response field.
-            responseBuilder.status(SC_OK_STRING);
-            responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(result).response(responseBuilder.build()).build());
             logBundleRequestCompletedMsg(requestDescription, initialTime, SC_OK);
+            return Bundle.Entry.builder()
+                    .resource(result)
+                    .response(Entry.Response.builder()
+                        .status(SC_OK_STRING)
+                        .build())
+                    .build();
 
         } else if (pathTokens.length == 2 && "_search".equals(pathTokens[1])) {
             // This is a 'search' request.
             Bundle searchResults = doSearch(pathTokens[0], null, null, queryParams, absoluteUri, null);
 
-            // Save the results of the operation in the bundle response field.
-            responseBuilder.status(SC_OK_STRING);
-            responseIndexAndEntries.put(entryIndex, responseEntryBuilder.resource(searchResults).response(responseBuilder.build()).build());
             logBundleRequestCompletedMsg(requestDescription, initialTime, SC_OK);
+            return Bundle.Entry.builder()
+                    .resource(searchResults)
+                    .response(Entry.Response.builder()
+                        .status(SC_OK_STRING)
+                        .build())
+                    .build();
 
         } else if (pathTokens.length == 1) {
             // This is a 'create' request.
@@ -2049,29 +2062,30 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             // Perform the 'create' or 'update' operation.
             FHIRRestOperationResponse ior;
-            Bundle.Entry.Request request = requestEntry.getRequest();
-            String ifNoneExist = request.getIfNoneExist() != null && request.getIfNoneExist().getValue() != null && !request.getIfNoneExist().getValue().isEmpty()
-                    ? request.getIfNoneExist().getValue() : null;
+            Entry.Request request = requestEntry.getRequest();
+            String ifNoneExist = request.getIfNoneExist() != null
+                    && request.getIfNoneExist().getValue() != null
+                    && !request.getIfNoneExist().getValue().isEmpty() ? request.getIfNoneExist().getValue() : null;
             if (ifNoneExist != null || resourceId == null) {
                 ior = doCreate(pathTokens[0], resource, ifNoneExist, !DO_VALIDATION);
             } else {
                 resource = resource.toBuilder().id(resourceId).build();
+                // Skip validation because its already been performed.
                 ior = doUpdate(pathTokens[0], resourceId, resource, null, null, !SKIPPABLE_UPDATE, !DO_VALIDATION);
             }
 
-            // Get the updated resource from FHIRRestOperationResponse which has the correct ID, meta, etc.
-            resource = ior.getResource();
-
             // If a local identifier was present and not already mapped to its external identifier, add mapping.
             if (localIdentifier != null && localRefMap.get(localIdentifier) == null) {
-                addLocalRefMapping(localRefMap, localIdentifier, null, resource);
+                addLocalRefMapping(localRefMap, localIdentifier, null, ior.getResource());
             }
 
-            // Process and replace bundle entry
-            Bundle.Entry resultEntry =
-                    setBundleResponseFields(responseEntry, resource, ior.getOperationOutcome(), ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription, initialTime);
-            responseIndexAndEntries.put(entryIndex, resultEntry);
+            // Use the validationOutcome and not the FHIRRestOperationResponse outcome.
+            OperationOutcome validationOutcome = null;
+            if (validationResponseEntry != null && validationResponseEntry.getResponse() != null) {
+                validationOutcome = validationResponseEntry.getResponse().getOutcome().as(OperationOutcome.class);
+            }
 
+            return buildResponseBundleEntry(ior, validationOutcome, requestDescription, initialTime);
         } else {
             String msg = "Request URL for bundled create requests should have a path with exactly one token (<resourceType>).";
             throw buildRestException(msg, IssueType.NOT_FOUND);
@@ -2083,8 +2097,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @param requestEntry
      *            the request bundle entry
-     * @param responseEntry
-     *            the response bundle entry
+     * @param validationResponseEntry
+     *            the response bundle entry created during validation, possibly null
      * @param responseIndexAndEntries
      *            the hashmap containing bundle entry indexes and their associated response entries
      * @param entryIndex
@@ -2099,11 +2113,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
+     * @return the bundle entry response
      * @throws Exception
      */
-    private void processEntryForPut(Bundle.Entry requestEntry, Bundle.Entry responseEntry, Map<Integer, Bundle.Entry> responseIndexAndEntries,
-        Integer entryIndex, Map<String, String> localRefMap, FHIRUrlParser requestURL, String absoluteUri, String requestDescription, long initialTime)
-        throws Exception {
+    private Entry processEntryForPut(Entry requestEntry, Entry validationResponseEntry, Map<Integer, Entry> responseIndexAndEntries,
+            Integer entryIndex, Map<String, String> localRefMap, FHIRUrlParser requestURL, String absoluteUri, String requestDescription, long initialTime)
+            throws Exception {
 
         String[] pathTokens = requestURL.getPathTokens();
         String type = null;
@@ -2150,31 +2165,28 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
         }
 
-        // Process and replace bundle entry.
-        Bundle.Entry resultEntry =
-                setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), ior.getLocationURI(), ior.getStatus().getStatusCode(), requestDescription, initialTime);
-        responseIndexAndEntries.put(entryIndex, resultEntry);
+        // Use the validationOutcome and not the FHIRRestOperationResponse outcome.
+        OperationOutcome validationOutcome = null;
+        if (validationResponseEntry != null && validationResponseEntry.getResponse() != null) {
+            validationOutcome = validationResponseEntry.getResponse().getOutcome().as(OperationOutcome.class);
+        }
+
+        return buildResponseBundleEntry(ior, validationOutcome, requestDescription, initialTime);
     }
 
     /**
      * Processes a request entry with a request method of DELETE.
      *
-     * @param responseEntry
-     *            the response bundle entry
-     * @param responseIndexAndEntries
-     *            the hashmap containing bundle entry indexes and their associated response entries
-     * @param entryIndex
-     *            the bundle entry index of the bundle entry being processed
      * @param requestURL
      *            the request URL
      * @param requestDescription
      *            a description of the request
      * @param initialTime
      *            the time the bundle entry processing started
+     * @return the bundle entry response
      * @throws Exception
      */
-    private void processEntryForDelete(Bundle.Entry responseEntry, Map<Integer, Bundle.Entry> responseIndexAndEntries, Integer entryIndex,
-        FHIRUrlParser requestURL, String requestDescription, long initialTime) throws Exception {
+    private Entry processEntryForDelete(FHIRUrlParser requestURL, String requestDescription, long initialTime) throws Exception {
 
         String[] pathTokens = requestURL.getPathTokens();
         String type = null;
@@ -2199,63 +2211,16 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         // Perform the 'delete' operation.
         FHIRRestOperationResponse ior = doDelete(type, id, requestURL.getQuery());
 
-        // Process and replace bundle entry.
-        Bundle.Entry resultEntry =
-                setBundleResponseFields(responseEntry, ior.getResource(), ior.getOperationOutcome(), null, ior.getStatus().getStatusCode(), requestDescription, initialTime);
-        responseIndexAndEntries.put(entryIndex, resultEntry);
-    }
+        int httpStatus = ior.getStatus().getStatusCode();
+        OperationOutcome oo = ior.getOperationOutcome();
 
-    /**
-     * @param responseBundle
-     * @param responseIndexAndEntries
-     * @return
-     */
-    private Bundle reconstructResponseBundle(Bundle responseBundle,
-        Map<Integer, Bundle.Entry> responseIndexAndEntries) {
-        // Re-construct the responseBundle
-        List<Bundle.Entry> responseEntries = new ArrayList<Bundle.Entry>();
-        for (int i = 0; i < responseBundle.getEntry().size(); i++) {
-            Bundle.Entry bundleEntry = responseIndexAndEntries.get(Integer.valueOf(i)) == null
-                    ? responseBundle.getEntry().get(i)
-                    : responseIndexAndEntries.get(Integer.valueOf(i));
-            responseEntries.add(bundleEntry);
-        }
-
-        responseBundle = responseBundle.toBuilder().entry(responseEntries).build();
-        return responseBundle;
-    }
-
-    /**
-     * Returns a list of Integers that provide the indices of the bundle entries associated with the specified http
-     * method.
-     *
-     * @param requestBundle
-     *            the request bundle
-     * @param httpMethod
-     *            the http method to look for
-     * @return
-     */
-    private List<Integer> getBundleRequestIndicesForMethod(Bundle requestBundle,
-        Bundle responseBundle, HTTPVerb httpMethod) {
-        List<Integer> indices = new ArrayList<>();
-        for (int i = 0; i < requestBundle.getEntry().size(); i++) {
-            Bundle.Entry requestEntry = requestBundle.getEntry().get(i);
-            Bundle.Entry.Request request = requestEntry.getRequest();
-
-            Bundle.Entry responseEntry = responseBundle.getEntry().get(i);
-            Bundle.Entry.Response response = responseEntry.getResponse();
-
-            // If the response status is SC_OK which means the request passed the validation,
-            // and this request entry's http method is the one we're looking for,
-            // then record the index in our list.
-            // (please notice that status can not be null since R4, So we set the response status as SC_OK
-            // after the resource validation. )
-            if (response.getStatus().equals(SC_OK_STRING)
-                    && request.getMethod().equals(httpMethod)) {
-                indices.add(Integer.valueOf(i));
-            }
-        }
-        return indices;
+        logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
+        return Entry.builder()
+                .response(Entry.Response.builder()
+                    .status(string(Integer.toString(httpStatus)))
+                    .outcome(oo)
+                    .build())
+                .build();
     }
 
     /**
@@ -2272,16 +2237,16 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     private static class BundleEntryComparator implements Comparator<Integer> {
-        private List<Bundle.Entry> entries;
+        private List<Entry> entries;
 
-        public BundleEntryComparator(List<Bundle.Entry> entries) {
+        public BundleEntryComparator(List<Entry> entries) {
             this.entries = entries;
         }
 
         @Override
         public int compare(Integer indexA, Integer indexB) {
-            Bundle.Entry a = entries.get(indexA);
-            Bundle.Entry b = entries.get(indexB);
+            Entry a = entries.get(indexA);
+            Entry b = entries.get(indexB);
             String pathA = getUrlPath(a);
             String pathB = getUrlPath(b);
 
@@ -2306,9 +2271,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            the bundle entry
      * @return the bundle entry's 'url' field's path component
      */
-    private static String getUrlPath(Bundle.Entry entry) {
+    private static String getUrlPath(Entry entry) {
         String path = null;
-        Bundle.Entry.Request request = entry.getRequest();
+        Entry.Request request = entry.getRequest();
         if (request != null) {
             if (request.getUrl() != null && request.getUrl().getValue() != null) {
                 FHIRUrlParser requestURL = new FHIRUrlParser(request.getUrl().getValue());
@@ -2343,18 +2308,21 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *
      * @return local reference map
      */
-    private Map<String, String> buildLocalRefMap(Bundle requestBundle, Bundle responseBundle) throws Exception {
-        Map<String, String> localRefMap = new HashMap<>();
+    private Map<String, String> buildLocalRefMap(Bundle requestBundle, Map<Integer, Entry> validationResponseEntries) throws Exception {
+            Map<String, String> localRefMap = new HashMap<>();
 
         for (int entryIndex=0; entryIndex<requestBundle.getEntry().size(); ++entryIndex) {
-            Bundle.Entry requestEntry = requestBundle.getEntry().get(entryIndex);
-            Bundle.Entry.Request request = requestEntry.getRequest();
-            Bundle.Entry responseEntry = responseBundle.getEntry().get(entryIndex);
-            Bundle.Entry.Response response = responseEntry.getResponse();
+            Entry requestEntry = requestBundle.getEntry().get(entryIndex);
+            Entry.Request request = requestEntry.getRequest();
+            Entry validationResponseEntry = validationResponseEntries.get(entryIndex);
 
-            // Only add mappings for POST and PUT requests where response is OK.
-            if (response.getStatus().equals(SC_OK_STRING) &&
-                    (request.getMethod().equals(HTTPVerb.POST) || request.getMethod().equals(HTTPVerb.PUT))) {
+            // Only add mappings for POST and PUT requests where response is ACCEPTED.
+            if (validationResponseEntry != null && !validationResponseEntry.getResponse().getStatus().equals(SC_ACCEPTED_STRING)) {
+                continue;
+            }
+
+            HTTPVerb.ValueSet method = request.getMethod().getValueAsEnumConstant();
+            if (method == HTTPVerb.ValueSet.POST || method == HTTPVerb.ValueSet.PUT) {
 
                 // Retrieve the local identifier from the request entry (if present).
                 String localIdentifier = retrieveLocalIdentifier(requestEntry);
@@ -2370,7 +2338,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
                         // Only add mapping for POST request if it's a non-conditional create.
                         // Only add mapping for PUT request if a resource ID is specified.
-                        if (request.getMethod().equals(HTTPVerb.POST) && pathTokens.length == 1 && !pathTokens[0].startsWith("$") &&
+                        if (method == HTTPVerb.ValueSet.POST && pathTokens.length == 1 && !pathTokens[0].startsWith("$") &&
                                 (request.getIfNoneExist() == null || request.getIfNoneExist().getValue() == null || request.getIfNoneExist().getValue().isEmpty())) {
                             // Generate external identifier and add mapping.
                             String externalIdentifier = ModelSupport.getTypeName(resource.getClass()) + "/" + persistence.generateResourceId();
@@ -2422,7 +2390,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            the bundle request entry
      * @return the local identifier
      */
-    private String retrieveLocalIdentifier(Bundle.Entry requestEntry) {
+    private String retrieveLocalIdentifier(Entry requestEntry) {
         String localIdentifier = null;
         if (requestEntry.getFullUrl() != null) {
             String fullUrl = requestEntry.getFullUrl().getValue();
@@ -2477,47 +2445,40 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         return fullUri.toString();
     }
 
-    private Bundle.Entry setBundleResponseFields(Bundle.Entry responseEntry, Resource resource,
-        OperationOutcome operationOutcome, URI locationURI, int httpStatus, String requestDescription, long initialTime) throws FHIROperationException {
+    private Entry buildResponseBundleEntry(FHIRRestOperationResponse operationResponse, OperationOutcome validationOutcome,
+            String requestDescription, long initialTime) throws FHIROperationException {
 
-        Bundle.Entry.Response response = responseEntry.getResponse();
-        Bundle.Entry.Response.Builder resBuilder = response.toBuilder();
-        resBuilder.status(string(Integer.toString(httpStatus)));
+        Resource resource = operationResponse.getResource();
+        URI locationURI = operationResponse.getLocationURI();
+        int httpStatus = operationResponse.getStatus().getStatusCode();
 
-        Bundle.Entry.Builder bundleEntryBuilder = responseEntry.toBuilder();
-
+        Entry.Response.Builder entryResponseBuilder = Entry.Response.builder()
+                .status(string(Integer.toString(httpStatus)))
+                .outcome(validationOutcome);
         if (resource != null) {
-            resBuilder =
-                    resBuilder.id(resource.getId()).lastModified(resource.getMeta().getLastUpdated()).etag(string(getEtagValue(resource)));
-
-            if (HTTPReturnPreference.REPRESENTATION.equals(FHIRRequestContext.get().getReturnPreference())) {
-                bundleEntryBuilder.resource(resource);
-            } else if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
-                OperationOutcome responseEntryOutcome = (OperationOutcome)responseEntry.getResource();
-                if (responseEntryOutcome != null && !responseEntryOutcome.equals(FHIRUtil.ALL_OK)) {
-                    if (operationOutcome.equals(FHIRUtil.ALL_OK)) {
-                        bundleEntryBuilder.resource(responseEntryOutcome);
-                    } else {
-                        List<Issue> issues = new ArrayList<>();
-                        issues.addAll(responseEntryOutcome.getIssue());
-                        issues.addAll(operationOutcome.getIssue());
-                        bundleEntryBuilder.resource(FHIRUtil.buildOperationOutcome(issues));
-                    }
-                } else {
-                    bundleEntryBuilder.resource(operationOutcome);
-                }
-            }
+            entryResponseBuilder = entryResponseBuilder
+                    .id(resource.getId())
+                    .lastModified(resource.getMeta().getLastUpdated())
+                    .etag(string(getEtagValue(resource)));
         }
         if (locationURI != null) {
-            resBuilder = resBuilder.location(Uri.of(locationURI.toString()));
+            entryResponseBuilder = entryResponseBuilder.location(Uri.of(locationURI.toString()));
+        }
+
+        Entry.Builder bundleEntryBuilder = Entry.builder();
+        if (HTTPReturnPreference.REPRESENTATION.equals(FHIRRequestContext.get().getReturnPreference())) {
+            bundleEntryBuilder.resource(resource);
+        } else if (HTTPReturnPreference.OPERATION_OUTCOME.equals(FHIRRequestContext.get().getReturnPreference())) {
+            // Given that we execute the operation with validation turned off, the operationResponse outcome is unlikely
+            // to contain useful information, but the validationOutcome already exists under the Entry.response
+            bundleEntryBuilder.resource(operationResponse.getOperationOutcome());
         }
 
         logBundleRequestCompletedMsg(requestDescription, initialTime, httpStatus);
-        return bundleEntryBuilder.response(resBuilder.build()).build();
+        return bundleEntryBuilder.response(entryResponseBuilder.build()).build();
     }
 
-    private void logBundleRequestCompletedMsg(String requestDescription, long initialTime,
-        int httpStatus) {
+    private void logBundleRequestCompletedMsg(String requestDescription, long initialTime, int httpStatus) {
         StringBuffer statusMsg = new StringBuffer();
         statusMsg.append(" status:[" + httpStatus + "]");
         double elapsedSecs = (System.currentTimeMillis() - initialTime) / 1000.0;
@@ -2541,8 +2502,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @return the bundle
      * @throws Exception
      */
-    Bundle createSearchBundle(List<Resource> resources, FHIRSearchContext searchContext, String type)
-        throws Exception {
+    Bundle createSearchBundle(List<Resource> resources, FHIRSearchContext searchContext, String type) throws Exception {
 
         // throws if we have a count of more than 2,147,483,647 resources
         UnsignedInt totalCount = searchContext.getTotalCount() != null ? UnsignedInt.of(searchContext.getTotalCount()) : null;
@@ -2592,7 +2552,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
 
             for (Resource resource : resources) {
-                Bundle.Entry.Builder entryBuilder = Bundle.Entry.builder();
+                Entry.Builder entryBuilder = Entry.builder();
                 if (resource != null) {
                     if (resource.getId() != null) {
                         entryBuilder.fullUrl(Uri.of(getRequestBaseUri(type) + "/" + resource.getClass().getSimpleName() + "/" + resource.getId()));
@@ -2609,7 +2569,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 }
                 // Search mode is determined by the matchResourceCount, which will be decremented each time through the loop.
                 // If the count is greater than 0, the mode is MATCH. If less than or equal to 0, the mode is INCLUDE.
-                Bundle.Entry entry = entryBuilder
+                Entry entry = entryBuilder
                     .search(Search.builder()
                         .mode(matchResourceCount-- > 0 ? SearchEntryMode.MATCH : SearchEntryMode.INCLUDE)
                         .score(Decimal.of("1"))
@@ -2621,7 +2581,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             if (!issues.isEmpty()) {
                 // Add OperationOutcome resource containing issues
                 bundleBuilder.entry(
-                    Bundle.Entry.builder()
+                    Entry.builder()
                     .search(Search.builder().mode(SearchEntryMode.OUTCOME).build())
                     .resource(FHIRUtil.buildOperationOutcome(issues))
                     .build());
@@ -2660,7 +2620,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @throws Exception if multiple resource types containing the same logical ID are found
      */
     private List<Issue> performSearchReferenceChecks(String resourceType, List<QueryParameter> chainQueryParameters,
-        List<QueryParameter> logicalIdReferenceQueryParameters, List<Resource> matchResources) throws Exception {
+            List<QueryParameter> logicalIdReferenceQueryParameters, List<Resource> matchResources) throws Exception {
         List<Issue> issues = new ArrayList<>();
 
         if (!chainQueryParameters.isEmpty() || !logicalIdReferenceQueryParameters.isEmpty()) {
@@ -2780,15 +2740,15 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // Create the 'request' entry, and set the request.url field.
             // 'create' --> url = "<resourceType>"
             // 'update'/'delete' --> url = "<resourceType>/<logicalId>"
-            Bundle.Entry.Request request =
-                    Bundle.Entry.Request.builder().method(method).url(Url.of(method == HTTPVerb.POST
+            Entry.Request request =
+                    Entry.Request.builder().method(method).url(Url.of(method == HTTPVerb.POST
                             ? resourceType : resourceType + "/" + logicalId)).build();
 
-            Bundle.Entry.Response response =
-                    Bundle.Entry.Response.builder().status(string("200")).build();
+            Entry.Response response =
+                    Entry.Response.builder().status(string("200")).build();
 
-            Bundle.Entry entry =
-                    Bundle.Entry.builder().request(request).fullUrl(Uri.of(getRequestBaseUri(type) + "/"
+            Entry entry =
+                    Entry.builder().request(request).fullUrl(Uri.of(getRequestBaseUri(type) + "/"
                             + resource.getClass().getSimpleName() + "/"
                             + resource.getId())).response(response).resource(resource).build();
 
@@ -3292,7 +3252,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
 
             Request.Builder requestBuilder = Request.builder();
-            Bundle.Entry.Response.Builder responseBuilder = Bundle.Entry.Response.builder();
+            Entry.Response.Builder responseBuilder = Entry.Response.builder();
             switch (changeRecord.getChangeType()) {
             case CREATE:
                 requestBuilder.method(HTTPVerb.POST);
@@ -3313,7 +3273,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             responseBuilder.lastModified(com.ibm.fhir.model.type.Instant.of(changeRecord.getChangeTstamp().atZone(UTC)));
 
-            Bundle.Entry.Builder entryBuilder = Bundle.Entry.builder();
+            Entry.Builder entryBuilder = Entry.builder();
             entryBuilder.fullUrl(Url.of(changeRecord.getResourceTypeName() + "/" + changeRecord.getLogicalId() + "/_history/" + changeRecord.getVersionId()));
             entryBuilder.request(requestBuilder.build());
             entryBuilder.response(responseBuilder.build());

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
@@ -36,7 +36,10 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
-        T updatedResource = (T) resource.toBuilder().id(generateResourceId()).meta(Meta.builder().versionId(Id.of("1")).lastUpdated(Instant.now()).build()).build();
+        T updatedResource = (T) resource.toBuilder()
+                .id(generateResourceId())
+                .meta(Meta.builder().versionId(Id.of("1")).lastUpdated(Instant.now()).build())
+                .build();
         SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                 .success(true)
                 .resource(updatedResource);

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -80,24 +80,6 @@ public class FHIRRestHelperTest {
                 .expression(string("Patient"))
                 .build())
             .build();
-    public static final OperationOutcome ID_AND_NO_NARRATIVE = OperationOutcome.builder()
-            .issue(Issue.builder()
-                .severity(IssueSeverity.WARNING)
-                .code(IssueType.INVARIANT)
-                .details(CodeableConcept.builder()
-                    .text(string("dom-6: A resource should have narrative for robust management"))
-                    .build())
-                .expression(string("Patient"))
-                .build(),
-                Issue.builder()
-                .severity(IssueSeverity.INFORMATION)
-                .code(IssueType.INFORMATIONAL)
-                .details(CodeableConcept.builder()
-                    .text(string("The create request resource included id: '1'; this id has been replaced"))
-                    .build())
-                .expression(string("<no expression>"))
-                .build())
-            .build();
 
     /**
      * Test transaction bundle post single.
@@ -141,10 +123,10 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(ALL_OK, entry.getResource());
+        assertEquals(entry.getResource(), ALL_OK);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/generated-0/_history/1", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/generated-0/_history/1");
+        assertEquals(response.getStatus().getValue(), "201");
     }
 
     /**
@@ -185,10 +167,11 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(NO_NARRATIVE, entry.getResource());
+        assertEquals(entry.getResource(), ALL_OK);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/generated-0/_history/1", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/generated-0/_history/1");
+        assertEquals(response.getStatus().getValue(), "201");
+        assertEquals(response.getOutcome(), NO_NARRATIVE);
     }
 
     /**
@@ -234,10 +217,10 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(ID_SPECIFIED, entry.getResource());
+        assertEquals(entry.getResource(), ID_SPECIFIED);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/generated-0/_history/1", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/generated-0/_history/1");
+        assertEquals(response.getStatus().getValue(), "201");
     }
 
     /**
@@ -279,10 +262,11 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(ID_AND_NO_NARRATIVE, entry.getResource());
+        assertEquals(entry.getResource(), ID_SPECIFIED);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/generated-0/_history/1", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/generated-0/_history/1");
+        assertEquals(response.getStatus().getValue(), "201");
+        assertEquals(response.getOutcome(), NO_NARRATIVE);
     }
 
     /**
@@ -553,13 +537,13 @@ public class FHIRRestHelperTest {
         for (Bundle.Entry entry : responseBundle.getEntry()) {
             Bundle.Entry.Response response = entry.getResponse();
             if (response.getLocation().getValue().startsWith("Patient")) {
-                assertEquals("Patient/generated-0/_history/1", response.getLocation().getValue());
-                assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+                assertEquals(response.getLocation().getValue(), "Patient/generated-0/_history/1");
+                assertEquals(response.getStatus().getValue(), "201");
             } else if (response.getLocation().getValue().startsWith("Procedure")) {
-                assertEquals("Procedure/generated-1/_history/1", response.getLocation().getValue());
-                assertEquals(Integer.toString(Response.Status.CREATED.getStatusCode()), response.getStatus().getValue());
+                assertEquals(response.getLocation().getValue(), "Procedure/generated-1/_history/1");
+                assertEquals(response.getStatus().getValue(), "201");
                 Procedure returnedProcedure = (Procedure) entry.getResource();
-                assertEquals("Patient/generated-0", returnedProcedure.getSubject().getReference().getValue());
+                assertEquals(returnedProcedure.getSubject().getReference().getValue(), "Patient/generated-0");
             } else {
                 fail();
             }
@@ -941,10 +925,11 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(NO_NARRATIVE, entry.getResource());
+        assertEquals(entry.getResource(), ALL_OK);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/1/_history/2", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.OK.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/1/_history/2");
+        assertEquals(response.getStatus().getValue(), "200");
+        assertEquals(response.getOutcome(), NO_NARRATIVE);
     }
 
     /**
@@ -987,10 +972,10 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(ID_SPECIFIED, entry.getResource());
+        assertEquals(entry.getResource(), ID_SPECIFIED);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/1/_history/2", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.OK.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/1/_history/2");
+        assertEquals(response.getStatus().getValue(), "200");
     }
 
     /**
@@ -1029,10 +1014,11 @@ public class FHIRRestHelperTest {
         assertNotNull(responseBundle);
         assertEquals(1, responseBundle.getEntry().size());
         Bundle.Entry entry = responseBundle.getEntry().get(0);
-        assertEquals(ID_AND_NO_NARRATIVE, entry.getResource());
+        assertEquals(entry.getResource(), ID_SPECIFIED);
         Bundle.Entry.Response response = entry.getResponse();
-        assertEquals("Patient/1/_history/2", response.getLocation().getValue());
-        assertEquals(Integer.toString(Response.Status.OK.getStatusCode()), response.getStatus().getValue());
+        assertEquals(response.getLocation().getValue(), "Patient/1/_history/2");
+        assertEquals(response.getStatus().getValue(), "200");
+        assertEquals(response.getOutcome(), NO_NARRATIVE);
     }
 
     /**


### PR DESCRIPTION
1. FHIRRestHelper.validateBundle now returns a sparse array (modeled as
a map) of bundle response entries with errors / warnings. It used to construct an
entire response bundle.

2. FHIRRestHelper.processEntriesByMethod replaces
FHIRRestHelper.processEntriesForMethod and iterates the request entries
a single time, instead of once-per-method.

3. Entries are collected into an array instead of "modifying" the
responseBundle with each one (which forced lots of needless copying
since our model is now immutable).

4. Stop duplicating custom operation results in the
`Bundle.entry.response.outcome` field of the response. We already copy
the operation's result in the `Bundle.entry.resource` and that should be
sufficient.

I also made significant formatting changes in FHIRRestHelper.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>