### PR TITLE
Audit record uses the exact value of: X-FHIR-FORWARDED-URL header as the URL called for the log entry #2473

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1429,6 +1429,12 @@ The following table describes the JSON fields of the CADF audit log entries logg
 |`observer/geolocation/city`                           |Value is determined by "fhirServer/audit/serviceProperties/geoCity" configuration property.|
 |`observer/geolocation/state`                          |Value is determined by "fhirServer/audit/serviceProperties/geoState" configuration property.|
 |`observer/geolocation/region`                         |Value is determined by "fhirServer/audit/serviceProperties/geoCounty" configuration property.|
+|`target/id`                                           |Value is the UUID from the resource|
+|`target/typeUri`                                      |Value is always "compute/node".|
+|`target/addresses/url`                                |Value determined by the HttpServletRequest for the server. The value does not use the `X-FHIR-FORWARDED-URL` http header|
+|`target/geolocation/city`                             |Value determined by "fhirServer/audit/serviceProperties/geoCity" configuration property.|
+|`target/geolocation/state`                            |Value determined by "fhirServer/audit/serviceProperties/geoState" configuration property.|
+|`target/geolocation/region`                           |Value determined by "fhirServer/audit/serviceProperties/geoCounty" configuration property.|
 
 Note for Batch/Transactions, attachments/content includes counts of the number of C-R-U-D-E actions.
 
@@ -1555,14 +1561,7 @@ The service can map to the CADF format or the FHIR AuditEvent resource format by
             "region": "USA",
             "annotations": [
             ]
-        },
-        "addresses": [
-            {
-                "url": "https://test.io:443/fhir-server/api/v4/Patient",
-                "name": "",
-                "port": ""
-            }
-        ]
+        }
     },
     "attachments": [
         {

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1429,7 +1429,7 @@ The following table describes the JSON fields of the CADF audit log entries logg
 |`observer/geolocation/city`                           |Value is determined by "fhirServer/audit/serviceProperties/geoCity" configuration property.|
 |`observer/geolocation/state`                          |Value is determined by "fhirServer/audit/serviceProperties/geoState" configuration property.|
 |`observer/geolocation/region`                         |Value is determined by "fhirServer/audit/serviceProperties/geoCounty" configuration property.|
-|`target/id`                                           |Value is the UUID from the resource|
+|`target/id`                                           |Value is the Logical ID from the resource|
 |`target/typeUri`                                      |Value is always "compute/node".|
 |`target/addresses/url`                                |Value determined by the HttpServletRequest for the server. The value does not use the `X-FHIR-FORWARDED-URL` http header|
 |`target/geolocation/city`                             |Value determined by "fhirServer/audit/serviceProperties/geoCity" configuration property.|

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/RestAuditLogger.java
@@ -643,7 +643,6 @@ public class RestAuditLogger {
         final String METHODNAME = "populateAuditLogEntry";
         log.entering(CLASSNAME, METHODNAME);
 
-        StringBuilder requestUrl;
         String patientIdExtUrl;
         List<String> userList = new ArrayList<>();
 
@@ -665,10 +664,13 @@ public class RestAuditLogger {
         entry.setLocation(new StringBuilder().append(request.getRemoteAddr()).append("/").append(request.getRemoteHost()).toString());
         entry.setContext(new Context());
 
-        // Uses the FHIRRestServletFilter to pass the OriginalRequestUri to the backend.
-        requestUrl = new StringBuilder(FHIRRequestContext.get().getOriginalRequestUri());
-
-        entry.getContext().setApiParameters(ApiParameters.builder().request(requestUrl.toString()).status(responseStatus.getStatusCode()).build());
+        // Per Issue 2473, the audit log is what changed on the server.
+        entry.getContext()
+            .setApiParameters(
+                ApiParameters.builder()
+                    .request(request.getRequestURI())
+                    .status(responseStatus.getStatusCode())
+                    .build());
         entry.getContext().setStartTime(FHIRUtilities.formatTimestamp(startTime));
         entry.getContext().setEndTime(FHIRUtilities.formatTimestamp(endTime));
         if (resource != null) {


### PR DESCRIPTION


Signed-off-by: Paul Bastide <pbastide@us.ibm.com>