### PR TITLE
Miscelaneous FHIRPersistenceJDBCImpl changes

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -59,11 +59,13 @@ import com.ibm.fhir.database.utils.query.Select;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.parser.FHIRJsonParser;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.Resource.Builder;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.resource.SearchParameter.Component;
 import com.ibm.fhir.model.type.Code;
@@ -355,12 +357,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         final String METHODNAME = "create";
         log.entering(CLASSNAME, METHODNAME);
 
-        // Most resources are well under 10K after being serialized and compressed
-        InputOutputByteStream ioStream = new InputOutputByteStream(DATA_BUFFER_INITIAL_SIZE);
         String logicalId;
-
-        // We need to update the meta in the resource, so we need a modifiable version
-        Resource.Builder resultResourceBuilder = resource.toBuilder();
 
         try (Connection connection = openConnection()) {
 
@@ -376,31 +373,11 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             // Set the resource id and meta fields.
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-            resultResourceBuilder.id(logicalId);
-            Meta meta = resource.getMeta();
-            Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
-            metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
-            metaBuilder.lastUpdated(lastUpdated);
-            resultResourceBuilder.meta(metaBuilder.build());
-
-            // rebuild the resource with updated meta
-            @SuppressWarnings("unchecked")
-            T updatedResource = (T) resultResourceBuilder.build();
+            T updatedResource = copyAndSetResourceMetaFields(logicalId, resource, newVersionNumber, lastUpdated);
 
             // Create the new Resource DTO instance.
-            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
-            resourceDTO.setLogicalId(logicalId);
-            resourceDTO.setVersionId(newVersionNumber);
-            Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
-            resourceDTO.setLastUpdated(timestamp);
-            resourceDTO.setResourceType(updatedResource.getClass().getSimpleName());
-
-            // Serialize and compress the Resource
-            GZIPOutputStream zipStream = new GZIPOutputStream(ioStream.outputStream());
-            FHIRGenerator.generator( Format.JSON, false).generate(updatedResource, zipStream);
-            zipStream.finish();
-            resourceDTO.setDataStream(ioStream);
-            zipStream.close();
+            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
+                    createResourceDTO(logicalId, newVersionNumber, lastUpdated, updatedResource);
 
             // The DAO objects are now created on-the-fly (not expensive to construct) and
             // given the connection to use while processing this request
@@ -446,6 +423,45 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         }
     }
 
