### PR TITLE
bump project modules to 4.8.0-SNAPSHOT

### DIFF
--- a/conformance/fhir-ig-carin-bb/pom.xml
+++ b/conformance/fhir-ig-carin-bb/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-carin-bb</artifactId>

--- a/conformance/fhir-ig-davinci-hrex/pom.xml
+++ b/conformance/fhir-ig-davinci-hrex/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-davinci-hrex</artifactId>

--- a/conformance/fhir-ig-davinci-pdex-formulary/pom.xml
+++ b/conformance/fhir-ig-davinci-pdex-formulary/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-davinci-pdex-formulary</artifactId>

--- a/conformance/fhir-ig-davinci-pdex-plan-net/pom.xml
+++ b/conformance/fhir-ig-davinci-pdex-plan-net/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-davinci-pdex-plan-net</artifactId>

--- a/conformance/fhir-ig-davinci-pdex/pom.xml
+++ b/conformance/fhir-ig-davinci-pdex/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-davinci-pdex</artifactId>

--- a/conformance/fhir-ig-mcode/pom.xml
+++ b/conformance/fhir-ig-mcode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-mcode</artifactId>

--- a/conformance/fhir-ig-us-core/pom.xml
+++ b/conformance/fhir-ig-us-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-ig-us-core</artifactId>

--- a/fhir-audit/pom.xml
+++ b/fhir-audit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-benchmark/pom.xml
+++ b/fhir-benchmark/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.ibm.fhir</groupId>
     <artifactId>fhir-benchmark</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>IBM FHIR Server - FHIR Benchmark</name>
@@ -38,17 +38,17 @@
         <dependency>
             <groupId>com.ibm.fhir</groupId>
             <artifactId>fhir-model</artifactId>
-            <version>4.7.0-SNAPSHOT</version>
+            <version>4.8.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.fhir</groupId>
             <artifactId>fhir-examples</artifactId>
-            <version>4.7.0-SNAPSHOT</version>
+            <version>4.8.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.fhir</groupId>
             <artifactId>fhir-validation</artifactId>
-            <version>4.7.0-SNAPSHOT</version>
+            <version>4.8.0-SNAPSHOT</version>
         </dependency>
         <!-- Updated to 4.0.1 -->
         <dependency>

--- a/fhir-bucket/pom.xml
+++ b/fhir-bucket/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-bulkdata-webapp/pom.xml
+++ b/fhir-bulkdata-webapp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
       

--- a/fhir-cache/pom.xml
+++ b/fhir-cache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-cache</artifactId>

--- a/fhir-cli/pom.xml
+++ b/fhir-cli/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-client/pom.xml
+++ b/fhir-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-config/pom.xml
+++ b/fhir-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-config</artifactId>

--- a/fhir-core/pom.xml
+++ b/fhir-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-database-utils/pom.xml
+++ b/fhir-database-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-examples-generator/pom.xml
+++ b/fhir-examples-generator/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-examples-generator/src/test/resources/examplesplugin/pom.xml
+++ b/fhir-examples-generator/src/test/resources/examplesplugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-examples/pom.xml
+++ b/fhir-examples/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>fhir-examples</artifactId>
     <groupId>com.ibm.fhir</groupId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
 
     <name>IBM FHIR Server - Examples</name>
     <url>https://github.com/ibm/fhir</url>

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -25,7 +25,7 @@ COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 FROM openliberty/open-liberty:21.0.0.3-kernel-slim-java11-openj9-ubi
 
 ARG VERBOSE=true
-ARG FHIR_VERSION=4.7.0-SNAPSHOT
+ARG FHIR_VERSION=4.8.0-SNAPSHOT
 
 # The following labels are required: 
 LABEL name='IBM FHIR Server'

--- a/fhir-install/pom.xml
+++ b/fhir-install/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-model/pom.xml
+++ b/fhir-model/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-notification/pom.xml
+++ b/fhir-notification/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-openapi/pom.xml
+++ b/fhir-openapi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.ibm.fhir</groupId>
     <artifactId>fhir-parent</artifactId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>IBM FHIR Server</name>
 
@@ -62,8 +62,8 @@
         <fhir-persistence-jdbc.index>MINIMAL_JSON</fhir-persistence-jdbc.index>
         <fhir-server-test.index>MINIMAL_JSON</fhir-server-test.index>
         <java.version>1.8</java.version>
-        <fhir-examples.version>4.7.0-SNAPSHOT</fhir-examples.version>
-        <fhir-tools.version>4.7.0-SNAPSHOT</fhir-tools.version>
+        <fhir-examples.version>4.8.0-SNAPSHOT</fhir-examples.version>
+        <fhir-tools.version>4.8.0-SNAPSHOT</fhir-tools.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     </properties>
 
@@ -1035,7 +1035,7 @@
                         <configuration>
                             <!-- speed up the build -->
                             <isOffline>true</isOffline>
