### PR TITLE
issue #1674 - workaround for HL7 FHIR-13601

### DIFF
--- a/fhir-registry/src/main/resources/hl7/fhir/core/package/SearchParameter-clinical-patient.json
+++ b/fhir-registry/src/main/resources/hl7/fhir/core/package/SearchParameter-clinical-patient.json
@@ -73,7 +73,6 @@
     "xpath": "f:AllergyIntolerance/f:patient | f:CarePlan/f:subject | f:CareTeam/f:subject | f:ClinicalImpression/f:subject | f:Composition/f:subject | f:Condition/f:subject | f:Consent/f:patient | f:DetectedIssue/f:patient | f:DeviceRequest/f:subject | f:DeviceUseStatement/f:subject | f:DiagnosticReport/f:subject | f:DocumentManifest/f:subject | f:DocumentReference/f:subject | f:Encounter/f:subject | f:EpisodeOfCare/f:patient | f:FamilyMemberHistory/f:patient | f:Flag/f:subject | f:Goal/f:subject | f:ImagingStudy/f:subject | f:Immunization/f:patient | f:List/f:subject | f:MedicationAdministration/f:subject | f:MedicationDispense/f:subject | f:MedicationRequest/f:subject | f:MedicationStatement/f:subject | f:NutritionOrder/f:patient | f:Observation/f:subject | f:Procedure/f:subject | f:RiskAssessment/f:subject | f:ServiceRequest/f:subject | f:SupplyDelivery/f:patient | f:VisionPrescription/f:patient",
     "xpathUsage": "normal",
     "target": [
-        "Patient",
-        "Group"
+        "Patient"
     ]
 }

--- a/fhir-registry/src/test/java/com/ibm/fhir/registry/tool/IndexGenerator.java
+++ b/fhir-registry/src/test/java/com/ibm/fhir/registry/tool/IndexGenerator.java
@@ -1,12 +1,12 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.registry.core.util;
+package com.ibm.fhir.registry.tool;
 
-import static com.ibm.fhir.registry.util.FHIRRegistryUtil.*;
+import static com.ibm.fhir.registry.util.FHIRRegistryUtil.getUrl;
 import static com.ibm.fhir.registry.util.FHIRRegistryUtil.getVersion;
 import static com.ibm.fhir.registry.util.FHIRRegistryUtil.isDefinitionalResource;
 
@@ -16,28 +16,31 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.registry.util.Index;
 import com.ibm.fhir.registry.util.Index.Entry;
 
 public class IndexGenerator {
     private static final List<String> DEFINITIONS = Arrays.asList(
-        "definitions/conceptmaps.json", 
-        "definitions/dataelements.json", 
-        "definitions/extension-definitions.json", 
-        "definitions/profiles-others.json", 
-        "definitions/profiles-resources.json", 
-        "definitions/profiles-types.json", 
-        "definitions/search-parameters.json", 
-        "definitions/v2-tables.json", 
-        "definitions/v3-codesystems.json", 
+        "definitions/conceptmaps.json",
+        "definitions/dataelements.json",
+        "definitions/extension-definitions.json",
+        "definitions/profiles-others.json",
+        "definitions/profiles-resources.json",
+        "definitions/profiles-types.json",
+        "definitions/search-parameters.json",
+        "definitions/v2-tables.json",
+        "definitions/v3-codesystems.json",
         "definitions/valuesets.json");
-    
+
     public static void main(String[] args) throws Exception {
         Index index = new Index(1);
         for (String definition : DEFINITIONS) {
@@ -45,11 +48,11 @@ public class IndexGenerator {
                 Bundle bundle = FHIRParser.parser(Format.JSON).parse(reader);
                 for (Bundle.Entry entry : bundle.getEntry()) {
                     Resource resource = entry.getResource();
-                    
+
                     if (!isDefinitionalResource(resource)) {
                         continue;
                     }
-                    
+
                     String id = resource.getId();
                     if (id == null) {
                         continue;
@@ -60,18 +63,25 @@ public class IndexGenerator {
                     if (url == null || version == null) {
                         continue;
                     }
-                    
+
+                    if (resource instanceof SearchParameter && id.equals("clinical-patient")) {
+                        // Workaround for https://jira.hl7.org/browse/FHIR-13601
+                        resource = ((SearchParameter) resource).toBuilder()
+                                .target(Collections.singleton(ResourceType.PATIENT))
+                                .build();
+                    }
+
                     String fileName = resource.getClass().getSimpleName() + "-" + id + ".json";
                     File file = new File("src/main/resources/hl7/fhir/core/package/" + fileName);
-                    
+
                     if (!file.exists()) {
                         file.getParentFile().mkdirs();
                     }
-                    
+
                     try (FileWriter writer = new FileWriter(file)) {
                         writer.write(resource.toString());
                     }
-                    
+
                     index.add(Entry.entry(resource));
                 }
             }


### PR DESCRIPTION
The built-in SearchParameter-clinical-patient search parameter should
have a single target of type "Patient" but instead it has a target of
both "Patient" and "Group".

In this commit, I move the fhir-registry IndexGenerator from
src/main/java to src/test/java and add a step to modify this one spec
resource so that users can search on the `patient` search parameter
without needing a type modifier.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>