### PR TITLE
Issue #2041 - Make quantity values searchable even without unit or code

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -277,7 +277,12 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         BigDecimal valueLow = param.getValueNumberLow();
         BigDecimal valueHigh = param.getValueNumberHigh();
 
-        // No isBase check because there are no system-level number search parameters
+        // System-level number search parameters are not supported
+        if (isBase(param)) {
+            String msg = "System-level number search parameters are not supported: " + parameterName;
+            logger.warning(msg);
+            throw new IllegalArgumentException(msg);
+        }
 
         try {
             int parameterNameId = getParameterNameId(parameterName);
@@ -401,7 +406,12 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         BigDecimal quantityLow = param.getValueNumberLow();
         BigDecimal quantityHigh = param.getValueNumberHigh();
 
-        // No isBase check because there are no system-level quantity search parameters
+        // System-level quantity search parameters are not supported
+        if (isBase(param)) {
+            String msg = "System-level quantity search parameters are not supported: " + parameterName;
+            logger.warning(msg);
+            throw new IllegalArgumentException(msg);
+        }
 
         // Skip anything with a null code, since CODE column is non-nullable,
         // but allow empty code for when no code or unit is specified
@@ -453,7 +463,12 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         double lat = param.getValueLatitude();
         double lng = param.getValueLongitude();
 
-        // No isBase check because there are no system-level location search parameters
+        // System-level location search parameters are not supported
+        if (isBase(param)) {
+            String msg = "System-level location search parameters are not supported: " + parameterName;
+            logger.warning(msg);
+            throw new IllegalArgumentException(msg);
+        }
 
         try {
             PreparedStatement insert = connection.prepareStatement(insertLocation);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -277,6 +277,8 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         BigDecimal valueLow = param.getValueNumberLow();
         BigDecimal valueHigh = param.getValueNumberHigh();
 
+        // No isBase check because there are no system-level number search parameters
+
         try {
             int parameterNameId = getParameterNameId(parameterName);
 
@@ -399,7 +401,7 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         BigDecimal quantityLow = param.getValueNumberLow();
         BigDecimal quantityHigh = param.getValueNumberHigh();
 
-        // XX why no check for isBase on this one?
+        // No isBase check because there are no system-level quantity search parameters
 
         // Skip anything with a null code, since CODE column is non-nullable,
         // but allow empty code for when no code or unit is specified
@@ -450,6 +452,8 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         String parameterName = param.getName();
         double lat = param.getValueLatitude();
         double lng = param.getValueLongitude();
+
+        // No isBase check because there are no system-level location search parameters
 
         try {
             PreparedStatement insert = connection.prepareStatement(insertLocation);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -399,10 +399,11 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
         BigDecimal quantityLow = param.getValueNumberLow();
         BigDecimal quantityHigh = param.getValueNumberHigh();
 
-        // XXX why no check for isBase on this one?
+        // XX why no check for isBase on this one?
 
-        // Skip anything with a null code
-        if (code == null || code.isEmpty()) {
+        // Skip anything with a null code, since CODE column is non-nullable,
+        // but allow empty code for when no code or unit is specified
+        if (code == null) {
             if (logger.isLoggable(Level.FINE)) {
                 logger.fine("CODELESS QUANTITY (skipped): " + parameterName + "=" + code + ":" + codeSystem + "{" + quantityValue + ", " + quantityLow + ", " + quantityHigh + "}");
             }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/QuantityParmVal.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/QuantityParmVal.java
@@ -15,7 +15,7 @@ import com.ibm.fhir.persistence.jdbc.JDBCConstants;
  * This class defines the Data Transfer Object representing a row in the X_QUANTITY_VALUES tables.
  */
 public class QuantityParmVal implements ExtractedParameterValue {
-    
+
     private String resourceType;
     private String name;
     private BigDecimal valueNumber;
@@ -23,7 +23,7 @@ public class QuantityParmVal implements ExtractedParameterValue {
     private BigDecimal valueNumberHigh;
     private String valueSystem;
     private String valueCode;
-    
+
     // The SearchParameter base type. If "Resource", then this is a Resource-level attribute
     private String base;
 
@@ -31,10 +31,12 @@ public class QuantityParmVal implements ExtractedParameterValue {
         super();
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getName() {
         return name;
     }
@@ -59,6 +61,10 @@ public class QuantityParmVal implements ExtractedParameterValue {
     }
 
     public String getValueCode() {
+        // X_QUANTITY_VALUES tables have non-nullable CODE column, so use empty string for no code
+        if (valueCode == null) {
+            return "";
+        }
         return valueCode;
     }
 
@@ -82,10 +88,12 @@ public class QuantityParmVal implements ExtractedParameterValue {
         this.valueNumberHigh = valueNumberHigh;
     }
 
+    @Override
     public String getResourceType() {
         return resourceType;
     }
 
+    @Override
     public void setResourceType(String resourceType) {
         this.resourceType = resourceType;
     }
@@ -93,6 +101,7 @@ public class QuantityParmVal implements ExtractedParameterValue {
     /**
      * We know our type, so we can call the correct method on the visitor
      */
+    @Override
     public void accept(ExtractedParameterValueVisitor visitor) throws FHIRPersistenceException {
         visitor.visit(this);
     }
@@ -100,6 +109,7 @@ public class QuantityParmVal implements ExtractedParameterValue {
     /**
      * @return the base
      */
+    @Override
     public String getBase() {
         return base;
     }
@@ -107,6 +117,7 @@ public class QuantityParmVal implements ExtractedParameterValue {
     /**
      * @param base the base to set
      */
+    @Override
     public void setBase(String base) {
         this.base = base;
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/JDBCParameterBuildingVisitor.java
@@ -553,6 +553,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
             BigDecimal value = quantity.getValue().getValue();
             BigDecimal valueLow = NumberParmBehaviorUtil.generateLowerBound(value);
             BigDecimal valueHigh = NumberParmBehaviorUtil.generateUpperBound(value);
+            boolean addedCodeOrUnit = false;
 
             // see https://gforge.hl7.org/gf/project/fhir/tracker/?action=TrackerItemEdit&tracker_item_id=19597
             if (quantity.getCode() != null && quantity.getCode().hasValue()) {
@@ -567,6 +568,7 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
                     p.setValueSystem(quantity.getSystem().getValue());
                 }
                 result.add(p);
+                addedCodeOrUnit = true;
             }
             if (quantity.getUnit() != null && quantity.getUnit().hasValue()) {
                 String displayUnit = quantity.getUnit().getValue();
@@ -580,7 +582,18 @@ public class JDBCParameterBuildingVisitor extends DefaultVisitor {
                     p.setValueNumberHigh(valueHigh);
                     p.setValueCode(displayUnit);
                     result.add(p);
+                    addedCodeOrUnit = true;
                 }
+            }
+            // If neither code nor unit was specified, add a QuantityParmVal just with the value
+            if (!addedCodeOrUnit) {
+                QuantityParmVal p = new QuantityParmVal();
+                p.setResourceType(resourceType);
+                p.setName(searchParamCode);
+                p.setValueNumber(value);
+                p.setValueNumberLow(valueLow);
+                p.setValueNumberHigh(valueHigh);
+                result.add(p);
             }
         }
         return false;

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
@@ -622,6 +622,20 @@ public class ParameterExtractionTest {
     }
 
     @Test
+    public void testQuantity_valueOnly() throws FHIRPersistenceProcessorException {
+        JDBCParameterBuildingVisitor parameterBuilder = new JDBCParameterBuildingVisitor(SAMPLE_REF_RESOURCE_TYPE, quantitySearchParam);
+        Quantity.builder()
+                .value(Decimal.of(1))
+                .build()
+                .accept(parameterBuilder);
+        List<ExtractedParameterValue> params = parameterBuilder.getResult();
+        assertEquals(params.size(), 1, "Number of extracted parameters");
+        assertEquals(((QuantityParmVal) params.get(0)).getValueNumber().intValue(), 1);
+        assertEquals(((QuantityParmVal) params.get(0)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((QuantityParmVal) params.get(0)).getValueCode(), "");
+    }
+
+    @Test
     public void testQuantity_null() throws FHIRPersistenceProcessorException {
         assertNullValueReturnsNoParameters(quantitySearchParam, Quantity.builder());
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -498,7 +498,7 @@ public class SearchTest extends FHIRServerTestBase {
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
-        
+
         response =
                 target.path("Patient").queryParam("identifier", "test|"+ patientIdentifierValue.toUpperCase())
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
@@ -1052,9 +1052,9 @@ public class SearchTest extends FHIRServerTestBase {
     }
 
     @Test(groups = { "server-search" }, dependsOnMethods = {"testCreateObservation" })
-    public void test_SearchObservationCodeSystem() throws Exception {
+    public void testSearchObservationValueOnly() throws Exception {
         FHIRParameters parameters = new FHIRParameters();
-        parameters.searchParam("component-value-quantity", "125.0||mmHg");
+        parameters.searchParam("component-value-quantity", "125.0");
         FHIRRequestHeader header =
                 new FHIRRequestHeader("X-FHIR-TENANT-ID", tenantName);
         FHIRRequestHeader header2 =
@@ -2283,7 +2283,7 @@ public class SearchTest extends FHIRServerTestBase {
             SearchAllTest.generateOutput(bundle);
         }
         assertTrue(bundle.getEntry().isEmpty());
-        
+
         response =
                 target.path("Condition")
                 .queryParam("evidence", "A4")
@@ -2298,7 +2298,7 @@ public class SearchTest extends FHIRServerTestBase {
             SearchAllTest.generateOutput(bundle);
         }
         assertTrue(bundle.getEntry().size() >= 1);
-        
+
         response =
                 target.path("Condition")
                 .queryParam("evidence", "a4")
@@ -2313,7 +2313,7 @@ public class SearchTest extends FHIRServerTestBase {
             SearchAllTest.generateOutput(bundle);
         }
         assertTrue(bundle.getEntry().isEmpty());
-        
+
         response =
                 target.path("Condition")
                 .queryParam("evidence", "http://terminology.hl7.org/CodeSystem/v2-0080|ST")
@@ -2328,7 +2328,7 @@ public class SearchTest extends FHIRServerTestBase {
             SearchAllTest.generateOutput(bundle);
         }
         assertTrue(bundle.getEntry().size() >= 1);
-        
+
         response =
                 target.path("Condition")
                 .queryParam("evidence", "http://terminology.hl7.org/CodeSystem/v2-0080|st")
@@ -2343,7 +2343,7 @@ public class SearchTest extends FHIRServerTestBase {
             SearchAllTest.generateOutput(bundle);
         }
         assertTrue(bundle.getEntry().size() >= 1);
-        
+
         response =
                 target.path("Condition")
                 .queryParam("evidence", "st")


### PR DESCRIPTION
Issue #2041 - Make quantity values searchable even without unit or code

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>