### PR TITLE
Allocate Tenant without TenantKey Fails in the ibm-fhir-schematool on db2 #2349

### DIFF
--- a/fhir-install/src/main/docker/ibm-fhir-schematool/Dockerfile
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/Dockerfile
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
@@ -20,7 +20,7 @@ RUN curl -L -o /opt/schematool/jq https://github.com/stedolan/jq/releases/downlo
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-ARG FHIR_VERSION=4.5.0
+ARG FHIR_VERSION=4.8.0
 
 # The following labels are required: 
 LABEL name='IBM FHIR Schema Tool'

--- a/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
@@ -255,7 +255,7 @@ function allocate_tenant {
         fi
 
         # Only in the case where we have a file we are loading we hit the issue
-        # where we need to override the default behavior or exiting on failure.
+        # where we need to override the default behavior of exiting on failure.
         set +o errexit
         set +o pipefail
 

--- a/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2020
+# (C) Copyright IBM Corp. 2020, 2021
 #
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
@@ -242,49 +242,44 @@ function allocate_tenant {
 
         # Tenant Key
         TK_FILE_STANZA=""
+        TK_FILE='/opt/schematool/workarea/persistence.key'
         if [ ! -z "${TENANT_KEY}" ]
         then
-            TK_FILE='/opt/schematool/workarea/persistence.key'
             echo "${TENANT_KEY}" > ${TK_FILE}
-            TK_FILE_STANZA="--tenant-key-file ${TK_FILE}"
-
-            # Only in the case where we have a file we are loading we hit the issue
-            # where we need to override the default behavior or exiting on failure.
-            set +o errexit
-            set +o pipefail
+        else
+            # not specified by the client, so we're randomly generating and inlining it
+            TENANT_KEY=$(openssl rand -base64 32)
+            echo "TENANT_KEY: ${TENANT_KEY}"
+            echo "${TENANT_KEY}" > ${TK_FILE}
+            echo "tenant.key=${TENANT_KEY}" >> ${TOOL_INPUT_FILE}
         fi
+
+        # Only in the case where we have a file we are loading we hit the issue
+        # where we need to override the default behavior or exiting on failure.
+        set +o errexit
+        set +o pipefail
 
         SCHEMA_FHIR=$(get_property schema.name.fhir .persistence[0].schema.fhir)
         if [ -z "${SCHEMA_FHIR}" ] || [ "null" = "${SCHEMA_FHIR}" ]
         then
             SCHEMA_FHIR="FHIRDATA"
         fi
-        _call_db2 "--schema-name ${SCHEMA_FHIR} --allocate-tenant ${TENANT_NAME} ${TK_FILE_STANZA} --pool-size 1"
 
-        # Always reset
-        set -o errexit
-        set -o pipefail
+        _call_db2 "--schema-name ${SCHEMA_FHIR} --allocate-tenant ${TENANT_NAME} --tenant-key-file ${TK_FILE} --pool-size 5"
 
         # Tenant Key and Name already exist
         ALREADY_EXISTS=$(grep "tenantName and tenantKey already exists" out.log)
-        if [ ! -z "${ALREADY_EXISTS}" ] && [ "$(cat response_code)" != "0" ]
+        if [ ! -z "${ALREADY_EXISTS}" ]
         then
             error_warn "Unexpected failure in allocate-tenant"
             exit 3;
         fi
 
-        # TenantKey File CHeck
-        if [ ! -z "${TK_FILE}" ]
-        then
-            # From File
-            TENANT_KEY_OUT="${TENANT_KEY}"
-        else
-            # Not from File
-            TENANT_KEY_OUT=`cat out.log | grep 'tenantKey"' | /opt/schematool/jq -r '.tenantKey'`
-        fi
-
-        echo "tenant.key=${TENANT_KEY_OUT}" >> ${TOOL_INPUT_FILE}
         TENANT_KEY=$(get_property tenant.key .persistence[0].tenant.key)
+
+        # Always reset
+        set -o errexit
+        set -o pipefail
     fi
 }
 
@@ -304,6 +299,9 @@ function test_tenant {
             SCHEMA_FHIR="FHIRDATA"
         fi
         _call_db2 "--test-tenant ${TENANT_NAME} --tenant-key ${TENANT_KEY} --schema-name ${SCHEMA_FHIR} --pool-size 1"
+        echo "Successful Setup of: "
+        echo "TENANT_NAME: ${TENANT_NAME}"
+        echo "TENANT_KEY: ${TENANT_KEY}"
     fi
 }
 
@@ -357,10 +355,10 @@ function grant_to_dbuser {
 
         if [ "${DB_TYPE}" = "db2" ]
         then
-            _call_db2 "--grant-to ${TARGET_USER} --target BATCH ${SCHEMA_BATCH} --target OAUTH "${SCHEMA_OAUTH}" --target DATA ${SCHEMA_FHIR} --pool-size 2"
+            _call_db2 "--grant-to ${TARGET_USER} --target BATCH ${SCHEMA_BATCH} --target OAUTH "${SCHEMA_OAUTH}" --target DATA ${SCHEMA_FHIR} --pool-size 5"
         elif [ "${DB_TYPE}" = "postgresql" ]
         then
-            _call_postgres "--grant-to ${TARGET_USER} --target BATCH ${SCHEMA_BATCH} --target OAUTH "${SCHEMA_OAUTH}" --target DATA ${SCHEMA_FHIR} --pool-size 2"
+            _call_postgres "--grant-to ${TARGET_USER} --target BATCH ${SCHEMA_BATCH} --target OAUTH "${SCHEMA_OAUTH}" --target DATA ${SCHEMA_FHIR} --pool-size 5"
         fi
     fi
 }
@@ -375,7 +373,12 @@ function refresh_tenants {
         then
             SCHEMA_FHIR="FHIRDATA"
         fi
-        _call_db2 "--refresh-tenants --schema-name ${SCHEMA_FHIR} --pool-size 1"
+
+        set +o errexit
+        set +o pipefail
+        _call_db2 "--refresh-tenants --schema-name ${SCHEMA_FHIR} --pool-size 5"
+        set -o errexit
+        set -o pipefail
     elif [ "${DB_TYPE}" = "postgresql" ]
     then
         echo "Skipping refresh-tenants as it's not needed on 'postgresql'"
@@ -673,8 +676,8 @@ function onboard_behavior {
 
         # Db2 only
         allocate_tenant
-        test_tenant
         refresh_tenants
+        test_tenant
     else
         info "The onboarding deployment flow is skipped"
     fi

--- a/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/2349.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/2349.sh
@@ -25,7 +25,7 @@ db2 grant connect on database TO USER testuser
 # 2 - use tool / exercise without TENANT_KEY
 docker-compose run tool --tool.behavior=onboard --db.host=192.168.86.29 --db.port=50000 --user=db2inst1 --password=change-password --db.database=fhirdb --sslConnection=false --db.type=db2 --schema.name.fhir=CLINIC --grant.to=testuser     --tenant.name=CLINICA
 
-# Check the TENANTS table // Should be 2700+
+# Check the TENANTS table
 docker-compose exec -it db su - db2inst1 -c "db2 connect to fhirdb; db2 SELECT COUNT(*) FROM FHIR_ADMIN.TENANTS"
 # You should see the tenant listed, and you should see the end CLINIC
 

--- a/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/2349.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/2349.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# ----------------------------------------------------------------------------
+# (C) Copyright IBM Corp. 2021
+#
+# SPDX-License-Identifier: Apache-2.0
+# ----------------------------------------------------------------------------
+
+# Issue - https://github.com/IBM/FHIR/issues/2349
+
+# 1 - Start the db
+docker-compose up -d db
+
+# Create the right pagesize in the db
+docker exec -it 2349_db_1 /bin/bash
+
+# In the terminal run the following: 
+useradd -g db2iadm1 testuser
+echo "testuser:password" | chpasswd
+su - db2inst1
+db2 drop db fhirdb
+db2 CREATE DB FHIRDB using codeset UTF-8 territory us PAGESIZE 32768
+db2 grant connect on database TO USER testuser
+
+# 2 - use tool / exercise without TENANT_KEY
+docker-compose run tool --tool.behavior=onboard --db.host=192.168.86.29 --db.port=50000 --user=db2inst1 --password=change-password --db.database=fhirdb --sslConnection=false --db.type=db2 --schema.name.fhir=CLINIC --grant.to=testuser     --tenant.name=CLINICA
+
+# Check the TENANTS table // Should be 2700+
+docker-compose exec -it db su - db2inst1 -c "db2 connect to fhirdb; db2 SELECT COUNT(*) FROM FHIR_ADMIN.TENANTS"
+# You should see the tenant listed, and you should see the end CLINIC
+
+# EOF

--- a/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/docker-compose.yml
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/tests/2349/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+services:
+  db:
+    image: ibmcom/db2:11.5.5.1
+    restart: always
+    environment:
+      DB2INST1_PASSWORD: change-password
+      LICENSE: accept
+      DBNAME: fhirdb
+    shm_size: 256MB
+    tty: true
+    stdin_open: true
+    hostname: db
+    sysctls:
+      net.core.somaxconn: 256
+      net.ipv4.tcp_syncookies: 0
+    privileged: true
+    ports:
+      - "50000:50000"
+  tool:
+    image: ibmcom/ibm-fhir-schematool:latest
+    restart: always
+    environment:
+      PLACEHOLDER: change-password
+    tty: true
+    stdin_open: true
+    hostname: tool
+    stop_grace_period: 2m
+    sysctls:
+      net.core.somaxconn: 256
+      net.ipv4.tcp_syncookies: 0
+      # To use all of 2 gigabytes
+      kernel.shmmax: 1055092736
+      kernel.shmall: 257591
+    privileged: true
+    command: tail -f /dev/null


### PR DESCRIPTION


Signed-off-by: Paul Bastide <pbastide@us.ibm.com>