### PR TITLE
Issue #2296, Issue #2377 - miscellaneous FHIRPath updates

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -1336,22 +1336,23 @@ public class FHIRPathEvaluator {
      * A context object used to pass information to/from the FHIRPath evaluation engine
      */
     public static class EvaluationContext {
+        public static final boolean DEFAULT_RESOLVE_RELATIVE_REFERENCES = false;
+
         private static final String UCUM_SYSTEM = "http://unitsofmeasure.org";
-        private static final Collection<FHIRPathNode> UCUM_SYSTEM_SINGLETON = singleton(stringValue(UCUM_SYSTEM));
-
         private static final String LOINC_SYSTEM = "http://loinc.org";
-        private static final Collection<FHIRPathNode> LOINC_SYSTEM_SINGLETON = singleton(stringValue(LOINC_SYSTEM));
-
         private static final String SCT_SYSTEM = "http://snomed.info/sct";
-        private static final Collection<FHIRPathNode> SCT_SYSTEM_SINGLETON = singleton(stringValue(SCT_SYSTEM));
 
+        private static final Collection<FHIRPathNode> UCUM_SYSTEM_SINGLETON = singleton(stringValue(UCUM_SYSTEM));
+        private static final Collection<FHIRPathNode> LOINC_SYSTEM_SINGLETON = singleton(stringValue(LOINC_SYSTEM));
+        private static final Collection<FHIRPathNode> SCT_SYSTEM_SINGLETON = singleton(stringValue(SCT_SYSTEM));
         private static final Collection<FHIRPathNode> TERM_SERVICE_SINGLETON = singleton(FHIRPathTermServiceNode.termServiceNode());
 
         private final FHIRPathTree tree;
         private final Map<String, Collection<FHIRPathNode>> externalConstantMap = new HashMap<>();
+        private final List<Issue> issues = new ArrayList<>();
 
         private Constraint constraint;
-        private final List<Issue> issues = new ArrayList<>();
+        private boolean resolveRelativeReferences = DEFAULT_RESOLVE_RELATIVE_REFERENCES;
 
         /**
          * Create an empty evaluation context, evaluating stand-alone expressions
@@ -1473,6 +1474,35 @@ public class FHIRPathEvaluator {
         }
 
         /**
+         * Get the list of supplemental issues that were generated during evaluation
+         *
+         * <p>Supplemental issues are used to convey additional information about the evaluation to the client
+         *
+         * @return
+         *     the list of supplemental issues that were generated during evaluation
+         */
+        public List<Issue> getIssues() {
+            return issues;
+        }
+
+        /**
+         * Clear the list of supplemental issues that were generated during evaluation
+         */
+        public void clearIssues() {
+            issues.clear();
+        }
+
+        /**
+         * Indicates whether this evaluation context has supplemental issues that were generated during evaluation
+         *
+         * @return
+         *     true if this evaluation context has supplemental issues that were generated during evaluation, otherwise false
+         */
+        public boolean hasIssues() {
+            return !issues.isEmpty();
+        }
+
+        /**
          * Set the constraint currently under evaluation
          *
          * <p>If a {@link Constraint} is the source of the expression under evaluation, then this method allows the
@@ -1514,32 +1544,23 @@ public class FHIRPathEvaluator {
         }
 
         /**
-         * Get the list of supplemental issues that were generated during evaluation
+         * Set the resolve relative references indicator
          *
-         * <p>Supplemental issues are used to convey additional information about the evaluation to the client
-         *
-         * @return
-         *     the list of supplemental issues that were generated during evaluation
+         * @param resolveRelativeReferences
+         *     the resolve relative references indicator
          */
-        public List<Issue> getIssues() {
-            return issues;
+        public void setResolveRelativeReferences(boolean resolveRelativeReferences) {
+            this.resolveRelativeReferences = resolveRelativeReferences;
         }
 
         /**
-         * Clear the list of supplemental issues that were generated during evaluation
-         */
-        public void clearIssues() {
-            issues.clear();
-        }
-
-        /**
-         * Indicates whether this evaluation context has supplemental issues that were generated during evaluation
+         * Indicates whether the evaluator using this evaluation context should resolve relative references (if possible)
          *
          * @return
-         *     true if this evaluation context has supplemental issues that were generated during evaluation, otherwise false
+         *     true if the evaluator using this evaluation context should resolve relative references (if possible), otherwise false
          */
-        public boolean hasIssues() {
-            return !issues.isEmpty();
+        public boolean resolveRelativeReferences() {
+            return resolveRelativeReferences;
         }
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ResolveFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ResolveFunction.java
@@ -8,9 +8,7 @@ package com.ibm.fhir.path.function;
 
 import static com.ibm.fhir.model.util.FHIRUtil.REFERENCE_PATTERN;
 import static com.ibm.fhir.model.util.ModelSupport.isResourceType;
-import static com.ibm.fhir.path.util.FHIRPathUtil.convertsToBoolean;
 import static com.ibm.fhir.path.util.FHIRPathUtil.getRootResourceNode;
-import static com.ibm.fhir.path.util.FHIRPathUtil.isTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,9 +27,6 @@ import com.ibm.fhir.path.FHIRPathType;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 
 public class ResolveFunction extends FHIRPathAbstractFunction {
-    public static final String RESOLVE_RELATIVE_REFERENCES = "resolveRelativeReferences";
-    public static final boolean DEFAULT_RESOLVE_RELATIVE_REFERENCES = false;
-
     private static final int BASE_URL_GROUP = 1;
     private static final int RESOURCE_TYPE_GROUP = 4;
     private static final int LOGICAL_ID_GROUP = 5;
@@ -103,7 +98,7 @@ public class ResolveFunction extends FHIRPathAbstractFunction {
                                 throw new IllegalArgumentException("Resource type found in reference URL does not match reference type");
                             }
                             String baseUrl = matcher.group(BASE_URL_GROUP);
-                            if ((baseUrl == null ||  matchesServiceBaseUrl(baseUrl)) && resolveRelativeReferences(evaluationContext)) {
+                            if ((baseUrl == null ||  matchesServiceBaseUrl(baseUrl)) && evaluationContext.resolveRelativeReferences()) {
                                 // relative reference
                                 resource = resolveRelativeReference(evaluationContext, node, resourceType, matcher.group(LOGICAL_ID_GROUP), matcher.group(VERSION_ID_GROUP));
                             }
@@ -169,13 +164,5 @@ public class ResolveFunction extends FHIRPathAbstractFunction {
             return reference.getType().getValue();
         }
         return null;
-    }
-
-    private boolean resolveRelativeReferences(EvaluationContext evaluationContext) {
-        Collection<FHIRPathNode> resolveRelativeReferences = evaluationContext.getExternalConstant(RESOLVE_RELATIVE_REFERENCES);
-        if (convertsToBoolean(resolveRelativeReferences)) {
-            return isTrue(resolveRelativeReferences);
-        }
-        return DEFAULT_RESOLVE_RELATIVE_REFERENCES;
     }
 }

--- a/fhir-path/src/test/resources/FHIRPath/tests-fhir-r4.xml
+++ b/fhir-path/src/test/resources/FHIRPath/tests-fhir-r4.xml
@@ -222,9 +222,7 @@
 		<test name="testLiteralTimeMinute" inputfile="patient-example.xml"><expression>@T14:34.is(Time)</expression><output type="boolean">true</output></test>
 		<test name="testLiteralTimeSecond" inputfile="patient-example.xml"><expression>@T14:34:28.is(Time)</expression><output type="boolean">true</output></test>
 		<test name="testLiteralTimeMillisecond" inputfile="patient-example.xml"><expression>@T14:34:28.123.is(Time)</expression><output type="boolean">true</output></test>
-        <!--
 		<test name="testLiteralTimeUTC" inputfile="patient-example.xml"><expression invalid="true">@T14:34:28Z.is(Time)</expression></test>
-		-->
 		<test name="testLiteralTimeTimezoneOffset" inputfile="patient-example.xml"><expression invalid="true">@T14:34:28+10:00.is(Time)</expression></test>
 
 		<test name="testLiteralQuantityDecimal" inputfile="patient-example.xml"><expression>10.1 'mg'.convertsToQuantity()</expression><output type="boolean">true</output></test>

--- a/fhir-profile/src/main/java/com/ibm/fhir/profile/ConstraintGenerator.java
+++ b/fhir-profile/src/main/java/com/ibm/fhir/profile/ConstraintGenerator.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.profile;
 
 import static com.ibm.fhir.model.util.ModelSupport.delimit;
 import static com.ibm.fhir.model.util.ModelSupport.isKeyword;
-import static com.ibm.fhir.model.util.ModelSupport.isResourceType;
 import static com.ibm.fhir.profile.ProfileSupport.HL7_STRUCTURE_DEFINITION_URL_PREFIX;
 import static com.ibm.fhir.profile.ProfileSupport.createConstraint;
 import static com.ibm.fhir.profile.ProfileSupport.getBinding;
@@ -562,14 +561,8 @@ public class ConstraintGenerator {
             sb.append(".");
         }
 
-        Type type = getTypes(elementDefinition).get(0);
-        String profile = getProfiles(type).get(0);
-        String code = type.getCode().getValue();
-        if (isResourceType(code)) {
-            sb.append("conformsTo('").append(profile).append("', true)");
-        } else {
-            sb.append("conformsTo('").append(profile).append("')");
-        }
+        String profile = getProfiles(getTypes(elementDefinition).get(0)).get(0);
+        sb.append("conformsTo('").append(profile).append("')");
 
         if (isRepeating(elementDefinition)) {
             sb.append(")");

--- a/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
+++ b/fhir-profile/src/main/java/com/ibm/fhir/profile/ProfileSupport.java
@@ -228,6 +228,34 @@ public final class ProfileSupport {
         return Collections.emptyList();
     }
 
+    public static boolean hasResourceAssertedProfile(Resource resource, StructureDefinition profile) {
+        Meta meta = resource.getMeta();
+        if (meta != null) {
+            for (Canonical canonical : meta.getProfile()) {
+                String value = canonical.getValue();
+
+                if (value == null) {
+                    continue;
+                }
+
+                String uri = value;
+                String version = null;
+
+                int index = value.indexOf("|");
+                if (index != -1) {
+                    uri = value.substring(0, index);
+                    version = value.substring(index + 1);
+                }
+
+                if (uri.equals(profile.getUrl().getValue()) &&
+                        (version == null || profile.getVersion() == null || version.equals(profile.getVersion().getValue()))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public static List<Constraint> getConstraints(String url, Class<?> type) {
         return getConstraints(Collections.singletonList(url), type);
     }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -54,12 +54,10 @@ import com.ibm.fhir.model.type.code.SearchParamType;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.model.util.JsonSupport;
 import com.ibm.fhir.model.util.ModelSupport;
-import com.ibm.fhir.path.FHIRPathBooleanValue;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.path.exception.FHIRPathException;
-import com.ibm.fhir.path.function.ResolveFunction;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.SearchConstants.Modifier;
 import com.ibm.fhir.search.SearchConstants.Prefix;
@@ -698,7 +696,6 @@ public class SearchUtil {
         // Create one time.
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         EvaluationContext evaluationContext = new EvaluationContext(resource);
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.FALSE);
 
         List<SearchParameter> parameters = getApplicableSearchParameters(resourceType.getSimpleName());
 
@@ -2564,7 +2561,6 @@ public class SearchUtil {
 
         try {
             EvaluationContext resourceContext = new FHIRPathEvaluator.EvaluationContext(fhirResource);
-            resourceContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.FALSE);
 
             // Extract any references we find matching parameters representing compartment membership.
             // For example CareTeam.participant can be used to refer to a Patient or RelatedPerson resource:

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/ServerResolveFunctionTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/ServerResolveFunctionTest.java
@@ -40,11 +40,9 @@ import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.code.ObservationStatus;
-import com.ibm.fhir.path.FHIRPathBooleanValue;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.path.function.ResolveFunction;
 import com.ibm.fhir.path.function.registry.FHIRPathFunctionRegistry;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
@@ -161,7 +159,7 @@ public class ServerResolveFunctionTest {
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         EvaluationContext evaluationContext = new EvaluationContext(observation);
 
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         Collection<FHIRPathNode> nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 
@@ -177,14 +175,14 @@ public class ServerResolveFunctionTest {
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve().deceased = false");
         assertEquals(nodes, SINGLETON_TRUE);
 
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.FALSE);
+        evaluationContext.setResolveRelativeReferences(false);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve().id = '12345'");
         assertEquals(nodes, empty());
 
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve().managingOrganization.resolve() is Organization");
         assertEquals(nodes, SINGLETON_TRUE);
 
@@ -202,7 +200,7 @@ public class ServerResolveFunctionTest {
                     .build())
                 .build();
         evaluationContext = new EvaluationContext(observation);
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 
@@ -217,7 +215,7 @@ public class ServerResolveFunctionTest {
                     .build())
                 .build();
         evaluationContext = new EvaluationContext(observation);
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 
@@ -232,7 +230,7 @@ public class ServerResolveFunctionTest {
                     .build())
                 .build();
         evaluationContext = new EvaluationContext(observation);
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 
@@ -247,7 +245,7 @@ public class ServerResolveFunctionTest {
                     .build())
                 .build();
         evaluationContext = new EvaluationContext(observation);
-        evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+        evaluationContext.setResolveRelativeReferences(true);
         nodes = evaluator.evaluate(evaluationContext, "subject.resolve() is Patient");
         assertEquals(nodes, SINGLETON_TRUE);
 

--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -35,14 +35,12 @@ import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.ModelSupport;
-import com.ibm.fhir.path.FHIRPathBooleanValue;
 import com.ibm.fhir.path.FHIRPathElementNode;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.FHIRPathResourceNode;
 import com.ibm.fhir.path.FHIRPathTree;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
-import com.ibm.fhir.path.function.ResolveFunction;
 import com.ibm.fhir.path.visitor.FHIRPathDefaultNodeVisitor;
 import com.ibm.fhir.profile.ProfileSupport;
 import com.ibm.fhir.registry.FHIRRegistry;
@@ -170,7 +168,7 @@ public class FHIRValidator {
             throw new IllegalArgumentException("Root must be resource node");
         }
         try {
-            evaluationContext.setExternalConstant(ResolveFunction.RESOLVE_RELATIVE_REFERENCES, FHIRPathBooleanValue.TRUE);
+            evaluationContext.setResolveRelativeReferences(true);
             List<Issue> issues = new ArrayList<>();
             validateProfileReferences(evaluationContext.getTree().getRoot().asResourceNode(), Arrays.asList(profiles), false, issues);
             issues.addAll(visitor.validate(evaluationContext, includeResourceAssertedProfiles, profiles));


### PR DESCRIPTION
Miscellaneous Updates

- Fold `resolveRelativeReferences` into the `EvaluationContext` class. Typically FHIRPath "external constants" are treated as data. In this case, however, we are using an external constant as configuration parameter. It makes more sense to make this a field in the `EvaluationContext` class itself.
- Created `hasResourceAssertedProfile` method in `ProfileSupport`
- Added validation logic to the `FHIRPathUtil.compile` method to prevent partial expressions from being evaluated without throwing an exception

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>