### PR TITLE
issue #2284 - support skippable updates for batch/transaction methods

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
@@ -905,6 +905,11 @@ public final class FHIRPathUtil {
 
         FHIRPathTree tree = evaluator.getEvaluationContext().getTree();
         FHIRPathNode parentNode = tree.getParent(node);
+
+        if (parentNode == null) {
+            throw new FHIRPatchException("Unable to compute the parent for '" + elementName + "';" +
+                    " a FHIRPathPatch replace FHIRPath must select a node with a parent", fhirPath);
+        }
         Visitable parent = parentNode.isResourceNode() ?
                 parentNode.asResourceNode().resource() : parentNode.asElementNode().element();
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -2335,7 +2335,7 @@ public class BundleTest extends FHIRServerTestBase {
     }
 
     /**
-     * Test transaction bundle put with post local reference dependency.
+     * Sets UPDATE_IF_MODIFIED_HEADER_NAME  and posts a transaction bundle with an update and a patch; both should be skipped on the server
      * Procedure has local reference to Patient.
      */
     @Test

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -8,8 +8,8 @@ package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.test.TestUtil.isResourceInResponse;
 import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 import java.util.ArrayList;
@@ -45,6 +45,7 @@ import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Practitioner;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Reference;
@@ -105,6 +106,8 @@ public class BundleTest extends FHIRServerTestBase {
 
     private static final String PREFER_HEADER_RETURN_REPRESENTATION = "return=representation";
     private static final String PREFER_HEADER_NAME = "Prefer";
+
+    private static final String UPDATE_IF_MODIFIED_HEADER_NAME = "X-FHIR-UPDATE-IF-MODIFIED";
 
     /**
      * Retrieve the server's conformance statement to determine the status of
@@ -2331,6 +2334,94 @@ public class BundleTest extends FHIRServerTestBase {
         assertGoodGetResponse(responseBundle.getEntry().get(1), Status.OK.getStatusCode(), HTTPReturnPreference.MINIMAL);
     }
 
+    /**
+     * Test transaction bundle put with post local reference dependency.
+     * Procedure has local reference to Patient.
+     */
+    @Test
+    public void testTransactionBundleWithSkippableUpdates() throws Exception {
+        String randomId = UUID.randomUUID().toString();
+        Patient patient = Patient.builder()
+                .id(randomId)
+                .active(com.ibm.fhir.model.type.Boolean.TRUE)
+                .build();
+        Bundle.Entry.Request bundleEntryRequest = Bundle.Entry.Request.builder()
+                .method(HTTPVerb.PUT)
+                .url(Uri.of("Patient/"+randomId))
+                .build();
+        Bundle.Entry bundleEntry = Bundle.Entry.builder()
+                .fullUrl(Uri.of("urn:1"))
+                .resource(patient)
+                .request(bundleEntryRequest)
+                .build();
+        Bundle.Entry bundleEntry2 = Bundle.Entry.builder()
+                .fullUrl(Uri.of("urn:2"))
+                .resource(patient)
+                .request(bundleEntryRequest)
+                .build();
+
+        Bundle.Entry.Request patchRequest = Bundle.Entry.Request.builder()
+                .method(HTTPVerb.PATCH)
+                .url(Uri.of("Patient/"+randomId))
+                .build();
+        Parameters nopPatch = Parameters.builder()
+                .parameter(Parameter.builder()
+                    .name(string("operation"))
+                    .part(Parameter.builder()
+                        .name(string("type"))
+                        .value(Code.of("replace"))
+                        .build())
+                    .part(Parameter.builder()
+                        .name(string("path"))
+                        .value(string("Patient.active"))
+                        .build())
+                    .part(Parameter.builder()
+                        .name(string("value"))
+                        .value(com.ibm.fhir.model.type.Boolean.TRUE)
+                        .build())
+                    .build())
+                .build();
+        Bundle.Entry bundleEntry3 = Bundle.Entry.builder()
+                .fullUrl(Uri.of("urn:3"))
+                .resource(nopPatch)
+                .request(patchRequest)
+                .build();
+
+        Bundle requestBundle = Bundle.builder()
+                .id("bundle1")
+                .type(BundleType.TRANSACTION)
+                .entry(bundleEntry, bundleEntry2, bundleEntry3)
+                .build();
+
+        // Process bundle
+        FHIRRequestHeader returnPref = FHIRRequestHeader.header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION);
+        FHIRRequestHeader updateOnlyIfModified = FHIRRequestHeader.header(UPDATE_IF_MODIFIED_HEADER_NAME, true);
+        FHIRResponse response = client.transaction(requestBundle, returnPref, updateOnlyIfModified);
+        assertNotNull(response);
+        assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
+        Bundle responseBundle = response.getResource(Bundle.class);
+        printBundle("PUT", "response", responseBundle);
+
+        // Validate results
+        assertNotNull(responseBundle);
+        assertEquals(3, responseBundle.getEntry().size());
+
+        Bundle.Entry entry1 = responseBundle.getEntry().get(0);
+        assertNotNull(entry1.getResource());
+        assertEquals(entry1.getResponse().getStatus().getValue(), "201");
+        assertEquals(entry1.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
+        Patient responsePatient = entry1.getResource().as(Patient.class);
+
+        Bundle.Entry entry2 = responseBundle.getEntry().get(1);
+        assertEquals(entry2.getResponse().getStatus().getValue(), "200");
+        assertEquals(entry2.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
+        assertEquals(entry2.getResource(), responsePatient);
+
+        Bundle.Entry entry3 = responseBundle.getEntry().get(2);
+        assertEquals(entry3.getResponse().getStatus().getValue(), "200");
+        assertEquals(entry3.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
+        assertEquals(entry3.getResource(), responsePatient);
+    }
 
     /**
      * Helper function to create a set of Observations, and return them in a

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIRResourceHelpers.java
@@ -295,9 +295,12 @@ public interface FHIRResourceHelpers {
      *
      * @param bundle
      *            the request Bundle
+     * @param skippableUpdates
+     *            if true, and the bundle contains an update for which the resource content in the update matches the existing
+     *            resource on the server, then skip the update; if false, then always attempt the updates specified in the bundle
      * @return the response Bundle
      */
-    Bundle doBundle(Bundle bundle) throws Exception;
+    Bundle doBundle(Bundle bundle, boolean skippableUpdates) throws Exception;
 
     FHIRPersistenceTransaction getTransaction() throws Exception;
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Batch.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -22,6 +23,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Bundle;
@@ -46,7 +48,7 @@ public class Batch extends FHIRResource {
     }
 
     @POST
-    public Response bundle(Resource resource) {
+    public Response bundle(Resource resource, @HeaderParam(FHIRConstants.UPDATE_IF_MODIFIED_HEADER) boolean updateOnlyIfModified) {
         log.entering(this.getClass().getName(), "bundle(Bundle)");
         Date startTime = new Date();
         Response.Status status = null;
@@ -65,7 +67,7 @@ public class Batch extends FHIRResource {
             }
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
-            responseBundle = helper.doBundle(inputBundle);
+            responseBundle = helper.doBundle(inputBundle, updateOnlyIfModified);
             status = Status.OK;
             return Response.ok(responseBundle).build();
         } catch (FHIRRestBundledRequestException e) {

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -1647,7 +1647,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle);
+            Bundle bundle = helper.doBundle(requestBundle, false);
             assertEquals(2, bundle.getEntry().size());
             for (Entry bundleEntry : bundle.getEntry()) {
                 assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
@@ -1715,7 +1715,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle);
+            helper.doBundle(requestBundle, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1786,7 +1786,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle);
+            Bundle bundle = helper.doBundle(requestBundle, false);
             assertEquals(2, bundle.getEntry().size());
             for (Entry bundleEntry : bundle.getEntry()) {
                 assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
@@ -1854,7 +1854,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doBundle(requestBundle);
+            Bundle bundle = helper.doBundle(requestBundle, false);
             assertEquals(2, bundle.getEntry().size());
             assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Patient'",
                 bundle.getEntry().get(0).getResource().as(OperationOutcome.class).getIssue().get(0).getDetails().getText().getValue());

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/ProfileValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/ProfileValidationConfigTest.java
@@ -647,7 +647,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle);
+            helper.doBundle(requestBundle, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -700,7 +700,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle);
+            helper.doBundle(requestBundle, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -754,7 +754,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle);
+            helper.doBundle(requestBundle, false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -807,7 +807,7 @@ public class ProfileValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doBundle(requestBundle);
+            helper.doBundle(requestBundle, false);
             fail();
         } catch (FHIRValidationException e) {
             // Validate results.

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -117,7 +117,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -161,7 +161,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -211,7 +211,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -256,7 +256,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -315,7 +315,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -382,7 +382,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -459,7 +459,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -529,7 +529,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -598,7 +598,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -737,7 +737,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -824,7 +824,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -878,7 +878,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -919,7 +919,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -966,7 +966,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1008,7 +1008,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1068,7 +1068,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1136,7 +1136,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1215,7 +1215,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1285,7 +1285,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1353,7 +1353,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1421,7 +1421,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1565,7 +1565,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1653,7 +1653,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1732,7 +1732,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);
@@ -1903,7 +1903,7 @@ public class FHIRRestHelperTest {
         // Process bundle
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.REPRESENTATION);
-        Bundle responseBundle = helper.doBundle(requestBundle);
+        Bundle responseBundle = helper.doBundle(requestBundle, false);
 
         // Validate results
         assertNotNull(responseBundle);


### PR DESCRIPTION
If `X-FHIR-UPDATE-IF-MODIFIED` is set to true on the request, then all
updates (including patches) in the bundle will be processed in accordance 
with this update optimization.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>