### PR TITLE
Issue #2305 - fix _include search with _total=none when no 'match'

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -711,11 +711,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 resources = this.convertResourceDTOList(resourceDTOList, resourceType, elements);
                 searchContext.setMatchCount(resources.size());
 
-                // Check if _include or _revinclude search. If so, generate queries for each _include or
-                // _revinclude parameter and add the returned 'include' resources to the 'match' resource
-                // list. All duplicates in the 'include' resources (duplicates of both 'match' and 'include'
-                // resources) will be removed and _elements processing will not be done for 'include' resources.
-                if (searchContext.hasIncludeParameters() || searchContext.hasRevIncludeParameters()) {
+                // If 'match' resources were found, check if _include or _revinclude search. If so, generate
+                // queries for each _include or _revinclude parameter and add the returned 'include' resources to the
+                // 'match' resource list. All duplicates in the 'include' resources (duplicates of both 'match' and
+                // 'include' resources) will be removed and _elements processing will not be done for 'include' resources.
+                if (resources.size() > 0 && (searchContext.hasIncludeParameters() || searchContext.hasRevIncludeParameters())) {
                     List<com.ibm.fhir.persistence.jdbc.dto.Resource> includeDTOList =
                             searchForIncludeResources(searchContext, resourceType, queryBuilder, resourceDao, resourceDTOList);
                     resources.addAll(this.convertResourceDTOList(includeDTOList, resourceType, null));

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
@@ -358,6 +358,22 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
     }
 
     /**
+     * This test queries an Observation and requests the inclusion of a referenced Patient,
+     * where the _total parameter is set to none. Since there is no Observation, no match
+     * or included resource will be returned.
+     * @throws Exception
+     */
+    @Test
+    public void testIncludeWithTotalNone() throws Exception {
+        Map<String, List<String>> queryParms = new HashMap<String, List<String>>();
+        queryParms.put("_id", Collections.singletonList(savedOrg1.getId()));
+        queryParms.put("_include", Collections.singletonList("Observation:patient"));
+        List<Resource> resources = runQueryTest(Observation.class, queryParms);
+        assertNotNull(resources);
+        assertEquals(0, resources.size());
+    }
+
+    /**
      * This test queries an Observation and requests the inclusion of a referenced Patient and a referenced Encounter.
      * The Observation only contains a referenced patient.
      * @throws Exception


### PR DESCRIPTION
Signed-off-by: Mike Schroeder <mschroed@us.ibm.com>