### PR TITLE
Move caffeine dependency from fhir-core to fhir-cache

### DIFF
--- a/fhir-cache/pom.xml
+++ b/fhir-cache/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>fhir-cache</artifactId>
     <dependencies>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-core</artifactId>
             <version>${project.version}</version>

--- a/fhir-core/pom.xml
+++ b/fhir-core/pom.xml
@@ -14,10 +14,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.ben-manes.caffeine</groupId>
-            <artifactId>caffeine</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
Initially John added Caffeine to fhir-core but he later refactored this
caching work to a separate module.  This commit updates the dependency
hierarchy to match.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>