### PR TITLE
modify Provenance-patient parameter during index generation

### DIFF
--- a/fhir-registry/src/test/java/com/ibm/fhir/registry/tool/IndexGenerator.java
+++ b/fhir-registry/src/test/java/com/ibm/fhir/registry/tool/IndexGenerator.java
@@ -64,7 +64,8 @@ public class IndexGenerator {
                         continue;
                     }
 
-                    if (resource instanceof SearchParameter && id.equals("clinical-patient")) {
+                    if (resource instanceof SearchParameter &&
+                            (id.equals("clinical-patient") || id.equals("Provenance-patient"))) {
                         // Workaround for https://jira.hl7.org/browse/FHIR-13601
                         resource = ((SearchParameter) resource).toBuilder()
                                 .target(Collections.singleton(ResourceType.PATIENT))


### PR DESCRIPTION
Per https://jira.hl7.org/browse/FHIR-32876 this search parameter is
wrong in the latest draft of the spec.  I thought it was wrong in our
packaged version (4.0.1) as well, but it turns out I was mistaken.

Still, I thought it would be good to keep this logic in place for when
we move to the R5 artifacts.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>