### PR TITLE
Issue #2292 - miscellaneous clean-up

### DIFF
--- a/fhir-cache/src/main/java/com/ibm/fhir/cache/util/CacheSupport.java
+++ b/fhir-cache/src/main/java/com/ibm/fhir/cache/util/CacheSupport.java
@@ -180,7 +180,7 @@ public final class CacheSupport {
      *     a thread-safe map view of entries in the cache instance
      */
     public static <K, V> Map<K, V> createCacheAsMap(int maximumSize) {
-        Cache<K,V> cache = createCache(maximumSize);
+        Cache<K, V> cache = createCache(maximumSize);
         return cache.asMap();
     }
 

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/ValidationSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/ValidationSupport.java
@@ -502,15 +502,15 @@ public final class ValidationSupport {
      */
     public static void checkValueSetBinding(Element element, String elementName, String valueSet, String system, String... codes) {
         if (element != null) {
-            boolean advancedCodeableConceptValidation = FHIRModelConfig.getExtendedCodeableConceptValidation();
+            boolean extendedCodeableConceptValidation = FHIRModelConfig.getExtendedCodeableConceptValidation();
             List<String> codeList = Arrays.asList(codes);
 
             if (element instanceof CodeableConcept) {
-                checkCodeableConcept((CodeableConcept)element, elementName, valueSet, system, codeList, advancedCodeableConceptValidation);
+                checkCodeableConcept((CodeableConcept)element, elementName, valueSet, system, codeList, extendedCodeableConceptValidation);
             } else if (element instanceof Coding || element instanceof Quantity) {
-                checkCoding(element, elementName, valueSet, system, codeList, advancedCodeableConceptValidation);
+                checkCoding(element, elementName, valueSet, system, codeList, extendedCodeableConceptValidation);
             } else if (element instanceof Code || element instanceof Uri || element instanceof com.ibm.fhir.model.type.String) {
-                checkCode(element, elementName, valueSet, codeList, advancedCodeableConceptValidation);
+                checkCode(element, elementName, valueSet, codeList, extendedCodeableConceptValidation);
             }
         }
     }
@@ -518,12 +518,12 @@ public final class ValidationSupport {
     /**
      * @throws IllegalStateExeption if the CodeableConcept element does not include a code from the required binding
      */
-    private static void checkCodeableConcept(CodeableConcept codeableConcept, String elementName, String valueSet, String system, List<String> codes, boolean advancedCodeableConceptValidation) {
-        if (advancedCodeableConceptValidation) {
+    private static void checkCodeableConcept(CodeableConcept codeableConcept, String elementName, String valueSet, String system, List<String> codes, boolean extendedCodeableConceptValidation) {
+        if (extendedCodeableConceptValidation) {
             if (codeableConcept.getCoding() != null) {
                 for (Coding coding : codeableConcept.getCoding()) {
                     try {
-                        checkCoding(coding, elementName, valueSet, system, codes, advancedCodeableConceptValidation);
+                        checkCoding(coding, elementName, valueSet, system, codes, extendedCodeableConceptValidation);
                         return;
                     } catch (IllegalStateException e) {}
                 }
@@ -544,8 +544,8 @@ public final class ValidationSupport {
     /**
      * @throws IllegalStateExeption if the Coding element does not include a code from the required binding
      */
-    private static void checkCoding(Element element, String elementName, String valueSet, String system, List<String> codes, boolean advancedCodeableConceptValidation) {
-        if (advancedCodeableConceptValidation) {
+    private static void checkCoding(Element element, String elementName, String valueSet, String system, List<String> codes, boolean extendedCodeableConceptValidation) {
+        if (extendedCodeableConceptValidation) {
             if (!hasOnlyDataAbsentReasonExtension(element)) {
                 if (hasSystemAndCodeValues(element)) {
                     String codingSystem = null;
@@ -558,12 +558,12 @@ public final class ValidationSupport {
                         codingCode = element.as(Quantity.class).getCode();
                     }
                     if (isSyntaxValidatedValueSet(valueSet)) {
-                        checkSyntaxValidatedCode(codingCode.getValue(), codingSystem, elementName, valueSet, advancedCodeableConceptValidation);
+                        checkSyntaxValidatedCode(codingCode.getValue(), codingSystem, elementName, valueSet, extendedCodeableConceptValidation);
                     } else {
                         if (!codingSystem.equals(system)) {
                             throw new IllegalStateException(String.format("Element '%s': '%s' is not a valid system for value set '%s'", elementName, codingSystem, valueSet));
                         } else {
-                            checkCode(codingCode, elementName, valueSet, codes, advancedCodeableConceptValidation);
+                            checkCode(codingCode, elementName, valueSet, codes, extendedCodeableConceptValidation);
                         }
                     }
                 } else {
@@ -576,8 +576,8 @@ public final class ValidationSupport {
     /**
      * @throws IllegalStateExeption if the code element is not from the required binding
      */
-    private static void checkCode(Element element, String elementName, String valueSet, List<String> codes, boolean advancedCodeableConceptValidation) {
-        if (advancedCodeableConceptValidation) {
+    private static void checkCode(Element element, String elementName, String valueSet, List<String> codes, boolean extendedCodeableConceptValidation) {
+        if (extendedCodeableConceptValidation) {
             if (!hasOnlyDataAbsentReasonExtension(element)) {
                 String codeValue = null;
                 if (element instanceof Code) {
@@ -589,7 +589,7 @@ public final class ValidationSupport {
                 }
                 if (codeValue != null) {
                     if (isSyntaxValidatedValueSet(valueSet)) {
-                        checkSyntaxValidatedCode(codeValue, null, elementName, valueSet, advancedCodeableConceptValidation);
+                        checkSyntaxValidatedCode(codeValue, null, elementName, valueSet, extendedCodeableConceptValidation);
                     } else if (!codes.contains(codeValue)) {
                         throw new IllegalStateException(String.format("Element '%s': '%s' is not a valid code for value set '%s'", elementName, codeValue, valueSet));
                     }
@@ -603,8 +603,8 @@ public final class ValidationSupport {
     /**
      * @throws IllegalStateExeption if the code element is not from the required binding
      */
-    private static void checkSyntaxValidatedCode(String code, String system, String elementName, String valueSet, boolean advancedCodeableConceptValidation) {
-        if (advancedCodeableConceptValidation) {
+    private static void checkSyntaxValidatedCode(String code, String system, String elementName, String valueSet, boolean extendedCodeableConceptValidation) {
+        if (extendedCodeableConceptValidation) {
             if (ALL_LANG_VALUE_SET_URL.contentEquals(valueSet)) {
                 if (system != null && !BCP_47_URN.equals(system)) {
                     throw new IllegalStateException(String.format("Element '%s': '%s' is not a valid system for value set '%s'", elementName, system, valueSet));

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
@@ -140,7 +140,7 @@ public class MemberOfFunction extends FHIRPathAbstractFunction {
                     }
                     return membershipCheckFailed(evaluationContext, elementNode, url, strength);
                 } catch (FHIRTermServiceException e) {
-                    generateIssue(evaluationContext, IssueSeverity.WARNING, IssueType.INCOMPLETE, "Membership check was not performed: value set '" + url + "' could not be expanded due to the following error: " + e.getMessage(), elementNode.path());
+                    generateIssue(evaluationContext, IssueSeverity.WARNING, IssueType.INCOMPLETE, "Membership check was not performed: value set '" + url + "' membership could not be checked due to the following error: '" + e.getMessage() + "'", elementNode.path());
                 }
             } else if (isSyntaxBased(valueSet)) {
                 // Validate against syntax-based value set

--- a/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
+++ b/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
@@ -419,23 +419,6 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
             .build();
     }
     
-    private void log(String method, String op, int status, double elapsedSecs) {
-        if (log.isLoggable(Level.FINEST)) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Completed remote request [")
-                .append(elapsedSecs)
-                .append(" secs]: " )
-                .append("method: [")
-                .append(method)
-                .append("] uri: [")
-                .append(buildRemoteRequestUri(op))
-                .append("] status: [")
-                .append(status)
-                .append("]");
-            log.finest(sb.toString());
-        }
-    }
-    
     private double elapsedSecs(long initialTime) {
         return (System.currentTimeMillis() - initialTime) / 1000.0;
     }
@@ -508,6 +491,23 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     in.close();
                 } catch (Throwable t) { }
             }
+        }
+    }
+
+    private void log(String method, String op, int status, double elapsedSecs) {
+        if (log.isLoggable(Level.FINEST)) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Completed remote request [")
+                .append(elapsedSecs)
+                .append(" secs]: " )
+                .append("method: [")
+                .append(method)
+                .append("] uri: [")
+                .append(buildRemoteRequestUri(op))
+                .append("] status: [")
+                .append(status)
+                .append("]");
+            log.finest(sb.toString());
         }
     }
 

--- a/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
+++ b/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
@@ -169,7 +169,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
-            
+
             long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
@@ -184,14 +184,14 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("code", code.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
-                    
+
             log("GET", "CodeSystem/$lookup", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
                 Parameters parameters = response.readEntity(Parameters.class);
                 return toConcept(code, parameters);
             }
-            
+
             return null;
         } finally {
             if (response != null) {
@@ -228,13 +228,13 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
-            
+
             long initialTime = System.currentTimeMillis();
 
             response = target.path("ValueSet").path("$expand")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .post(Entity.entity(parameters, FHIRMediaType.APPLICATION_FHIR_JSON));
-            
+
             log("POST", "ValueSet/$expand", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
@@ -278,7 +278,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
-            
+
             long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
@@ -295,7 +295,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("code", code.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
-                    
+
             log("GET", "CodeSystem/$validate-code", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
@@ -344,7 +344,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
-            
+
             long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
@@ -363,7 +363,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("codeB", codeB.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
-                                                    
+
             log("GET", "CodeSystem/$subsumes", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
@@ -418,11 +418,11 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                 .build())
             .build();
     }
-    
+
     private double elapsedSecs(long initialTime) {
         return (System.currentTimeMillis() - initialTime) / 1000.0;
     }
-    
+
     private FHIRTermServiceException errorOccurred(Response response, String op) {
         OperationOutcome outcome = getOperationOutcome(response);
 
@@ -497,16 +497,15 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
     private void log(String method, String op, int status, double elapsedSecs) {
         if (log.isLoggable(Level.FINEST)) {
             StringBuilder sb = new StringBuilder();
-            sb.append("Completed remote request [")
-                .append(elapsedSecs)
-                .append(" secs]: " )
-                .append("method: [")
+            sb.append("method:[")
                 .append(method)
-                .append("] uri: [")
+                .append("] uri:[")
                 .append(buildRemoteRequestUri(op))
-                .append("] status: [")
+                .append("] status:[")
                 .append(status)
-                .append("]");
+                .append("] elapsed:[")
+                .append(elapsedSecs)
+                .append(" secs]");
             log.finest(sb.toString());
         }
     }

--- a/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
+++ b/fhir-term-remote/src/main/java/com/ibm/fhir/term/remote/provider/RemoteTermServiceProvider.java
@@ -169,6 +169,8 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
+            
+            long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
                 target.path("CodeSystem").path("$lookup")
@@ -182,12 +184,14 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("code", code.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
+                    
+            log("GET", "CodeSystem/$lookup", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
                 Parameters parameters = response.readEntity(Parameters.class);
                 return toConcept(code, parameters);
             }
-
+            
             return null;
         } finally {
             if (response != null) {
@@ -224,10 +228,14 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
+            
+            long initialTime = System.currentTimeMillis();
 
             response = target.path("ValueSet").path("$expand")
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .post(Entity.entity(parameters, FHIRMediaType.APPLICATION_FHIR_JSON));
+            
+            log("POST", "ValueSet/$expand", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
                 JsonObject valueSet = response.readEntity(JsonObject.class);
@@ -244,7 +252,7 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                 return result;
             }
 
-            throw errorOccurred(response, "ValueSet", "expand");
+            throw errorOccurred(response, "ValueSet/$expand");
         } finally {
             if (response != null) {
                 response.close();
@@ -270,6 +278,8 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
+            
+            long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
                 target.path("CodeSystem")
@@ -285,6 +295,8 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("code", code.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
+                    
+            log("GET", "CodeSystem/$validate-code", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
                 Parameters parameters = response.readEntity(Parameters.class);
@@ -332,6 +344,8 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         Response response = null;
         try {
             WebTarget target = client.target(base);
+            
+            long initialTime = System.currentTimeMillis();
 
             response = (codeSystem.getVersion() != null) ?
                 target.path("CodeSystem")
@@ -349,6 +363,8 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                     .queryParam("codeB", codeB.getValue())
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .get();
+                                                    
+            log("GET", "CodeSystem/$subsumes", response.getStatus(), elapsedSecs(initialTime));
 
             if (response.getStatus() == Status.OK.getStatusCode()) {
                 Parameters parameters = response.readEntity(Parameters.class);
@@ -359,12 +375,30 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                 }
             }
 
-            throw errorOccurred(response, "CodeSystem", "subsumes");
+            throw errorOccurred(response, "CodeSystem/$subsumes");
         } finally {
             if (response != null) {
                 response.close();
             }
         }
+    }
+
+    private String buildErrorMessage(String op) {
+        return new StringBuilder()
+            .append("A communication or processing error occurred during the remote ")
+            .append(op)
+            .append(" operation (endpoint: ")
+            .append(buildRemoteRequestUri(op))
+            .append(")")
+            .toString();
+    }
+
+    private String buildRemoteRequestUri(String op) {
+        return new StringBuilder()
+            .append(base)
+            .append("/")
+            .append(op)
+            .toString();
     }
 
     private Parameters buildValueSetExpandParameters(CodeSystem codeSystem, List<Filter> filters) {
@@ -384,16 +418,32 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
                 .build())
             .build();
     }
-
-    private FHIRTermServiceException errorOccurred(Response response, String type, String op) {
-        OperationOutcome outcome = null;
-        try {
-            outcome = response.readEntity(OperationOutcome.class);
-        } catch (IllegalArgumentException | ProcessingException e) {
-            log.log(Level.SEVERE, "An error occurred while reading the entity", e);
+    
+    private void log(String method, String op, int status, double elapsedSecs) {
+        if (log.isLoggable(Level.FINEST)) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Completed remote request [")
+                .append(elapsedSecs)
+                .append(" secs]: " )
+                .append("method: [")
+                .append(method)
+                .append("] uri: [")
+                .append(buildRemoteRequestUri(op))
+                .append("] status: [")
+                .append(status)
+                .append("]");
+            log.finest(sb.toString());
         }
+    }
+    
+    private double elapsedSecs(long initialTime) {
+        return (System.currentTimeMillis() - initialTime) / 1000.0;
+    }
+    
+    private FHIRTermServiceException errorOccurred(Response response, String op) {
+        OperationOutcome outcome = getOperationOutcome(response);
 
-        String message = String.format("RemoteTermServiceProvider: a communication or processing error occurred during the remote %s %s operation", type, op);
+        String message = buildErrorMessage(op);
 
         List<Issue> issues = new ArrayList<>();
 
@@ -403,7 +453,6 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
             .details(CodeableConcept.builder()
                 .text(string(message))
                 .build())
-            .diagnostics(string(String.format("Remote endpoint: %s/%s/$%s", base, type, op)))
             .build());
 
         if (outcome != null) {
@@ -411,6 +460,16 @@ public class RemoteTermServiceProvider extends AbstractTermServiceProvider {
         }
 
         return new FHIRTermServiceException(message, issues);
+    }
+
+    private OperationOutcome getOperationOutcome(Response response) {
+        OperationOutcome outcome = null;
+        try {
+            outcome = response.readEntity(OperationOutcome.class);
+        } catch (IllegalArgumentException | ProcessingException e) {
+            log.log(Level.SEVERE, "An error occurred while reading the entity", e);
+        }
+        return outcome;
     }
 
     private KeyStore loadKeyStoreFile(Configuration.TrustStore trustStore) {

--- a/fhir-term-remote/src/test/java/com/ibm/fhir/term/remote/provider/test/RemoteTermServiceProviderTest.java
+++ b/fhir-term-remote/src/test/java/com/ibm/fhir/term/remote/provider/test/RemoteTermServiceProviderTest.java
@@ -36,7 +36,7 @@ import com.ibm.fhir.term.util.CodeSystemSupport;
 
 public class RemoteTermServiceProviderTest {
     public static void main(String[] args) {
-        Logger logger = Logger.getLogger(CachingProxy.class.getName());
+        Logger logger = Logger.getLogger(RemoteTermServiceProvider.class.getName());
         logger.setLevel(Level.FINEST);
         Handler handler = new ConsoleHandler();
         handler.setLevel(Level.FINEST);

--- a/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/service/provider/RegistryTermServiceProvider.java
@@ -32,7 +32,7 @@ public class RegistryTermServiceProvider extends AbstractTermServiceProvider {
         return CodeSystemSupport.getConcepts(concept);
     }
 
-    @Cacheable
+    @Cacheable(maximumSize = 1024)
     @Override
     public Concept getConcept(CodeSystem codeSystem, Code code) {
         checkArguments(codeSystem, code);


### PR DESCRIPTION
- Fixed minor spacing issue in `CacheSupport` class
- Renamed `advancedCodeableConceptValidation` to `extendedCodeableConceptValidation` to match the configuration property name
- Added `maximumSize` to the `@Cacheable` annotation on the `RegistryTermServiceProvider.getConcept` method
- Added code to optionally log remote term service requests when log level is set to FINEST
- Updated error message in `MemberOfFunction`

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>