### PR TITLE
issue #2384 - move the private hashCode member to the abstract parents

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Account.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Account.java
@@ -87,8 +87,6 @@ public class Account extends DomainResource {
     @ReferenceTarget({ "Account" })
     private final Reference partOf;
 
-    private volatile int hashCode;
-
     private Account(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -873,8 +871,6 @@ public class Account extends DomainResource {
         @Summary
         private final PositiveInt priority;
 
-        private volatile int hashCode;
-
         private Coverage(Builder builder) {
             super(builder);
             coverage = ValidationSupport.requireNonNull(builder.coverage, "coverage");
@@ -1155,8 +1151,6 @@ public class Account extends DomainResource {
         private final Reference party;
         private final Boolean onHold;
         private final Period period;
-
-        private volatile int hashCode;
 
         private Guarantor(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ActivityDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ActivityDefinition.java
@@ -227,8 +227,6 @@ public class ActivityDefinition extends DomainResource {
     private final Canonical transform;
     private final List<DynamicValue> dynamicValue;
 
-    private volatile int hashCode;
-
     private ActivityDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -2476,8 +2474,6 @@ public class ActivityDefinition extends DomainResource {
         )
         private final CodeableConcept role;
 
-        private volatile int hashCode;
-
         private Participant(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2747,8 +2743,6 @@ public class ActivityDefinition extends DomainResource {
         private final String path;
         @Required
         private final Expression expression;
-
-        private volatile int hashCode;
 
         private DynamicValue(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/AdverseEvent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/AdverseEvent.java
@@ -146,8 +146,6 @@ public class AdverseEvent extends DomainResource {
     @ReferenceTarget({ "ResearchStudy" })
     private final List<Reference> study;
 
-    private volatile int hashCode;
-
     private AdverseEvent(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -1354,8 +1352,6 @@ public class AdverseEvent extends DomainResource {
         @Summary
         private final List<Causality> causality;
 
-        private volatile int hashCode;
-
         private SuspectEntity(Builder builder) {
             super(builder);
             instance = ValidationSupport.requireNonNull(builder.instance, "instance");
@@ -1673,8 +1669,6 @@ public class AdverseEvent extends DomainResource {
                 valueSet = "http://hl7.org/fhir/ValueSet/adverse-event-causality-method"
             )
             private final CodeableConcept method;
-
-            private volatile int hashCode;
 
             private Causality(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/AllergyIntolerance.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/AllergyIntolerance.java
@@ -140,8 +140,6 @@ public class AllergyIntolerance extends DomainResource {
     private final List<Annotation> note;
     private final List<Reaction> reaction;
 
-    private volatile int hashCode;
-
     private AllergyIntolerance(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1125,8 +1123,6 @@ public class AllergyIntolerance extends DomainResource {
         )
         private final CodeableConcept exposureRoute;
         private final List<Annotation> note;
-
-        private volatile int hashCode;
 
         private Reaction(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Appointment.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Appointment.java
@@ -190,8 +190,6 @@ public class Appointment extends DomainResource {
     private final List<Participant> participant;
     private final List<Period> requestedPeriod;
 
-    private volatile int hashCode;
-
     private Appointment(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1520,8 +1518,6 @@ public class Appointment extends DomainResource {
         @Required
         private final ParticipationStatus status;
         private final Period period;
-
-        private volatile int hashCode;
 
         private Participant(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/AppointmentResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/AppointmentResponse.java
@@ -92,8 +92,6 @@ public class AppointmentResponse extends DomainResource {
     private final ParticipantStatus participantStatus;
     private final String comment;
 
-    private volatile int hashCode;
-
     private AppointmentResponse(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/AuditEvent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/AuditEvent.java
@@ -204,8 +204,6 @@ public class AuditEvent extends DomainResource {
     private final Source source;
     private final List<Entity> entity;
 
-    private volatile int hashCode;
-
     private AuditEvent(Builder builder) {
         super(builder);
         type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -990,8 +988,6 @@ public class AuditEvent extends DomainResource {
         )
         private final List<CodeableConcept> purposeOfUse;
 
-        private volatile int hashCode;
-
         private Agent(Builder builder) {
             super(builder);
             type = builder.type;
@@ -1630,8 +1626,6 @@ public class AuditEvent extends DomainResource {
             )
             private final AuditEventAgentNetworkType type;
 
-            private volatile int hashCode;
-
             private Network(Builder builder) {
                 super(builder);
                 address = builder.address;
@@ -1901,8 +1895,6 @@ public class AuditEvent extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/audit-source-type"
         )
         private final List<Coding> type;
-
-        private volatile int hashCode;
 
         private Source(Builder builder) {
             super(builder);
@@ -2267,8 +2259,6 @@ public class AuditEvent extends DomainResource {
         @Summary
         private final Base64Binary query;
         private final List<Detail> detail;
-
-        private volatile int hashCode;
 
         private Entity(Builder builder) {
             super(builder);
@@ -2787,8 +2777,6 @@ public class AuditEvent extends DomainResource {
             @Choice({ String.class, Base64Binary.class })
             @Required
             private final Element value;
-
-            private volatile int hashCode;
 
             private Detail(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Basic.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Basic.java
@@ -64,8 +64,6 @@ public class Basic extends DomainResource {
     @ReferenceTarget({ "Practitioner", "PractitionerRole", "Patient", "RelatedPerson", "Organization" })
     private final Reference author;
 
-    private volatile int hashCode;
-
     private Basic(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Binary.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Binary.java
@@ -49,8 +49,6 @@ public class Binary extends Resource {
     private final Reference securityContext;
     private final Base64Binary data;
 
-    private volatile int hashCode;
-
     private Binary(Builder builder) {
         super(builder);
         contentType = ValidationSupport.requireNonNull(builder.contentType, "contentType");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/BiologicallyDerivedProduct.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/BiologicallyDerivedProduct.java
@@ -85,8 +85,6 @@ public class BiologicallyDerivedProduct extends DomainResource {
     private final Manipulation manipulation;
     private final List<Storage> storage;
 
-    private volatile int hashCode;
-
     private BiologicallyDerivedProduct(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -870,8 +868,6 @@ public class BiologicallyDerivedProduct extends DomainResource {
         @Choice({ DateTime.class, Period.class })
         private final Element collected;
 
-        private volatile int hashCode;
-
         private Collection(Builder builder) {
             super(builder);
             collector = builder.collector;
@@ -1194,8 +1190,6 @@ public class BiologicallyDerivedProduct extends DomainResource {
         private final Reference additive;
         @Choice({ DateTime.class, Period.class })
         private final Element time;
-
-        private volatile int hashCode;
 
         private Processing(Builder builder) {
             super(builder);
@@ -1532,8 +1526,6 @@ public class BiologicallyDerivedProduct extends DomainResource {
         @Choice({ DateTime.class, Period.class })
         private final Element time;
 
-        private volatile int hashCode;
-
         private Manipulation(Builder builder) {
             super(builder);
             description = builder.description;
@@ -1806,8 +1798,6 @@ public class BiologicallyDerivedProduct extends DomainResource {
         )
         private final BiologicallyDerivedProductStorageScale scale;
         private final Period duration;
-
-        private volatile int hashCode;
 
         private Storage(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/BodyStructure.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/BodyStructure.java
@@ -82,8 +82,6 @@ public class BodyStructure extends DomainResource {
     @Required
     private final Reference patient;
 
-    private volatile int hashCode;
-
     private BodyStructure(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Bundle.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Bundle.java
@@ -148,8 +148,6 @@ public class Bundle extends Resource {
     @Summary
     private final Signature signature;
 
-    private volatile int hashCode;
-
     private Bundle(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -581,8 +579,6 @@ public class Bundle extends Resource {
         @Required
         private final Uri url;
 
-        private volatile int hashCode;
-
         private Link(Builder builder) {
             super(builder);
             relation = ValidationSupport.requireNonNull(builder.relation, "relation");
@@ -866,8 +862,6 @@ public class Bundle extends Resource {
         private final Request request;
         @Summary
         private final Response response;
-
-        private volatile int hashCode;
 
         private Entry(Builder builder) {
             super(builder);
@@ -1293,8 +1287,6 @@ public class Bundle extends Resource {
             @Summary
             private final Decimal score;
 
-            private volatile int hashCode;
-
             private Search(Builder builder) {
                 super(builder);
                 mode = builder.mode;
@@ -1574,8 +1566,6 @@ public class Bundle extends Resource {
             private final String ifMatch;
             @Summary
             private final String ifNoneExist;
-
-            private volatile int hashCode;
 
             private Request(Builder builder) {
                 super(builder);
@@ -1991,8 +1981,6 @@ public class Bundle extends Resource {
             private final Instant lastModified;
             @Summary
             private final Resource outcome;
-
-            private volatile int hashCode;
 
             private Response(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CapabilityStatement.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CapabilityStatement.java
@@ -255,8 +255,6 @@ public class CapabilityStatement extends DomainResource {
     @Summary
     private final List<Document> document;
 
-    private volatile int hashCode;
-
     private CapabilityStatement(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1669,8 +1667,6 @@ public class CapabilityStatement extends DomainResource {
         @Summary
         private final DateTime releaseDate;
 
-        private volatile int hashCode;
-
         private Software(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -1974,8 +1970,6 @@ public class CapabilityStatement extends DomainResource {
         @Summary
         @ReferenceTarget({ "Organization" })
         private final Reference custodian;
-
-        private volatile int hashCode;
 
         private Implementation(Builder builder) {
             super(builder);
@@ -2300,8 +2294,6 @@ public class CapabilityStatement extends DomainResource {
         @Summary
         private final List<CapabilityStatement.Rest.Resource.Operation> operation;
         private final List<Canonical> compartment;
-
-        private volatile int hashCode;
 
         private Rest(Builder builder) {
             super(builder);
@@ -2869,8 +2861,6 @@ public class CapabilityStatement extends DomainResource {
             private final List<CodeableConcept> service;
             private final Markdown description;
 
-            private volatile int hashCode;
-
             private Security(Builder builder) {
                 super(builder);
                 cors = builder.cors;
@@ -3230,8 +3220,6 @@ public class CapabilityStatement extends DomainResource {
             private final List<SearchParam> searchParam;
             @Summary
             private final List<Operation> operation;
-
-            private volatile int hashCode;
 
             private Resource(Builder builder) {
                 super(builder);
@@ -4142,8 +4130,6 @@ public class CapabilityStatement extends DomainResource {
                 private final TypeRestfulInteraction code;
                 private final Markdown documentation;
 
-                private volatile int hashCode;
-
                 private Interaction(Builder builder) {
                     super(builder);
                     code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -4422,8 +4408,6 @@ public class CapabilityStatement extends DomainResource {
                 @Required
                 private final SearchParamType type;
                 private final Markdown documentation;
-
-                private volatile int hashCode;
 
                 private SearchParam(Builder builder) {
                     super(builder);
@@ -4770,8 +4754,6 @@ public class CapabilityStatement extends DomainResource {
                 private final Canonical definition;
                 private final Markdown documentation;
 
-                private volatile int hashCode;
-
                 private Operation(Builder builder) {
                     super(builder);
                     name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -5092,8 +5074,6 @@ public class CapabilityStatement extends DomainResource {
             private final SystemRestfulInteraction code;
             private final Markdown documentation;
 
-            private volatile int hashCode;
-
             private Interaction(Builder builder) {
                 super(builder);
                 code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -5365,8 +5345,6 @@ public class CapabilityStatement extends DomainResource {
         private final Markdown documentation;
         @Summary
         private final List<SupportedMessage> supportedMessage;
-
-        private volatile int hashCode;
 
         private Messaging(Builder builder) {
             super(builder);
@@ -5740,8 +5718,6 @@ public class CapabilityStatement extends DomainResource {
             @Required
             private final Url address;
 
-            private volatile int hashCode;
-
             private Endpoint(Builder builder) {
                 super(builder);
                 protocol = ValidationSupport.requireNonNull(builder.protocol, "protocol");
@@ -6023,8 +5999,6 @@ public class CapabilityStatement extends DomainResource {
             @Required
             private final Canonical definition;
 
-            private volatile int hashCode;
-
             private SupportedMessage(Builder builder) {
                 super(builder);
                 mode = ValidationSupport.requireNonNull(builder.mode, "mode");
@@ -6305,8 +6279,6 @@ public class CapabilityStatement extends DomainResource {
         @Summary
         @Required
         private final Canonical profile;
-
-        private volatile int hashCode;
 
         private Document(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CarePlan.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CarePlan.java
@@ -139,8 +139,6 @@ public class CarePlan extends DomainResource {
     private final List<Activity> activity;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private CarePlan(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1597,8 +1595,6 @@ public class CarePlan extends DomainResource {
         private final Reference reference;
         private final Detail detail;
 
-        private volatile int hashCode;
-
         private Activity(Builder builder) {
             super(builder);
             outcomeCodeableConcept = Collections.unmodifiableList(ValidationSupport.checkList(builder.outcomeCodeableConcept, "outcomeCodeableConcept", CodeableConcept.class));
@@ -2088,8 +2084,6 @@ public class CarePlan extends DomainResource {
             private final SimpleQuantity dailyAmount;
             private final SimpleQuantity quantity;
             private final String description;
-
-            private volatile int hashCode;
 
             private Detail(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CareTeam.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CareTeam.java
@@ -101,8 +101,6 @@ public class CareTeam extends DomainResource {
     private final List<ContactPoint> telecom;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private CareTeam(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1024,8 +1022,6 @@ public class CareTeam extends DomainResource {
         @ReferenceTarget({ "Organization" })
         private final Reference onBehalfOf;
         private final Period period;
-
-        private volatile int hashCode;
 
         private Participant(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CatalogEntry.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CatalogEntry.java
@@ -75,8 +75,6 @@ public class CatalogEntry extends DomainResource {
     private final List<CodeableConcept> additionalClassification;
     private final List<RelatedEntry> relatedEntry;
 
-    private volatile int hashCode;
-
     private CatalogEntry(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -943,8 +941,6 @@ public class CatalogEntry extends DomainResource {
         @ReferenceTarget({ "CatalogEntry" })
         @Required
         private final Reference item;
-
-        private volatile int hashCode;
 
         private RelatedEntry(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ChargeItem.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ChargeItem.java
@@ -142,8 +142,6 @@ public class ChargeItem extends DomainResource {
     private final List<Annotation> note;
     private final List<Reference> supportingInformation;
 
-    private volatile int hashCode;
-
     private ChargeItem(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1608,8 +1606,6 @@ public class ChargeItem extends DomainResource {
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "Organization", "CareTeam", "Patient", "Device", "RelatedPerson" })
         @Required
         private final Reference actor;
-
-        private volatile int hashCode;
 
         private Performer(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ChargeItemDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ChargeItemDefinition.java
@@ -137,8 +137,6 @@ public class ChargeItemDefinition extends DomainResource {
     private final List<Applicability> applicability;
     private final List<PropertyGroup> propertyGroup;
 
-    private volatile int hashCode;
-
     private ChargeItemDefinition(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1433,8 +1431,6 @@ public class ChargeItemDefinition extends DomainResource {
         private final String language;
         private final String expression;
 
-        private volatile int hashCode;
-
         private Applicability(Builder builder) {
             super(builder);
             description = builder.description;
@@ -1731,8 +1727,6 @@ public class ChargeItemDefinition extends DomainResource {
     public static class PropertyGroup extends BackboneElement {
         private final List<ChargeItemDefinition.Applicability> applicability;
         private final List<PriceComponent> priceComponent;
-
-        private volatile int hashCode;
 
         private PropertyGroup(Builder builder) {
             super(builder);
@@ -2052,8 +2046,6 @@ public class ChargeItemDefinition extends DomainResource {
             private final CodeableConcept code;
             private final Decimal factor;
             private final Money amount;
-
-            private volatile int hashCode;
 
             private PriceComponent(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Claim.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Claim.java
@@ -168,8 +168,6 @@ public class Claim extends DomainResource {
     private final List<Item> item;
     private final Money total;
 
-    private volatile int hashCode;
-
     private Claim(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1585,8 +1583,6 @@ public class Claim extends DomainResource {
         private final CodeableConcept relationship;
         private final Identifier reference;
 
-        private volatile int hashCode;
-
         private Related(Builder builder) {
             super(builder);
             claim = builder.claim;
@@ -1891,8 +1887,6 @@ public class Claim extends DomainResource {
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "Organization", "Patient", "RelatedPerson" })
         private final Reference party;
 
-        private volatile int hashCode;
-
         private Payee(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2186,8 +2180,6 @@ public class Claim extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/provider-qualification"
         )
         private final CodeableConcept qualification;
-
-        private volatile int hashCode;
 
         private CareTeam(Builder builder) {
             super(builder);
@@ -2585,8 +2577,6 @@ public class Claim extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/missing-tooth-reason"
         )
         private final CodeableConcept reason;
-
-        private volatile int hashCode;
 
         private SupportingInfo(Builder builder) {
             super(builder);
@@ -3031,8 +3021,6 @@ public class Claim extends DomainResource {
         )
         private final CodeableConcept packageCode;
 
-        private volatile int hashCode;
-
         private Diagnosis(Builder builder) {
             super(builder);
             sequence = ValidationSupport.requireNonNull(builder.sequence, "sequence");
@@ -3448,8 +3436,6 @@ public class Claim extends DomainResource {
         private final Element procedure;
         @ReferenceTarget({ "Device" })
         private final List<Reference> udi;
-
-        private volatile int hashCode;
 
         private Procedure(Builder builder) {
             super(builder);
@@ -3888,8 +3874,6 @@ public class Claim extends DomainResource {
         private final List<String> preAuthRef;
         @ReferenceTarget({ "ClaimResponse" })
         private final Reference claimResponse;
-
-        private volatile int hashCode;
 
         private Insurance(Builder builder) {
             super(builder);
@@ -4367,8 +4351,6 @@ public class Claim extends DomainResource {
         @Choice({ Address.class, Reference.class })
         private final Element location;
 
-        private volatile int hashCode;
-
         private Accident(Builder builder) {
             super(builder);
             date = ValidationSupport.requireNonNull(builder.date, "date");
@@ -4754,8 +4736,6 @@ public class Claim extends DomainResource {
         @ReferenceTarget({ "Encounter" })
         private final List<Reference> encounter;
         private final List<Detail> detail;
-
-        private volatile int hashCode;
 
         private Item(Builder builder) {
             super(builder);
@@ -5904,8 +5884,6 @@ public class Claim extends DomainResource {
             private final List<Reference> udi;
             private final List<SubDetail> subDetail;
 
-            private volatile int hashCode;
-
             private Detail(Builder builder) {
                 super(builder);
                 sequence = ValidationSupport.requireNonNull(builder.sequence, "sequence");
@@ -6622,8 +6600,6 @@ public class Claim extends DomainResource {
                 private final Money net;
                 @ReferenceTarget({ "Device" })
                 private final List<Reference> udi;
-
-                private volatile int hashCode;
 
                 private SubDetail(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ClaimResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ClaimResponse.java
@@ -175,8 +175,6 @@ public class ClaimResponse extends DomainResource {
     private final List<Insurance> insurance;
     private final List<Error> error;
 
-    private volatile int hashCode;
-
     private ClaimResponse(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1581,8 +1579,6 @@ public class ClaimResponse extends DomainResource {
         private final List<Adjudication> adjudication;
         private final List<Detail> detail;
 
-        private volatile int hashCode;
-
         private Item(Builder builder) {
             super(builder);
             itemSequence = ValidationSupport.requireNonNull(builder.itemSequence, "itemSequence");
@@ -1994,8 +1990,6 @@ public class ClaimResponse extends DomainResource {
             private final Money amount;
             private final Decimal value;
 
-            private volatile int hashCode;
-
             private Adjudication(Builder builder) {
                 super(builder);
                 category = ValidationSupport.requireNonNull(builder.category, "category");
@@ -2331,8 +2325,6 @@ public class ClaimResponse extends DomainResource {
             @Required
             private final List<ClaimResponse.Item.Adjudication> adjudication;
             private final List<SubDetail> subDetail;
-
-            private volatile int hashCode;
 
             private Detail(Builder builder) {
                 super(builder);
@@ -2727,8 +2719,6 @@ public class ClaimResponse extends DomainResource {
                 private final PositiveInt subDetailSequence;
                 private final List<PositiveInt> noteNumber;
                 private final List<ClaimResponse.Item.Adjudication> adjudication;
-
-                private volatile int hashCode;
 
                 private SubDetail(Builder builder) {
                     super(builder);
@@ -3126,8 +3116,6 @@ public class ClaimResponse extends DomainResource {
         @Required
         private final List<ClaimResponse.Item.Adjudication> adjudication;
         private final List<Detail> detail;
-
-        private volatile int hashCode;
 
         private AddItem(Builder builder) {
             super(builder);
@@ -4156,8 +4144,6 @@ public class ClaimResponse extends DomainResource {
             private final List<ClaimResponse.Item.Adjudication> adjudication;
             private final List<SubDetail> subDetail;
 
-            private volatile int hashCode;
-
             private Detail(Builder builder) {
                 super(builder);
                 productOrService = ValidationSupport.requireNonNull(builder.productOrService, "productOrService");
@@ -4751,8 +4737,6 @@ public class ClaimResponse extends DomainResource {
                 @Required
                 private final List<ClaimResponse.Item.Adjudication> adjudication;
 
-                private volatile int hashCode;
-
                 private SubDetail(Builder builder) {
                     super(builder);
                     productOrService = ValidationSupport.requireNonNull(builder.productOrService, "productOrService");
@@ -5288,8 +5272,6 @@ public class ClaimResponse extends DomainResource {
         @Required
         private final Money amount;
 
-        private volatile int hashCode;
-
         private Total(Builder builder) {
             super(builder);
             category = ValidationSupport.requireNonNull(builder.category, "category");
@@ -5580,8 +5562,6 @@ public class ClaimResponse extends DomainResource {
         @Required
         private final Money amount;
         private final Identifier identifier;
-
-        private volatile int hashCode;
 
         private Payment(Builder builder) {
             super(builder);
@@ -5994,8 +5974,6 @@ public class ClaimResponse extends DomainResource {
         )
         private final CodeableConcept language;
 
-        private volatile int hashCode;
-
         private ProcessNote(Builder builder) {
             super(builder);
             number = builder.number;
@@ -6332,8 +6310,6 @@ public class ClaimResponse extends DomainResource {
         private final String businessArrangement;
         @ReferenceTarget({ "ClaimResponse" })
         private final Reference claimResponse;
-
-        private volatile int hashCode;
 
         private Insurance(Builder builder) {
             super(builder);
@@ -6724,8 +6700,6 @@ public class ClaimResponse extends DomainResource {
         )
         @Required
         private final CodeableConcept code;
-
-        private volatile int hashCode;
 
         private Error(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ClinicalImpression.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ClinicalImpression.java
@@ -117,8 +117,6 @@ public class ClinicalImpression extends DomainResource {
     private final List<Reference> supportingInfo;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private ClinicalImpression(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1323,8 +1321,6 @@ public class ClinicalImpression extends DomainResource {
         @ReferenceTarget({ "Observation", "QuestionnaireResponse", "FamilyMemberHistory", "DiagnosticReport", "RiskAssessment", "ImagingStudy", "Media" })
         private final List<Reference> item;
 
-        private volatile int hashCode;
-
         private Investigation(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1645,8 +1641,6 @@ public class ClinicalImpression extends DomainResource {
         @ReferenceTarget({ "Condition", "Observation", "Media" })
         private final Reference itemReference;
         private final String basis;
-
-        private volatile int hashCode;
 
         private Finding(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CodeSystem.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CodeSystem.java
@@ -175,8 +175,6 @@ public class CodeSystem extends DomainResource {
     private final List<Property> property;
     private final List<Concept> concept;
 
-    private volatile int hashCode;
-
     private CodeSystem(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1497,8 +1495,6 @@ public class CodeSystem extends DomainResource {
         @Required
         private final String value;
 
-        private volatile int hashCode;
-
         private Filter(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1869,8 +1865,6 @@ public class CodeSystem extends DomainResource {
         @Required
         private final PropertyType type;
 
-        private volatile int hashCode;
-
         private Property(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -2213,8 +2207,6 @@ public class CodeSystem extends DomainResource {
         private final List<Designation> designation;
         private final List<Property> property;
         private final List<CodeSystem.Concept> concept;
-
-        private volatile int hashCode;
 
         private Concept(Builder builder) {
             super(builder);
@@ -2691,8 +2683,6 @@ public class CodeSystem extends DomainResource {
             @Required
             private final String value;
 
-            private volatile int hashCode;
-
             private Designation(Builder builder) {
                 super(builder);
                 language = builder.language;
@@ -2993,8 +2983,6 @@ public class CodeSystem extends DomainResource {
             @Choice({ Code.class, Coding.class, String.class, Integer.class, Boolean.class, DateTime.class, Decimal.class })
             @Required
             private final Element value;
-
-            private volatile int hashCode;
 
             private Property(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Communication.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Communication.java
@@ -139,8 +139,6 @@ public class Communication extends DomainResource {
     private final List<Payload> payload;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private Communication(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1550,8 +1548,6 @@ public class Communication extends DomainResource {
         @Choice({ String.class, Attachment.class, Reference.class })
         @Required
         private final Element content;
-
-        private volatile int hashCode;
 
         private Payload(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CommunicationRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CommunicationRequest.java
@@ -136,8 +136,6 @@ public class CommunicationRequest extends DomainResource {
     private final List<Reference> reasonReference;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private CommunicationRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1466,8 +1464,6 @@ public class CommunicationRequest extends DomainResource {
         @Choice({ String.class, Attachment.class, Reference.class })
         @Required
         private final Element content;
-
-        private volatile int hashCode;
 
         private Payload(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CompartmentDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CompartmentDefinition.java
@@ -101,8 +101,6 @@ public class CompartmentDefinition extends DomainResource {
     @Summary
     private final List<Resource> resource;
 
-    private volatile int hashCode;
-
     private CompartmentDefinition(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -958,8 +956,6 @@ public class CompartmentDefinition extends DomainResource {
         @Summary
         private final List<String> param;
         private final String documentation;
-
-        private volatile int hashCode;
 
         private Resource(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Composition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Composition.java
@@ -158,8 +158,6 @@ public class Composition extends DomainResource {
     private final List<Event> event;
     private final List<Section> section;
 
-    private volatile int hashCode;
-
     private Composition(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -1126,8 +1124,6 @@ public class Composition extends DomainResource {
         @ReferenceTarget({ "Patient", "RelatedPerson", "Practitioner", "PractitionerRole", "Organization" })
         private final Reference party;
 
-        private volatile int hashCode;
-
         private Attester(Builder builder) {
             super(builder);
             mode = ValidationSupport.requireNonNull(builder.mode, "mode");
@@ -1445,8 +1441,6 @@ public class Composition extends DomainResource {
         @Required
         private final Element target;
 
-        private volatile int hashCode;
-
         private RelatesTo(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1737,8 +1731,6 @@ public class Composition extends DomainResource {
         private final Period period;
         @Summary
         private final List<Reference> detail;
-
-        private volatile int hashCode;
 
         private Event(Builder builder) {
             super(builder);
@@ -2113,8 +2105,6 @@ public class Composition extends DomainResource {
         )
         private final CodeableConcept emptyReason;
         private final List<Composition.Section> section;
-
-        private volatile int hashCode;
 
         private Section(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ConceptMap.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ConceptMap.java
@@ -140,8 +140,6 @@ public class ConceptMap extends DomainResource {
     private final Element target;
     private final List<Group> group;
 
-    private volatile int hashCode;
-
     private ConceptMap(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1143,8 +1141,6 @@ public class ConceptMap extends DomainResource {
         private final List<Element> element;
         private final Unmapped unmapped;
 
-        private volatile int hashCode;
-
         private Group(Builder builder) {
             super(builder);
             source = builder.source;
@@ -1559,8 +1555,6 @@ public class ConceptMap extends DomainResource {
             private final String display;
             private final List<Target> target;
 
-            private volatile int hashCode;
-
             private Element(Builder builder) {
                 super(builder);
                 code = builder.code;
@@ -1880,8 +1874,6 @@ public class ConceptMap extends DomainResource {
                 private final String comment;
                 private final List<DependsOn> dependsOn;
                 private final List<ConceptMap.Group.Element.Target.DependsOn> product;
-
-                private volatile int hashCode;
 
                 private Target(Builder builder) {
                     super(builder);
@@ -2328,8 +2320,6 @@ public class ConceptMap extends DomainResource {
                     private final String value;
                     private final String display;
 
-                    private volatile int hashCode;
-
                     private DependsOn(Builder builder) {
                         super(builder);
                         property = ValidationSupport.requireNonNull(builder.property, "property");
@@ -2676,8 +2666,6 @@ public class ConceptMap extends DomainResource {
             private final Code code;
             private final String display;
             private final Canonical url;
-
-            private volatile int hashCode;
 
             private Unmapped(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Condition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Condition.java
@@ -177,8 +177,6 @@ public class Condition extends DomainResource {
     private final List<Evidence> evidence;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private Condition(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1218,8 +1216,6 @@ public class Condition extends DomainResource {
         )
         private final CodeableConcept type;
 
-        private volatile int hashCode;
-
         private Stage(Builder builder) {
             super(builder);
             summary = builder.summary;
@@ -1553,8 +1549,6 @@ public class Condition extends DomainResource {
         private final List<CodeableConcept> code;
         @Summary
         private final List<Reference> detail;
-
-        private volatile int hashCode;
 
         private Evidence(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Consent.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Consent.java
@@ -205,8 +205,6 @@ public class Consent extends DomainResource {
     @Summary
     private final Provision provision;
 
-    private volatile int hashCode;
-
     private Consent(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1121,8 +1119,6 @@ public class Consent extends DomainResource {
         private final Uri authority;
         private final Uri uri;
 
-        private volatile int hashCode;
-
         private Policy(Builder builder) {
             super(builder);
             authority = builder.authority;
@@ -1390,8 +1386,6 @@ public class Consent extends DomainResource {
         @ReferenceTarget({ "Patient", "RelatedPerson" })
         private final Reference verifiedWith;
         private final DateTime verificationDate;
-
-        private volatile int hashCode;
 
         private Verification(Builder builder) {
             super(builder);
@@ -1750,8 +1744,6 @@ public class Consent extends DomainResource {
         @Summary
         private final List<Data> data;
         private final List<Consent.Provision> provision;
-
-        private volatile int hashCode;
 
         private Provision(Builder builder) {
             super(builder);
@@ -2471,8 +2463,6 @@ public class Consent extends DomainResource {
             @Required
             private final Reference reference;
 
-            private volatile int hashCode;
-
             private Actor(Builder builder) {
                 super(builder);
                 role = ValidationSupport.requireNonNull(builder.role, "role");
@@ -2766,8 +2756,6 @@ public class Consent extends DomainResource {
             @Summary
             @Required
             private final Reference reference;
-
-            private volatile int hashCode;
 
             private Data(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Contract.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Contract.java
@@ -194,8 +194,6 @@ public class Contract extends DomainResource {
     @Choice({ Attachment.class, Reference.class })
     private final Element legallyBinding;
 
-    private volatile int hashCode;
-
     private Contract(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1973,8 +1971,6 @@ public class Contract extends DomainResource {
         private final ContractPublicationStatus publicationStatus;
         private final Markdown copyright;
 
-        private volatile int hashCode;
-
         private ContentDefinition(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2414,8 +2410,6 @@ public class Contract extends DomainResource {
         private final List<Asset> asset;
         private final List<Action> action;
         private final List<Contract.Term> group;
-
-        private volatile int hashCode;
 
         private Term(Builder builder) {
             super(builder);
@@ -3110,8 +3104,6 @@ public class Contract extends DomainResource {
             )
             private final List<Coding> control;
 
-            private volatile int hashCode;
-
             private SecurityLabel(Builder builder) {
                 super(builder);
                 number = Collections.unmodifiableList(ValidationSupport.checkList(builder.number, "number", UnsignedInt.class));
@@ -3531,8 +3523,6 @@ public class Contract extends DomainResource {
             private final String text;
             private final List<String> linkId;
             private final List<UnsignedInt> securityLabelNumber;
-
-            private volatile int hashCode;
 
             private Offer(Builder builder) {
                 super(builder);
@@ -4173,8 +4163,6 @@ public class Contract extends DomainResource {
                 @Required
                 private final CodeableConcept role;
 
-                private volatile int hashCode;
-
                 private Party(Builder builder) {
                     super(builder);
                     reference = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.reference, "reference", Reference.class));
@@ -4490,8 +4478,6 @@ public class Contract extends DomainResource {
                 @Required
                 private final Element value;
 
-                private volatile int hashCode;
-
                 private Answer(Builder builder) {
                     super(builder);
                     value = ValidationSupport.requireChoiceElement(builder.value, "value", Boolean.class, Decimal.class, Integer.class, Date.class, DateTime.class, Time.class, String.class, Uri.class, Attachment.class, Coding.class, Quantity.class, Reference.class);
@@ -4790,8 +4776,6 @@ public class Contract extends DomainResource {
             private final List<Contract.Term.Offer.Answer> answer;
             private final List<UnsignedInt> securityLabelNumber;
             private final List<ValuedItem> valuedItem;
-
-            private volatile int hashCode;
 
             private Asset(Builder builder) {
                 super(builder);
@@ -5685,8 +5669,6 @@ public class Contract extends DomainResource {
                 private final List<CodeableConcept> code;
                 private final String text;
 
-                private volatile int hashCode;
-
                 private Context(Builder builder) {
                     super(builder);
                     reference = builder.reference;
@@ -6013,8 +5995,6 @@ public class Contract extends DomainResource {
                 private final Reference recipient;
                 private final List<String> linkId;
                 private final List<UnsignedInt> securityLabelNumber;
-
-                private volatile int hashCode;
 
                 private ValuedItem(Builder builder) {
                     super(builder);
@@ -6792,8 +6772,6 @@ public class Contract extends DomainResource {
             private final List<String> reasonLinkId;
             private final List<Annotation> note;
             private final List<UnsignedInt> securityLabelNumber;
-
-            private volatile int hashCode;
 
             private Action(Builder builder) {
                 super(builder);
@@ -8012,8 +7990,6 @@ public class Contract extends DomainResource {
                 )
                 private final CodeableConcept role;
 
-                private volatile int hashCode;
-
                 private Subject(Builder builder) {
                     super(builder);
                     reference = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.reference, "reference", Reference.class));
@@ -8339,8 +8315,6 @@ public class Contract extends DomainResource {
         private final Reference party;
         @Required
         private final List<Signature> signature;
-
-        private volatile int hashCode;
 
         private Signer(Builder builder) {
             super(builder);
@@ -8682,8 +8656,6 @@ public class Contract extends DomainResource {
         @Required
         private final Element content;
 
-        private volatile int hashCode;
-
         private Friendly(Builder builder) {
             super(builder);
             content = ValidationSupport.requireChoiceElement(builder.content, "content", Attachment.class, Reference.class);
@@ -8937,8 +8909,6 @@ public class Contract extends DomainResource {
         @Required
         private final Element content;
 
-        private volatile int hashCode;
-
         private Legal(Builder builder) {
             super(builder);
             content = ValidationSupport.requireChoiceElement(builder.content, "content", Attachment.class, Reference.class);
@@ -9189,8 +9159,6 @@ public class Contract extends DomainResource {
         @Choice({ Attachment.class, Reference.class })
         @Required
         private final Element content;
-
-        private volatile int hashCode;
 
         private Rule(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Coverage.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Coverage.java
@@ -143,8 +143,6 @@ public class Coverage extends DomainResource {
     @ReferenceTarget({ "Contract" })
     private final List<Reference> contract;
 
-    private volatile int hashCode;
-
     private Coverage(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1171,8 +1169,6 @@ public class Coverage extends DomainResource {
         @Summary
         private final String name;
 
-        private volatile int hashCode;
-
         private Class(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -1486,8 +1482,6 @@ public class Coverage extends DomainResource {
         @Required
         private final Element value;
         private final List<Exception> exception;
-
-        private volatile int hashCode;
 
         private CostToBeneficiary(Builder builder) {
             super(builder);
@@ -1819,8 +1813,6 @@ public class Coverage extends DomainResource {
             private final CodeableConcept type;
             @Summary
             private final Period period;
-
-            private volatile int hashCode;
 
             private Exception(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CoverageEligibilityRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CoverageEligibilityRequest.java
@@ -107,8 +107,6 @@ public class CoverageEligibilityRequest extends DomainResource {
     private final List<Insurance> insurance;
     private final List<Item> item;
 
-    private volatile int hashCode;
-
     private CoverageEligibilityRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1024,8 +1022,6 @@ public class CoverageEligibilityRequest extends DomainResource {
         private final Reference information;
         private final Boolean appliesToAll;
 
-        private volatile int hashCode;
-
         private SupportingInfo(Builder builder) {
             super(builder);
             sequence = ValidationSupport.requireNonNull(builder.sequence, "sequence");
@@ -1330,8 +1326,6 @@ public class CoverageEligibilityRequest extends DomainResource {
         @Required
         private final Reference coverage;
         private final String businessArrangement;
-
-        private volatile int hashCode;
 
         private Insurance(Builder builder) {
             super(builder);
@@ -1666,8 +1660,6 @@ public class CoverageEligibilityRequest extends DomainResource {
         private final Reference facility;
         private final List<Diagnosis> diagnosis;
         private final List<Reference> detail;
-
-        private volatile int hashCode;
 
         private Item(Builder builder) {
             super(builder);
@@ -2275,8 +2267,6 @@ public class CoverageEligibilityRequest extends DomainResource {
                 valueSet = "http://hl7.org/fhir/ValueSet/icd-10"
             )
             private final Element diagnosis;
-
-            private volatile int hashCode;
 
             private Diagnosis(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/CoverageEligibilityResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/CoverageEligibilityResponse.java
@@ -123,8 +123,6 @@ public class CoverageEligibilityResponse extends DomainResource {
     private final CodeableConcept form;
     private final List<Error> error;
 
-    private volatile int hashCode;
-
     private CoverageEligibilityResponse(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1047,8 +1045,6 @@ public class CoverageEligibilityResponse extends DomainResource {
         private final Period benefitPeriod;
         private final List<Item> item;
 
-        private volatile int hashCode;
-
         private Insurance(Builder builder) {
             super(builder);
             coverage = ValidationSupport.requireNonNull(builder.coverage, "coverage");
@@ -1460,8 +1456,6 @@ public class CoverageEligibilityResponse extends DomainResource {
             )
             private final List<CodeableConcept> authorizationSupporting;
             private final Uri authorizationUrl;
-
-            private volatile int hashCode;
 
             private Item(Builder builder) {
                 super(builder);
@@ -2172,8 +2166,6 @@ public class CoverageEligibilityResponse extends DomainResource {
                 @Choice({ UnsignedInt.class, String.class, Money.class })
                 private final Element used;
 
-                private volatile int hashCode;
-
                 private Benefit(Builder builder) {
                     super(builder);
                     type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2492,8 +2484,6 @@ public class CoverageEligibilityResponse extends DomainResource {
         )
         @Required
         private final CodeableConcept code;
-
-        private volatile int hashCode;
 
         private Error(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DetectedIssue.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DetectedIssue.java
@@ -112,8 +112,6 @@ public class DetectedIssue extends DomainResource {
     private final Uri reference;
     private final List<Mitigation> mitigation;
 
-    private volatile int hashCode;
-
     private DetectedIssue(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -916,8 +914,6 @@ public class DetectedIssue extends DomainResource {
         private final List<CodeableConcept> code;
         private final List<Reference> detail;
 
-        private volatile int hashCode;
-
         private Evidence(Builder builder) {
             super(builder);
             code = Collections.unmodifiableList(ValidationSupport.checkList(builder.code, "code", CodeableConcept.class));
@@ -1227,8 +1223,6 @@ public class DetectedIssue extends DomainResource {
         private final DateTime date;
         @ReferenceTarget({ "Practitioner", "PractitionerRole" })
         private final Reference author;
-
-        private volatile int hashCode;
 
         private Mitigation(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Device.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Device.java
@@ -116,8 +116,6 @@ public class Device extends DomainResource {
     @ReferenceTarget({ "Device" })
     private final Reference parent;
 
-    private volatile int hashCode;
-
     private Device(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1493,8 +1491,6 @@ public class Device extends DomainResource {
         )
         private final UDIEntryType entryType;
 
-        private volatile int hashCode;
-
         private UdiCarrier(Builder builder) {
             super(builder);
             deviceIdentifier = builder.deviceIdentifier;
@@ -1916,8 +1912,6 @@ public class Device extends DomainResource {
         @Required
         private final DeviceNameType type;
 
-        private volatile int hashCode;
-
         private DeviceName(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -2191,8 +2185,6 @@ public class Device extends DomainResource {
         private final CodeableConcept systemType;
         private final String version;
 
-        private volatile int hashCode;
-
         private Specialization(Builder builder) {
             super(builder);
             systemType = ValidationSupport.requireNonNull(builder.systemType, "systemType");
@@ -2460,8 +2452,6 @@ public class Device extends DomainResource {
         private final Identifier component;
         @Required
         private final String value;
-
-        private volatile int hashCode;
 
         private Version(Builder builder) {
             super(builder);
@@ -2761,8 +2751,6 @@ public class Device extends DomainResource {
         private final CodeableConcept type;
         private final List<Quantity> valueQuantity;
         private final List<CodeableConcept> valueCode;
-
-        private volatile int hashCode;
 
         private Property(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceDefinition.java
@@ -94,8 +94,6 @@ public class DeviceDefinition extends DomainResource {
     private final Reference parentDevice;
     private final List<Material> material;
 
-    private volatile int hashCode;
-
     private DeviceDefinition(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1390,8 +1388,6 @@ public class DeviceDefinition extends DomainResource {
         @Required
         private final Uri jurisdiction;
 
-        private volatile int hashCode;
-
         private UdiDeviceIdentifier(Builder builder) {
             super(builder);
             deviceIdentifier = ValidationSupport.requireNonNull(builder.deviceIdentifier, "deviceIdentifier");
@@ -1706,8 +1702,6 @@ public class DeviceDefinition extends DomainResource {
         @Required
         private final DeviceNameType type;
 
-        private volatile int hashCode;
-
         private DeviceName(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -1981,8 +1975,6 @@ public class DeviceDefinition extends DomainResource {
         private final String systemType;
         private final String version;
 
-        private volatile int hashCode;
-
         private Specialization(Builder builder) {
             super(builder);
             systemType = ValidationSupport.requireNonNull(builder.systemType, "systemType");
@@ -2249,8 +2241,6 @@ public class DeviceDefinition extends DomainResource {
         @Required
         private final CodeableConcept type;
         private final List<CodeableConcept> description;
-
-        private volatile int hashCode;
 
         private Capability(Builder builder) {
             super(builder);
@@ -2539,8 +2529,6 @@ public class DeviceDefinition extends DomainResource {
         private final CodeableConcept type;
         private final List<Quantity> valueQuantity;
         private final List<CodeableConcept> valueCode;
-
-        private volatile int hashCode;
 
         private Property(Builder builder) {
             super(builder);
@@ -2880,8 +2868,6 @@ public class DeviceDefinition extends DomainResource {
         private final CodeableConcept substance;
         private final Boolean alternate;
         private final Boolean allergenicIndicator;
-
-        private volatile int hashCode;
 
         private Material(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceMetric.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceMetric.java
@@ -123,8 +123,6 @@ public class DeviceMetric extends DomainResource {
     @Summary
     private final List<Calibration> calibration;
 
-    private volatile int hashCode;
-
     private DeviceMetric(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -842,8 +840,6 @@ public class DeviceMetric extends DomainResource {
         private final DeviceMetricCalibrationState state;
         @Summary
         private final Instant time;
-
-        private volatile int hashCode;
 
         private Calibration(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceRequest.java
@@ -151,8 +151,6 @@ public class DeviceRequest extends DomainResource {
     @ReferenceTarget({ "Provenance" })
     private final List<Reference> relevantHistory;
 
-    private volatile int hashCode;
-
     private DeviceRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1576,8 +1574,6 @@ public class DeviceRequest extends DomainResource {
         private final CodeableConcept code;
         @Choice({ CodeableConcept.class, Quantity.class, Range.class, Boolean.class })
         private final Element value;
-
-        private volatile int hashCode;
 
         private Parameter(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceUseStatement.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DeviceUseStatement.java
@@ -99,8 +99,6 @@ public class DeviceUseStatement extends DomainResource {
     private final CodeableConcept bodySite;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private DeviceUseStatement(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DiagnosticReport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DiagnosticReport.java
@@ -129,8 +129,6 @@ public class DiagnosticReport extends DomainResource {
     private final List<CodeableConcept> conclusionCode;
     private final List<Attachment> presentedForm;
 
-    private volatile int hashCode;
-
     private DiagnosticReport(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1357,8 +1355,6 @@ public class DiagnosticReport extends DomainResource {
         @ReferenceTarget({ "Media" })
         @Required
         private final Reference link;
-
-        private volatile int hashCode;
 
         private Media(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DocumentManifest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DocumentManifest.java
@@ -85,8 +85,6 @@ public class DocumentManifest extends DomainResource {
     private final List<Reference> content;
     private final List<Related> related;
 
-    private volatile int hashCode;
-
     private DocumentManifest(Builder builder) {
         super(builder);
         masterIdentifier = builder.masterIdentifier;
@@ -936,8 +934,6 @@ public class DocumentManifest extends DomainResource {
     public static class Related extends BackboneElement {
         private final Identifier identifier;
         private final Reference ref;
-
-        private volatile int hashCode;
 
         private Related(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/DocumentReference.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/DocumentReference.java
@@ -146,8 +146,6 @@ public class DocumentReference extends DomainResource {
     @Summary
     private final Context context;
 
-    private volatile int hashCode;
-
     private DocumentReference(Builder builder) {
         super(builder);
         masterIdentifier = builder.masterIdentifier;
@@ -1153,8 +1151,6 @@ public class DocumentReference extends DomainResource {
         @Required
         private final Reference target;
 
-        private volatile int hashCode;
-
         private RelatesTo(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1438,8 +1434,6 @@ public class DocumentReference extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/formatcodes"
         )
         private final Coding format;
-
-        private volatile int hashCode;
 
         private Content(Builder builder) {
             super(builder);
@@ -1734,8 +1728,6 @@ public class DocumentReference extends DomainResource {
         @ReferenceTarget({ "Patient" })
         private final Reference sourcePatientInfo;
         private final List<Reference> related;
-
-        private volatile int hashCode;
 
         private Context(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EffectEvidenceSynthesis.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EffectEvidenceSynthesis.java
@@ -237,8 +237,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
     private final List<EffectEstimate> effectEstimate;
     private final List<Certainty> certainty;
 
-    private volatile int hashCode;
-
     private EffectEvidenceSynthesis(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1929,8 +1927,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
         private final Integer numberOfStudies;
         private final Integer numberOfParticipants;
 
-        private volatile int hashCode;
-
         private SampleSize(Builder builder) {
             super(builder);
             description = builder.description;
@@ -2236,8 +2232,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
         @ReferenceTarget({ "RiskEvidenceSynthesis" })
         @Required
         private final Reference riskEvidenceSynthesis;
-
-        private volatile int hashCode;
 
         private ResultsByExposure(Builder builder) {
             super(builder);
@@ -2594,8 +2588,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
         )
         private final CodeableConcept unitOfMeasure;
         private final List<PrecisionEstimate> precisionEstimate;
-
-        private volatile int hashCode;
 
         private EffectEstimate(Builder builder) {
             super(builder);
@@ -3008,8 +3000,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
             private final Decimal from;
             private final Decimal to;
 
-            private volatile int hashCode;
-
             private PrecisionEstimate(Builder builder) {
                 super(builder);
                 type = builder.type;
@@ -3338,8 +3328,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
         private final List<CodeableConcept> rating;
         private final List<Annotation> note;
         private final List<CertaintySubcomponent> certaintySubcomponent;
-
-        private volatile int hashCode;
 
         private Certainty(Builder builder) {
             super(builder);
@@ -3702,8 +3690,6 @@ public class EffectEvidenceSynthesis extends DomainResource {
             )
             private final List<CodeableConcept> rating;
             private final List<Annotation> note;
-
-            private volatile int hashCode;
 
             private CertaintySubcomponent(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Encounter.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Encounter.java
@@ -198,8 +198,6 @@ public class Encounter extends DomainResource {
     @ReferenceTarget({ "Encounter" })
     private final Reference partOf;
 
-    private volatile int hashCode;
-
     private Encounter(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1618,8 +1616,6 @@ public class Encounter extends DomainResource {
         @Required
         private final Period period;
 
-        private volatile int hashCode;
-
         private StatusHistory(Builder builder) {
             super(builder);
             status = ValidationSupport.requireNonNull(builder.status, "status");
@@ -1901,8 +1897,6 @@ public class Encounter extends DomainResource {
         @Required
         private final Period period;
 
-        private volatile int hashCode;
-
         private ClassHistory(Builder builder) {
             super(builder);
             clazz = ValidationSupport.requireNonNull(builder.clazz, "class");
@@ -2181,8 +2175,6 @@ public class Encounter extends DomainResource {
         @Summary
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "RelatedPerson" })
         private final Reference individual;
-
-        private volatile int hashCode;
 
         private Participant(Builder builder) {
             super(builder);
@@ -2513,8 +2505,6 @@ public class Encounter extends DomainResource {
         )
         private final CodeableConcept use;
         private final PositiveInt rank;
-
-        private volatile int hashCode;
 
         private Diagnosis(Builder builder) {
             super(builder);
@@ -2868,8 +2858,6 @@ public class Encounter extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/encounter-discharge-disposition"
         )
         private final CodeableConcept dischargeDisposition;
-
-        private volatile int hashCode;
 
         private Hospitalization(Builder builder) {
             super(builder);
@@ -3440,8 +3428,6 @@ public class Encounter extends DomainResource {
         )
         private final CodeableConcept physicalType;
         private final Period period;
-
-        private volatile int hashCode;
 
         private Location(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Endpoint.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Endpoint.java
@@ -107,8 +107,6 @@ public class Endpoint extends DomainResource {
     private final Url address;
     private final List<String> header;
 
-    private volatile int hashCode;
-
     private Endpoint(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EnrollmentRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EnrollmentRequest.java
@@ -62,8 +62,6 @@ public class EnrollmentRequest extends DomainResource {
     @ReferenceTarget({ "Coverage" })
     private final Reference coverage;
 
-    private volatile int hashCode;
-
     private EnrollmentRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EnrollmentResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EnrollmentResponse.java
@@ -70,8 +70,6 @@ public class EnrollmentResponse extends DomainResource {
     @ReferenceTarget({ "Practitioner", "PractitionerRole", "Organization" })
     private final Reference requestProvider;
 
-    private volatile int hashCode;
-
     private EnrollmentResponse(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EpisodeOfCare.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EpisodeOfCare.java
@@ -96,8 +96,6 @@ public class EpisodeOfCare extends DomainResource {
     @ReferenceTarget({ "Account" })
     private final List<Reference> account;
 
-    private volatile int hashCode;
-
     private EpisodeOfCare(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -992,8 +990,6 @@ public class EpisodeOfCare extends DomainResource {
         @Required
         private final Period period;
 
-        private volatile int hashCode;
-
         private StatusHistory(Builder builder) {
             super(builder);
             status = ValidationSupport.requireNonNull(builder.status, "status");
@@ -1274,8 +1270,6 @@ public class EpisodeOfCare extends DomainResource {
         private final CodeableConcept role;
         @Summary
         private final PositiveInt rank;
-
-        private volatile int hashCode;
 
         private Diagnosis(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EventDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EventDefinition.java
@@ -153,8 +153,6 @@ public class EventDefinition extends DomainResource {
     @Required
     private final List<TriggerDefinition> trigger;
 
-    private volatile int hashCode;
-
     private EventDefinition(Builder builder) {
         super(builder);
         url = builder.url;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Evidence.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Evidence.java
@@ -138,8 +138,6 @@ public class Evidence extends DomainResource {
     @ReferenceTarget({ "EvidenceVariable" })
     private final List<Reference> outcome;
 
-    private volatile int hashCode;
-
     private Evidence(Builder builder) {
         super(builder);
         url = builder.url;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/EvidenceVariable.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/EvidenceVariable.java
@@ -151,8 +151,6 @@ public class EvidenceVariable extends DomainResource {
     @Required
     private final List<Characteristic> characteristic;
 
-    private volatile int hashCode;
-
     private EvidenceVariable(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1612,8 +1610,6 @@ public class EvidenceVariable extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/group-measure|4.0.1"
         )
         private final GroupMeasure groupMeasure;
-
-        private volatile int hashCode;
 
         private Characteristic(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ExampleScenario.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ExampleScenario.java
@@ -110,8 +110,6 @@ public class ExampleScenario extends DomainResource {
     private final List<Process> process;
     private final List<Canonical> workflow;
 
-    private volatile int hashCode;
-
     private ExampleScenario(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1154,8 +1152,6 @@ public class ExampleScenario extends DomainResource {
         private final String name;
         private final Markdown description;
 
-        private volatile int hashCode;
-
         private Actor(Builder builder) {
             super(builder);
             actorId = ValidationSupport.requireNonNull(builder.actorId, "actorId");
@@ -1498,8 +1494,6 @@ public class ExampleScenario extends DomainResource {
         private final Markdown description;
         private final List<Version> version;
         private final List<ContainedInstance> containedInstance;
-
-        private volatile int hashCode;
 
         private Instance(Builder builder) {
             super(builder);
@@ -1935,8 +1929,6 @@ public class ExampleScenario extends DomainResource {
             @Required
             private final Markdown description;
 
-            private volatile int hashCode;
-
             private Version(Builder builder) {
                 super(builder);
                 versionId = ValidationSupport.requireNonNull(builder.versionId, "versionId");
@@ -2206,8 +2198,6 @@ public class ExampleScenario extends DomainResource {
             @Required
             private final String resourceId;
             private final String versionId;
-
-            private volatile int hashCode;
 
             private ContainedInstance(Builder builder) {
                 super(builder);
@@ -2480,8 +2470,6 @@ public class ExampleScenario extends DomainResource {
         private final Markdown preConditions;
         private final Markdown postConditions;
         private final List<Step> step;
-
-        private volatile int hashCode;
 
         private Process(Builder builder) {
             super(builder);
@@ -2863,8 +2851,6 @@ public class ExampleScenario extends DomainResource {
             private final Operation operation;
             private final List<Alternative> alternative;
 
-            private volatile int hashCode;
-
             private Step(Builder builder) {
                 super(builder);
                 process = Collections.unmodifiableList(ValidationSupport.checkList(builder.process, "process", ExampleScenario.Process.class));
@@ -3236,8 +3222,6 @@ public class ExampleScenario extends DomainResource {
                 private final Boolean receiverActive;
                 private final ExampleScenario.Instance.ContainedInstance request;
                 private final ExampleScenario.Instance.ContainedInstance response;
-
-                private volatile int hashCode;
 
                 private Operation(Builder builder) {
                     super(builder);
@@ -3755,8 +3739,6 @@ public class ExampleScenario extends DomainResource {
                 private final String title;
                 private final Markdown description;
                 private final List<ExampleScenario.Process.Step> step;
-
-                private volatile int hashCode;
 
                 private Alternative(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ExplanationOfBenefit.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ExplanationOfBenefit.java
@@ -218,8 +218,6 @@ public class ExplanationOfBenefit extends DomainResource {
     private final Period benefitPeriod;
     private final List<BenefitBalance> benefitBalance;
 
-    private volatile int hashCode;
-
     private ExplanationOfBenefit(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -2290,8 +2288,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final CodeableConcept relationship;
         private final Identifier reference;
 
-        private volatile int hashCode;
-
         private Related(Builder builder) {
             super(builder);
             claim = builder.claim;
@@ -2595,8 +2591,6 @@ public class ExplanationOfBenefit extends DomainResource {
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "Organization", "Patient", "RelatedPerson" })
         private final Reference party;
 
-        private volatile int hashCode;
-
         private Payee(Builder builder) {
             super(builder);
             type = builder.type;
@@ -2883,8 +2877,6 @@ public class ExplanationOfBenefit extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/provider-qualification"
         )
         private final CodeableConcept qualification;
-
-        private volatile int hashCode;
 
         private CareTeam(Builder builder) {
             super(builder);
@@ -3282,8 +3274,6 @@ public class ExplanationOfBenefit extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/missing-tooth-reason"
         )
         private final Coding reason;
-
-        private volatile int hashCode;
 
         private SupportingInfo(Builder builder) {
             super(builder);
@@ -3728,8 +3718,6 @@ public class ExplanationOfBenefit extends DomainResource {
         )
         private final CodeableConcept packageCode;
 
-        private volatile int hashCode;
-
         private Diagnosis(Builder builder) {
             super(builder);
             sequence = ValidationSupport.requireNonNull(builder.sequence, "sequence");
@@ -4145,8 +4133,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final Element procedure;
         @ReferenceTarget({ "Device" })
         private final List<Reference> udi;
-
-        private volatile int hashCode;
 
         private Procedure(Builder builder) {
             super(builder);
@@ -4579,8 +4565,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final Reference coverage;
         private final List<String> preAuthRef;
 
-        private volatile int hashCode;
-
         private Insurance(Builder builder) {
             super(builder);
             focal = ValidationSupport.requireNonNull(builder.focal, "focal");
@@ -4920,8 +4904,6 @@ public class ExplanationOfBenefit extends DomainResource {
         @ReferenceTarget({ "Location" })
         @Choice({ Address.class, Reference.class })
         private final Element location;
-
-        private volatile int hashCode;
 
         private Accident(Builder builder) {
             super(builder);
@@ -5303,8 +5285,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final List<PositiveInt> noteNumber;
         private final List<Adjudication> adjudication;
         private final List<Detail> detail;
-
-        private volatile int hashCode;
 
         private Item(Builder builder) {
             super(builder);
@@ -6531,8 +6511,6 @@ public class ExplanationOfBenefit extends DomainResource {
             private final Money amount;
             private final Decimal value;
 
-            private volatile int hashCode;
-
             private Adjudication(Builder builder) {
                 super(builder);
                 category = ValidationSupport.requireNonNull(builder.category, "category");
@@ -6909,8 +6887,6 @@ public class ExplanationOfBenefit extends DomainResource {
             private final List<PositiveInt> noteNumber;
             private final List<ExplanationOfBenefit.Item.Adjudication> adjudication;
             private final List<SubDetail> subDetail;
-
-            private volatile int hashCode;
 
             private Detail(Builder builder) {
                 super(builder);
@@ -7733,8 +7709,6 @@ public class ExplanationOfBenefit extends DomainResource {
                 private final List<PositiveInt> noteNumber;
                 private final List<ExplanationOfBenefit.Item.Adjudication> adjudication;
 
-                private volatile int hashCode;
-
                 private SubDetail(Builder builder) {
                     super(builder);
                     sequence = ValidationSupport.requireNonNull(builder.sequence, "sequence");
@@ -8520,8 +8494,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final List<PositiveInt> noteNumber;
         private final List<ExplanationOfBenefit.Item.Adjudication> adjudication;
         private final List<Detail> detail;
-
-        private volatile int hashCode;
 
         private AddItem(Builder builder) {
             super(builder);
@@ -9547,8 +9519,6 @@ public class ExplanationOfBenefit extends DomainResource {
             private final List<ExplanationOfBenefit.Item.Adjudication> adjudication;
             private final List<SubDetail> subDetail;
 
-            private volatile int hashCode;
-
             private Detail(Builder builder) {
                 super(builder);
                 productOrService = ValidationSupport.requireNonNull(builder.productOrService, "productOrService");
@@ -10136,8 +10106,6 @@ public class ExplanationOfBenefit extends DomainResource {
                 private final List<PositiveInt> noteNumber;
                 private final List<ExplanationOfBenefit.Item.Adjudication> adjudication;
 
-                private volatile int hashCode;
-
                 private SubDetail(Builder builder) {
                     super(builder);
                     productOrService = ValidationSupport.requireNonNull(builder.productOrService, "productOrService");
@@ -10668,8 +10636,6 @@ public class ExplanationOfBenefit extends DomainResource {
         @Required
         private final Money amount;
 
-        private volatile int hashCode;
-
         private Total(Builder builder) {
             super(builder);
             category = ValidationSupport.requireNonNull(builder.category, "category");
@@ -10958,8 +10924,6 @@ public class ExplanationOfBenefit extends DomainResource {
         private final Date date;
         private final Money amount;
         private final Identifier identifier;
-
-        private volatile int hashCode;
 
         private Payment(Builder builder) {
             super(builder);
@@ -11361,8 +11325,6 @@ public class ExplanationOfBenefit extends DomainResource {
         )
         private final CodeableConcept language;
 
-        private volatile int hashCode;
-
         private ProcessNote(Builder builder) {
             super(builder);
             number = builder.number;
@@ -11715,8 +11677,6 @@ public class ExplanationOfBenefit extends DomainResource {
         )
         private final CodeableConcept term;
         private final List<Financial> financial;
-
-        private volatile int hashCode;
 
         private BenefitBalance(Builder builder) {
             super(builder);
@@ -12200,8 +12160,6 @@ public class ExplanationOfBenefit extends DomainResource {
             private final Element allowed;
             @Choice({ UnsignedInt.class, Money.class })
             private final Element used;
-
-            private volatile int hashCode;
 
             private Financial(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/FamilyMemberHistory.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/FamilyMemberHistory.java
@@ -151,8 +151,6 @@ public class FamilyMemberHistory extends DomainResource {
     private final List<Annotation> note;
     private final List<Condition> condition;
 
-    private volatile int hashCode;
-
     private FamilyMemberHistory(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1260,8 +1258,6 @@ public class FamilyMemberHistory extends DomainResource {
         @Choice({ Age.class, Range.class, Period.class, String.class })
         private final Element onset;
         private final List<Annotation> note;
-
-        private volatile int hashCode;
 
         private Condition(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Flag.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Flag.java
@@ -86,8 +86,6 @@ public class Flag extends DomainResource {
     @ReferenceTarget({ "Device", "Organization", "Patient", "Practitioner", "PractitionerRole" })
     private final Reference author;
 
-    private volatile int hashCode;
-
     private Flag(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Goal.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Goal.java
@@ -157,8 +157,6 @@ public class Goal extends DomainResource {
     @ReferenceTarget({ "Observation" })
     private final List<Reference> outcomeReference;
 
-    private volatile int hashCode;
-
     private Goal(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1189,8 +1187,6 @@ public class Goal extends DomainResource {
         @Summary
         @Choice({ Date.class, Duration.class })
         private final Element due;
-
-        private volatile int hashCode;
 
         private Target(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/GraphDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/GraphDefinition.java
@@ -119,8 +119,6 @@ public class GraphDefinition extends DomainResource {
     private final Canonical profile;
     private final List<Link> link;
 
-    private volatile int hashCode;
-
     private GraphDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1014,8 +1012,6 @@ public class GraphDefinition extends DomainResource {
         private final String description;
         private final List<Target> target;
 
-        private volatile int hashCode;
-
         private Link(Builder builder) {
             super(builder);
             path = builder.path;
@@ -1427,8 +1423,6 @@ public class GraphDefinition extends DomainResource {
             private final Canonical profile;
             private final List<Compartment> compartment;
             private final List<GraphDefinition.Link> link;
-
-            private volatile int hashCode;
 
             private Target(Builder builder) {
                 super(builder);
@@ -1851,8 +1845,6 @@ public class GraphDefinition extends DomainResource {
                 private final GraphCompartmentRule rule;
                 private final String expression;
                 private final String description;
-
-                private volatile int hashCode;
 
                 private Compartment(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Group.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Group.java
@@ -96,8 +96,6 @@ public class Group extends DomainResource {
     private final List<Characteristic> characteristic;
     private final List<Member> member;
 
-    private volatile int hashCode;
-
     private Group(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -810,8 +808,6 @@ public class Group extends DomainResource {
         private final Boolean exclude;
         private final Period period;
 
-        private volatile int hashCode;
-
         private Characteristic(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1157,8 +1153,6 @@ public class Group extends DomainResource {
         private final Reference entity;
         private final Period period;
         private final Boolean inactive;
-
-        private volatile int hashCode;
 
         private Member(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/GuidanceResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/GuidanceResponse.java
@@ -87,8 +87,6 @@ public class GuidanceResponse extends DomainResource {
     private final Reference result;
     private final List<DataRequirement> dataRequirement;
 
-    private volatile int hashCode;
-
     private GuidanceResponse(Builder builder) {
         super(builder);
         requestIdentifier = builder.requestIdentifier;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/HealthcareService.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/HealthcareService.java
@@ -156,8 +156,6 @@ public class HealthcareService extends DomainResource {
     @ReferenceTarget({ "Endpoint" })
     private final List<Reference> endpoint;
 
-    private volatile int hashCode;
-
     private HealthcareService(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1591,8 +1589,6 @@ public class HealthcareService extends DomainResource {
         private final CodeableConcept code;
         private final Markdown comment;
 
-        private volatile int hashCode;
-
         private Eligibility(Builder builder) {
             super(builder);
             code = builder.code;
@@ -1859,8 +1855,6 @@ public class HealthcareService extends DomainResource {
         private final Boolean allDay;
         private final Time availableStartTime;
         private final Time availableEndTime;
-
-        private volatile int hashCode;
 
         private AvailableTime(Builder builder) {
             super(builder);
@@ -2203,8 +2197,6 @@ public class HealthcareService extends DomainResource {
         @Required
         private final String description;
         private final Period during;
-
-        private volatile int hashCode;
 
         private NotAvailable(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImagingStudy.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImagingStudy.java
@@ -171,8 +171,6 @@ public class ImagingStudy extends DomainResource {
     @Summary
     private final List<Series> series;
 
-    private volatile int hashCode;
-
     private ImagingStudy(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1471,8 +1469,6 @@ public class ImagingStudy extends DomainResource {
         private final List<Performer> performer;
         private final List<Instance> instance;
 
-        private volatile int hashCode;
-
         private Series(Builder builder) {
             super(builder);
             uid = ValidationSupport.requireNonNull(builder.uid, "uid");
@@ -2181,8 +2177,6 @@ public class ImagingStudy extends DomainResource {
             @Required
             private final Reference actor;
 
-            private volatile int hashCode;
-
             private Performer(Builder builder) {
                 super(builder);
                 function = builder.function;
@@ -2470,8 +2464,6 @@ public class ImagingStudy extends DomainResource {
             private final Coding sopClass;
             private final UnsignedInt number;
             private final String title;
-
-            private volatile int hashCode;
 
             private Instance(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Immunization.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Immunization.java
@@ -178,8 +178,6 @@ public class Immunization extends DomainResource {
     private final List<Reaction> reaction;
     private final List<ProtocolApplied> protocolApplied;
 
-    private volatile int hashCode;
-
     private Immunization(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1636,8 +1634,6 @@ public class Immunization extends DomainResource {
         @Required
         private final Reference actor;
 
-        private volatile int hashCode;
-
         private Performer(Builder builder) {
             super(builder);
             function = builder.function;
@@ -1913,8 +1909,6 @@ public class Immunization extends DomainResource {
         private final Uri reference;
         private final DateTime publicationDate;
         private final DateTime presentationDate;
-
-        private volatile int hashCode;
 
         private Education(Builder builder) {
             super(builder);
@@ -2239,8 +2233,6 @@ public class Immunization extends DomainResource {
         private final Reference detail;
         private final Boolean reported;
 
-        private volatile int hashCode;
-
         private Reaction(Builder builder) {
             super(builder);
             date = builder.date;
@@ -2549,8 +2541,6 @@ public class Immunization extends DomainResource {
         private final Element doseNumber;
         @Choice({ PositiveInt.class, String.class })
         private final Element seriesDoses;
-
-        private volatile int hashCode;
 
         private ProtocolApplied(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImmunizationEvaluation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImmunizationEvaluation.java
@@ -103,8 +103,6 @@ public class ImmunizationEvaluation extends DomainResource {
     @Choice({ PositiveInt.class, String.class })
     private final Element seriesDoses;
 
-    private volatile int hashCode;
-
     private ImmunizationEvaluation(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImmunizationRecommendation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImmunizationRecommendation.java
@@ -73,8 +73,6 @@ public class ImmunizationRecommendation extends DomainResource {
     @Required
     private final List<Recommendation> recommendation;
 
-    private volatile int hashCode;
-
     private ImmunizationRecommendation(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -651,8 +649,6 @@ public class ImmunizationRecommendation extends DomainResource {
         @ReferenceTarget({ "Immunization", "ImmunizationEvaluation" })
         private final List<Reference> supportingImmunization;
         private final List<Reference> supportingPatientInformation;
-
-        private volatile int hashCode;
 
         private Recommendation(Builder builder) {
             super(builder);
@@ -1384,8 +1380,6 @@ public class ImmunizationRecommendation extends DomainResource {
             private final CodeableConcept code;
             @Required
             private final DateTime value;
-
-            private volatile int hashCode;
 
             private DateCriterion(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImplementationGuide.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ImplementationGuide.java
@@ -158,8 +158,6 @@ public class ImplementationGuide extends DomainResource {
     private final Definition definition;
     private final Manifest manifest;
 
-    private volatile int hashCode;
-
     private ImplementationGuide(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1275,8 +1273,6 @@ public class ImplementationGuide extends DomainResource {
         @Summary
         private final String version;
 
-        private volatile int hashCode;
-
         private DependsOn(Builder builder) {
             super(builder);
             uri = ValidationSupport.requireNonNull(builder.uri, "uri");
@@ -1584,8 +1580,6 @@ public class ImplementationGuide extends DomainResource {
         @Required
         private final Canonical profile;
 
-        private volatile int hashCode;
-
         private Global(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -1858,8 +1852,6 @@ public class ImplementationGuide extends DomainResource {
         private final Page page;
         private final List<Parameter> parameter;
         private final List<Template> template;
-
-        private volatile int hashCode;
 
         private Definition(Builder builder) {
             super(builder);
@@ -2308,8 +2300,6 @@ public class ImplementationGuide extends DomainResource {
             private final String name;
             private final String description;
 
-            private volatile int hashCode;
-
             private Grouping(Builder builder) {
                 super(builder);
                 name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -2589,8 +2579,6 @@ public class ImplementationGuide extends DomainResource {
             @Choice({ Boolean.class, Canonical.class })
             private final Element example;
             private final Id groupingId;
-
-            private volatile int hashCode;
 
             private Resource(Builder builder) {
                 super(builder);
@@ -3028,8 +3016,6 @@ public class ImplementationGuide extends DomainResource {
             private final GuidePageGeneration generation;
             private final List<ImplementationGuide.Definition.Page> page;
 
-            private volatile int hashCode;
-
             private Page(Builder builder) {
                 super(builder);
                 name = ValidationSupport.requireChoiceElement(builder.name, "name", Url.class, Reference.class);
@@ -3404,8 +3390,6 @@ public class ImplementationGuide extends DomainResource {
             @Required
             private final String value;
 
-            private volatile int hashCode;
-
             private Parameter(Builder builder) {
                 super(builder);
                 code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -3680,8 +3664,6 @@ public class ImplementationGuide extends DomainResource {
             @Required
             private final String source;
             private final String scope;
-
-            private volatile int hashCode;
 
             private Template(Builder builder) {
                 super(builder);
@@ -3989,8 +3971,6 @@ public class ImplementationGuide extends DomainResource {
         private final List<Page> page;
         private final List<String> image;
         private final List<String> other;
-
-        private volatile int hashCode;
 
         private Manifest(Builder builder) {
             super(builder);
@@ -4447,8 +4427,6 @@ public class ImplementationGuide extends DomainResource {
             private final Element example;
             private final Url relativePath;
 
-            private volatile int hashCode;
-
             private Resource(Builder builder) {
                 super(builder);
                 reference = ValidationSupport.requireNonNull(builder.reference, "reference");
@@ -4755,8 +4733,6 @@ public class ImplementationGuide extends DomainResource {
             private final String name;
             private final String title;
             private final List<String> anchor;
-
-            private volatile int hashCode;
 
             private Page(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/InsurancePlan.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/InsurancePlan.java
@@ -108,8 +108,6 @@ public class InsurancePlan extends DomainResource {
     private final List<Coverage> coverage;
     private final List<Plan> plan;
 
-    private volatile int hashCode;
-
     private InsurancePlan(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1089,8 +1087,6 @@ public class InsurancePlan extends DomainResource {
         private final List<ContactPoint> telecom;
         private final Address address;
 
-        private volatile int hashCode;
-
         private Contact(Builder builder) {
             super(builder);
             purpose = builder.purpose;
@@ -1435,8 +1431,6 @@ public class InsurancePlan extends DomainResource {
         private final List<Reference> network;
         @Required
         private final List<Benefit> benefit;
-
-        private volatile int hashCode;
 
         private Coverage(Builder builder) {
             super(builder);
@@ -1794,8 +1788,6 @@ public class InsurancePlan extends DomainResource {
             private final String requirement;
             private final List<Limit> limit;
 
-            private volatile int hashCode;
-
             private Benefit(Builder builder) {
                 super(builder);
                 type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2112,8 +2104,6 @@ public class InsurancePlan extends DomainResource {
                 private final Quantity value;
                 private final CodeableConcept code;
 
-                private volatile int hashCode;
-
                 private Limit(Builder builder) {
                     super(builder);
                     value = builder.value;
@@ -2384,8 +2374,6 @@ public class InsurancePlan extends DomainResource {
         private final List<Reference> network;
         private final List<GeneralCost> generalCost;
         private final List<SpecificCost> specificCost;
-
-        private volatile int hashCode;
 
         private Plan(Builder builder) {
             super(builder);
@@ -2896,8 +2884,6 @@ public class InsurancePlan extends DomainResource {
             private final Money cost;
             private final String comment;
 
-            private volatile int hashCode;
-
             private GeneralCost(Builder builder) {
                 super(builder);
                 type = builder.type;
@@ -3220,8 +3206,6 @@ public class InsurancePlan extends DomainResource {
             private final CodeableConcept category;
             private final List<Benefit> benefit;
 
-            private volatile int hashCode;
-
             private SpecificCost(Builder builder) {
                 super(builder);
                 category = ValidationSupport.requireNonNull(builder.category, "category");
@@ -3507,8 +3491,6 @@ public class InsurancePlan extends DomainResource {
                 @Required
                 private final CodeableConcept type;
                 private final List<Cost> cost;
-
-                private volatile int hashCode;
 
                 private Benefit(Builder builder) {
                     super(builder);
@@ -3805,8 +3787,6 @@ public class InsurancePlan extends DomainResource {
                     private final CodeableConcept applicability;
                     private final List<CodeableConcept> qualifiers;
                     private final Quantity value;
-
-                    private volatile int hashCode;
 
                     private Cost(Builder builder) {
                         super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Invoice.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Invoice.java
@@ -92,8 +92,6 @@ public class Invoice extends DomainResource {
     private final Markdown paymentTerms;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private Invoice(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1040,8 +1038,6 @@ public class Invoice extends DomainResource {
         @Required
         private final Reference actor;
 
-        private volatile int hashCode;
-
         private Participant(Builder builder) {
             super(builder);
             role = builder.role;
@@ -1325,8 +1321,6 @@ public class Invoice extends DomainResource {
         @Required
         private final Element chargeItem;
         private final List<PriceComponent> priceComponent;
-
-        private volatile int hashCode;
 
         private LineItem(Builder builder) {
             super(builder);
@@ -1678,8 +1672,6 @@ public class Invoice extends DomainResource {
             private final CodeableConcept code;
             private final Decimal factor;
             private final Money amount;
-
-            private volatile int hashCode;
 
             private PriceComponent(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Library.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Library.java
@@ -174,8 +174,6 @@ public class Library extends DomainResource {
     @Summary
     private final List<Attachment> content;
 
-    private volatile int hashCode;
-
     private Library(Builder builder) {
         super(builder);
         url = builder.url;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Linkage.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Linkage.java
@@ -61,8 +61,6 @@ public class Linkage extends DomainResource {
     @Required
     private final List<Item> item;
 
-    private volatile int hashCode;
-
     private Linkage(Builder builder) {
         super(builder);
         active = builder.active;
@@ -513,8 +511,6 @@ public class Linkage extends DomainResource {
         @Summary
         @Required
         private final Reference resource;
-
-        private volatile int hashCode;
 
         private Item(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/List.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/List.java
@@ -143,8 +143,6 @@ public class List extends DomainResource {
     )
     private final CodeableConcept emptyReason;
 
-    private volatile int hashCode;
-
     private List(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -961,8 +959,6 @@ public class List extends DomainResource {
         private final DateTime date;
         @Required
         private final Reference item;
-
-        private volatile int hashCode;
 
         private Entry(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Location.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Location.java
@@ -132,8 +132,6 @@ public class Location extends DomainResource {
     @ReferenceTarget({ "Endpoint" })
     private final List<Reference> endpoint;
 
-    private volatile int hashCode;
-
     private Location(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1127,8 +1125,6 @@ public class Location extends DomainResource {
         private final Decimal latitude;
         private final Decimal altitude;
 
-        private volatile int hashCode;
-
         private Position(Builder builder) {
             super(builder);
             longitude = ValidationSupport.requireNonNull(builder.longitude, "longitude");
@@ -1442,8 +1438,6 @@ public class Location extends DomainResource {
         private final Boolean allDay;
         private final Time openingTime;
         private final Time closingTime;
-
-        private volatile int hashCode;
 
         private HoursOfOperation(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Measure.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Measure.java
@@ -247,8 +247,6 @@ public class Measure extends DomainResource {
     private final List<Group> group;
     private final List<SupplementalData> supplementalData;
 
-    private volatile int hashCode;
-
     private Measure(Builder builder) {
         super(builder);
         url = builder.url;
@@ -2213,8 +2211,6 @@ public class Measure extends DomainResource {
         private final List<Population> population;
         private final List<Stratifier> stratifier;
 
-        private volatile int hashCode;
-
         private Group(Builder builder) {
             super(builder);
             code = builder.code;
@@ -2588,8 +2584,6 @@ public class Measure extends DomainResource {
             @Required
             private final Expression criteria;
 
-            private volatile int hashCode;
-
             private Population(Builder builder) {
                 super(builder);
                 code = builder.code;
@@ -2890,8 +2884,6 @@ public class Measure extends DomainResource {
             private final String description;
             private final Expression criteria;
             private final List<Component> component;
-
-            private volatile int hashCode;
 
             private Stratifier(Builder builder) {
                 super(builder);
@@ -3243,8 +3235,6 @@ public class Measure extends DomainResource {
                 @Required
                 private final Expression criteria;
 
-                private volatile int hashCode;
-
                 private Component(Builder builder) {
                     super(builder);
                     code = builder.code;
@@ -3557,8 +3547,6 @@ public class Measure extends DomainResource {
         private final String description;
         @Required
         private final Expression criteria;
-
-        private volatile int hashCode;
 
         private SupplementalData(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MeasureReport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MeasureReport.java
@@ -128,8 +128,6 @@ public class MeasureReport extends DomainResource {
     private final List<Group> group;
     private final List<Reference> evaluatedResource;
 
-    private volatile int hashCode;
-
     private MeasureReport(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -889,8 +887,6 @@ public class MeasureReport extends DomainResource {
         private final Quantity measureScore;
         private final List<Stratifier> stratifier;
 
-        private volatile int hashCode;
-
         private Group(Builder builder) {
             super(builder);
             code = builder.code;
@@ -1265,8 +1261,6 @@ public class MeasureReport extends DomainResource {
             @ReferenceTarget({ "List" })
             private final Reference subjectResults;
 
-            private volatile int hashCode;
-
             private Population(Builder builder) {
                 super(builder);
                 code = builder.code;
@@ -1564,8 +1558,6 @@ public class MeasureReport extends DomainResource {
         public static class Stratifier extends BackboneElement {
             private final List<CodeableConcept> code;
             private final List<Stratum> stratum;
-
-            private volatile int hashCode;
 
             private Stratifier(Builder builder) {
                 super(builder);
@@ -1870,8 +1862,6 @@ public class MeasureReport extends DomainResource {
                 private final List<Component> component;
                 private final List<Population> population;
                 private final Quantity measureScore;
-
-                private volatile int hashCode;
 
                 private Stratum(Builder builder) {
                     super(builder);
@@ -2239,8 +2229,6 @@ public class MeasureReport extends DomainResource {
                     @Required
                     private final CodeableConcept value;
 
-                    private volatile int hashCode;
-
                     private Component(Builder builder) {
                         super(builder);
                         code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -2517,8 +2505,6 @@ public class MeasureReport extends DomainResource {
                     private final Integer count;
                     @ReferenceTarget({ "List" })
                     private final Reference subjectResults;
-
-                    private volatile int hashCode;
 
                     private Population(Builder builder) {
                         super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Media.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Media.java
@@ -152,8 +152,6 @@ public class Media extends DomainResource {
     private final Attachment content;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private Media(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Medication.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Medication.java
@@ -85,8 +85,6 @@ public class Medication extends DomainResource {
     private final List<Ingredient> ingredient;
     private final Batch batch;
 
-    private volatile int hashCode;
-
     private Medication(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -700,8 +698,6 @@ public class Medication extends DomainResource {
         private final Boolean isActive;
         private final Ratio strength;
 
-        private volatile int hashCode;
-
         private Ingredient(Builder builder) {
             super(builder);
             item = ValidationSupport.requireChoiceElement(builder.item, "item", CodeableConcept.class, Reference.class);
@@ -1013,8 +1009,6 @@ public class Medication extends DomainResource {
     public static class Batch extends BackboneElement {
         private final String lotNumber;
         private final DateTime expirationDate;
-
-        private volatile int hashCode;
 
         private Batch(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationAdministration.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationAdministration.java
@@ -142,8 +142,6 @@ public class MedicationAdministration extends DomainResource {
     @ReferenceTarget({ "Provenance" })
     private final List<Reference> eventHistory;
 
-    private volatile int hashCode;
-
     private MedicationAdministration(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1392,8 +1390,6 @@ public class MedicationAdministration extends DomainResource {
         @Required
         private final Reference actor;
 
-        private volatile int hashCode;
-
         private Performer(Builder builder) {
             super(builder);
             function = builder.function;
@@ -1692,8 +1688,6 @@ public class MedicationAdministration extends DomainResource {
         private final SimpleQuantity dose;
         @Choice({ Ratio.class, SimpleQuantity.class })
         private final Element rate;
-
-        private volatile int hashCode;
 
         private Dosage(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationDispense.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationDispense.java
@@ -144,8 +144,6 @@ public class MedicationDispense extends DomainResource {
     @ReferenceTarget({ "Provenance" })
     private final List<Reference> eventHistory;
 
-    private volatile int hashCode;
-
     private MedicationDispense(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1545,8 +1543,6 @@ public class MedicationDispense extends DomainResource {
         @Required
         private final Reference actor;
 
-        private volatile int hashCode;
-
         private Performer(Builder builder) {
             super(builder);
             function = builder.function;
@@ -1843,8 +1839,6 @@ public class MedicationDispense extends DomainResource {
         private final List<CodeableConcept> reason;
         @ReferenceTarget({ "Practitioner", "PractitionerRole" })
         private final List<Reference> responsibleParty;
-
-        private volatile int hashCode;
 
         private Substitution(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationKnowledge.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationKnowledge.java
@@ -109,8 +109,6 @@ public class MedicationKnowledge extends DomainResource {
     private final List<Regulatory> regulatory;
     private final List<Kinetics> kinetics;
 
-    private volatile int hashCode;
-
     private MedicationKnowledge(Builder builder) {
         super(builder);
         code = builder.code;
@@ -1456,8 +1454,6 @@ public class MedicationKnowledge extends DomainResource {
         @Required
         private final List<Reference> reference;
 
-        private volatile int hashCode;
-
         private RelatedMedicationKnowledge(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -1761,8 +1757,6 @@ public class MedicationKnowledge extends DomainResource {
         @ReferenceTarget({ "DocumentReference", "Media" })
         private final Reference source;
 
-        private volatile int hashCode;
-
         private Monograph(Builder builder) {
             super(builder);
             type = builder.type;
@@ -2032,8 +2026,6 @@ public class MedicationKnowledge extends DomainResource {
         private final Element item;
         private final Boolean isActive;
         private final Ratio strength;
-
-        private volatile int hashCode;
 
         private Ingredient(Builder builder) {
             super(builder);
@@ -2349,8 +2341,6 @@ public class MedicationKnowledge extends DomainResource {
         @Required
         private final Money cost;
 
-        private volatile int hashCode;
-
         private Cost(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2653,8 +2643,6 @@ public class MedicationKnowledge extends DomainResource {
         private final CodeableConcept type;
         private final String name;
 
-        private volatile int hashCode;
-
         private MonitoringProgram(Builder builder) {
             super(builder);
             type = builder.type;
@@ -2916,8 +2904,6 @@ public class MedicationKnowledge extends DomainResource {
         @Choice({ CodeableConcept.class, Reference.class })
         private final Element indication;
         private final List<PatientCharacteristics> patientCharacteristics;
-
-        private volatile int hashCode;
 
         private AdministrationGuidelines(Builder builder) {
             super(builder);
@@ -3265,8 +3251,6 @@ public class MedicationKnowledge extends DomainResource {
             @Required
             private final List<com.ibm.fhir.model.type.Dosage> dosage;
 
-            private volatile int hashCode;
-
             private Dosage(Builder builder) {
                 super(builder);
                 type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -3560,8 +3544,6 @@ public class MedicationKnowledge extends DomainResource {
             @Required
             private final Element characteristic;
             private final List<String> value;
-
-            private volatile int hashCode;
 
             private PatientCharacteristics(Builder builder) {
                 super(builder);
@@ -3857,8 +3839,6 @@ public class MedicationKnowledge extends DomainResource {
         private final CodeableConcept type;
         private final List<CodeableConcept> classification;
 
-        private volatile int hashCode;
-
         private MedicineClassification(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -4151,8 +4131,6 @@ public class MedicationKnowledge extends DomainResource {
         private final CodeableConcept type;
         private final SimpleQuantity quantity;
 
-        private volatile int hashCode;
-
         private Packaging(Builder builder) {
             super(builder);
             type = builder.type;
@@ -4420,8 +4398,6 @@ public class MedicationKnowledge extends DomainResource {
         private final CodeableConcept type;
         @Choice({ CodeableConcept.class, String.class, SimpleQuantity.class, Base64Binary.class })
         private final Element value;
-
-        private volatile int hashCode;
 
         private DrugCharacteristic(Builder builder) {
             super(builder);
@@ -4693,8 +4669,6 @@ public class MedicationKnowledge extends DomainResource {
         private final List<Substitution> substitution;
         private final List<Schedule> schedule;
         private final MaxDispense maxDispense;
-
-        private volatile int hashCode;
 
         private Regulatory(Builder builder) {
             super(builder);
@@ -5071,8 +5045,6 @@ public class MedicationKnowledge extends DomainResource {
             @Required
             private final Boolean allowed;
 
-            private volatile int hashCode;
-
             private Substitution(Builder builder) {
                 super(builder);
                 type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -5342,8 +5314,6 @@ public class MedicationKnowledge extends DomainResource {
             @Required
             private final CodeableConcept schedule;
 
-            private volatile int hashCode;
-
             private Schedule(Builder builder) {
                 super(builder);
                 schedule = ValidationSupport.requireNonNull(builder.schedule, "schedule");
@@ -5579,8 +5549,6 @@ public class MedicationKnowledge extends DomainResource {
             @Required
             private final SimpleQuantity quantity;
             private final Duration period;
-
-            private volatile int hashCode;
 
             private MaxDispense(Builder builder) {
                 super(builder);
@@ -5849,8 +5817,6 @@ public class MedicationKnowledge extends DomainResource {
         private final List<SimpleQuantity> areaUnderCurve;
         private final List<SimpleQuantity> lethalDose50;
         private final Duration halfLifePeriod;
-
-        private volatile int hashCode;
 
         private Kinetics(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationRequest.java
@@ -181,8 +181,6 @@ public class MedicationRequest extends DomainResource {
     @ReferenceTarget({ "Provenance" })
     private final List<Reference> eventHistory;
 
-    private volatile int hashCode;
-
     private MedicationRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1957,8 +1955,6 @@ public class MedicationRequest extends DomainResource {
         @ReferenceTarget({ "Organization" })
         private final Reference performer;
 
-        private volatile int hashCode;
-
         private DispenseRequest(Builder builder) {
             super(builder);
             initialFill = builder.initialFill;
@@ -2388,8 +2384,6 @@ public class MedicationRequest extends DomainResource {
             private final SimpleQuantity quantity;
             private final Duration duration;
 
-            private volatile int hashCode;
-
             private InitialFill(Builder builder) {
                 super(builder);
                 quantity = builder.quantity;
@@ -2665,8 +2659,6 @@ public class MedicationRequest extends DomainResource {
             valueSet = "http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason"
         )
         private final CodeableConcept reason;
-
-        private volatile int hashCode;
 
         private Substitution(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationStatement.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicationStatement.java
@@ -143,8 +143,6 @@ public class MedicationStatement extends DomainResource {
     private final List<Annotation> note;
     private final List<Dosage> dosage;
 
-    private volatile int hashCode;
-
     private MedicationStatement(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProduct.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProduct.java
@@ -96,8 +96,6 @@ public class MedicinalProduct extends DomainResource {
     @Summary
     private final List<SpecialDesignation> specialDesignation;
 
-    private volatile int hashCode;
-
     private MedicinalProduct(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1385,8 +1383,6 @@ public class MedicinalProduct extends DomainResource {
         @Summary
         private final List<CountryLanguage> countryLanguage;
 
-        private volatile int hashCode;
-
         private Name(Builder builder) {
             super(builder);
             productName = ValidationSupport.requireNonNull(builder.productName, "productName");
@@ -1727,8 +1723,6 @@ public class MedicinalProduct extends DomainResource {
             @Required
             private final Coding type;
 
-            private volatile int hashCode;
-
             private NamePart(Builder builder) {
                 super(builder);
                 part = ValidationSupport.requireNonNull(builder.part, "part");
@@ -2003,8 +1997,6 @@ public class MedicinalProduct extends DomainResource {
             @Summary
             @Required
             private final CodeableConcept language;
-
-            private volatile int hashCode;
 
             private CountryLanguage(Builder builder) {
                 super(builder);
@@ -2318,8 +2310,6 @@ public class MedicinalProduct extends DomainResource {
         @Summary
         @ReferenceTarget({ "Organization" })
         private final Reference regulator;
-
-        private volatile int hashCode;
 
         private ManufacturingBusinessOperation(Builder builder) {
             super(builder);
@@ -2754,8 +2744,6 @@ public class MedicinalProduct extends DomainResource {
         private final DateTime date;
         @Summary
         private final CodeableConcept species;
-
-        private volatile int hashCode;
 
         private SpecialDesignation(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductAuthorization.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductAuthorization.java
@@ -82,8 +82,6 @@ public class MedicinalProductAuthorization extends DomainResource {
     @Summary
     private final Procedure procedure;
 
-    private volatile int hashCode;
-
     private MedicinalProductAuthorization(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -995,8 +993,6 @@ public class MedicinalProductAuthorization extends DomainResource {
         @Summary
         private final Period validityPeriod;
 
-        private volatile int hashCode;
-
         private JurisdictionalAuthorization(Builder builder) {
             super(builder);
             identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1396,8 +1392,6 @@ public class MedicinalProductAuthorization extends DomainResource {
         private final Element date;
         @Summary
         private final List<MedicinalProductAuthorization.Procedure> application;
-
-        private volatile int hashCode;
 
         private Procedure(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductContraindication.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductContraindication.java
@@ -62,8 +62,6 @@ public class MedicinalProductContraindication extends DomainResource {
     @Summary
     private final List<Population> population;
 
-    private volatile int hashCode;
-
     private MedicinalProductContraindication(Builder builder) {
         super(builder);
         subject = Collections.unmodifiableList(ValidationSupport.checkList(builder.subject, "subject", Reference.class));
@@ -715,8 +713,6 @@ public class MedicinalProductContraindication extends DomainResource {
         @Choice({ CodeableConcept.class, Reference.class })
         @Required
         private final Element medication;
-
-        private volatile int hashCode;
 
         private OtherTherapy(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductIndication.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductIndication.java
@@ -66,8 +66,6 @@ public class MedicinalProductIndication extends DomainResource {
     @Summary
     private final List<Population> population;
 
-    private volatile int hashCode;
-
     private MedicinalProductIndication(Builder builder) {
         super(builder);
         subject = Collections.unmodifiableList(ValidationSupport.checkList(builder.subject, "subject", Reference.class));
@@ -781,8 +779,6 @@ public class MedicinalProductIndication extends DomainResource {
         @Choice({ CodeableConcept.class, Reference.class })
         @Required
         private final Element medication;
-
-        private volatile int hashCode;
 
         private OtherTherapy(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductIngredient.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductIngredient.java
@@ -60,8 +60,6 @@ public class MedicinalProductIngredient extends DomainResource {
     @Summary
     private final Substance substance;
 
-    private volatile int hashCode;
-
     private MedicinalProductIngredient(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -621,8 +619,6 @@ public class MedicinalProductIngredient extends DomainResource {
         @Summary
         private final List<Strength> strength;
 
-        private volatile int hashCode;
-
         private SpecifiedSubstance(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -985,8 +981,6 @@ public class MedicinalProductIngredient extends DomainResource {
             private final List<CodeableConcept> country;
             @Summary
             private final List<ReferenceStrength> referenceStrength;
-
-            private volatile int hashCode;
 
             private Strength(Builder builder) {
                 super(builder);
@@ -1466,8 +1460,6 @@ public class MedicinalProductIngredient extends DomainResource {
                 @Summary
                 private final List<CodeableConcept> country;
 
-                private volatile int hashCode;
-
                 private ReferenceStrength(Builder builder) {
                     super(builder);
                     substance = builder.substance;
@@ -1851,8 +1843,6 @@ public class MedicinalProductIngredient extends DomainResource {
         private final CodeableConcept code;
         @Summary
         private final List<MedicinalProductIngredient.SpecifiedSubstance.Strength> strength;
-
-        private volatile int hashCode;
 
         private Substance(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductInteraction.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductInteraction.java
@@ -60,8 +60,6 @@ public class MedicinalProductInteraction extends DomainResource {
     @Summary
     private final CodeableConcept management;
 
-    private volatile int hashCode;
-
     private MedicinalProductInteraction(Builder builder) {
         super(builder);
         subject = Collections.unmodifiableList(ValidationSupport.checkList(builder.subject, "subject", Reference.class));
@@ -641,8 +639,6 @@ public class MedicinalProductInteraction extends DomainResource {
         @Choice({ Reference.class, CodeableConcept.class })
         @Required
         private final Element item;
-
-        private volatile int hashCode;
 
         private Interactant(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductManufactured.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductManufactured.java
@@ -61,8 +61,6 @@ public class MedicinalProductManufactured extends DomainResource {
     @Summary
     private final List<CodeableConcept> otherCharacteristics;
 
-    private volatile int hashCode;
-
     private MedicinalProductManufactured(Builder builder) {
         super(builder);
         manufacturedDoseForm = ValidationSupport.requireNonNull(builder.manufacturedDoseForm, "manufacturedDoseForm");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductPackaged.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductPackaged.java
@@ -70,8 +70,6 @@ public class MedicinalProductPackaged extends DomainResource {
     @Required
     private final List<PackageItem> packageItem;
 
-    private volatile int hashCode;
-
     private MedicinalProductPackaged(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -816,8 +814,6 @@ public class MedicinalProductPackaged extends DomainResource {
         @Summary
         private final Identifier immediatePackaging;
 
-        private volatile int hashCode;
-
         private BatchIdentifier(Builder builder) {
             super(builder);
             outerPackaging = ValidationSupport.requireNonNull(builder.outerPackaging, "outerPackaging");
@@ -1110,8 +1106,6 @@ public class MedicinalProductPackaged extends DomainResource {
         @Summary
         @ReferenceTarget({ "Organization" })
         private final List<Reference> manufacturer;
-
-        private volatile int hashCode;
 
         private PackageItem(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductPharmaceutical.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductPharmaceutical.java
@@ -65,8 +65,6 @@ public class MedicinalProductPharmaceutical extends DomainResource {
     @Required
     private final List<RouteOfAdministration> routeOfAdministration;
 
-    private volatile int hashCode;
-
     private MedicinalProductPharmaceutical(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -726,8 +724,6 @@ public class MedicinalProductPharmaceutical extends DomainResource {
         @Summary
         private final CodeableConcept status;
 
-        private volatile int hashCode;
-
         private Characteristics(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1006,8 +1002,6 @@ public class MedicinalProductPharmaceutical extends DomainResource {
         private final Duration maxTreatmentPeriod;
         @Summary
         private final List<TargetSpecies> targetSpecies;
-
-        private volatile int hashCode;
 
         private RouteOfAdministration(Builder builder) {
             super(builder);
@@ -1467,8 +1461,6 @@ public class MedicinalProductPharmaceutical extends DomainResource {
             @Summary
             private final List<WithdrawalPeriod> withdrawalPeriod;
 
-            private volatile int hashCode;
-
             private TargetSpecies(Builder builder) {
                 super(builder);
                 code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1759,8 +1751,6 @@ public class MedicinalProductPharmaceutical extends DomainResource {
                 private final Quantity value;
                 @Summary
                 private final String supportingInformation;
-
-                private volatile int hashCode;
 
                 private WithdrawalPeriod(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductUndesirableEffect.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MedicinalProductUndesirableEffect.java
@@ -52,8 +52,6 @@ public class MedicinalProductUndesirableEffect extends DomainResource {
     @Summary
     private final List<Population> population;
 
-    private volatile int hashCode;
-
     private MedicinalProductUndesirableEffect(Builder builder) {
         super(builder);
         subject = Collections.unmodifiableList(ValidationSupport.checkList(builder.subject, "subject", Reference.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MessageDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MessageDefinition.java
@@ -160,8 +160,6 @@ public class MessageDefinition extends DomainResource {
     private final List<AllowedResponse> allowedResponse;
     private final List<Canonical> graph;
 
-    private volatile int hashCode;
-
     private MessageDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1459,8 +1457,6 @@ public class MessageDefinition extends DomainResource {
         private final UnsignedInt min;
         private final String max;
 
-        private volatile int hashCode;
-
         private Focus(Builder builder) {
             super(builder);
             code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -1796,8 +1792,6 @@ public class MessageDefinition extends DomainResource {
         @Required
         private final Canonical message;
         private final Markdown situation;
-
-        private volatile int hashCode;
 
         private AllowedResponse(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MessageHeader.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MessageHeader.java
@@ -96,8 +96,6 @@ public class MessageHeader extends DomainResource {
     @Summary
     private final Canonical definition;
 
-    private volatile int hashCode;
-
     private MessageHeader(Builder builder) {
         super(builder);
         event = ValidationSupport.requireChoiceElement(builder.event, "event", Coding.class, Uri.class);
@@ -851,8 +849,6 @@ public class MessageHeader extends DomainResource {
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "Organization" })
         private final Reference receiver;
 
-        private volatile int hashCode;
-
         private Destination(Builder builder) {
             super(builder);
             name = builder.name;
@@ -1205,8 +1201,6 @@ public class MessageHeader extends DomainResource {
         @Summary
         @Required
         private final Url endpoint;
-
-        private volatile int hashCode;
 
         private Source(Builder builder) {
             super(builder);
@@ -1579,8 +1573,6 @@ public class MessageHeader extends DomainResource {
         @Summary
         @ReferenceTarget({ "OperationOutcome" })
         private final Reference details;
-
-        private volatile int hashCode;
 
         private Response(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/MolecularSequence.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/MolecularSequence.java
@@ -121,8 +121,6 @@ public class MolecularSequence extends DomainResource {
     @Summary
     private final List<StructureVariant> structureVariant;
 
-    private volatile int hashCode;
-
     private MolecularSequence(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1149,8 +1147,6 @@ public class MolecularSequence extends DomainResource {
         @Summary
         private final Integer windowEnd;
 
-        private volatile int hashCode;
-
         private ReferenceSeq(Builder builder) {
             super(builder);
             chromosome = builder.chromosome;
@@ -1667,8 +1663,6 @@ public class MolecularSequence extends DomainResource {
         @ReferenceTarget({ "Observation" })
         private final Reference variantPointer;
 
-        private volatile int hashCode;
-
         private Variant(Builder builder) {
             super(builder);
             start = builder.start;
@@ -2129,8 +2123,6 @@ public class MolecularSequence extends DomainResource {
         private final Decimal fScore;
         @Summary
         private final Roc roc;
-
-        private volatile int hashCode;
 
         private Quality(Builder builder) {
             super(builder);
@@ -2834,8 +2826,6 @@ public class MolecularSequence extends DomainResource {
             @Summary
             private final List<Decimal> fMeasure;
 
-            private volatile int hashCode;
-
             private Roc(Builder builder) {
                 super(builder);
                 score = Collections.unmodifiableList(ValidationSupport.checkList(builder.score, "score", Integer.class));
@@ -3409,8 +3399,6 @@ public class MolecularSequence extends DomainResource {
         @Summary
         private final String readsetId;
 
-        private volatile int hashCode;
-
         private Repository(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -3819,8 +3807,6 @@ public class MolecularSequence extends DomainResource {
         @Summary
         private final Inner inner;
 
-        private volatile int hashCode;
-
         private StructureVariant(Builder builder) {
             super(builder);
             variantType = builder.variantType;
@@ -4174,8 +4160,6 @@ public class MolecularSequence extends DomainResource {
             @Summary
             private final Integer end;
 
-            private volatile int hashCode;
-
             private Outer(Builder builder) {
                 super(builder);
                 start = builder.start;
@@ -4440,8 +4424,6 @@ public class MolecularSequence extends DomainResource {
             private final Integer start;
             @Summary
             private final Integer end;
-
-            private volatile int hashCode;
 
             private Inner(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/NamingSystem.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/NamingSystem.java
@@ -142,8 +142,6 @@ public class NamingSystem extends DomainResource {
     @Required
     private final List<UniqueId> uniqueId;
 
-    private volatile int hashCode;
-
     private NamingSystem(Builder builder) {
         super(builder);
         name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -983,8 +981,6 @@ public class NamingSystem extends DomainResource {
         private final Boolean preferred;
         private final String comment;
         private final Period period;
-
-        private volatile int hashCode;
 
         private UniqueId(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/NutritionOrder.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/NutritionOrder.java
@@ -128,8 +128,6 @@ public class NutritionOrder extends DomainResource {
     private final EnteralFormula enteralFormula;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private NutritionOrder(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1242,8 +1240,6 @@ public class NutritionOrder extends DomainResource {
         @Summary
         private final String instruction;
 
-        private volatile int hashCode;
-
         private OralDiet(Builder builder) {
             super(builder);
             type = Collections.unmodifiableList(ValidationSupport.checkList(builder.type, "type", CodeableConcept.class));
@@ -1739,8 +1735,6 @@ public class NutritionOrder extends DomainResource {
             private final CodeableConcept modifier;
             private final SimpleQuantity amount;
 
-            private volatile int hashCode;
-
             private Nutrient(Builder builder) {
                 super(builder);
                 modifier = builder.modifier;
@@ -2012,8 +2006,6 @@ public class NutritionOrder extends DomainResource {
             )
             private final CodeableConcept foodType;
 
-            private volatile int hashCode;
-
             private Texture(Builder builder) {
                 super(builder);
                 modifier = builder.modifier;
@@ -2284,8 +2276,6 @@ public class NutritionOrder extends DomainResource {
         private final SimpleQuantity quantity;
         @Summary
         private final String instruction;
-
-        private volatile int hashCode;
 
         private Supplement(Builder builder) {
             super(builder);
@@ -2689,8 +2679,6 @@ public class NutritionOrder extends DomainResource {
         private final SimpleQuantity maxVolumeToDeliver;
         @Summary
         private final String administrationInstruction;
-
-        private volatile int hashCode;
 
         private EnteralFormula(Builder builder) {
             super(builder);
@@ -3206,8 +3194,6 @@ public class NutritionOrder extends DomainResource {
             private final SimpleQuantity quantity;
             @Choice({ SimpleQuantity.class, Ratio.class })
             private final Element rate;
-
-            private volatile int hashCode;
 
             private Administration(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Observation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Observation.java
@@ -226,8 +226,6 @@ public class Observation extends DomainResource {
     @Summary
     private final List<Component> component;
 
-    private volatile int hashCode;
-
     private Observation(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1744,8 +1742,6 @@ public class Observation extends DomainResource {
         private final Range age;
         private final String text;
 
-        private volatile int hashCode;
-
         private ReferenceRange(Builder builder) {
             super(builder);
             low = builder.low;
@@ -2198,8 +2194,6 @@ public class Observation extends DomainResource {
         )
         private final List<CodeableConcept> interpretation;
         private final List<Observation.ReferenceRange> referenceRange;
-
-        private volatile int hashCode;
 
         private Component(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ObservationDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ObservationDefinition.java
@@ -124,8 +124,6 @@ public class ObservationDefinition extends DomainResource {
     @ReferenceTarget({ "ValueSet" })
     private final Reference criticalCodedValueSet;
 
-    private volatile int hashCode;
-
     private ObservationDefinition(Builder builder) {
         super(builder);
         category = Collections.unmodifiableList(ValidationSupport.checkList(builder.category, "category", CodeableConcept.class));
@@ -962,8 +960,6 @@ public class ObservationDefinition extends DomainResource {
         private final Decimal conversionFactor;
         private final Integer decimalPrecision;
 
-        private volatile int hashCode;
-
         private QuantitativeDetails(Builder builder) {
             super(builder);
             customaryUnit = builder.customaryUnit;
@@ -1315,8 +1311,6 @@ public class ObservationDefinition extends DomainResource {
         private final Range age;
         private final Range gestationalAge;
         private final String condition;
-
-        private volatile int hashCode;
 
         private QualifiedInterval(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/OperationDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/OperationDefinition.java
@@ -170,8 +170,6 @@ public class OperationDefinition extends DomainResource {
     private final List<Parameter> parameter;
     private final List<Overload> overload;
 
-    private volatile int hashCode;
-
     private OperationDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1500,8 +1498,6 @@ public class OperationDefinition extends DomainResource {
         private final List<ReferencedFrom> referencedFrom;
         private final List<OperationDefinition.Parameter> part;
 
-        private volatile int hashCode;
-
         private Parameter(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -2135,8 +2131,6 @@ public class OperationDefinition extends DomainResource {
             @Required
             private final Canonical valueSet;
 
-            private volatile int hashCode;
-
             private Binding(Builder builder) {
                 super(builder);
                 strength = ValidationSupport.requireNonNull(builder.strength, "strength");
@@ -2409,8 +2403,6 @@ public class OperationDefinition extends DomainResource {
             private final String source;
             private final String sourceId;
 
-            private volatile int hashCode;
-
             private ReferencedFrom(Builder builder) {
                 super(builder);
                 source = ValidationSupport.requireNonNull(builder.source, "source");
@@ -2680,8 +2672,6 @@ public class OperationDefinition extends DomainResource {
     public static class Overload extends BackboneElement {
         private final List<String> parameterName;
         private final String comment;
-
-        private volatile int hashCode;
 
         private Overload(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/OperationOutcome.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/OperationOutcome.java
@@ -48,8 +48,6 @@ public class OperationOutcome extends DomainResource {
     @Required
     private final List<Issue> issue;
 
-    private volatile int hashCode;
-
     private OperationOutcome(Builder builder) {
         super(builder);
         issue = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.issue, "issue", Issue.class));
@@ -444,8 +442,6 @@ public class OperationOutcome extends DomainResource {
         private final List<String> location;
         @Summary
         private final List<String> expression;
-
-        private volatile int hashCode;
 
         private Issue(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Organization.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Organization.java
@@ -104,8 +104,6 @@ public class Organization extends DomainResource {
     @ReferenceTarget({ "Endpoint" })
     private final List<Reference> endpoint;
 
-    private volatile int hashCode;
-
     private Organization(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -885,8 +883,6 @@ public class Organization extends DomainResource {
         private final HumanName name;
         private final List<ContactPoint> telecom;
         private final Address address;
-
-        private volatile int hashCode;
 
         private Contact(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/OrganizationAffiliation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/OrganizationAffiliation.java
@@ -96,8 +96,6 @@ public class OrganizationAffiliation extends DomainResource {
     @ReferenceTarget({ "Endpoint" })
     private final List<Reference> endpoint;
 
-    private volatile int hashCode;
-
     private OrganizationAffiliation(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Parameters.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Parameters.java
@@ -98,8 +98,6 @@ public class Parameters extends Resource {
     @Summary
     private final List<Parameter> parameter;
 
-    private volatile int hashCode;
-
     private Parameters(Builder builder) {
         super(builder);
         parameter = Collections.unmodifiableList(ValidationSupport.checkList(builder.parameter, "parameter", Parameter.class));
@@ -314,8 +312,6 @@ public class Parameters extends Resource {
         private final Resource resource;
         @Summary
         private final List<Parameters.Parameter> part;
-
-        private volatile int hashCode;
 
         private Parameter(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Patient.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Patient.java
@@ -133,8 +133,6 @@ public class Patient extends DomainResource {
     @Summary
     private final List<Link> link;
 
-    private volatile int hashCode;
-
     private Patient(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1181,8 +1179,6 @@ public class Patient extends DomainResource {
         private final Reference organization;
         private final Period period;
 
-        private volatile int hashCode;
-
         private Contact(Builder builder) {
             super(builder);
             relationship = Collections.unmodifiableList(ValidationSupport.checkList(builder.relationship, "relationship", CodeableConcept.class));
@@ -1653,8 +1649,6 @@ public class Patient extends DomainResource {
         private final CodeableConcept language;
         private final Boolean preferred;
 
-        private volatile int hashCode;
-
         private Communication(Builder builder) {
             super(builder);
             language = ValidationSupport.requireNonNull(builder.language, "language");
@@ -1936,8 +1930,6 @@ public class Patient extends DomainResource {
         )
         @Required
         private final LinkType type;
-
-        private volatile int hashCode;
 
         private Link(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/PaymentNotice.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/PaymentNotice.java
@@ -87,8 +87,6 @@ public class PaymentNotice extends DomainResource {
     )
     private final CodeableConcept paymentStatus;
 
-    private volatile int hashCode;
-
     private PaymentNotice(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/PaymentReconciliation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/PaymentReconciliation.java
@@ -99,8 +99,6 @@ public class PaymentReconciliation extends DomainResource {
     private final CodeableConcept formCode;
     private final List<ProcessNote> processNote;
 
-    private volatile int hashCode;
-
     private PaymentReconciliation(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -985,8 +983,6 @@ public class PaymentReconciliation extends DomainResource {
         private final Reference payee;
         private final Money amount;
 
-        private volatile int hashCode;
-
         private Detail(Builder builder) {
             super(builder);
             identifier = builder.identifier;
@@ -1528,8 +1524,6 @@ public class PaymentReconciliation extends DomainResource {
         )
         private final NoteType type;
         private final String text;
-
-        private volatile int hashCode;
 
         private ProcessNote(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Person.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Person.java
@@ -75,8 +75,6 @@ public class Person extends DomainResource {
     private final Boolean active;
     private final List<Link> link;
 
-    private volatile int hashCode;
-
     private Person(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -805,8 +803,6 @@ public class Person extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/identity-assuranceLevel|4.0.1"
         )
         private final IdentityAssuranceLevel assurance;
-
-        private volatile int hashCode;
 
         private Link(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/PlanDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/PlanDefinition.java
@@ -213,8 +213,6 @@ public class PlanDefinition extends DomainResource {
     private final List<Goal> goal;
     private final List<Action> action;
 
-    private volatile int hashCode;
-
     private PlanDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1846,8 +1844,6 @@ public class PlanDefinition extends DomainResource {
         private final List<RelatedArtifact> documentation;
         private final List<Target> target;
 
-        private volatile int hashCode;
-
         private Goal(Builder builder) {
             super(builder);
             category = builder.category;
@@ -2341,8 +2337,6 @@ public class PlanDefinition extends DomainResource {
             private final Element detail;
             private final Duration due;
 
-            private volatile int hashCode;
-
             private Target(Builder builder) {
                 super(builder);
                 measure = builder.measure;
@@ -2723,8 +2717,6 @@ public class PlanDefinition extends DomainResource {
         private final Canonical transform;
         private final List<DynamicValue> dynamicValue;
         private final List<PlanDefinition.Action> action;
-
-        private volatile int hashCode;
 
         private Action(Builder builder) {
             super(builder);
@@ -4061,8 +4053,6 @@ public class PlanDefinition extends DomainResource {
             private final ActionConditionKind kind;
             private final Expression expression;
 
-            private volatile int hashCode;
-
             private Condition(Builder builder) {
                 super(builder);
                 kind = ValidationSupport.requireNonNull(builder.kind, "kind");
@@ -4338,8 +4328,6 @@ public class PlanDefinition extends DomainResource {
             private final ActionRelationshipType relationship;
             @Choice({ Duration.class, Range.class })
             private final Element offset;
-
-            private volatile int hashCode;
 
             private RelatedAction(Builder builder) {
                 super(builder);
@@ -4661,8 +4649,6 @@ public class PlanDefinition extends DomainResource {
             )
             private final CodeableConcept role;
 
-            private volatile int hashCode;
-
             private Participant(Builder builder) {
                 super(builder);
                 type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -4930,8 +4916,6 @@ public class PlanDefinition extends DomainResource {
         public static class DynamicValue extends BackboneElement {
             private final String path;
             private final Expression expression;
-
-            private volatile int hashCode;
 
             private DynamicValue(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Practitioner.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Practitioner.java
@@ -92,8 +92,6 @@ public class Practitioner extends DomainResource {
     )
     private final List<CodeableConcept> communication;
 
-    private volatile int hashCode;
-
     private Practitioner(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -872,8 +870,6 @@ public class Practitioner extends DomainResource {
         private final Period period;
         @ReferenceTarget({ "Organization" })
         private final Reference issuer;
-
-        private volatile int hashCode;
 
         private Qualification(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/PractitionerRole.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/PractitionerRole.java
@@ -101,8 +101,6 @@ public class PractitionerRole extends DomainResource {
     @ReferenceTarget({ "Endpoint" })
     private final List<Reference> endpoint;
 
-    private volatile int hashCode;
-
     private PractitionerRole(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1077,8 +1075,6 @@ public class PractitionerRole extends DomainResource {
         private final Time availableStartTime;
         private final Time availableEndTime;
 
-        private volatile int hashCode;
-
         private AvailableTime(Builder builder) {
             super(builder);
             daysOfWeek = Collections.unmodifiableList(ValidationSupport.checkList(builder.daysOfWeek, "daysOfWeek", DaysOfWeek.class));
@@ -1420,8 +1416,6 @@ public class PractitionerRole extends DomainResource {
         @Required
         private final String description;
         private final Period during;
-
-        private volatile int hashCode;
 
         private NotAvailable(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Procedure.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Procedure.java
@@ -187,8 +187,6 @@ public class Procedure extends DomainResource {
     )
     private final List<CodeableConcept> usedCode;
 
-    private volatile int hashCode;
-
     private Procedure(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1891,8 +1889,6 @@ public class Procedure extends DomainResource {
         @ReferenceTarget({ "Organization" })
         private final Reference onBehalfOf;
 
-        private volatile int hashCode;
-
         private Performer(Builder builder) {
             super(builder);
             function = builder.function;
@@ -2217,8 +2213,6 @@ public class Procedure extends DomainResource {
         @ReferenceTarget({ "Device" })
         @Required
         private final Reference manipulated;
-
-        private volatile int hashCode;
 
         private FocalDevice(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Provenance.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Provenance.java
@@ -111,8 +111,6 @@ public class Provenance extends DomainResource {
     private final List<Entity> entity;
     private final List<Signature> signature;
 
-    private volatile int hashCode;
-
     private Provenance(Builder builder) {
         super(builder);
         target = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.target, "target", Reference.class));
@@ -911,8 +909,6 @@ public class Provenance extends DomainResource {
         @ReferenceTarget({ "Practitioner", "PractitionerRole", "RelatedPerson", "Patient", "Device", "Organization" })
         private final Reference onBehalfOf;
 
-        private volatile int hashCode;
-
         private Agent(Builder builder) {
             super(builder);
             type = builder.type;
@@ -1296,8 +1292,6 @@ public class Provenance extends DomainResource {
         @Required
         private final Reference what;
         private final List<Provenance.Agent> agent;
-
-        private volatile int hashCode;
 
         private Entity(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Questionnaire.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Questionnaire.java
@@ -236,8 +236,6 @@ public class Questionnaire extends DomainResource {
     private final List<Coding> code;
     private final List<Item> item;
 
-    private volatile int hashCode;
-
     private Questionnaire(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1461,8 +1459,6 @@ public class Questionnaire extends DomainResource {
         private final List<Initial> initial;
         private final List<Questionnaire.Item> item;
 
-        private volatile int hashCode;
-
         private Item(Builder builder) {
             super(builder);
             linkId = ValidationSupport.requireNonNull(builder.linkId, "linkId");
@@ -2328,8 +2324,6 @@ public class Questionnaire extends DomainResource {
             @Required
             private final Element answer;
 
-            private volatile int hashCode;
-
             private EnableWhen(Builder builder) {
                 super(builder);
                 question = ValidationSupport.requireNonNull(builder.question, "question");
@@ -2655,8 +2649,6 @@ public class Questionnaire extends DomainResource {
             private final Element value;
             private final Boolean initialSelected;
 
-            private volatile int hashCode;
-
             private AnswerOption(Builder builder) {
                 super(builder);
                 value = ValidationSupport.requireChoiceElement(builder.value, "value", Integer.class, Date.class, Time.class, String.class, Coding.class, Reference.class);
@@ -2940,8 +2932,6 @@ public class Questionnaire extends DomainResource {
             )
             @Required
             private final Element value;
-
-            private volatile int hashCode;
 
             private Initial(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/QuestionnaireResponse.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/QuestionnaireResponse.java
@@ -100,8 +100,6 @@ public class QuestionnaireResponse extends DomainResource {
     private final Reference source;
     private final List<Item> item;
 
-    private volatile int hashCode;
-
     private QuestionnaireResponse(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -881,8 +879,6 @@ public class QuestionnaireResponse extends DomainResource {
         private final List<Answer> answer;
         private final List<QuestionnaireResponse.Item> item;
 
-        private volatile int hashCode;
-
         private Item(Builder builder) {
             super(builder);
             linkId = ValidationSupport.requireNonNull(builder.linkId, "linkId");
@@ -1287,8 +1283,6 @@ public class QuestionnaireResponse extends DomainResource {
             )
             private final Element value;
             private final List<QuestionnaireResponse.Item> item;
-
-            private volatile int hashCode;
 
             private Answer(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/RelatedPerson.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/RelatedPerson.java
@@ -106,8 +106,6 @@ public class RelatedPerson extends DomainResource {
     private final Period period;
     private final List<Communication> communication;
 
-    private volatile int hashCode;
-
     private RelatedPerson(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -949,8 +947,6 @@ public class RelatedPerson extends DomainResource {
         @Required
         private final CodeableConcept language;
         private final Boolean preferred;
-
-        private volatile int hashCode;
 
         private Communication(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/RequestGroup.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/RequestGroup.java
@@ -136,8 +136,6 @@ public class RequestGroup extends DomainResource {
     private final List<Annotation> note;
     private final List<Action> action;
 
-    private volatile int hashCode;
-
     private RequestGroup(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1302,8 +1300,6 @@ public class RequestGroup extends DomainResource {
         private final Reference resource;
         private final List<RequestGroup.Action> action;
 
-        private volatile int hashCode;
-
         private Action(Builder builder) {
             super(builder);
             prefix = builder.prefix;
@@ -2253,8 +2249,6 @@ public class RequestGroup extends DomainResource {
             private final ActionConditionKind kind;
             private final Expression expression;
 
-            private volatile int hashCode;
-
             private Condition(Builder builder) {
                 super(builder);
                 kind = ValidationSupport.requireNonNull(builder.kind, "kind");
@@ -2530,8 +2524,6 @@ public class RequestGroup extends DomainResource {
             private final ActionRelationshipType relationship;
             @Choice({ Duration.class, Range.class })
             private final Element offset;
-
-            private volatile int hashCode;
 
             private RelatedAction(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchDefinition.java
@@ -166,8 +166,6 @@ public class ResearchDefinition extends DomainResource {
     @ReferenceTarget({ "ResearchElementDefinition" })
     private final Reference outcome;
 
-    private volatile int hashCode;
-
     private ResearchDefinition(Builder builder) {
         super(builder);
         url = builder.url;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchElementDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchElementDefinition.java
@@ -181,8 +181,6 @@ public class ResearchElementDefinition extends DomainResource {
     @Required
     private final List<Characteristic> characteristic;
 
-    private volatile int hashCode;
-
     private ResearchElementDefinition(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1884,8 +1882,6 @@ public class ResearchElementDefinition extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/group-measure|4.0.1"
         )
         private final GroupMeasure participantEffectiveGroupMeasure;
-
-        private volatile int hashCode;
 
         private Characteristic(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchStudy.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchStudy.java
@@ -181,8 +181,6 @@ public class ResearchStudy extends DomainResource {
     private final List<Arm> arm;
     private final List<Objective> objective;
 
-    private volatile int hashCode;
-
     private ResearchStudy(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1625,8 +1623,6 @@ public class ResearchStudy extends DomainResource {
         private final CodeableConcept type;
         private final String description;
 
-        private volatile int hashCode;
-
         private Arm(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -1930,8 +1926,6 @@ public class ResearchStudy extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/research-study-objective-type"
         )
         private final CodeableConcept type;
-
-        private volatile int hashCode;
 
         private Objective(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchSubject.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ResearchSubject.java
@@ -71,8 +71,6 @@ public class ResearchSubject extends DomainResource {
     @ReferenceTarget({ "Consent" })
     private final Reference consent;
 
-    private volatile int hashCode;
-
     private ResearchSubject(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Resource.java
@@ -55,6 +55,8 @@ public abstract class Resource extends AbstractVisitable {
     )
     protected final Code language;
 
+    protected volatile int hashCode;
+
     protected Resource(Builder builder) {
         id = builder.id;
         meta = builder.meta;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/RiskAssessment.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/RiskAssessment.java
@@ -114,8 +114,6 @@ public class RiskAssessment extends DomainResource {
     private final String mitigation;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private RiskAssessment(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1147,8 +1145,6 @@ public class RiskAssessment extends DomainResource {
         @Choice({ Period.class, Range.class })
         private final Element when;
         private final String rationale;
-
-        private volatile int hashCode;
 
         private Prediction(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/RiskEvidenceSynthesis.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/RiskEvidenceSynthesis.java
@@ -214,8 +214,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
     private final RiskEstimate riskEstimate;
     private final List<Certainty> certainty;
 
-    private volatile int hashCode;
-
     private RiskEvidenceSynthesis(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1792,8 +1790,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
         private final Integer numberOfStudies;
         private final Integer numberOfParticipants;
 
-        private volatile int hashCode;
-
         private SampleSize(Builder builder) {
             super(builder);
             description = builder.description;
@@ -2100,8 +2096,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
         private final Integer denominatorCount;
         private final Integer numeratorCount;
         private final List<PrecisionEstimate> precisionEstimate;
-
-        private volatile int hashCode;
 
         private RiskEstimate(Builder builder) {
             super(builder);
@@ -2545,8 +2539,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
             private final Decimal from;
             private final Decimal to;
 
-            private volatile int hashCode;
-
             private PrecisionEstimate(Builder builder) {
                 super(builder);
                 type = builder.type;
@@ -2875,8 +2867,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
         private final List<CodeableConcept> rating;
         private final List<Annotation> note;
         private final List<CertaintySubcomponent> certaintySubcomponent;
-
-        private volatile int hashCode;
 
         private Certainty(Builder builder) {
             super(builder);
@@ -3239,8 +3229,6 @@ public class RiskEvidenceSynthesis extends DomainResource {
             )
             private final List<CodeableConcept> rating;
             private final List<Annotation> note;
-
-            private volatile int hashCode;
 
             private CertaintySubcomponent(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Schedule.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Schedule.java
@@ -89,8 +89,6 @@ public class Schedule extends DomainResource {
     private final Period planningHorizon;
     private final String comment;
 
-    private volatile int hashCode;
-
     private Schedule(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SearchParameter.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SearchParameter.java
@@ -180,8 +180,6 @@ public class SearchParameter extends DomainResource {
     private final List<String> chain;
     private final List<Component> component;
 
-    private volatile int hashCode;
-
     private SearchParameter(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1544,8 +1542,6 @@ public class SearchParameter extends DomainResource {
         private final Canonical definition;
         @Required
         private final String expression;
-
-        private volatile int hashCode;
 
         private Component(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ServiceRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ServiceRequest.java
@@ -212,8 +212,6 @@ public class ServiceRequest extends DomainResource {
     @ReferenceTarget({ "Provenance" })
     private final List<Reference> relevantHistory;
 
-    private volatile int hashCode;
-
     private ServiceRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Slot.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Slot.java
@@ -117,8 +117,6 @@ public class Slot extends DomainResource {
     private final Boolean overbooked;
     private final String comment;
 
-    private volatile int hashCode;
-
     private Slot(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Specimen.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Specimen.java
@@ -110,8 +110,6 @@ public class Specimen extends DomainResource {
     private final List<CodeableConcept> condition;
     private final List<Annotation> note;
 
-    private volatile int hashCode;
-
     private Specimen(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1036,8 +1034,6 @@ public class Specimen extends DomainResource {
         )
         private final Element fastingStatus;
 
-        private volatile int hashCode;
-
         private Collection(Builder builder) {
             super(builder);
             collector = builder.collector;
@@ -1485,8 +1481,6 @@ public class Specimen extends DomainResource {
         @Choice({ DateTime.class, Period.class })
         private final Element time;
 
-        private volatile int hashCode;
-
         private Processing(Builder builder) {
             super(builder);
             description = builder.description;
@@ -1866,8 +1860,6 @@ public class Specimen extends DomainResource {
             valueSet = "http://terminology.hl7.org/ValueSet/v2-0371"
         )
         private final Element additive;
-
-        private volatile int hashCode;
 
         private Container(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SpecimenDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SpecimenDefinition.java
@@ -82,8 +82,6 @@ public class SpecimenDefinition extends DomainResource {
     private final List<CodeableConcept> collection;
     private final List<TypeTested> typeTested;
 
-    private volatile int hashCode;
-
     private SpecimenDefinition(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -660,8 +658,6 @@ public class SpecimenDefinition extends DomainResource {
         private final List<CodeableConcept> rejectionCriterion;
         private final List<Handling> handling;
 
-        private volatile int hashCode;
-
         private TypeTested(Builder builder) {
             super(builder);
             isDerived = builder.isDerived;
@@ -1183,8 +1179,6 @@ public class SpecimenDefinition extends DomainResource {
             private final List<Additive> additive;
             private final String preparation;
 
-            private volatile int hashCode;
-
             private Container(Builder builder) {
                 super(builder);
                 material = builder.material;
@@ -1667,8 +1661,6 @@ public class SpecimenDefinition extends DomainResource {
                 @Required
                 private final Element additive;
 
-                private volatile int hashCode;
-
                 private Additive(Builder builder) {
                     super(builder);
                     additive = ValidationSupport.requireChoiceElement(builder.additive, "additive", CodeableConcept.class, Reference.class);
@@ -1927,8 +1919,6 @@ public class SpecimenDefinition extends DomainResource {
             private final Range temperatureRange;
             private final Duration maxDuration;
             private final String instruction;
-
-            private volatile int hashCode;
 
             private Handling(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/StructureDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/StructureDefinition.java
@@ -348,8 +348,6 @@ public class StructureDefinition extends DomainResource {
     private final Snapshot snapshot;
     private final Differential differential;
 
-    private volatile int hashCode;
-
     private StructureDefinition(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1730,8 +1728,6 @@ public class StructureDefinition extends DomainResource {
         private final String name;
         private final String comment;
 
-        private volatile int hashCode;
-
         private Mapping(Builder builder) {
             super(builder);
             identity = ValidationSupport.requireNonNull(builder.identity, "identity");
@@ -2070,8 +2066,6 @@ public class StructureDefinition extends DomainResource {
         @Required
         private final String expression;
 
-        private volatile int hashCode;
-
         private Context(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2342,8 +2336,6 @@ public class StructureDefinition extends DomainResource {
         @Required
         private final List<ElementDefinition> element;
 
-        private volatile int hashCode;
-
         private Snapshot(Builder builder) {
             super(builder);
             element = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.element, "element", ElementDefinition.class));
@@ -2600,8 +2592,6 @@ public class StructureDefinition extends DomainResource {
     public static class Differential extends BackboneElement {
         @Required
         private final List<ElementDefinition> element;
-
-        private volatile int hashCode;
 
         private Differential(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/StructureMap.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/StructureMap.java
@@ -177,8 +177,6 @@ public class StructureMap extends DomainResource {
     @Required
     private final List<Group> group;
 
-    private volatile int hashCode;
-
     private StructureMap(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1248,8 +1246,6 @@ public class StructureMap extends DomainResource {
         private final String alias;
         private final String documentation;
 
-        private volatile int hashCode;
-
         private Structure(Builder builder) {
             super(builder);
             url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1600,8 +1596,6 @@ public class StructureMap extends DomainResource {
         @Summary
         @Required
         private final List<Rule> rule;
-
-        private volatile int hashCode;
 
         private Group(Builder builder) {
             super(builder);
@@ -2058,8 +2052,6 @@ public class StructureMap extends DomainResource {
             private final StructureMapInputMode mode;
             private final String documentation;
 
-            private volatile int hashCode;
-
             private Input(Builder builder) {
                 super(builder);
                 name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -2401,8 +2393,6 @@ public class StructureMap extends DomainResource {
             @Summary
             private final List<Dependent> dependent;
             private final String documentation;
-
-            private volatile int hashCode;
 
             private Rule(Builder builder) {
                 super(builder);
@@ -2905,8 +2895,6 @@ public class StructureMap extends DomainResource {
                 private final String check;
                 @Summary
                 private final String logMessage;
-
-                private volatile int hashCode;
 
                 private Source(Builder builder) {
                     super(builder);
@@ -3545,8 +3533,6 @@ public class StructureMap extends DomainResource {
                 @Summary
                 private final List<Parameter> parameter;
 
-                private volatile int hashCode;
-
                 private Target(Builder builder) {
                     super(builder);
                     context = builder.context;
@@ -4033,8 +4019,6 @@ public class StructureMap extends DomainResource {
                     @Required
                     private final Element value;
 
-                    private volatile int hashCode;
-
                     private Parameter(Builder builder) {
                         super(builder);
                         value = ValidationSupport.requireChoiceElement(builder.value, "value", Id.class, String.class, Boolean.class, Integer.class, Decimal.class);
@@ -4283,8 +4267,6 @@ public class StructureMap extends DomainResource {
                 @Summary
                 @Required
                 private final List<String> variable;
-
-                private volatile int hashCode;
 
                 private Dependent(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Subscription.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Subscription.java
@@ -74,8 +74,6 @@ public class Subscription extends DomainResource {
     @Required
     private final Channel channel;
 
-    private volatile int hashCode;
-
     private Subscription(Builder builder) {
         super(builder);
         status = ValidationSupport.requireNonNull(builder.status, "status");
@@ -655,8 +653,6 @@ public class Subscription extends DomainResource {
         private final Code payload;
         @Summary
         private final List<String> header;
-
-        private volatile int hashCode;
 
         private Channel(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Substance.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Substance.java
@@ -94,8 +94,6 @@ public class Substance extends DomainResource {
     @Summary
     private final List<Ingredient> ingredient;
 
-    private volatile int hashCode;
-
     private Substance(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -709,8 +707,6 @@ public class Substance extends DomainResource {
         @Summary
         private final SimpleQuantity quantity;
 
-        private volatile int hashCode;
-
         private Instance(Builder builder) {
             super(builder);
             identifier = builder.identifier;
@@ -1011,8 +1007,6 @@ public class Substance extends DomainResource {
         )
         @Required
         private final Element substance;
-
-        private volatile int hashCode;
 
         private Ingredient(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceNucleicAcid.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceNucleicAcid.java
@@ -54,8 +54,6 @@ public class SubstanceNucleicAcid extends DomainResource {
     @Summary
     private final List<Subunit> subunit;
 
-    private volatile int hashCode;
-
     private SubstanceNucleicAcid(Builder builder) {
         super(builder);
         sequenceType = builder.sequenceType;
@@ -568,8 +566,6 @@ public class SubstanceNucleicAcid extends DomainResource {
         @Summary
         private final List<Sugar> sugar;
 
-        private volatile int hashCode;
-
         private Subunit(Builder builder) {
             super(builder);
             subunit = builder.subunit;
@@ -1078,8 +1074,6 @@ public class SubstanceNucleicAcid extends DomainResource {
             @Summary
             private final String residueSite;
 
-            private volatile int hashCode;
-
             private Linkage(Builder builder) {
                 super(builder);
                 connectivity = builder.connectivity;
@@ -1413,8 +1407,6 @@ public class SubstanceNucleicAcid extends DomainResource {
             private final String name;
             @Summary
             private final String residueSite;
-
-            private volatile int hashCode;
 
             private Sugar(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstancePolymer.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstancePolymer.java
@@ -56,8 +56,6 @@ public class SubstancePolymer extends DomainResource {
     @Summary
     private final List<Repeat> repeat;
 
-    private volatile int hashCode;
-
     private SubstancePolymer(Builder builder) {
         super(builder);
         clazz = builder.clazz;
@@ -631,8 +629,6 @@ public class SubstancePolymer extends DomainResource {
         @Summary
         private final List<StartingMaterial> startingMaterial;
 
-        private volatile int hashCode;
-
         private MonomerSet(Builder builder) {
             super(builder);
             ratioType = builder.ratioType;
@@ -916,8 +912,6 @@ public class SubstancePolymer extends DomainResource {
             private final Boolean isDefining;
             @Summary
             private final SubstanceAmount amount;
-
-            private volatile int hashCode;
 
             private StartingMaterial(Builder builder) {
                 super(builder);
@@ -1246,8 +1240,6 @@ public class SubstancePolymer extends DomainResource {
         private final CodeableConcept repeatUnitAmountType;
         @Summary
         private final List<RepeatUnit> repeatUnit;
-
-        private volatile int hashCode;
 
         private Repeat(Builder builder) {
             super(builder);
@@ -1596,8 +1588,6 @@ public class SubstancePolymer extends DomainResource {
             private final List<DegreeOfPolymerisation> degreeOfPolymerisation;
             @Summary
             private final List<StructuralRepresentation> structuralRepresentation;
-
-            private volatile int hashCode;
 
             private RepeatUnit(Builder builder) {
                 super(builder);
@@ -1992,8 +1982,6 @@ public class SubstancePolymer extends DomainResource {
                 @Summary
                 private final SubstanceAmount amount;
 
-                private volatile int hashCode;
-
                 private DegreeOfPolymerisation(Builder builder) {
                     super(builder);
                     degree = builder.degree;
@@ -2256,8 +2244,6 @@ public class SubstancePolymer extends DomainResource {
                 private final String representation;
                 @Summary
                 private final Attachment attachment;
-
-                private volatile int hashCode;
 
                 private StructuralRepresentation(Builder builder) {
                     super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceProtein.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceProtein.java
@@ -55,8 +55,6 @@ public class SubstanceProtein extends DomainResource {
     @Summary
     private final List<Subunit> subunit;
 
-    private volatile int hashCode;
-
     private SubstanceProtein(Builder builder) {
         super(builder);
         sequenceType = builder.sequenceType;
@@ -584,8 +582,6 @@ public class SubstanceProtein extends DomainResource {
         private final Identifier cTerminalModificationId;
         @Summary
         private final String cTerminalModification;
-
-        private volatile int hashCode;
 
         private Subunit(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceReferenceInformation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceReferenceInformation.java
@@ -57,8 +57,6 @@ public class SubstanceReferenceInformation extends DomainResource {
     @Summary
     private final List<Target> target;
 
-    private volatile int hashCode;
-
     private SubstanceReferenceInformation(Builder builder) {
         super(builder);
         comment = builder.comment;
@@ -604,8 +602,6 @@ public class SubstanceReferenceInformation extends DomainResource {
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
 
-        private volatile int hashCode;
-
         private Gene(Builder builder) {
             super(builder);
             geneSequenceOrigin = builder.geneSequenceOrigin;
@@ -931,8 +927,6 @@ public class SubstanceReferenceInformation extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private GeneElement(Builder builder) {
             super(builder);
@@ -1261,8 +1255,6 @@ public class SubstanceReferenceInformation extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private Classification(Builder builder) {
             super(builder);
@@ -1651,8 +1643,6 @@ public class SubstanceReferenceInformation extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private Target(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceSourceMaterial.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceSourceMaterial.java
@@ -75,8 +75,6 @@ public class SubstanceSourceMaterial extends DomainResource {
     @Summary
     private final List<PartDescription> partDescription;
 
-    private volatile int hashCode;
-
     private SubstanceSourceMaterial(Builder builder) {
         super(builder);
         sourceMaterialClass = builder.sourceMaterialClass;
@@ -964,8 +962,6 @@ public class SubstanceSourceMaterial extends DomainResource {
         @Summary
         private final CodeableConcept materialType;
 
-        private volatile int hashCode;
-
         private FractionDescription(Builder builder) {
             super(builder);
             fraction = builder.fraction;
@@ -1243,8 +1239,6 @@ public class SubstanceSourceMaterial extends DomainResource {
         private final Hybrid hybrid;
         @Summary
         private final OrganismGeneral organismGeneral;
-
-        private volatile int hashCode;
 
         private Organism(Builder builder) {
             super(builder);
@@ -1721,8 +1715,6 @@ public class SubstanceSourceMaterial extends DomainResource {
             @Summary
             private final String authorDescription;
 
-            private volatile int hashCode;
-
             private Author(Builder builder) {
                 super(builder);
                 authorType = builder.authorType;
@@ -2000,8 +1992,6 @@ public class SubstanceSourceMaterial extends DomainResource {
             private final String paternalOrganismName;
             @Summary
             private final CodeableConcept hybridType;
-
-            private volatile int hashCode;
 
             private Hybrid(Builder builder) {
                 super(builder);
@@ -2373,8 +2363,6 @@ public class SubstanceSourceMaterial extends DomainResource {
             @Summary
             private final CodeableConcept order;
 
-            private volatile int hashCode;
-
             private OrganismGeneral(Builder builder) {
                 super(builder);
                 kingdom = builder.kingdom;
@@ -2698,8 +2686,6 @@ public class SubstanceSourceMaterial extends DomainResource {
         private final CodeableConcept part;
         @Summary
         private final CodeableConcept partLocation;
-
-        private volatile int hashCode;
 
         private PartDescription(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceSpecification.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SubstanceSpecification.java
@@ -95,8 +95,6 @@ public class SubstanceSpecification extends DomainResource {
     @ReferenceTarget({ "SubstanceSourceMaterial" })
     private final Reference sourceMaterial;
 
-    private volatile int hashCode;
-
     private SubstanceSpecification(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -1185,8 +1183,6 @@ public class SubstanceSpecification extends DomainResource {
         @Choice({ Quantity.class, String.class })
         private final Element amount;
 
-        private volatile int hashCode;
-
         private Moiety(Builder builder) {
             super(builder);
             role = builder.role;
@@ -1618,8 +1614,6 @@ public class SubstanceSpecification extends DomainResource {
         @Choice({ Quantity.class, String.class })
         private final Element amount;
 
-        private volatile int hashCode;
-
         private Property(Builder builder) {
             super(builder);
             category = builder.category;
@@ -2005,8 +1999,6 @@ public class SubstanceSpecification extends DomainResource {
         private final List<Reference> source;
         @Summary
         private final List<Representation> representation;
-
-        private volatile int hashCode;
 
         private Structure(Builder builder) {
             super(builder);
@@ -2534,8 +2526,6 @@ public class SubstanceSpecification extends DomainResource {
             @Summary
             private final MolecularWeight molecularWeight;
 
-            private volatile int hashCode;
-
             private Isotope(Builder builder) {
                 super(builder);
                 identifier = builder.identifier;
@@ -2891,8 +2881,6 @@ public class SubstanceSpecification extends DomainResource {
                 @Summary
                 private final Quantity amount;
 
-                private volatile int hashCode;
-
                 private MolecularWeight(Builder builder) {
                     super(builder);
                     method = builder.method;
@@ -3190,8 +3178,6 @@ public class SubstanceSpecification extends DomainResource {
             private final String representation;
             @Summary
             private final Attachment attachment;
-
-            private volatile int hashCode;
 
             private Representation(Builder builder) {
                 super(builder);
@@ -3492,8 +3478,6 @@ public class SubstanceSpecification extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private Code(Builder builder) {
             super(builder);
@@ -3899,8 +3883,6 @@ public class SubstanceSpecification extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private Name(Builder builder) {
             super(builder);
@@ -4606,8 +4588,6 @@ public class SubstanceSpecification extends DomainResource {
             @Summary
             private final DateTime date;
 
-            private volatile int hashCode;
-
             private Official(Builder builder) {
                 super(builder);
                 authority = builder.authority;
@@ -4914,8 +4894,6 @@ public class SubstanceSpecification extends DomainResource {
         @Summary
         @ReferenceTarget({ "DocumentReference" })
         private final List<Reference> source;
-
-        private volatile int hashCode;
 
         private Relationship(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SupplyDelivery.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SupplyDelivery.java
@@ -85,8 +85,6 @@ public class SupplyDelivery extends DomainResource {
     @ReferenceTarget({ "Practitioner", "PractitionerRole" })
     private final List<Reference> receiver;
 
-    private volatile int hashCode;
-
     private SupplyDelivery(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -887,8 +885,6 @@ public class SupplyDelivery extends DomainResource {
             valueSet = "http://hl7.org/fhir/ValueSet/supply-item"
         )
         private final Element item;
-
-        private volatile int hashCode;
 
         private SuppliedItem(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/SupplyRequest.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/SupplyRequest.java
@@ -120,8 +120,6 @@ public class SupplyRequest extends DomainResource {
     @ReferenceTarget({ "Organization", "Location", "Patient" })
     private final Reference deliverTo;
 
-    private volatile int hashCode;
-
     private SupplyRequest(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1091,8 +1089,6 @@ public class SupplyRequest extends DomainResource {
         private final CodeableConcept code;
         @Choice({ CodeableConcept.class, Quantity.class, Range.class, Boolean.class })
         private final Element value;
-
-        private volatile int hashCode;
 
         private Parameter(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/Task.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/Task.java
@@ -214,8 +214,6 @@ public class Task extends DomainResource {
     private final List<Input> input;
     private final List<Output> output;
 
-    private volatile int hashCode;
-
     private Task(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -1771,8 +1769,6 @@ public class Task extends DomainResource {
         @ReferenceTarget({ "Patient", "Practitioner", "PractitionerRole", "RelatedPerson", "Group", "Organization" })
         private final List<Reference> recipient;
 
-        private volatile int hashCode;
-
         private Restriction(Builder builder) {
             super(builder);
             repetitions = builder.repetitions;
@@ -2112,8 +2108,6 @@ public class Task extends DomainResource {
         @Required
         private final Element value;
 
-        private volatile int hashCode;
-
         private Input(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2444,8 +2438,6 @@ public class Task extends DomainResource {
         @Choice({ Base64Binary.class, Boolean.class, Canonical.class, Code.class, Date.class, DateTime.class, Decimal.class, Id.class, Instant.class, Integer.class, Markdown.class, Oid.class, PositiveInt.class, String.class, Time.class, UnsignedInt.class, Uri.class, Url.class, Uuid.class, Address.class, Age.class, Annotation.class, Attachment.class, CodeableConcept.class, Coding.class, ContactPoint.class, Count.class, Distance.class, Duration.class, HumanName.class, Identifier.class, Money.class, Period.class, Quantity.class, Range.class, Ratio.class, Reference.class, SampledData.class, Signature.class, Timing.class, ContactDetail.class, Contributor.class, DataRequirement.class, Expression.class, ParameterDefinition.class, RelatedArtifact.class, TriggerDefinition.class, UsageContext.class, Dosage.class, Meta.class })
         @Required
         private final Element value;
-
-        private volatile int hashCode;
 
         private Output(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/TerminologyCapabilities.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/TerminologyCapabilities.java
@@ -172,8 +172,6 @@ public class TerminologyCapabilities extends DomainResource {
     private final Translation translation;
     private final Closure closure;
 
-    private volatile int hashCode;
-
     private TerminologyCapabilities(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1363,8 +1361,6 @@ public class TerminologyCapabilities extends DomainResource {
         @Summary
         private final String version;
 
-        private volatile int hashCode;
-
         private Software(Builder builder) {
             super(builder);
             name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -1635,8 +1631,6 @@ public class TerminologyCapabilities extends DomainResource {
         @Summary
         private final Url url;
 
-        private volatile int hashCode;
-
         private Implementation(Builder builder) {
             super(builder);
             description = ValidationSupport.requireNonNull(builder.description, "description");
@@ -1904,8 +1898,6 @@ public class TerminologyCapabilities extends DomainResource {
         private final Canonical uri;
         private final List<Version> version;
         private final Boolean subsumption;
-
-        private volatile int hashCode;
 
         private CodeSystem(Builder builder) {
             super(builder);
@@ -2221,8 +2213,6 @@ public class TerminologyCapabilities extends DomainResource {
             private final List<Code> language;
             private final List<Filter> filter;
             private final List<Code> property;
-
-            private volatile int hashCode;
 
             private Version(Builder builder) {
                 super(builder);
@@ -2668,8 +2658,6 @@ public class TerminologyCapabilities extends DomainResource {
                 @Required
                 private final List<Code> op;
 
-                private volatile int hashCode;
-
                 private Filter(Builder builder) {
                     super(builder);
                     code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -2965,8 +2953,6 @@ public class TerminologyCapabilities extends DomainResource {
         private final Boolean incomplete;
         private final List<Parameter> parameter;
         private final Markdown textFilter;
-
-        private volatile int hashCode;
 
         private Expansion(Builder builder) {
             super(builder);
@@ -3340,8 +3326,6 @@ public class TerminologyCapabilities extends DomainResource {
             private final Code name;
             private final String documentation;
 
-            private volatile int hashCode;
-
             private Parameter(Builder builder) {
                 super(builder);
                 name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -3609,8 +3593,6 @@ public class TerminologyCapabilities extends DomainResource {
         @Required
         private final Boolean translations;
 
-        private volatile int hashCode;
-
         private ValidateCode(Builder builder) {
             super(builder);
             translations = ValidationSupport.requireNonNull(builder.translations, "translations");
@@ -3846,8 +3828,6 @@ public class TerminologyCapabilities extends DomainResource {
         @Required
         private final Boolean needsMap;
 
-        private volatile int hashCode;
-
         private Translation(Builder builder) {
             super(builder);
             needsMap = ValidationSupport.requireNonNull(builder.needsMap, "needsMap");
@@ -4081,8 +4061,6 @@ public class TerminologyCapabilities extends DomainResource {
      */
     public static class Closure extends BackboneElement {
         private final Boolean translation;
-
-        private volatile int hashCode;
 
         private Closure(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/TestReport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/TestReport.java
@@ -103,8 +103,6 @@ public class TestReport extends DomainResource {
     private final List<Test> test;
     private final Teardown teardown;
 
-    private volatile int hashCode;
-
     private TestReport(Builder builder) {
         super(builder);
         identifier = builder.identifier;
@@ -854,8 +852,6 @@ public class TestReport extends DomainResource {
         private final Uri uri;
         private final String display;
 
-        private volatile int hashCode;
-
         private Participant(Builder builder) {
             super(builder);
             type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -1156,8 +1152,6 @@ public class TestReport extends DomainResource {
         @Required
         private final List<Action> action;
 
-        private volatile int hashCode;
-
         private Setup(Builder builder) {
             super(builder);
             action = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.action, "action", Action.class));
@@ -1413,8 +1407,6 @@ public class TestReport extends DomainResource {
         public static class Action extends BackboneElement {
             private final Operation operation;
             private final Assert _assert;
-
-            private volatile int hashCode;
 
             private Action(Builder builder) {
                 super(builder);
@@ -1681,8 +1673,6 @@ public class TestReport extends DomainResource {
                 private final TestReportActionResult result;
                 private final Markdown message;
                 private final Uri detail;
-
-                private volatile int hashCode;
 
                 private Operation(Builder builder) {
                     super(builder);
@@ -1989,8 +1979,6 @@ public class TestReport extends DomainResource {
                 private final Markdown message;
                 private final String detail;
 
-                private volatile int hashCode;
-
                 private Assert(Builder builder) {
                     super(builder);
                     result = ValidationSupport.requireNonNull(builder.result, "result");
@@ -2291,8 +2279,6 @@ public class TestReport extends DomainResource {
         private final String description;
         @Required
         private final List<Action> action;
-
-        private volatile int hashCode;
 
         private Test(Builder builder) {
             super(builder);
@@ -2612,8 +2598,6 @@ public class TestReport extends DomainResource {
             private final TestReport.Setup.Action.Operation operation;
             private final TestReport.Setup.Action.Assert _assert;
 
-            private volatile int hashCode;
-
             private Action(Builder builder) {
                 super(builder);
                 operation = builder.operation;
@@ -2875,8 +2859,6 @@ public class TestReport extends DomainResource {
         @Required
         private final List<Action> action;
 
-        private volatile int hashCode;
-
         private Teardown(Builder builder) {
             super(builder);
             action = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.action, "action", Action.class));
@@ -3132,8 +3114,6 @@ public class TestReport extends DomainResource {
         public static class Action extends BackboneElement {
             @Required
             private final TestReport.Setup.Action.Operation operation;
-
-            private volatile int hashCode;
 
             private Action(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/TestScript.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/TestScript.java
@@ -243,8 +243,6 @@ public class TestScript extends DomainResource {
     private final List<Test> test;
     private final Teardown teardown;
 
-    private volatile int hashCode;
-
     private TestScript(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -1525,8 +1523,6 @@ public class TestScript extends DomainResource {
         @Required
         private final Coding profile;
 
-        private volatile int hashCode;
-
         private Origin(Builder builder) {
             super(builder);
             index = ValidationSupport.requireNonNull(builder.index, "index");
@@ -1804,8 +1800,6 @@ public class TestScript extends DomainResource {
         @Required
         private final Coding profile;
 
-        private volatile int hashCode;
-
         private Destination(Builder builder) {
             super(builder);
             index = ValidationSupport.requireNonNull(builder.index, "index");
@@ -2075,8 +2069,6 @@ public class TestScript extends DomainResource {
         private final List<Link> link;
         @Required
         private final List<Capability> capability;
-
-        private volatile int hashCode;
 
         private Metadata(Builder builder) {
             super(builder);
@@ -2386,8 +2378,6 @@ public class TestScript extends DomainResource {
             private final Uri url;
             private final String description;
 
-            private volatile int hashCode;
-
             private Link(Builder builder) {
                 super(builder);
                 url = ValidationSupport.requireNonNull(builder.url, "url");
@@ -2661,8 +2651,6 @@ public class TestScript extends DomainResource {
             private final List<Uri> link;
             @Required
             private final Canonical capabilities;
-
-            private volatile int hashCode;
 
             private Capability(Builder builder) {
                 super(builder);
@@ -3141,8 +3129,6 @@ public class TestScript extends DomainResource {
         private final Boolean autodelete;
         private final Reference resource;
 
-        private volatile int hashCode;
-
         private Fixture(Builder builder) {
             super(builder);
             autocreate = ValidationSupport.requireNonNull(builder.autocreate, "autocreate");
@@ -3457,8 +3443,6 @@ public class TestScript extends DomainResource {
         private final String hint;
         private final String path;
         private final Id sourceId;
-
-        private volatile int hashCode;
 
         private Variable(Builder builder) {
             super(builder);
@@ -3916,8 +3900,6 @@ public class TestScript extends DomainResource {
         @Required
         private final List<Action> action;
 
-        private volatile int hashCode;
-
         private Setup(Builder builder) {
             super(builder);
             action = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.action, "action", Action.class));
@@ -4173,8 +4155,6 @@ public class TestScript extends DomainResource {
         public static class Action extends BackboneElement {
             private final Operation operation;
             private final Assert _assert;
-
-            private volatile int hashCode;
 
             private Action(Builder builder) {
                 super(builder);
@@ -4479,8 +4459,6 @@ public class TestScript extends DomainResource {
                 private final Id sourceId;
                 private final Id targetId;
                 private final String url;
-
-                private volatile int hashCode;
 
                 private Operation(Builder builder) {
                     super(builder);
@@ -5240,8 +5218,6 @@ public class TestScript extends DomainResource {
                     @Required
                     private final String value;
 
-                    private volatile int hashCode;
-
                     private RequestHeader(Builder builder) {
                         super(builder);
                         field = ValidationSupport.requireNonNull(builder.field, "field");
@@ -5568,8 +5544,6 @@ public class TestScript extends DomainResource {
                 private final String value;
                 @Required
                 private final Boolean warningOnly;
-
-                private volatile int hashCode;
 
                 private Assert(Builder builder) {
                     super(builder);
@@ -6470,8 +6444,6 @@ public class TestScript extends DomainResource {
         @Required
         private final List<Action> action;
 
-        private volatile int hashCode;
-
         private Test(Builder builder) {
             super(builder);
             name = builder.name;
@@ -6790,8 +6762,6 @@ public class TestScript extends DomainResource {
             private final TestScript.Setup.Action.Operation operation;
             private final TestScript.Setup.Action.Assert _assert;
 
-            private volatile int hashCode;
-
             private Action(Builder builder) {
                 super(builder);
                 operation = builder.operation;
@@ -7052,8 +7022,6 @@ public class TestScript extends DomainResource {
         @Required
         private final List<Action> action;
 
-        private volatile int hashCode;
-
         private Teardown(Builder builder) {
             super(builder);
             action = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.action, "action", Action.class));
@@ -7309,8 +7277,6 @@ public class TestScript extends DomainResource {
         public static class Action extends BackboneElement {
             @Required
             private final TestScript.Setup.Action.Operation operation;
-
-            private volatile int hashCode;
 
             private Action(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/ValueSet.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/ValueSet.java
@@ -178,8 +178,6 @@ public class ValueSet extends DomainResource {
     private final Compose compose;
     private final Expansion expansion;
 
-    private volatile int hashCode;
-
     private ValueSet(Builder builder) {
         super(builder);
         url = builder.url;
@@ -1176,8 +1174,6 @@ public class ValueSet extends DomainResource {
         private final List<Include> include;
         private final List<ValueSet.Compose.Include> exclude;
 
-        private volatile int hashCode;
-
         private Compose(Builder builder) {
             super(builder);
             lockedDate = builder.lockedDate;
@@ -1561,8 +1557,6 @@ public class ValueSet extends DomainResource {
             private final List<Filter> filter;
             @Summary
             private final List<Canonical> valueSet;
-
-            private volatile int hashCode;
 
             private Include(Builder builder) {
                 super(builder);
@@ -1986,8 +1980,6 @@ public class ValueSet extends DomainResource {
                 private final String display;
                 private final List<Designation> designation;
 
-                private volatile int hashCode;
-
                 private Concept(Builder builder) {
                     super(builder);
                     code = ValidationSupport.requireNonNull(builder.code, "code");
@@ -2325,8 +2317,6 @@ public class ValueSet extends DomainResource {
                     @Required
                     private final String value;
 
-                    private volatile int hashCode;
-
                     private Designation(Builder builder) {
                         super(builder);
                         language = builder.language;
@@ -2639,8 +2629,6 @@ public class ValueSet extends DomainResource {
                 @Summary
                 @Required
                 private final String value;
-
-                private volatile int hashCode;
 
                 private Filter(Builder builder) {
                     super(builder);
@@ -2958,8 +2946,6 @@ public class ValueSet extends DomainResource {
         private final Integer offset;
         private final List<Parameter> parameter;
         private final List<Contains> contains;
-
-        private volatile int hashCode;
 
         private Expansion(Builder builder) {
             super(builder);
@@ -3406,8 +3392,6 @@ public class ValueSet extends DomainResource {
             @Choice({ String.class, Boolean.class, Integer.class, Decimal.class, Uri.class, Code.class, DateTime.class })
             private final Element value;
 
-            private volatile int hashCode;
-
             private Parameter(Builder builder) {
                 super(builder);
                 name = ValidationSupport.requireNonNull(builder.name, "name");
@@ -3692,8 +3676,6 @@ public class ValueSet extends DomainResource {
             private final String display;
             private final List<ValueSet.Compose.Include.Concept.Designation> designation;
             private final List<ValueSet.Expansion.Contains> contains;
-
-            private volatile int hashCode;
 
             private Contains(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/VerificationResult.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/VerificationResult.java
@@ -152,8 +152,6 @@ public class VerificationResult extends DomainResource {
     private final Attestation attestation;
     private final List<Validator> validator;
 
-    private volatile int hashCode;
-
     private VerificationResult(Builder builder) {
         super(builder);
         target = Collections.unmodifiableList(ValidationSupport.checkList(builder.target, "target", Reference.class));
@@ -1046,8 +1044,6 @@ public class VerificationResult extends DomainResource {
         )
         private final List<CodeableConcept> pushTypeAvailable;
 
-        private volatile int hashCode;
-
         private PrimarySource(Builder builder) {
             super(builder);
             who = builder.who;
@@ -1553,8 +1549,6 @@ public class VerificationResult extends DomainResource {
         private final Signature proxySignature;
         private final Signature sourceSignature;
 
-        private volatile int hashCode;
-
         private Attestation(Builder builder) {
             super(builder);
             who = builder.who;
@@ -2023,8 +2017,6 @@ public class VerificationResult extends DomainResource {
         private final Reference organization;
         private final String identityCertificate;
         private final Signature attestationSignature;
-
-        private volatile int hashCode;
 
         private Validator(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/resource/VisionPrescription.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/resource/VisionPrescription.java
@@ -83,8 +83,6 @@ public class VisionPrescription extends DomainResource {
     @Required
     private final List<LensSpecification> lensSpecification;
 
-    private volatile int hashCode;
-
     private VisionPrescription(Builder builder) {
         super(builder);
         identifier = Collections.unmodifiableList(ValidationSupport.checkList(builder.identifier, "identifier", Identifier.class));
@@ -754,8 +752,6 @@ public class VisionPrescription extends DomainResource {
         private final String color;
         private final String brand;
         private final List<Annotation> note;
-
-        private volatile int hashCode;
 
         private LensSpecification(Builder builder) {
             super(builder);
@@ -1444,8 +1440,6 @@ public class VisionPrescription extends DomainResource {
             )
             @Required
             private final VisionBase base;
-
-            private volatile int hashCode;
 
             private Prism(Builder builder) {
                 super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Address.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Address.java
@@ -62,8 +62,6 @@ public class Address extends Element {
     @Summary
     private final Period period;
 
-    private volatile int hashCode;
-
     private Address(Builder builder) {
         super(builder);
         use = builder.use;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Age.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Age.java
@@ -44,8 +44,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Age extends Quantity {
-    private volatile int hashCode;
-
     private Age(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Annotation.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Annotation.java
@@ -33,8 +33,6 @@ public class Annotation extends Element {
     @Required
     private final Markdown text;
 
-    private volatile int hashCode;
-
     private Annotation(Builder builder) {
         super(builder);
         author = ValidationSupport.choiceElement(builder.author, "author", Reference.class, String.class);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Attachment.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Attachment.java
@@ -67,8 +67,6 @@ public class Attachment extends Element {
     @Summary
     private final DateTime creation;
 
-    private volatile int hashCode;
-
     private Attachment(Builder builder) {
         super(builder);
         contentType = builder.contentType;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Base64Binary.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Base64Binary.java
@@ -23,8 +23,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Base64Binary extends Element {
     private final byte[] value;
 
-    private volatile int hashCode;
-
     private Base64Binary(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Boolean.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Boolean.java
@@ -24,8 +24,6 @@ public class Boolean extends Element {
 
     private final java.lang.Boolean value;
 
-    private volatile int hashCode;
-
     private Boolean(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Canonical.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Canonical.java
@@ -18,8 +18,6 @@ import com.ibm.fhir.model.visitor.Visitor;
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Canonical extends Uri {
-    private volatile int hashCode;
-
     private Canonical(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Code.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Code.java
@@ -20,8 +20,6 @@ import com.ibm.fhir.model.visitor.Visitor;
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Code extends String {
-    private volatile int hashCode;
-
     protected Code(Builder builder) {
         super(builder);
         ValidationSupport.checkCode(value);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/CodeableConcept.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/CodeableConcept.java
@@ -28,8 +28,6 @@ public class CodeableConcept extends Element {
     @Summary
     private final String text;
 
-    private volatile int hashCode;
-
     private CodeableConcept(Builder builder) {
         super(builder);
         coding = Collections.unmodifiableList(ValidationSupport.checkList(builder.coding, "coding", Coding.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Coding.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Coding.java
@@ -31,8 +31,6 @@ public class Coding extends Element {
     @Summary
     private final Boolean userSelected;
 
-    private volatile int hashCode;
-
     private Coding(Builder builder) {
         super(builder);
         system = builder.system;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ContactDetail.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ContactDetail.java
@@ -28,8 +28,6 @@ public class ContactDetail extends Element {
     @Summary
     private final List<ContactPoint> telecom;
 
-    private volatile int hashCode;
-
     private ContactDetail(Builder builder) {
         super(builder);
         name = builder.name;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ContactPoint.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ContactPoint.java
@@ -56,8 +56,6 @@ public class ContactPoint extends Element {
     @Summary
     private final Period period;
 
-    private volatile int hashCode;
-
     private ContactPoint(Builder builder) {
         super(builder);
         system = builder.system;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Contributor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Contributor.java
@@ -42,8 +42,6 @@ public class Contributor extends Element {
     @Summary
     private final List<ContactDetail> contact;
 
-    private volatile int hashCode;
-
     private Contributor(Builder builder) {
         super(builder);
         type = ValidationSupport.requireNonNull(builder.type, "type");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Count.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Count.java
@@ -28,8 +28,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Count extends Quantity {
-    private volatile int hashCode;
-
     private Count(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/DataRequirement.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/DataRequirement.java
@@ -86,8 +86,6 @@ public class DataRequirement extends Element {
     @Summary
     private final List<Sort> sort;
 
-    private volatile int hashCode;
-
     private DataRequirement(Builder builder) {
         super(builder);
         type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -633,8 +631,6 @@ public class DataRequirement extends Element {
         @Summary
         private final List<Coding> code;
 
-        private volatile int hashCode;
-
         private CodeFilter(Builder builder) {
             super(builder);
             path = builder.path;
@@ -1000,8 +996,6 @@ public class DataRequirement extends Element {
         @Choice({ DateTime.class, Period.class, Duration.class })
         private final Element value;
 
-        private volatile int hashCode;
-
         private DateFilter(Builder builder) {
             super(builder);
             path = builder.path;
@@ -1322,8 +1316,6 @@ public class DataRequirement extends Element {
         )
         @Required
         private final SortDirection direction;
-
-        private volatile int hashCode;
 
         private Sort(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Date.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Date.java
@@ -29,8 +29,6 @@ public class Date extends Element {
 
     private final TemporalAccessor value;
 
-    private volatile int hashCode;
-
     private Date(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
@@ -40,8 +40,6 @@ public class DateTime extends Element {
 
     private final TemporalAccessor value;
 
-    private volatile int hashCode;
-
     private DateTime(Builder builder) {
         super(builder);
         value = ModelSupport.truncateTime(builder.value, ChronoUnit.MICROS);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Decimal.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Decimal.java
@@ -22,8 +22,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Decimal extends Element {
     private final BigDecimal value;
 
-    private volatile int hashCode;
-
     private Decimal(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Distance.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Distance.java
@@ -44,8 +44,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Distance extends Quantity {
-    private volatile int hashCode;
-
     private Distance(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Dosage.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Dosage.java
@@ -84,8 +84,6 @@ public class Dosage extends BackboneElement {
     @Summary
     private final SimpleQuantity maxDosePerLifetime;
 
-    private volatile int hashCode;
-
     private Dosage(Builder builder) {
         super(builder);
         sequence = builder.sequence;
@@ -750,8 +748,6 @@ public class Dosage extends BackboneElement {
         @Summary
         @Choice({ Ratio.class, Range.class, SimpleQuantity.class })
         private final Element rate;
-
-        private volatile int hashCode;
 
         private DoseAndRate(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Duration.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Duration.java
@@ -44,8 +44,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Duration extends Quantity {
-    private volatile int hashCode;
-
     private Duration(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Element.java
@@ -34,6 +34,8 @@ public abstract class Element extends AbstractVisitable {
     protected final java.lang.String id;
     protected final List<Extension> extension;
 
+    protected volatile int hashCode;
+
     protected Element(Builder builder) {
         id = builder.id;
         extension = Collections.unmodifiableList(ValidationSupport.checkList(builder.extension, "extension", Extension.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ElementDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ElementDefinition.java
@@ -268,8 +268,6 @@ public class ElementDefinition extends BackboneElement {
     @Summary
     private final List<Mapping> mapping;
 
-    private volatile int hashCode;
-
     private ElementDefinition(Builder builder) {
         super(builder);
         path = ValidationSupport.requireNonNull(builder.path, "path");
@@ -1993,8 +1991,6 @@ public class ElementDefinition extends BackboneElement {
         @Required
         private final SlicingRules rules;
 
-        private volatile int hashCode;
-
         private Slicing(Builder builder) {
             super(builder);
             discriminator = Collections.unmodifiableList(ValidationSupport.checkList(builder.discriminator, "discriminator", Discriminator.class));
@@ -2362,8 +2358,6 @@ public class ElementDefinition extends BackboneElement {
             @Required
             private final String path;
 
-            private volatile int hashCode;
-
             private Discriminator(Builder builder) {
                 super(builder);
                 type = ValidationSupport.requireNonNull(builder.type, "type");
@@ -2644,8 +2638,6 @@ public class ElementDefinition extends BackboneElement {
         @Summary
         @Required
         private final String max;
-
-        private volatile int hashCode;
 
         private Base(Builder builder) {
             super(builder);
@@ -2978,8 +2970,6 @@ public class ElementDefinition extends BackboneElement {
             valueSet = "http://hl7.org/fhir/ValueSet/reference-version-rules|4.0.1"
         )
         private final ReferenceVersionRules versioning;
-
-        private volatile int hashCode;
 
         private Type(Builder builder) {
             super(builder);
@@ -3434,8 +3424,6 @@ public class ElementDefinition extends BackboneElement {
         @Required
         private final Element value;
 
-        private volatile int hashCode;
-
         private Example(Builder builder) {
             super(builder);
             label = ValidationSupport.requireNonNull(builder.label, "label");
@@ -3778,8 +3766,6 @@ public class ElementDefinition extends BackboneElement {
         private final String xpath;
         @Summary
         private final Canonical source;
-
-        private volatile int hashCode;
 
         private Constraint(Builder builder) {
             super(builder);
@@ -4220,8 +4206,6 @@ public class ElementDefinition extends BackboneElement {
         @Summary
         private final Canonical valueSet;
 
-        private volatile int hashCode;
-
         private Binding(Builder builder) {
             super(builder);
             strength = ValidationSupport.requireNonNull(builder.strength, "strength");
@@ -4532,8 +4516,6 @@ public class ElementDefinition extends BackboneElement {
         private final String map;
         @Summary
         private final String comment;
-
-        private volatile int hashCode;
 
         private Mapping(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Expression.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Expression.java
@@ -59,8 +59,6 @@ public class Expression extends Element {
     @Summary
     private final Uri reference;
 
-    private volatile int hashCode;
-
     private Expression(Builder builder) {
         super(builder);
         description = builder.description;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Extension.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Extension.java
@@ -34,8 +34,6 @@ public class Extension extends Element {
     @Choice({ Base64Binary.class, Boolean.class, Canonical.class, Code.class, Date.class, DateTime.class, Decimal.class, Id.class, Instant.class, Integer.class, Markdown.class, Oid.class, PositiveInt.class, String.class, Time.class, UnsignedInt.class, Uri.class, Url.class, Uuid.class, Address.class, Age.class, Annotation.class, Attachment.class, CodeableConcept.class, Coding.class, ContactPoint.class, Count.class, Distance.class, Duration.class, HumanName.class, Identifier.class, Money.class, Period.class, Quantity.class, Range.class, Ratio.class, Reference.class, SampledData.class, Signature.class, Timing.class, ContactDetail.class, Contributor.class, DataRequirement.class, Expression.class, ParameterDefinition.class, RelatedArtifact.class, TriggerDefinition.class, UsageContext.class, Dosage.class, Meta.class })
     private final Element value;
 
-    private volatile int hashCode;
-
     private Extension(Builder builder) {
         super(builder);
         url = ValidationSupport.requireNonNull(builder.url, "url");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/HumanName.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/HumanName.java
@@ -47,8 +47,6 @@ public class HumanName extends Element {
     @Summary
     private final Period period;
 
-    private volatile int hashCode;
-
     private HumanName(Builder builder) {
         super(builder);
         use = builder.use;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Id.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Id.java
@@ -20,8 +20,6 @@ import com.ibm.fhir.model.visitor.Visitor;
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Id extends String {
-    private volatile int hashCode;
-
     private Id(Builder builder) {
         super(builder);
         ValidationSupport.checkId(value);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Identifier.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Identifier.java
@@ -59,8 +59,6 @@ public class Identifier extends Element {
     @ReferenceTarget({ "Organization" })
     private final Reference assigner;
 
-    private volatile int hashCode;
-
     private Identifier(Builder builder) {
         super(builder);
         use = builder.use;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
@@ -33,8 +33,6 @@ public class Instant extends Element {
 
     private final ZonedDateTime value;
 
-    private volatile int hashCode;
-
     private Instant(Builder builder) {
         super(builder);
         value = ModelSupport.truncateTime(builder.value, ChronoUnit.MICROS);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Integer.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Integer.java
@@ -21,8 +21,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Integer extends Element {
     protected final java.lang.Integer value;
 
-    private volatile int hashCode;
-
     protected Integer(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Markdown.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Markdown.java
@@ -18,8 +18,6 @@ import com.ibm.fhir.model.visitor.Visitor;
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Markdown extends String {
-    private volatile int hashCode;
-
     private Markdown(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/MarketingStatus.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/MarketingStatus.java
@@ -36,8 +36,6 @@ public class MarketingStatus extends BackboneElement {
     @Summary
     private final DateTime restoreDate;
 
-    private volatile int hashCode;
-
     private MarketingStatus(Builder builder) {
         super(builder);
         country = ValidationSupport.requireNonNull(builder.country, "country");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Meta.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Meta.java
@@ -60,8 +60,6 @@ public class Meta extends Element {
     )
     private final List<Coding> tag;
 
-    private volatile int hashCode;
-
     private Meta(Builder builder) {
         super(builder);
         versionId = builder.versionId;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Money.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Money.java
@@ -33,8 +33,6 @@ public class Money extends Element {
     )
     private final Code currency;
 
-    private volatile int hashCode;
-
     private Money(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/MoneyQuantity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/MoneyQuantity.java
@@ -28,8 +28,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class MoneyQuantity extends Quantity {
-    private volatile int hashCode;
-
     private MoneyQuantity(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Narrative.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Narrative.java
@@ -51,8 +51,6 @@ public class Narrative extends Element {
     @Required
     private final Xhtml div;
 
-    private volatile int hashCode;
-
     private Narrative(Builder builder) {
         super(builder);
         status = ValidationSupport.requireNonNull(builder.status, "status");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Oid.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Oid.java
@@ -22,8 +22,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Oid extends Uri {
     private static final Pattern PATTERN = Pattern.compile("urn:oid:[0-2](\\.(0|[1-9][0-9]*))+");
 
-    private volatile int hashCode;
-
     private Oid(Builder builder) {
         super(builder);
         ValidationSupport.checkValue(value, PATTERN);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ParameterDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ParameterDefinition.java
@@ -55,8 +55,6 @@ public class ParameterDefinition extends Element {
     @Summary
     private final Canonical profile;
 
-    private volatile int hashCode;
-
     private ParameterDefinition(Builder builder) {
         super(builder);
         name = builder.name;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Period.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Period.java
@@ -33,8 +33,6 @@ public class Period extends Element {
     @Summary
     private final DateTime end;
 
-    private volatile int hashCode;
-
     private Period(Builder builder) {
         super(builder);
         start = builder.start;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Population.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Population.java
@@ -31,8 +31,6 @@ public class Population extends BackboneElement {
     @Summary
     private final CodeableConcept physiologicalCondition;
 
-    private volatile int hashCode;
-
     private Population(Builder builder) {
         super(builder);
         age = ValidationSupport.choiceElement(builder.age, "age", Range.class, CodeableConcept.class);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/PositiveInt.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/PositiveInt.java
@@ -21,8 +21,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class PositiveInt extends Integer {
     private static final int MIN_VALUE = 1;
 
-    private volatile int hashCode;
-
     private PositiveInt(Builder builder) {
         super(builder);
         ValidationSupport.checkValue(value, MIN_VALUE);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ProdCharacteristic.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ProdCharacteristic.java
@@ -47,8 +47,6 @@ public class ProdCharacteristic extends BackboneElement {
     @Summary
     private final CodeableConcept scoring;
 
-    private volatile int hashCode;
-
     private ProdCharacteristic(Builder builder) {
         super(builder);
         height = builder.height;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/ProductShelfLife.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/ProductShelfLife.java
@@ -35,8 +35,6 @@ public class ProductShelfLife extends BackboneElement {
     @Summary
     private final List<CodeableConcept> specialPrecautionsForStorage;
 
-    private volatile int hashCode;
-
     private ProductShelfLife(Builder builder) {
         super(builder);
         identifier = builder.identifier;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Quantity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Quantity.java
@@ -49,8 +49,6 @@ public class Quantity extends Element {
     @Summary
     protected final Code code;
 
-    private volatile int hashCode;
-
     protected Quantity(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Range.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Range.java
@@ -33,8 +33,6 @@ public class Range extends Element {
     @Summary
     private final SimpleQuantity high;
 
-    private volatile int hashCode;
-
     private Range(Builder builder) {
         super(builder);
         low = builder.low;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Ratio.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Ratio.java
@@ -33,8 +33,6 @@ public class Ratio extends Element {
     @Summary
     private final Quantity denominator;
 
-    private volatile int hashCode;
-
     private Ratio(Builder builder) {
         super(builder);
         numerator = builder.numerator;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Reference.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Reference.java
@@ -53,8 +53,6 @@ public class Reference extends Element {
     @Summary
     private final String display;
 
-    private volatile int hashCode;
-
     private Reference(Builder builder) {
         super(builder);
         reference = builder.reference;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/RelatedArtifact.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/RelatedArtifact.java
@@ -46,8 +46,6 @@ public class RelatedArtifact extends Element {
     @Summary
     private final Canonical resource;
 
-    private volatile int hashCode;
-
     private RelatedArtifact(Builder builder) {
         super(builder);
         type = ValidationSupport.requireNonNull(builder.type, "type");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/SampledData.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/SampledData.java
@@ -39,8 +39,6 @@ public class SampledData extends Element {
     private final PositiveInt dimensions;
     private final String data;
 
-    private volatile int hashCode;
-
     private SampledData(Builder builder) {
         super(builder);
         origin = ValidationSupport.requireNonNull(builder.origin, "origin");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Signature.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Signature.java
@@ -73,8 +73,6 @@ public class Signature extends Element {
     private final Code sigFormat;
     private final Base64Binary data;
 
-    private volatile int hashCode;
-
     private Signature(Builder builder) {
         super(builder);
         type = Collections.unmodifiableList(ValidationSupport.checkNonEmptyList(builder.type, "type", Coding.class));

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/SimpleQuantity.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/SimpleQuantity.java
@@ -29,8 +29,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 )
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class SimpleQuantity extends Quantity {
-    private volatile int hashCode;
-
     private SimpleQuantity(Builder builder) {
         super(builder);
         ValidationSupport.prohibited(comparator, "comparator");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/String.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/String.java
@@ -21,8 +21,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class String extends Element {
     protected final java.lang.String value;
 
-    private volatile int hashCode;
-
     protected String(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/SubstanceAmount.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/SubstanceAmount.java
@@ -34,8 +34,6 @@ public class SubstanceAmount extends BackboneElement {
     @Summary
     private final ReferenceRange referenceRange;
 
-    private volatile int hashCode;
-
     private SubstanceAmount(Builder builder) {
         super(builder);
         amount = ValidationSupport.choiceElement(builder.amount, "amount", Quantity.class, Range.class, String.class);
@@ -379,8 +377,6 @@ public class SubstanceAmount extends BackboneElement {
         private final Quantity lowLimit;
         @Summary
         private final Quantity highLimit;
-
-        private volatile int hashCode;
 
         private ReferenceRange(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Time.java
@@ -32,8 +32,6 @@ public class Time extends Element {
 
     private final LocalTime value;
 
-    private volatile int hashCode;
-
     private Time(Builder builder) {
         super(builder);
         value = ModelSupport.truncateTime(builder.value, ChronoUnit.MICROS);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Timing.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Timing.java
@@ -117,8 +117,6 @@ public class Timing extends BackboneElement {
     )
     private final CodeableConcept code;
 
-    private volatile int hashCode;
-
     private Timing(Builder builder) {
         super(builder);
         event = Collections.unmodifiableList(ValidationSupport.checkList(builder.event, "event", DateTime.class));
@@ -487,8 +485,6 @@ public class Timing extends BackboneElement {
         private final List<EventTiming> when;
         @Summary
         private final UnsignedInt offset;
-
-        private volatile int hashCode;
 
         private Repeat(Builder builder) {
             super(builder);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/TriggerDefinition.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/TriggerDefinition.java
@@ -72,8 +72,6 @@ public class TriggerDefinition extends Element {
     @Summary
     private final Expression condition;
 
-    private volatile int hashCode;
-
     private TriggerDefinition(Builder builder) {
         super(builder);
         type = ValidationSupport.requireNonNull(builder.type, "type");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/UnsignedInt.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/UnsignedInt.java
@@ -21,8 +21,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class UnsignedInt extends Integer {
     private static final int MIN_VALUE = 0;
 
-    private volatile int hashCode;
-
     private UnsignedInt(Builder builder) {
         super(builder);
         ValidationSupport.checkValue(value, MIN_VALUE);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Uri.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Uri.java
@@ -21,8 +21,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Uri extends Element {
     protected final java.lang.String value;
 
-    private volatile int hashCode;
-
     protected Uri(Builder builder) {
         super(builder);
         value = builder.value;

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Url.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Url.java
@@ -18,8 +18,6 @@ import com.ibm.fhir.model.visitor.Visitor;
  */
 @Generated("com.ibm.fhir.tools.CodeGenerator")
 public class Url extends Uri {
-    private volatile int hashCode;
-
     private Url(Builder builder) {
         super(builder);
     }

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/UsageContext.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/UsageContext.java
@@ -57,8 +57,6 @@ public class UsageContext extends Element {
     @Required
     private final Element value;
 
-    private volatile int hashCode;
-
     private UsageContext(Builder builder) {
         super(builder);
         code = ValidationSupport.requireNonNull(builder.code, "code");

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Uuid.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Uuid.java
@@ -22,8 +22,6 @@ import com.ibm.fhir.model.visitor.Visitor;
 public class Uuid extends Uri {
     private static final Pattern PATTERN = Pattern.compile("urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
-    private volatile int hashCode;
-
     private Uuid(Builder builder) {
         super(builder);
         ValidationSupport.checkValue(value, PATTERN);

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Xhtml.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Xhtml.java
@@ -28,8 +28,6 @@ public class Xhtml extends Element {
     @Required
     private final java.lang.String value;
 
-    private volatile int hashCode;
-
     private Xhtml(Builder builder) {
         super(builder);
         value = ValidationSupport.requireNonNull(builder.value, "value");

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -1101,8 +1101,8 @@ public class CodeGenerator {
                 cb.newLine();
             }
 
-            if (!isAbstract(structureDefinition)) {
-                cb.field(mods("private", "volatile"), "int", "hashCode").newLine();
+            if (isAbstract(structureDefinition) && ("Resource".equals(className) || "Element".equals(className))) {
+                cb.field(mods("protected", "volatile"), "int", "hashCode").newLine();
             }
 
             cb.constructor(mods(visibility), className, args("Builder builder"));


### PR DESCRIPTION
There's no need for each concrete type to define / redefine its own
private member for this and it was causing some trouble with downstream
tooling.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>