### PR TITLE
fhir-notification: Limit handling for 1M #1948

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -557,8 +557,11 @@ Field name     | Type   | Description
 `lastUpdated`  | String | The date and time of the last update made to the resource associated with the notification event.
 `resourceId`   | String | The logical id of the resource associated with the notification event.
 `resource`     | String | A stringified JSON object which is the resource associated with the notification event.
+`tenantId`     | String | The tenant that generated this notification
+`datasourceId` | String | The datasource used by the tenant
 
 The following JSON is an example of a serialized notification event:
+
 ```
 {
   "lastUpdated":"2016-06-01T10:36:23.232-05:00",
@@ -568,6 +571,8 @@ The following JSON is an example of a serialized notification event:
   "resource":{ …<contents of resource>… }
 }
 ```
+
+If the resource is over the limit specified in `fhirServer/notifications/common/maxNotificationSizeBytes`, the default value is to subset `id`, `meta` and `resourceType` and add the subset to the FHIRNotificationEvent. In alternative configurations, user may set `fhirServer/notifications/common/maxNotificationSizeBehavior` to `omit` and subsequently retrieve the resource using the location.
 
 ### 4.2.2 WebSocket
 The WebSocket implementation of the notification service will publish notification event messages to a WebSocket. To enable WebSocket notifications, set the `fhirServer/notifications/websocket/enabled` property to `true`, as in the following example:
@@ -629,6 +634,8 @@ In the `connectionProperties` property group in preceding example, you'll notice
 Before you enable Kafka notifications, it's important to understand the topology of the environment in which the FHIR server instance will be running. Your topic name selection should be done in consideration of the topology. If you have multiple instances of the FHIR server clustered together to form a single logical endpoint, then each of those instances should be configured to use the same Kafka topic for notifications. This is so that notification consumers (subscribers) can subscribe to a single topic and receive all the notifications published by each of the FHIR server instances within the cluster.
 
 On the other hand, if you have two completely independent FHIR server instances, then you should configure each one with its own topic name.
