### PR TITLE
issue 2420 set Derby isolationLevel to avoid deadlock during ingestion

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -184,7 +184,7 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
      * with concurrency issues caused when deletes are mingled with inserts/updates
      *
      * Note the execution flow aligns very closely with the DB2 stored procedure
-     * implementation (fhir-persistence-schema/src/main/resources/add_any_resource.sql)
+     * implementation (fhir-persistence-schema/src/main/resources/db2/add_any_resource.sql)
      *
      * @param tablePrefix
      * @param parameters
@@ -567,19 +567,5 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
         }
 
         return result;
-    }
-
-    /**
-     * Safely close the ResultSet
-     * @param rs
-     */
-    private void safeClose(ResultSet rs) {
-        try {
-            if (rs != null) {
-                rs.close();
-            }
-        } catch (SQLException x) {
-            // NOP
-        }
     }
 }

--- a/fhir-server/liberty-config/configDropins/defaults/datasource.xml
+++ b/fhir-server/liberty-config/configDropins/defaults/datasource.xml
@@ -7,7 +7,7 @@
     <!-- ============================================================== -->
     <!-- TENANT: default; DSID: default; TYPE: read-write               -->
     <!-- ============================================================== -->
-    <dataSource id="bootstrapDefaultDefault" jndiName="jdbc/bootstrap_default_default" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
+    <dataSource id="bootstrapDefaultDefault" jndiName="jdbc/bootstrap_default_default" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s" isolationLevel="TRANSACTION_READ_COMMITTED">
         <jdbcDriver javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource" libraryRef="sharedLibDerby"/>
         <properties.derby.embedded databaseName="derby/fhirDB"/>
         <connectionManager maxPoolSize="50" minPoolSize="10"/>

--- a/fhir-server/liberty-config/configDropins/disabled/datasource-derby.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/datasource-derby.xml
@@ -2,7 +2,7 @@
     <!-- ============================================================== -->
     <!-- TENANT: tenant1; DSID: profile; TYPE: read-write               -->
     <!-- ============================================================== -->
-    <dataSource id="fhirTenant1Profile" jndiName="jdbc/fhir_tenant1_profile" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
+    <dataSource id="fhirTenant1Profile" jndiName="jdbc/fhir_tenant1_profile" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s" isolationLevel="TRANSACTION_READ_COMMITTED">
         <jdbcDriver javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource" libraryRef="sharedLibDerby"/>
         <properties.derby.embedded databaseName="derby/profile"/>
         <connectionManager maxPoolSize="50" minPoolSize="10"/>
@@ -11,7 +11,7 @@
     <!-- ============================================================== -->
     <!-- TENANT: tenant1; DSID: reference; TYPE: read-write             -->
     <!-- ============================================================== -->
-    <dataSource id="fhirTenant1Reference" jndiName="jdbc/fhir_tenant1_reference" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
+    <dataSource id="fhirTenant1Reference" jndiName="jdbc/fhir_tenant1_reference" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s" isolationLevel="TRANSACTION_READ_COMMITTED">
         <jdbcDriver javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource" libraryRef="sharedLibDerby"/>
         <properties.derby.embedded databaseName="derby/reference"/>
         <connectionManager maxPoolSize="50" minPoolSize="10"/>
@@ -20,7 +20,7 @@
     <!-- ============================================================== -->
     <!-- TENANT: tenant1; DSID: study1; TYPE: read-write                -->
     <!-- ============================================================== -->
-    <dataSource id="fhirTenant1Study1" jndiName="jdbc/fhir_tenant1_study1" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
+    <dataSource id="fhirTenant1Study1" jndiName="jdbc/fhir_tenant1_study1" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s" isolationLevel="TRANSACTION_READ_COMMITTED">
         <jdbcDriver javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource" libraryRef="sharedLibDerby"/>
         <properties.derby.embedded databaseName="derby/study1"/>
         <connectionManager maxPoolSize="50" minPoolSize="10"/>


### PR DESCRIPTION
Also aligned the stored procedures for Db2 and PostgreSQL so they match the logic of the Derby DAO. This ended up eliminating an update statement which we were executing for new resources which could be avoided. This should help PostgreSQL in particular, because it avoids tombstones which would need to be vacuumed.
Signed-off-by: Robin Arnold <robin.arnold23@ibm.com>