+    private <T extends Resource> com.ibm.fhir.persistence.jdbc.dto.Resource createResourceDTO(String logicalId, int newVersionNumber,
+            Instant lastUpdated, T updatedResource) throws IOException, FHIRGeneratorException {
+
+        Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
+
+        com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
+        resourceDTO.setLogicalId(logicalId);
+        resourceDTO.setVersionId(newVersionNumber);
+        resourceDTO.setLastUpdated(timestamp);
+        resourceDTO.setResourceType(updatedResource.getClass().getSimpleName());
+
+        // Most resources are well under 10K after being serialized and compressed
+        InputOutputByteStream ioStream = new InputOutputByteStream(DATA_BUFFER_INITIAL_SIZE);
+
+        // Serialize and compress the Resource
+        try (GZIPOutputStream zipStream = new GZIPOutputStream(ioStream.outputStream())) {
+            FHIRGenerator.generator(Format.JSON, false).generate(updatedResource, zipStream);
+            zipStream.finish();
+            resourceDTO.setDataStream(ioStream);
+        }
+
+        return resourceDTO;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Resource> T copyAndSetResourceMetaFields(String logicalId, T resource, int newVersionNumber, Instant lastUpdated) {
+        Meta meta = resource.getMeta();
+        Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
+        metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
+        metaBuilder.lastUpdated(lastUpdated);
+
+        Builder resourceBuilder = resource.toBuilder();
+        resourceBuilder.setValidating(false);
+        return (T) resourceBuilder
+                .id(logicalId)
+                .meta(metaBuilder.build())
+                .build();
+    }
+
     /**
      * Convenience method to construct a new instance of the {@link ResourceDAO}
      * @param connection the connection to the database for the DAO to use
@@ -454,7 +470,8 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
      * @throws FHIRPersistenceException
      * @throws FHIRPersistenceDataAccessException
      */
-    private ResourceDAO makeResourceDAO(Connection connection) throws FHIRPersistenceDataAccessException, FHIRPersistenceException, IllegalArgumentException {
+    private ResourceDAO makeResourceDAO(Connection connection)
+            throws FHIRPersistenceDataAccessException, FHIRPersistenceException, IllegalArgumentException {
 
         // The resourceDAO is made before any database interaction, so this is a great spot
         // to prefill the caches if needed
@@ -512,10 +529,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
         Class<? extends Resource> resourceType = resource.getClass();
         com.ibm.fhir.persistence.jdbc.dto.Resource existingResourceDTO;
-        InputOutputByteStream ioStream = new InputOutputByteStream(DATA_BUFFER_INITIAL_SIZE);
-
-        // Resources are immutable, so we need a new builder to update it (since R4)
-        Resource.Builder resultResourceBuilder = resource.toBuilder();
 
         try (Connection connection = openConnection()) {
             ResourceDAO resourceDao = makeResourceDAO(connection);
@@ -565,33 +578,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 log.fine("Storing new FHIR Resource '" + resource.getClass().getSimpleName() + "/" + logicalId + "', version=" + newVersionNumber);
             }
 
-            Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-
             // Set the resource id and meta fields.
-//            resultBuilder.id(logicalId);
-            Meta meta = resource.getMeta();
-            Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
-            metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
-            metaBuilder.lastUpdated(lastUpdated);
-            resultResourceBuilder.meta(metaBuilder.build());
-
-            @SuppressWarnings("unchecked")
-            T updatedResource = (T) resultResourceBuilder.build();
+            Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+            T updatedResource = copyAndSetResourceMetaFields(resource.getId(), resource, newVersionNumber, lastUpdated);
 
             // Create the new Resource DTO instance.
-            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
-            resourceDTO.setLogicalId(logicalId);
-            resourceDTO.setVersionId(newVersionNumber);
-            Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
-            resourceDTO.setLastUpdated(timestamp);
-            resourceDTO.setResourceType(updatedResource.getClass().getSimpleName());
-
-            // Serialize and compress the Resource
-            GZIPOutputStream zipStream = new GZIPOutputStream(ioStream.outputStream());
-            FHIRGenerator.generator(Format.JSON, false).generate(updatedResource, zipStream);
-            zipStream.finish();
-            resourceDTO.setDataStream(ioStream);
-            zipStream.close();
+            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
+                    createResourceDTO(logicalId, newVersionNumber, lastUpdated, updatedResource);
 
             // Persist the Resource DTO.
             resourceDao.setPersistenceContext(context);
@@ -1350,9 +1343,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
         com.ibm.fhir.persistence.jdbc.dto.Resource existingResourceDTO = null;
         T existingResource = null;
-        InputOutputByteStream ioStream = new InputOutputByteStream(DATA_BUFFER_INITIAL_SIZE);
-
-        Resource.Builder resourceBuilder;
 
         try (Connection connection = openConnection()) {
             ResourceDAO resourceDao = makeResourceDAO(connection);
@@ -1366,7 +1356,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             if (existingResourceDTO.isDeleted()) {
                 existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
-                resourceBuilder = existingResource.toBuilder();
 
                 addWarning(IssueType.DELETED, "Resource of type'" + resourceType.getSimpleName() +
                         "' with id '" + logicalId + "' is already deleted.");
@@ -1381,38 +1370,15 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             existingResource = this.convertResourceDTO(existingResourceDTO, resourceType, null);
 
-            // Resources are immutable, so we need a new builder to update it (since R4)
-            resourceBuilder = existingResource.toBuilder();
-
             int newVersionNumber = existingResourceDTO.getVersionId() + 1;
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
 
             // Update the soft-delete resource to reflect the new version and lastUpdated values.
-            Meta meta = existingResource.getMeta();
-            Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
-            metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
-            metaBuilder.lastUpdated(lastUpdated);
-            resourceBuilder.meta(metaBuilder.build());
-
-
-            @SuppressWarnings("unchecked")
-            T updatedResource = (T) resourceBuilder.build();
+            T updatedResource = copyAndSetResourceMetaFields(existingResource.getId(), existingResource, newVersionNumber, lastUpdated);
 
             // Create a new Resource DTO instance to represent the deleted version.
-            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO = new com.ibm.fhir.persistence.jdbc.dto.Resource();
-            resourceDTO.setLogicalId(logicalId);
-            resourceDTO.setVersionId(newVersionNumber);
-
-            // Serialize and compress the Resource
-            GZIPOutputStream zipStream = new GZIPOutputStream(ioStream.outputStream());
-            FHIRGenerator.generator(Format.JSON, false).generate(updatedResource, zipStream);
-            zipStream.finish();
-            resourceDTO.setDataStream(ioStream);
-            zipStream.close();
-
-            Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
-            resourceDTO.setLastUpdated(timestamp);
-            resourceDTO.setResourceType(resourceType.getSimpleName());
+            com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
+                    createResourceDTO(logicalId, newVersionNumber, lastUpdated, updatedResource);
             resourceDTO.setDeleted(true);
 
             // Persist the logically deleted Resource DTO.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -373,7 +373,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             // Set the resource id and meta fields.
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-            T updatedResource = copyAndSetResourceMetaFields(logicalId, resource, newVersionNumber, lastUpdated);
+            T updatedResource = copyAndSetResourceMetaFields(resource, logicalId, newVersionNumber, lastUpdated);
 
             // Create the new Resource DTO instance.
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
@@ -423,8 +423,19 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         }
     }
 
-    private <T extends Resource> com.ibm.fhir.persistence.jdbc.dto.Resource createResourceDTO(String logicalId, int newVersionNumber,
-            Instant lastUpdated, T updatedResource) throws IOException, FHIRGeneratorException {
+    /**
+     * Creates and returns a data transfer object (DTO) with the contents of the passed arguments.
+     *
+     * @param logicalId
+     * @param newVersionNumber
+     * @param lastUpdated
+     * @param updatedResource
+     * @return
+     * @throws IOException
+     * @throws FHIRGeneratorException
+     */
+    private com.ibm.fhir.persistence.jdbc.dto.Resource createResourceDTO(String logicalId, int newVersionNumber,
+            Instant lastUpdated, Resource updatedResource) throws IOException, FHIRGeneratorException {
 
         Timestamp timestamp = FHIRUtilities.convertToTimestamp(lastUpdated.getValue());
 
@@ -447,8 +458,18 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         return resourceDTO;
     }
 
+    /**
+     * Creates and returns a copy of the passed resource with the {@code Resource.id}
+     * {@code Resource.meta.versionId}, and {@code Resource.meta.lastUpdated} elements replaced.
+     *
+     * @param resource
+     * @param logicalId
+     * @param newVersionNumber
+     * @param lastUpdated
+     * @return the updated resource
+     */
     @SuppressWarnings("unchecked")
-    private <T extends Resource> T copyAndSetResourceMetaFields(String logicalId, T resource, int newVersionNumber, Instant lastUpdated) {
+    private <T extends Resource> T copyAndSetResourceMetaFields(T resource, String logicalId, int newVersionNumber, Instant lastUpdated) {
         Meta meta = resource.getMeta();
         Meta.Builder metaBuilder = meta == null ? Meta.builder() : meta.toBuilder();
         metaBuilder.versionId(Id.of(Integer.toString(newVersionNumber)));
@@ -580,7 +601,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             // Set the resource id and meta fields.
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
-            T updatedResource = copyAndSetResourceMetaFields(resource.getId(), resource, newVersionNumber, lastUpdated);
+            T updatedResource = copyAndSetResourceMetaFields(resource, resource.getId(), newVersionNumber, lastUpdated);
 
             // Create the new Resource DTO instance.
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
@@ -1374,7 +1395,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             Instant lastUpdated = Instant.now(ZoneOffset.UTC);
 
             // Update the soft-delete resource to reflect the new version and lastUpdated values.
-            T updatedResource = copyAndSetResourceMetaFields(existingResource.getId(), existingResource, newVersionNumber, lastUpdated);
+            T updatedResource = copyAndSetResourceMetaFields(existingResource, existingResource.getId(), newVersionNumber, lastUpdated);
 
             // Create a new Resource DTO instance to represent the deleted version.
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/TimestampPrefixedUUIDTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/TimestampPrefixedUUIDTest.java
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.model.util.ValidationSupport;
 import com.ibm.fhir.persistence.jdbc.util.TimestampPrefixedUUID;
 
 /**
@@ -25,6 +26,10 @@ public class TimestampPrefixedUUIDTest {
         for (int i=0; i<10; i++) {
             // We need a time gap between the two strings
             String s1 = provider.createNewIdentityValue();
+
+            // Ensure the generated id is always valid
+            ValidationSupport.checkId(s1);
+
             try {
                 // It's only 10ms, which is sufficient. We don't want to make it any longer
                 // for the sake of slowing down the build.
@@ -32,7 +37,12 @@ public class TimestampPrefixedUUIDTest {
             } catch (InterruptedException x) {
                 // NOP. Not gonna happen
             }
+
             String s2 = provider.createNewIdentityValue();
+
+            // Ensure the generated id is always valid
+            ValidationSupport.checkId(s2);
+
             assertTrue(s1.compareTo(s2) < 0); // s1 < s2
         }
     }


### PR DESCRIPTION
1. refactored common logic from across create, update, and delete
methods into private helpers `copyAndSetResourceMetaFields` and
`createResourceDTO`

2. set the resourceBuilder to non-validating in
copyAndSetResourceMetaFields since the resource has already been
validated by this point

3. use try-with-catch for the GZIPOutputStream to ensure we never leak
resources

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>