+
+The FHIRNotificationEvent is asynchronous by default. If you want to specify a synchronous request, you can set `fhirServer/notifications/kafka/sync` to true, which ensures no message is lost in publishing, however it does add latency in each request.
 
 ### 4.2.3 NATS
 The [NATS](http://nats.io) implementation of the notification service publishes notification event messages to a NATS streaming cluster. To configure the NATS notification publisher, configure properties in the `fhir-server-config.json` file as shown in the following example:
@@ -1995,8 +2002,11 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/resources/<resourceType>/searchParameterCombinations`|string list|A comma-separated list of search parameter combinations supported for this resource type. Each search parameter combination is a string, where a plus sign, `+`, separates the search parameters that can be used in combination. To indicate that searching without any search parameters is allowed, an empty string must be included in the list. Including an asterisk, `*`, in the list indicates support of any search parameter combination. For resources without the property, the value of `fhirServer/resources/Resource/searchParameterCombinations` is used.|
 |`fhirServer/resources/<resourceType>/profiles/atLeastOne`|string list|A comma-separated list of profiles, at least one of which must be specified in a resource's `meta.profile` element and be successfully validated against in order for a resource of this type to be persisted to the FHIR server. If this property is not specified, or if an empty list is specified, the value of `fhirServer/resources/Resource/profiles/atLeastOne` will be used.|
 |`fhirServer/notifications/common/includeResourceTypes`|string list|A comma-separated list of resource types for which notification event messages should be published.|
+|`fhirServer/notifications/common/maxNotificationSizeBytes`|integer|The maximum size in byte of the notification that should be sent|
+|`fhirServer/notifications/common/maxNotificationSizeBehavior`|string|The behavior of the notification framework when a notification is over the maxNotificationSizeBytes. Valid values are subset and omit|
 |`fhirServer/notifications/websocket/enabled`|boolean|A boolean flag which indicates whether or not websocket notifications are enabled.|
 |`fhirServer/notifications/kafka/enabled`|boolean|A boolean flag which indicates whether or not kafka notifications are enabled.|
+|`fhirServer/notifications/kafka/sync`|boolean|A boolean flag which indicates whether or not the FHIRNotificationEvent is sent in a synchronous mode|
 |`fhirServer/notifications/kafka/topicName`|string|The name of the topic to which kafka notification event messages should be published.|
 |`fhirServer/notifications/kafka/connectionProperties`|property list|A group of connection properties used to configure the KafkaProducer. These properties are used as-is when instantiating the KafkaProducer used by the FHIR server for publishing notification event messages.|
 |`fhirServer/notifications/nats/enabled`|boolean|A boolean flag which indicates whether or not NATS notifications are enabled.|
@@ -2142,8 +2152,11 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/resources/<resourceType>/searchParameterCombinations`|null (inherits from `fhirServer/resources/Resource/searchParameterCombinations`)|
 |`fhirServer/resources/<resourceType>/profiles/atLeastOne`|null (inherits from `fhirServer/resources/Resource/profiles/atLeastOne`)|
 |`fhirServer/notifications/common/includeResourceTypes`|`["*"]`|
+|`fhirServer/notifications/common/maxNotificationSizeBytes`|integer|1000000|
+|`fhirServer/notifications/common/maxNotificationSizeBehavior`|string|subset|
 |`fhirServer/notifications/websocket/enabled`|false|
 |`fhirServer/notifications/kafka/enabled`|false|
+|`fhirServer/notifications/kafka/sync`|false|
 |`fhirServer/notifications/kafka/topicName`|fhirNotifications|
 |`fhirServer/notifications/kafka/connectionProperties`|`{}`|
 |`fhirServer/notifications/nats/enabled`|false|
@@ -2279,8 +2292,11 @@ must restart the server for that change to take effect.
 |`fhirServer/resources/<resourceType>/searchParameterCombinations`|Y|Y|
 |`fhirServer/resources/<resourceType>/profiles/atLeastOne`|Y|Y|
 |`fhirServer/notifications/common/includeResourceTypes`|N|N|
+|`fhirServer/notifications/common/maxNotificationSizeBytes`|Y|N|
+|`fhirServer/notifications/common/maxNotificationSizeBehavior`|Y|N|
 |`fhirServer/notifications/websocket/enabled`|N|N|
 |`fhirServer/notifications/kafka/enabled`|N|N|
+|`fhirServer/notifications/kafka/sync`|Y|N|
 |`fhirServer/notifications/kafka/topicName`|N|N|
 |`fhirServer/notifications/kafka/connectionProperties`|N|N|
 |`fhirServer/notifications/nats/enabled`|N|N|

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -568,6 +568,8 @@ The following JSON is an example of a serialized notification event:
   "location":"Observation/3859/_history/1",
   "operationType":"create",
   "resourceId":"3859",
+  "tenantId":"default",
+  "datasourceId":"default",
   "resource":{ …<contents of resource>… }
 }
 ```

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -85,10 +85,13 @@ public class FHIRConfiguration {
 
     // Notification config properties
     public static final String PROPERTY_NOTIFICATION_RESOURCE_TYPES = "fhirServer/notifications/common/includeResourceTypes";
+    public static final String PROPERTY_NOTIFICATION_NOTIFICATION_SIZE_BEHAVIOR = "fhirServer/notifications/common/maxNotificationSizeBehavior";
+    public static final String PROPERTY_NOTIFICATION_MAX_SIZE = "fhirServer/notifications/common/maxNotificationSizeBytes";
     public static final String PROPERTY_WEBSOCKET_ENABLED = "fhirServer/notifications/websocket/enabled";
     public static final String PROPERTY_KAFKA_ENABLED = "fhirServer/notifications/kafka/enabled";
     public static final String PROPERTY_KAFKA_TOPICNAME = "fhirServer/notifications/kafka/topicName";
     public static final String PROPERTY_KAFKA_CONNECTIONPROPS = "fhirServer/notifications/kafka/connectionProperties";
+    public static final String PROPERTY_KAFKA_SYNC = "fhirServer/notifications/kafka/sync";
     public static final String PROPERTY_NATS_ENABLED = "fhirServer/notifications/nats/enabled";
     public static final String PROPERTY_NATS_CLUSTER = "fhirServer/notifications/nats/cluster";
     public static final String PROPERTY_NATS_CHANNEL = "fhirServer/notifications/nats/channel";

--- a/fhir-notification/pom.xml
+++ b/fhir-notification/pom.xml
@@ -25,5 +25,10 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/util/FHIRNotificationUtil.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/util/FHIRNotificationUtil.java
@@ -120,8 +120,8 @@ public class FHIRNotificationUtil {
                 builder.add("datasourceId", event.getDatasourceId());
                 builder.add("tenantId", event.getTenantId());
                 jsonObject = builder.build();
+                jsonString = jsonObject.toString();
             }
-            jsonString = jsonObject.toString();
         } else {
             JsonObject jsonObject = builder.build();
             jsonString = jsonObject.toString();

--- a/fhir-notification/src/main/java/com/ibm/fhir/notification/util/FHIRNotificationUtil.java
+++ b/fhir-notification/src/main/java/com/ibm/fhir/notification/util/FHIRNotificationUtil.java
@@ -7,6 +7,20 @@
 package com.ibm.fhir.notification.util;
 
 import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.exception.FHIRException;
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRJsonParser;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.model.util.JsonSupport;
+import com.ibm.fhir.notification.FHIRNotificationEvent;
+import com.ibm.fhir.search.SearchConstants;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
@@ -16,26 +30,39 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonReaderFactory;
 
-import com.ibm.fhir.exception.FHIRException;
-import com.ibm.fhir.model.util.JsonSupport;
-import com.ibm.fhir.notification.FHIRNotificationEvent;
-
+/**
+ * FHIRNotificationUtil supports serializing and deserializing the FHIRNotificationEvent based on conditions.
+ */
 public class FHIRNotificationUtil {
+    private static final Logger LOG = Logger.getLogger(FHIRNotificationUtil.class.getSimpleName());
     private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
     private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(null);
+
+    private static final int DEFAULT_MAX_SIZE = 1000000;
+
+    private FHIRNotificationUtil() {
+        // No Operation
+    }
+
+    /**
+     * serialize the FHIRNotificationEvent
+     *
+     * @param jsonString the input string
+     * @return FHIRNotificationEvent without the Resource
+     */
     public static FHIRNotificationEvent toNotificationEvent(String jsonString) {
         try (JsonReader reader = JSON_READER_FACTORY.createReader(new StringReader(jsonString))) {
             JsonObject jsonObject = reader.readObject();
             FHIRNotificationEvent event = new FHIRNotificationEvent();
-            event.setOperationType(jsonObject.getString("operationType"));
-            event.setLocation(jsonObject.getString("location"));
             event.setLastUpdated(jsonObject.getString("lastUpdated"));
+            event.setLocation(jsonObject.getString("location"));
+            event.setOperationType(jsonObject.getString("operationType"));
             event.setResourceId(jsonObject.getString("resourceId"));
             event.setDatasourceId(jsonObject.getString("datasourceId"));
             event.setTenantId(jsonObject.getString("tenantId"));
             return event;
         } catch (JsonException e) {
-            System.out.println("Failed to parse json string: " + e.getLocalizedMessage());
+            LOG.warning("Failed to parse json string: " + e.getLocalizedMessage());
             return null;
         }
     }
@@ -58,11 +85,47 @@ public class FHIRNotificationUtil {
         builder.add("tenantId", event.getTenantId());
 
         // If it's a delete operation, don't add as there is no actual resource in the event.
+        String jsonString;
         if (!"delete".equals(event.getOperationType()) && includeResource && event.getResource() != null) {
             builder.add("resource", JsonSupport.toJsonObject(event.getResource()));
+            JsonObject jsonObject = builder.build();
+
+            jsonString = jsonObject.toString();
+            long length = jsonString.getBytes().length;
+
+            int maxSize = FHIRConfigHelper.getIntProperty(FHIRConfiguration.PROPERTY_NOTIFICATION_MAX_SIZE, DEFAULT_MAX_SIZE);
+            if (length > maxSize) {
+                LOG.fine(() -> event.getResource().getClass().getSimpleName() + "/" + event.getResourceId() + " is over the size limit - '" + length + "' > '" + maxSize + "'");
+
+                // If we are including a subset, we'll add here.
+                String subset = FHIRConfigHelper.getStringProperty(FHIRConfiguration.PROPERTY_NOTIFICATION_NOTIFICATION_SIZE_BEHAVIOR, "subset");
+                if ("subset".equals(subset)) {
+                    List<String> elements = Arrays.asList("id", "meta", "resourceType");
+                    com.ibm.fhir.model.resource.Resource resource = FHIRParser.parser(Format.JSON)
+                                                                        .as(FHIRJsonParser.class)
+                                                                        .parseAndFilter(JsonSupport.toJsonObject(event.getResource()), elements);
+                    // add a SUBSETTED tag to this resource to indicate that its elements have been filtered
+                    if (!FHIRUtil.hasTag(resource, SearchConstants.SUBSETTED_TAG)) {
+                        resource = FHIRUtil.addTag(resource, SearchConstants.SUBSETTED_TAG);
+                    }
+                    builder.add("resource", JsonSupport.toJsonObject(resource));
+                } else {
+                    LOG.fine(() -> "Omitting the resource in FHIRNotificationEvent");
+                }
+                // the build method wipes out any preexisting values, we have to add them back.
+                builder.add("lastUpdated", event.getLastUpdated());
+                builder.add("location", event.getLocation());
+                builder.add("operationType", event.getOperationType());
+                builder.add("resourceId", event.getResourceId());
+                builder.add("datasourceId", event.getDatasourceId());
+                builder.add("tenantId", event.getTenantId());
+                jsonObject = builder.build();
+            }
+            jsonString = jsonObject.toString();
+        } else {
+            JsonObject jsonObject = builder.build();
+            jsonString = jsonObject.toString();
         }
-        JsonObject jsonObject = builder.build();
-        String jsonString = jsonObject.toString();
         return jsonString;
     }
 }

--- a/fhir-notification/src/test/java/com/ibm/fhir/notification/util/FHIRNotificationUtilTest.java
+++ b/fhir-notification/src/test/java/com/ibm/fhir/notification/util/FHIRNotificationUtilTest.java
@@ -1,0 +1,229 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.notification.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import java.lang.reflect.Method;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.exception.FHIRException;
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.notification.FHIRNotificationEvent;
+
+/**
+ * FHIRNotificationUtil Tests
+ */
+public class FHIRNotificationUtilTest {
+
+    @BeforeClass
+    public void setup() {
+        FHIRConfiguration.setConfigHome("src/test/resources");
+    }
+
+    @BeforeMethod
+    public void startMethod(Method method) throws FHIRException {
+        // Configure the request context for our search tests
+        FHIRRequestContext context = FHIRRequestContext.get();
+        if (context == null) {
+            context = new FHIRRequestContext();
+        }
+        FHIRRequestContext.set(context);
+
+        //Facilitate the switching of tenant configurations based on method name
+        String tenant = "default";
+        String methodName = method.getName();
+        if (methodName.contains("_tenant_")) {
+            int idx = methodName.indexOf("_tenant_") + "_tenant_".length();
+            tenant = methodName.substring(idx);
+        }
+        context.setTenantId(tenant);
+
+        context.setOriginalRequestUri("https://localhost:9443/fhir-server/api/v4");
+    }
+
+    @AfterMethod
+    public void clearThreadLocal() {
+        FHIRRequestContext.remove();
+    }
+
+    @Test
+    public void testUtil_NotDeleteDontInclude_tenant_default() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, false),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteAndInclude_tenant_default() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\",\"resource\":{\"resourceType\":\"Parameters\",\"id\":\"144f2a21-856d-40d8-8411-2cb482ba0c6f\"}}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteAndInclude_tenant_omit() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteAndInclude_tenant_subset() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"resource\":{\"resourceType\":\"Parameters\",\"id\":\"144f2a21-856d-40d8-8411-2cb482ba0c6f\",\"meta\":{\"tag\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/v3-ObservationValue\",\"code\":\"SUBSETTED\",\"display\":\"subsetted\"}]}},\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteAndInclude_tenant_empty() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"resource\":{\"resourceType\":\"Parameters\",\"id\":\"144f2a21-856d-40d8-8411-2cb482ba0c6f\",\"meta\":{\"tag\":[{\"system\":\"http://terminology.hl7.org/CodeSystem/v3-ObservationValue\",\"code\":\"SUBSETTED\",\"display\":\"subsetted\"}]}},\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteNotInclude_tenant_default() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, false),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_NotDeleteIncludeWithoutResource_tenant_default() throws FHIRException {
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("$operation");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_Delete_tenant_default() throws FHIRException {
+        Parameters.Builder builder = Parameters.builder();
+        builder.id("144f2a21-856d-40d8-8411-2cb482ba0c6f");
+        Parameters parms = builder.build();
+
+        FHIRNotificationEvent evt = new FHIRNotificationEvent();
+        evt.setLastUpdated("2021-10-10");
+        evt.setLocation("Patient/1-2-3-4");
+        evt.setOperationType("delete");
+        evt.setResourceId("1-2-3-4");
+        evt.setDatasourceId("default");
+        evt.setTenantId("default");
+        evt.setResource(parms);
+
+        assertEquals(FHIRNotificationUtil.toJsonString(evt, true),
+            "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"delete\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}");
+    }
+
+    @Test
+    public void testUtil_RoundTrip_tenant_default() throws FHIRException {
+        String jsonString = "{\"lastUpdated\":\"2021-10-10\",\"location\":\"Patient/1-2-3-4\",\"operationType\":\"$operation\",\"resourceId\":\"1-2-3-4\",\"datasourceId\":\"default\",\"tenantId\":\"default\"}";
+        FHIRNotificationEvent evt = FHIRNotificationUtil.toNotificationEvent(jsonString);
+        assertNotNull(evt);
+        assertEquals(evt.getLastUpdated(),"2021-10-10");
+        assertEquals(evt.getLocation(),"Patient/1-2-3-4");
+        assertEquals(evt.getOperationType(),"$operation");
+        assertEquals(evt.getResourceId(),"1-2-3-4");
+        assertEquals(evt.getDatasourceId(),"default");
+        assertEquals(evt.getTenantId(),"default");
+        assertNull(evt.getResource());
+    }
+
+    @Test
+    public void testUtil_BadJson_tenant_default() throws FHIRException {
+        String jsonString = "{\"";
+        FHIRNotificationEvent evt = FHIRNotificationUtil.toNotificationEvent(jsonString);
+        assertNull(evt);
+    }
+}

--- a/fhir-notification/src/test/resources/config/empty/fhir-server-config.json
+++ b/fhir-notification/src/test/resources/config/empty/fhir-server-config.json
@@ -1,0 +1,11 @@
+{
+    "__comment": "FHIR Server - Notification - Test Configuration",
+    "fhirServer": {
+        "notifications": {
+            "common": {
+                "maxNotificationSizeBytes": 1,
+                "maxNotificationSizeBehavior": "subset"
+            }
+        }
+    }
+}

--- a/fhir-notification/src/test/resources/config/omit/fhir-server-config.json
+++ b/fhir-notification/src/test/resources/config/omit/fhir-server-config.json
@@ -1,0 +1,11 @@
+{
+    "__comment": "FHIR Server - Notification - Test Configuration",
+    "fhirServer": {
+        "notifications": {
+            "common": {
+                "maxNotificationSizeBytes": 1,
+                "maxNotificationSizeBehavior": "omit"
+            }
+        }
+    }
+}

--- a/fhir-notification/src/test/resources/config/subset/fhir-server-config.json
+++ b/fhir-notification/src/test/resources/config/subset/fhir-server-config.json
@@ -1,0 +1,10 @@
+{
+    "__comment": "FHIR Server - Notification - Test Configuration",
+    "fhirServer": {
+        "notifications": {
+            "common": {
+                "maxNotificationSizeBytes": 1
+            }
+        }
+    }
+}

--- a/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
+++ b/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
@@ -17,6 +17,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.notification.FHIRNotificationEvent;
 import com.ibm.fhir.notification.FHIRNotificationService;
 import com.ibm.fhir.notification.FHIRNotificationSubscriber;
@@ -27,7 +29,7 @@ import com.ibm.fhir.notification.util.FHIRNotificationUtil;
  * This class implements the FHIR server notification service via a Kafka topic.
  */
 public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscriber {
-    private static final Logger log = Logger.getLogger(FHIRNotificationKafkaPublisher.class.getName());
+    private static final Logger LOG = Logger.getLogger(FHIRNotificationKafkaPublisher.class.getName());
 
     private static FHIRNotificationService service = FHIRNotificationService.getInstance();
 
@@ -41,11 +43,11 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
     }
 
     public FHIRNotificationKafkaPublisher(String topicName, Properties kafkaProps) {
-        log.entering(this.getClass().getName(), "ctor");
+        LOG.entering(this.getClass().getName(), "ctor");
         try {
             init(topicName, kafkaProps);
         } finally {
-            log.exiting(this.getClass().getName(), "ctor");
+            LOG.exiting(this.getClass().getName(), "ctor");
         }
     }
 
@@ -53,13 +55,13 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
      * Performs any required initialization to allow us to publish events to the topic.
      */
     private void init(String topicName, Properties kafkaProps) {
-        log.entering(this.getClass().getName(), "init");
+        LOG.entering(this.getClass().getName(), "init");
         try {
             this.topicName = topicName;
             this.kafkaProps = kafkaProps;
-            if (log.isLoggable(Level.FINER)) {
-                log.finer("Kafka publisher is configured with the following properties:\n" + this.kafkaProps.toString());
-                log.finer("Topic name: " + this.topicName);
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Kafka publisher is configured with the following properties:\n" + this.kafkaProps.toString());
+                LOG.finer("Topic name: " + this.topicName);
             }
 
             // We'll hard-code some properties to ensure they are set correctly.
@@ -79,13 +81,13 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
             // Register this Kafka implementation as a "subscriber" with our Notification Service.
             // This means that our "notify" method will be called when the server publishes an event.
             service.subscribe(this);
-            log.info("Initialized Kafka publisher for topic '" + topicName + "' using bootstrap servers: " + bootstrapServers + ".");
+            LOG.info("Initialized Kafka publisher for topic '" + topicName + "' using bootstrap servers: " + bootstrapServers + ".");
         } catch (Throwable t) {
             String msg = "Caught exception while initializing Kafka publisher.";
-            log.log(Level.SEVERE, msg, t);
+            LOG.log(Level.SEVERE, msg, t);
             throw new IllegalStateException(msg, t);
         } finally {
-            log.exiting(this.getClass().getName(), "init");
+            LOG.exiting(this.getClass().getName(), "init");
         }
     }
 
@@ -93,43 +95,50 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
      * Performs any necessary "shutdown" logic to disconnect from the topic.
      */
     public void shutdown() {
-        log.entering(this.getClass().getName(), "shutdown");
+        LOG.entering(this.getClass().getName(), "shutdown");
 
         try {
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Shutting down Kafka publisher for topic: '" + topicName + "'.");
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Shutting down Kafka publisher for topic: '" + topicName + "'.");
             }
             if (producer != null) {
                 producer.close();
             }
         } finally {
-            log.exiting(this.getClass().getName(), "shutdown");
+            LOG.exiting(this.getClass().getName(), "shutdown");
         }
     }
 
     @Override
     public void notify(FHIRNotificationEvent event) throws FHIRNotificationException {
-        log.entering(this.getClass().getName(), "notify");
+        LOG.entering(this.getClass().getName(), "notify");
         String topicId = "[" + this.kafkaProps.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) + "]/" + topicName;
         String jsonString = null;
         try {
             jsonString = FHIRNotificationUtil.toJsonString(event, true);
 
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Publishing kafka notification event to topic '" + topicId + "',\nmessage: " + jsonString);
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Publishing kafka notification event to topic '" + topicId + "',\nmessage: " + jsonString);
             }
 
-            producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId));
-
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Returned from async kafka send...");
+            boolean aysnc = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_SYNC, false);
+            if (aysnc) {
+                producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId));
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("Returned from async kafka send...");
+                }
+            } else {
+                RecordMetadata metadata = producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId)).get();
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine(" Record Produced to Topic '" + metadata.topic() + "' at time " + metadata.timestamp());
+                }
             }
         } catch (Throwable e) {
             String msg = buildNotificationErrorMessage(topicId, (jsonString == null ? "<null>" : jsonString));
-            log.log(Level.SEVERE, msg , e);
+            LOG.log(Level.SEVERE, msg , e);
             throw new FHIRNotificationException(msg, e);
         } finally {
-            log.exiting(this.getClass().getName(), "notify");
+            LOG.exiting(this.getClass().getName(), "notify");
         }
     }
 
@@ -150,22 +159,20 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
          */
         @Override
         public void onCompletion(RecordMetadata recordMetadata, Exception exception) {
-            log.entering(this.getClass().getName(), "onCompletion");
+            LOG.entering(this.getClass().getName(), "onCompletion");
 
             try {
                 // No exception implies that the send operation succeeded, so log an info message.
                 if (exception == null) {
-                    log.info("Successfully published kafka notification event for resource: " + event.getLocation());
-                }
-
-                // If we detected a 'send' failure, then log an error message that includes the notification message
-                // that we tried to send.
-                else {
+                    LOG.info("Successfully published kafka notification event for resource: " + event.getLocation());
+                } else {
+                    // If we detected a 'send' failure, then log an error message that includes the notification message
+                    // that we tried to send.
                     String msg = buildNotificationErrorMessage(topicId, notificationEvent);
-                    log.log(Level.SEVERE, msg, exception);
+                    LOG.log(Level.SEVERE, msg, exception);
                 }
             } finally {
-                log.exiting(this.getClass().getName(), "onCompletion");
+                LOG.exiting(this.getClass().getName(), "onCompletion");
             }
         }
     }

--- a/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
+++ b/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
@@ -121,8 +121,8 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
                 LOG.fine("Publishing kafka notification event to topic '" + topicId + "',\nmessage: " + jsonString);
             }
 
-            boolean sysnc = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_SYNC, false);
-            if (sysnc) {
+            boolean sync = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_SYNC, false);
+            if (!sync) {
                 producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId));
                 if (LOG.isLoggable(Level.FINE)) {
                     LOG.fine("Returned from async kafka send...");

--- a/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
+++ b/notification/fhir-notification-kafka/src/main/java/com/ibm/fhir/notifications/kafka/impl/FHIRNotificationKafkaPublisher.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -121,8 +121,8 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
                 LOG.fine("Publishing kafka notification event to topic '" + topicId + "',\nmessage: " + jsonString);
             }
 
-            boolean aysnc = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_SYNC, false);
-            if (aysnc) {
+            boolean sysnc = FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_KAFKA_SYNC, false);
+            if (sysnc) {
                 producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId));
                 if (LOG.isLoggable(Level.FINE)) {
                     LOG.fine("Returned from async kafka send...");
@@ -130,7 +130,7 @@ public class FHIRNotificationKafkaPublisher implements FHIRNotificationSubscribe
             } else {
                 RecordMetadata metadata = producer.send(new ProducerRecord<String, String>(topicName, jsonString), new KafkaPublisherCallback(event, jsonString, topicId)).get();
                 if (LOG.isLoggable(Level.FINE)) {
-                    LOG.fine(" Record Produced to Topic '" + metadata.topic() + "' at time " + metadata.timestamp());
+                    LOG.fine("Record Produced to Topic '" + metadata.topic() + "' at time " + metadata.timestamp());
                 }
             }
         } catch (Throwable e) {


### PR DESCRIPTION
- Updated fhir server's users guide to outline new preferences and add
missing fields
- Updated FHIRNotificationUtil to support new max Size behavior and
bytes so that it can be tuned to each use case by subset or omit when it
hits a limit. (There is no spanning/splitting to avoid delivery order
issues)
- Add Synchronous support to Kafka Notification and documentation how to
enable (users can now chose if they want a lossy approach or not)
- Add test coverage for fhir-notification and FHIRNotificationUtil

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>