### PR TITLE
Cleanly handle tablespace removal error (fix for  When multiple tenants exist, Drop Tenant Results in an incorrect FHIRDATA.PARAMETER_NAMES association and drop. #2354 )

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/TableSpaceRemovalException.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/TableSpaceRemovalException.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +12,7 @@ package com.ibm.fhir.database.utils.api;
 public class TableSpaceRemovalException extends DataAccessException {
 
     // All exceptions are serializable
-    private static final long serialVersionUID = -3385697603070014498L;
+    private static final long serialVersionUID = -338568883070014498L;
 
     private boolean transactionRetryable;
 

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/TableSpaceRemovalException.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/TableSpaceRemovalException.java
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright IBM Corp. 2019
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.database.utils.api;
+
+/**
+ * When there is an issue removing the Tablespace
+ */
+public class TableSpaceRemovalException extends DataAccessException {
+
+    // All exceptions are serializable
+    private static final long serialVersionUID = -3385697603070014498L;
+
+    private boolean transactionRetryable;
+
+    /**
+     * Public constructor
+     * @param msg
+     */
+    public TableSpaceRemovalException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Public constructor
+     * @param msg
+     * @param t
+     */
+    public TableSpaceRemovalException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    /**
+     * Public constructor
+     * @param t
+     */
+    public TableSpaceRemovalException(Throwable t) {
+        super(t);
+    }
+
+    /**
+     * Setter for the transactionRetryable flag
+     * @param flag
+     */
+    @Override
+    public void setTransactionRetryable(boolean flag) {
+        this.transactionRetryable = flag;
+    }
+
+    /**
+     * Getter for the transactionRetryable flag
+     * @return true if the transaction could be retried
+     */
+    @Override
+    public boolean isTransactionRetryable() {
+        return this.transactionRetryable;
+    }
+}


### PR DESCRIPTION
The core issue was a timing problem with lots of partitions dettaching. 
This adds a delay to the dropTablespace so the async operation can complete, and cleanly exit with a specific error code so downstream consumers can work around the issue. 

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>