### PR TITLE
Issue #2365 - Show resource ids in conditional delete operation outcome

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -419,6 +420,9 @@ public class DeleteTest extends FHIRServerTestBase {
             assertResponse(response.getResponse(), Response.Status.OK.getStatusCode());
             assertNotNull(response.getETag());
             assertEquals("W/\"2\"", response.getETag());
+            // Check for resourceId in details message
+            OperationOutcome operationOutcome = response.getResource(OperationOutcome.class);
+            assertTrue(operationOutcome.getIssue().get(0).getDetails().getText().getValue().contains(obsId));
         } else {
             assertResponse(response.getResponse(), Response.Status.METHOD_NOT_ALLOWED.getStatusCode());
         }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1810,7 +1810,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 txn.commit();
                 txn = null;
             }
-            
+
             return Arrays.asList(responseEntries);
 
         } finally {
@@ -2563,6 +2563,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 Entry.Builder entryBuilder = Entry.builder();
                 if (resource != null) {
                     if (resource.getId() != null) {
+                        entryBuilder.id(resource.getId());
                         entryBuilder.fullUrl(Uri.of(getRequestBaseUri(type) + "/" + resource.getClass().getSimpleName() + "/" + resource.getId()));
                     } else {
                         String msg = "A resource with no id was found.";


### PR DESCRIPTION
Issue #2365 - Show resource ids in conditional delete operation outcome

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>