-                            <!-- no matter the JDK running the javadoc, it's 
+                            <!-- no matter the JDK running the javadoc, it's
                                 important this be at the minimum level we support, which is 11. -->
                             <source>11</source>
                             <!-- we don't need package -->
@@ -1055,7 +1055,7 @@
                             <windowtitle>IBM FHIR Server</windowtitle>
                             <doctitle>${project.name} ${project.version}</doctitle>
                             <additionalOptions>
-                                <!-- makes the frames visible, disabled and 
+                                <!-- makes the frames visible, disabled and
                                     going away eventually -->
                                 <additionalOption>--frames</additionalOption>
                                 <!-- Fixes the undefined redirect in search -->
@@ -1130,7 +1130,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <!-- Do not move this up to top level as it'll cause 
+                        <!-- Do not move this up to top level as it'll cause
                             a conflict with m2e restrictions on v2.6 -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>

--- a/fhir-path/pom.xml
+++ b/fhir-path/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     

--- a/fhir-persistence-jdbc/pom.xml
+++ b/fhir-persistence-jdbc/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-persistence-proxy/pom.xml
+++ b/fhir-persistence-proxy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-persistence-schema/pom.xml
+++ b/fhir-persistence-schema/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-persistence-scout/pom.xml
+++ b/fhir-persistence-scout/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-persistence/pom.xml
+++ b/fhir-persistence/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-profile/pom.xml
+++ b/fhir-profile/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-provider/pom.xml
+++ b/fhir-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-registry/pom.xml
+++ b/fhir-registry/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-registry</artifactId>

--- a/fhir-search/pom.xml
+++ b/fhir-search/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-server-test/pom.xml
+++ b/fhir-server-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-server-webapp/pom.xml
+++ b/fhir-server-webapp/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-smart/pom.xml
+++ b/fhir-smart/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-swagger-generator/pom.xml
+++ b/fhir-swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/fhir-term-graph/pom.xml
+++ b/fhir-term-graph/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-term-graph</artifactId>

--- a/fhir-term-remote/pom.xml
+++ b/fhir-term-remote/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     

--- a/fhir-term/pom.xml
+++ b/fhir-term/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-term</artifactId>

--- a/fhir-tools/pom.xml
+++ b/fhir-tools/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ibm.fhir</groupId>
-    <version>4.7.0-SNAPSHOT</version>
+    <version>4.8.0-SNAPSHOT</version>
     <artifactId>fhir-tools</artifactId>
 
     <packaging>maven-plugin</packaging>

--- a/fhir-tools/src/test/resources/modelplugin/pom.xml
+++ b/fhir-tools/src/test/resources/modelplugin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.ibm.fhir</groupId>
 		<artifactId>fhir-parent</artifactId>
-		<version>4.7.0-SNAPSHOT</version>
+		<version>4.8.0-SNAPSHOT</version>
 		<relativePath>../fhir-parent</relativePath>
 	</parent>
 

--- a/fhir-validation/pom.xml
+++ b/fhir-validation/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
 

--- a/notification/fhir-notification-kafka/pom.xml
+++ b/notification/fhir-notification-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/notification/fhir-notification-nats/pom.xml
+++ b/notification/fhir-notification-nats/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/notification/fhir-notification-websocket/pom.xml
+++ b/notification/fhir-notification-websocket/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/operation/fhir-operation-apply/pom.xml
+++ b/operation/fhir-operation-apply/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     

--- a/operation/fhir-operation-bulkdata/pom.xml
+++ b/operation/fhir-operation-bulkdata/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/operation/fhir-operation-convert/pom.xml
+++ b/operation/fhir-operation-convert/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/operation/fhir-operation-document/pom.xml
+++ b/operation/fhir-operation-document/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     

--- a/operation/fhir-operation-everything/pom.xml
+++ b/operation/fhir-operation-everything/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     

--- a/operation/fhir-operation-healthcheck/pom.xml
+++ b/operation/fhir-operation-healthcheck/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     

--- a/operation/fhir-operation-reindex/pom.xml
+++ b/operation/fhir-operation-reindex/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     

--- a/operation/fhir-operation-term/pom.xml
+++ b/operation/fhir-operation-term/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     <artifactId>fhir-operation-term</artifactId>

--- a/operation/fhir-operation-test/pom.xml
+++ b/operation/fhir-operation-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
 

--- a/operation/fhir-operation-validate/pom.xml
+++ b/operation/fhir-operation-validate/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
-        <version>4.7.0-SNAPSHOT</version>
+        <version>4.8.0-SNAPSHOT</version>
         <relativePath>../../fhir-parent</relativePath>
     </parent>
     


### PR DESCRIPTION
I also tried changing our modules to reference fhir-examples 4.7.1 (instead of the snapshot), but it turns out we have already merged https://github.com/IBM/FHIR/pull/2278/files which relies on the latest snapshot.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>