### PR TITLE
Be more lenient for List in the fhir-smart authz interceptor

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/patient/resource/PatientResourceHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/patient/resource/PatientResourceHandler.java
@@ -76,7 +76,7 @@ public class PatientResourceHandler extends SystemExportResourceHandler {
      * @param patientIds the patient ids to use to scope the search
      * @throws Exception
      */
-    public List<Resource> executeSearch(List<String> patientIds) throws Exception {
+    public List<Resource> executeSearch(Set<String> patientIds) throws Exception {
         List<Map<String, List<String>>> typeFilters = searchParametersForResoureTypes.get(resourceType);
         boolean isDoDuplicationCheck = typeFilters != null && typeFilters.size() > 1 ?
                 true : adapter.shouldStorageProviderCheckDuplicate(ctx.getSource());

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/group/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/group/ChunkReader.java
@@ -148,7 +148,7 @@ public class ChunkReader extends com.ibm.fhir.bulkdata.jbatch.export.patient.Chu
             if (!patientIds.isEmpty()) {
                 patientHandler.register(chunkData, ctx, getPersistence(), pageSize, resourceType, searchParametersForResoureTypes, ctx.getSource());
 
-                List<Resource> resources = patientHandler.executeSearch(new ArrayList<>(patientIds));
+                List<Resource> resources = patientHandler.executeSearch(patientIds);
                 if (FHIRMediaType.APPLICATION_PARQUET.equals(ctx.getFhirExportFormat())) {
                     dto.setResources(resources);
                 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/ChunkReader.java
@@ -241,9 +241,9 @@ public class ChunkReader extends AbstractItemReader {
                     logger.fine("readItem[" + ctx.getPartitionResourceType() + "]: loaded " + patientResources.size() + " patients");
                 }
 
-                List<String> patientIds = patientResources.stream()
+                Set<String> patientIds = patientResources.stream()
                             .map(item -> item.getId())
-                            .collect(Collectors.toList());
+                            .collect(Collectors.toSet());
 
                 if (!patientIds.isEmpty()) {
                     handler.register(chunkData, ctx, fhirPersistence, pageSize, resourceType, searchParametersForResoureTypes, ctx.getSource());

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/impl/FHIRPersistenceInterceptorMgr.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/interceptor/impl/FHIRPersistenceInterceptorMgr.java
@@ -6,10 +6,10 @@
 
 package com.ibm.fhir.persistence.interceptor.impl;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,7 +35,7 @@ public class FHIRPersistenceInterceptorMgr {
     private static FHIRPersistenceInterceptorMgr instance = new FHIRPersistenceInterceptorMgr();
 
     // Our list of discovered interceptors.
-    List<FHIRPersistenceInterceptor> interceptors = new ArrayList<>();
+    List<FHIRPersistenceInterceptor> interceptors = new CopyOnWriteArrayList<>();
 
     public static FHIRPersistenceInterceptorMgr getInstance() {
         return instance;

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchCompartmentTest.java
@@ -15,8 +15,10 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.testng.annotations.Test;
 
@@ -213,25 +215,25 @@ public abstract class AbstractSearchCompartmentTest extends AbstractPLSearchTest
         Map<String, List<String>> queryParms = new HashMap<>(1);
         queryParms.put("string", Collections.singletonList("testString"));
         assertTrue("Expected resource was not returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PATIENT_ID, OTHER_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{PATIENT_ID, OTHER_ID})),
                     queryParms, savedResource));
         assertTrue("Expected resource was not returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{OTHER_ID, PATIENT_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{OTHER_ID, PATIENT_ID})),
                     queryParms, savedResource));
         assertFalse("Unexpected resource was returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID})),
                     queryParms, savedResource));
 
         queryParms.clear();
         queryParms.put("subject:Basic.string", Collections.singletonList("testString"));
         assertTrue("Expected resource was not returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PATIENT_ID, OTHER_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{PATIENT_ID, OTHER_ID})),
                     queryParms, composition));
         assertTrue("Expected resource was not returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{OTHER_ID, PATIENT_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{OTHER_ID, PATIENT_ID})),
                     queryParms, composition));
         assertFalse("Unexpected resource was returned from the search",
-            multiCompartmentSearchReturnsResource(PATIENT, Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID}),
+            multiCompartmentSearchReturnsResource(PATIENT, new HashSet<>(Arrays.asList(new String[]{PRACTITIONER_ID, OTHER_ID})),
                     queryParms, composition));
     }
 
@@ -239,7 +241,7 @@ public abstract class AbstractSearchCompartmentTest extends AbstractPLSearchTest
      * Executes the compartment query and returns whether the expected resource was in the result set
      * @throws Exception
      */
-    protected boolean multiCompartmentSearchReturnsResource(String compartmentType, List<String> compartmentIds,
+    protected boolean multiCompartmentSearchReturnsResource(String compartmentType, Set<String> compartmentIds,
             Map<String, List<String>> queryParms, Resource expectedResource) throws Exception {
 
         List<? extends Resource> resources = runCompartmentQueryTest(compartmentType, compartmentIds,

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
@@ -217,7 +218,7 @@ public abstract class AbstractPersistenceTest {
         return executeCompartmentQuery(resourceType, maxPageSize, searchContext);
     }
 
-    protected List<Resource> runCompartmentQueryTest(String compartmentName, List<String> compartmentLogicalIds, Class<? extends Resource> resourceType, Map<String, List<String>> queryParms, Integer maxPageSize) throws Exception {
+    protected List<Resource> runCompartmentQueryTest(String compartmentName, Set<String> compartmentLogicalIds, Class<? extends Resource> resourceType, Map<String, List<String>> queryParms, Integer maxPageSize) throws Exception {
         FHIRSearchContext searchContext = SearchUtil.parseQueryParameters(resourceType, queryParms);
         QueryParameter inclusionCriteria = SearchUtil.buildInclusionCriteria(compartmentName, compartmentLogicalIds, resourceType.getSimpleName());
         if (inclusionCriteria != null) {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
@@ -101,8 +101,8 @@ public class DateTimeHandler {
      * Calculates a lower bound absolutely.
      * No matter if the time is AFTER the current time.
      *
-     * @param now
-     * @param cur
+     * @param now the instant representing "now"...the now to compare against for computing the "approximation" range
+     * @param cur the search parameter value instant
      * @return
      */
     public static Instant generateLowerBoundApproximation(Instant now, Instant cur) {
@@ -121,7 +121,7 @@ public class DateTimeHandler {
     public static Instant generateLowerBound(Prefix prefix, TemporalAccessor value, String originalString) {
         Instant response;
 
-        if (prefix != null && Prefix.AP.compareTo(prefix) == 0) {
+        if (prefix == Prefix.AP) {
             Instant cur = generateValue(value, originalString);
             Instant now = java.time.Instant.now();
             response = generateLowerBoundApproximation(now, cur);

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1561,7 +1561,7 @@ public class SearchUtil {
     public static FHIRSearchContext parseCompartmentQueryParameters(String compartmentName, String compartmentLogicalId,
             Class<?> resourceType, Map<String, List<String>> queryParameters, boolean lenient) throws Exception {
 
-        List<String> compartmentLogicalIds = Collections.singletonList(compartmentLogicalId);
+        Set<String> compartmentLogicalIds = Collections.singleton(compartmentLogicalId);
         QueryParameter inclusionCriteria = buildInclusionCriteria(compartmentName, compartmentLogicalIds, resourceType.getSimpleName());
         FHIRSearchContext context = parseQueryParameters(resourceType, queryParameters, lenient);
 
@@ -1582,7 +1582,7 @@ public class SearchUtil {
      * @return
      * @throws FHIRSearchException
      */
-    public static QueryParameter buildInclusionCriteria(String compartmentName, List<String> compartmentLogicalIds, String resourceType)
+    public static QueryParameter buildInclusionCriteria(String compartmentName, Set<String> compartmentLogicalIds, String resourceType)
             throws FHIRSearchException {
         QueryParameter rootParameter = null;
 

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -291,6 +291,21 @@ public class AuthzPolicyEnforcementTest {
             fail("Patient interaction was not allowed but should have been");
         }
 
+        // Invalid compartment search: not a Patient compartment
+        try {
+            queryParameterValue.setValueString("Device/" + PATIENT_ID);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            fail("Patient interaction was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(), "Compartment search for compartment type 'Device' is not permitted.");
+        }
+
         // Invalid compartment search: wrong Patient compartment
         try {
             queryParameterValue.setValueString("Patient/bogus");

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -291,21 +291,6 @@ public class AuthzPolicyEnforcementTest {
             fail("Patient interaction was not allowed but should have been");
         }
 
-        // Invalid compartment search: not a Patient compartment
-        try {
-            queryParameterValue.setValueString("Encounter/" + PATIENT_ID);
-            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
-            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
-            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
-            interceptor.beforeSearch(event);
-            fail("Patient interaction was allowed but should not be");
-        } catch (FHIRPersistenceInterceptorException e) {
-            // success
-            assertEquals(1, e.getIssues().size());
-            assertEquals(IssueType.FORBIDDEN, e.getIssues().get(0).getCode());
-            assertEquals("Compartment search with compartment 'Encounter' is not permitted.", e.getIssues().get(0).getDetails().getText().getValue());
-        }
-
         // Invalid compartment search: wrong Patient compartment
         try {
             queryParameterValue.setValueString("Patient/bogus");

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -97,6 +97,7 @@ public class AuthzPolicyEnforcementTest {
         observation = observation.toBuilder()
                 .id(OBSERVATION_ID)
                 .subject(Reference.builder().reference(string("Patient/" + PATIENT_ID)).build())
+                .encounter(Reference.builder().reference(string("Encounter/" + MockPersistenceImpl.ENCOUNTER_ID_GOOD)).build())
                 .build();
 
         observationProvenance = provenanceBase.toBuilder()
@@ -291,21 +292,6 @@ public class AuthzPolicyEnforcementTest {
             fail("Patient interaction was not allowed but should have been");
         }
 
-        // Invalid compartment search: not a Patient compartment
-        try {
-            queryParameterValue.setValueString("Device/" + PATIENT_ID);
-            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
-            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
-            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
-            interceptor.beforeSearch(event);
-            fail("Patient interaction was allowed but should not be");
-        } catch (FHIRPersistenceInterceptorException e) {
-            // success
-            assertEquals(e.getIssues().size(), 1);
-            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
-            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(), "Compartment search for compartment type 'Device' is not permitted.");
-        }
-
         // Invalid compartment search: wrong Patient compartment
         try {
             queryParameterValue.setValueString("Patient/bogus");
@@ -318,22 +304,98 @@ public class AuthzPolicyEnforcementTest {
             // success
             assertEquals(1, e.getIssues().size());
             assertEquals(IssueType.FORBIDDEN, e.getIssues().get(0).getCode());
-            assertEquals("Interaction with 'Patient/bogus' is not permitted under patient context '[" + PATIENT_ID + "]'.", e.getIssues().get(0).getDetails().getText().getValue());
+            assertEquals("Interaction with 'Patient/bogus' is not permitted for patient context [" + PATIENT_ID + "]", e.getIssues().get(0).getDetails().getText().getValue());
         }
 
-        // Invalid compartment search: resource type not in Patient compartment
+        // Valid compartment search: Encounter in Patient compartment
         try {
-            queryParameterValue.setValueString("Patient/" + PATIENT_ID);
-            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Practitioner");
+            queryParameterValue.setValueString("Encounter/" + MockPersistenceImpl.ENCOUNTER_ID_GOOD);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
             properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
-            FHIRPersistenceEvent event = new FHIRPersistenceEvent(practitioner, properties);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+        } catch (FHIRPersistenceInterceptorException e) {
+            fail("Patient interaction was not allowed but should have been");
+        }
+
+        // Invalid compartment search: Encounter not in Patient compartment
+        try {
+            queryParameterValue.setValueString("Encounter/" + MockPersistenceImpl.ENCOUNTER_ID_BAD);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
             interceptor.beforeSearch(event);
             fail("Patient interaction was allowed but should not be");
         } catch (FHIRPersistenceInterceptorException e) {
             // success
-            assertEquals(1, e.getIssues().size());
-            assertEquals(IssueType.INVALID, e.getIssues().get(0).getCode());
-            assertEquals("Resource type 'Practitioner' is not valid for Patient compartment search.", e.getIssues().get(0).getDetails().getText().getValue());
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
+                "Interaction with 'Encounter/" + MockPersistenceImpl.ENCOUNTER_ID_BAD + "' is not permitted for patient context [" + PATIENT_ID + "]");
+        }
+
+        // Invalid compartment search: Encounter compartment resource does not exist
+        try {
+            queryParameterValue.setValueString("Encounter/bogus");
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            fail("Patient interaction was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
+                "The resource 'Encounter/bogus' does not exist.");
+        }
+
+        // Invalid compartment search: Device compartment
+        try {
+            queryParameterValue.setValueString("Device/" + PATIENT_ID);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            fail("Patient interaction was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
+                "Compartment search for compartment type 'Device' is not permitted.");
+        }
+
+        // Invalid compartment search: Practitioner compartment
+        try {
+            queryParameterValue.setValueString("Practitioner/" + PATIENT_ID);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            fail("Patient interaction was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
+                "Compartment search for compartment type 'Practitioner' is not permitted.");
+        }
+
+        // Invalid compartment search: RelatedPerson compartment
+        try {
+            queryParameterValue.setValueString("RelatedPerson/" + PATIENT_ID);
+            properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
+            properties.put(FHIRPersistenceEvent.PROPNAME_SEARCH_CONTEXT_IMPL, searchContext);
+            FHIRPersistenceEvent event = new FHIRPersistenceEvent(observation, properties);
+            interceptor.beforeSearch(event);
+            fail("Patient interaction was allowed but should not be");
+        } catch (FHIRPersistenceInterceptorException e) {
+            // success
+            assertEquals(e.getIssues().size(), 1);
+            assertEquals(e.getIssues().get(0).getCode(), IssueType.FORBIDDEN);
+            assertEquals(e.getIssues().get(0).getDetails().getText().getValue(),
+                "Compartment search for compartment type 'RelatedPerson' is not permitted.");
         }
 
         // Valid non-compartment search: converted to Patient compartment search


### PR DESCRIPTION
These changes add special-case logic for List resources:
1. even though Lists can be in the patient compartment, searches for
Lists will no longer become automatically scoped to the patient
compartment because some lists (e.g. Formulary Coverage Plans) must be
accessible to the patient despite being exist outside the compartment
(affects beforeSearch).
2. access to List resources that conform to the DaVinci Drug Formulary
Coverage Plan will be allowed without compartment membership checking
(affects afterRead, afterVRead, afterHistory, and afterSearch).

I also converted the compartmentLogicalIds from a List to a Set because
the set of compartmentLogicalIds is order-independent and shouldn't have
duplicates.

Finally, I loosened the compartment-search constraint in the interceptor
so that we allow compartment searches for specific encounters (when they
belong to the patient compartment) and custom compartments that are 
system-defined.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>