### PR TITLE
issue #2510 - make FHIRPathUtil threadsafe

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -83,9 +83,12 @@ import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.path.function.FHIRPathFunction;
 import com.ibm.fhir.path.util.FHIRPathUtil;
 
+import net.jcip.annotations.NotThreadSafe;
+
 /**
  * A FHIRPath evaluation engine that implements the FHIRPath 2.0.0 <a href="http://hl7.org/fhirpath/N1/">specification</a>
  */
+@NotThreadSafe
 public class FHIRPathEvaluator {
     private static final Logger log = Logger.getLogger(FHIRPathEvaluator.class.getName());
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -87,6 +87,8 @@ import net.jcip.annotations.NotThreadSafe;
 
 /**
  * A FHIRPath evaluation engine that implements the FHIRPath 2.0.0 <a href="http://hl7.org/fhirpath/N1/">specification</a>
+ *
+ * The static factory method {@link #evaluator()} is threadsafe, but the created instances are not.
  */
 @NotThreadSafe
 public class FHIRPathEvaluator {

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/AddingVisitor.java
@@ -29,10 +29,10 @@ class AddingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @throws IllegalArgumentException
      */
     public AddingVisitor(Visitable parent, String parentPath, String elementName, Visitable value) {
-        this.path = Objects.requireNonNull(parentPath);
-        this.elementNameToAdd = Objects.requireNonNull(elementName);
+        this.path = Objects.requireNonNull(parentPath, "parentPath");
+        this.elementNameToAdd = Objects.requireNonNull(elementName, "elementName");
         this.isRepeatingElement = ModelSupport.isRepeatingElement(parent.getClass(), elementName);
-        this.value = Objects.requireNonNull(value) instanceof Code ?
+        this.value = Objects.requireNonNull(value, "value") instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)value) : value;
     }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/DeletingVisitor.java
@@ -14,7 +14,7 @@ class DeletingVisitor<T extends Visitable> extends CopyingVisitor<T> {
     private String pathToDelete;
 
     public DeletingVisitor(String pathToDelete) {
-        this.pathToDelete = Objects.requireNonNull(pathToDelete);
+        this.pathToDelete = Objects.requireNonNull(pathToDelete, "pathToDelete");
     }
 
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/FHIRPathUtil.java
@@ -88,8 +88,6 @@ import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.exception.FHIRPathException;
 
 public final class FHIRPathUtil {
-    private static FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
-
     public static final Set<String> STRING_TRUE_VALUES = new HashSet<>(Arrays.asList("true", "t", "yes", "y", "1", "1.0"));
     public static final Set<String> STRING_FALSE_VALUES = new HashSet<>(Arrays.asList("false", "f", "no", "n", "0", "0.0"));
     public static final Integer INTEGER_TRUE = 1;
@@ -892,8 +890,10 @@ public final class FHIRPathUtil {
      * @throws FHIRPatchException
      * @throws NullPointerException if any of the passed arguments are null
      */
-    public static <T extends Visitable> T add(T elementOrResource, String fhirPath, String elementName, Visitable value) throws FHIRPathException, FHIRPatchException {
-        FHIRPathNode node = evaluateToSingle(elementOrResource, fhirPath);
+    public static <T extends Visitable> T add(T elementOrResource, String fhirPath, String elementName, Visitable value)
+            throws FHIRPathException, FHIRPatchException {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        FHIRPathNode node = evaluateToSingle(evaluator, elementOrResource, fhirPath);
         Visitable parent = node.isResourceNode() ?
                 node.asResourceNode().resource() : node.asElementNode().element();
 
@@ -913,7 +913,8 @@ public final class FHIRPathUtil {
      * @throws NullPointerException if any of the passed arguments are null
      */
     public static <T extends Visitable> T delete(T elementOrResource, String fhirPath) throws FHIRPathException, FHIRPatchException {
-        FHIRPathNode node = evaluateToSingle(elementOrResource, fhirPath);
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        FHIRPathNode node = evaluateToSingle(evaluator, elementOrResource, fhirPath);
 
         try {
             DeletingVisitor<T> deletingVisitor = new DeletingVisitor<T>(node.path());
@@ -932,7 +933,8 @@ public final class FHIRPathUtil {
      * @throws NullPointerException if any of the passed arguments are null
      */
     public static <T extends Visitable> T replace(T elementOrResource, String fhirPath, Visitable value) throws FHIRPathException, FHIRPatchException {
-        FHIRPathNode node = evaluateToSingle(elementOrResource, fhirPath);
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+        FHIRPathNode node = evaluateToSingle(evaluator, elementOrResource, fhirPath);
         String elementName = node.name();
 
         FHIRPathTree tree = evaluator.getEvaluationContext().getTree();
@@ -955,13 +957,15 @@ public final class FHIRPathUtil {
     }
 
     /**
+     * @param evaluator
      * @param elementOrResource
      * @param fhirPath
      * @return
      * @throws FHIRPathException
      * @throws FHIRPatchException if the fhirPath does not evaluate to a single node
      */
-    private static FHIRPathNode evaluateToSingle(Visitable elementOrResource, String fhirPath) throws FHIRPathException, FHIRPatchException {
+    private static FHIRPathNode evaluateToSingle(FHIRPathEvaluator evaluator, Visitable elementOrResource, String fhirPath)
+            throws FHIRPathException, FHIRPatchException {
         /*
          * 1. The FHIRPath statement must return a single element.
          * 2. The FHIRPath statement SHALL NOT cross resources using the resolve() function
@@ -991,6 +995,7 @@ public final class FHIRPathUtil {
      */
     public static <T extends Visitable> T insert(T elementOrResource, String fhirPath, int index, Visitable value)
             throws FHIRPathException, FHIRPatchException {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         Collection<FHIRPathNode> nodes = evaluator.evaluate(elementOrResource, fhirPath);
         if (index > nodes.size()) {
             throw new FHIRPatchException("Index must be equal or less than the number of elements in the list", fhirPath);
@@ -1021,6 +1026,7 @@ public final class FHIRPathUtil {
      */
     public static <T extends Visitable> T move(T elementOrResource, String fhirPath, int source, int target)
             throws FHIRPathException, FHIRPatchException {
+        FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         Collection<FHIRPathNode> nodes = evaluator.evaluate(elementOrResource, fhirPath);
         if (source > nodes.size() || target > nodes.size()) {
             throw new FHIRPatchException("Source and target indices must be less than or equal to"

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/InsertingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/InsertingVisitor.java
@@ -26,10 +26,10 @@ class InsertingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @throws IllegalArgumentException
      */
     public InsertingVisitor(Visitable parent, String parentPath, String elementName, int index, Visitable value) {
-        this.parentPath = Objects.requireNonNull(parentPath);
-        this.elementNameToInsert = Objects.requireNonNull(elementName);
+        this.parentPath = Objects.requireNonNull(parentPath, "parentPath");
+        this.elementNameToInsert = Objects.requireNonNull(elementName, "elementName");
         this.index = index;
-        this.value = Objects.requireNonNull(value) instanceof Code ?
+        this.value = Objects.requireNonNull(value, "value") instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)value) : value;
     }
 

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/MovingVisitor.java
@@ -24,8 +24,8 @@ class MovingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @param value
      */
     public MovingVisitor(String parentPath, String elementName, int sourceIndex, int targetIndex) {
-        this.parentPath = Objects.requireNonNull(parentPath);
-        this.elementName = Objects.requireNonNull(elementName);
+        this.parentPath = Objects.requireNonNull(parentPath, "parentPath");
+        this.elementName = Objects.requireNonNull(elementName, "elementName");
         this.sourceIndex = sourceIndex;
         this.targetIndex = targetIndex;
     }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/util/ReplacingVisitor.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/util/ReplacingVisitor.java
@@ -25,8 +25,8 @@ class ReplacingVisitor<T extends Visitable> extends CopyingVisitor<T> {
      * @throws IllegalArgumentException
      */
     public ReplacingVisitor(Visitable parent, String elementName, String pathToReplace, Visitable newValue) {
-        this.pathToReplace = Objects.requireNonNull(pathToReplace);
-        this.newValue = Objects.requireNonNull(newValue) instanceof Code ?
+        this.pathToReplace = Objects.requireNonNull(pathToReplace, "pathToReplace");
+        this.newValue = Objects.requireNonNull(newValue, "newValue") instanceof Code ?
                 convertToCodeSubtype(parent, elementName, (Code)newValue) : newValue;
     }
 

--- a/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathUtilTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/patch/test/FHIRPathUtilTest.java
@@ -7,6 +7,14 @@ package com.ibm.fhir.path.patch.test;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.patch.exception.FHIRPatchException;
@@ -44,5 +52,144 @@ public class FHIRPathUtilTest {
 
         assertEquals(modifiedBundle.getEntry().get(0).getResource(), patient);
         assertEquals(modifiedBundle.getEntry().get(1).getResource(), practitioner);
+    }
+
+    @Test
+    private void testConcurrentPatches() throws FHIRPathException, FHIRPatchException, InterruptedException, ExecutionException {
+        List<Callable<Bundle>> concurrentUpdates = new ArrayList<>();
+        int maxThreads = 12;
+        ExecutorService executor = Executors.newFixedThreadPool(maxThreads);
+
+        // 1. Execute a set of adds in parallel.
+        Entry addEntry = Entry.builder().fullUrl(Uri.of("add")).build();
+        for (int i = 0; i < maxThreads; i++) {
+            concurrentUpdates.add(new Add(bundle, addEntry));
+        }
+        List<Future<Bundle>> futureResults = executor.invokeAll(concurrentUpdates);
+        for (Future<Bundle> future : futureResults) {
+            assertEquals(future.get().getEntry().size(), 1, "Each bundle should have 1 entry.");
+        }
+
+
+        // 2. Execute a set of inserts in parallel.
+        concurrentUpdates = new ArrayList<>();
+        Entry insertEntry = Entry.builder().fullUrl(Uri.of("insert")).build();
+
+        for (Future<Bundle> future : futureResults) {
+            concurrentUpdates.add(new Insert(future.get(), insertEntry));
+        }
+        futureResults = executor.invokeAll(concurrentUpdates);
+        for (Future<Bundle> future : futureResults) {
+            assertEquals(future.get().getEntry().size(), 2, "Each bundle should have 2 entries.");
+        }
+
+
+        // 3. Execute a set of replacements in parallel.
+        concurrentUpdates = new ArrayList<>();
+        Entry replaceEntry = Entry.builder().fullUrl(Uri.of("replace")).build();
+
+        for (Future<Bundle> future : futureResults) {
+            concurrentUpdates.add(new Replace(future.get(), replaceEntry));
+        }
+        futureResults = executor.invokeAll(concurrentUpdates);
+        for (Future<Bundle> future : futureResults) {
+            assertEquals(future.get().getEntry().size(), 2, "Each bundle should have 2 entries.");
+        }
+
+
+        // 4. Execute a set of moves in parallel.
+        concurrentUpdates = new ArrayList<>();
+
+        for (Future<Bundle> future : futureResults) {
+            concurrentUpdates.add(new Move(future.get()));
+        }
+        futureResults = executor.invokeAll(concurrentUpdates);
+        for (Future<Bundle> future : futureResults) {
+            assertEquals(future.get().getEntry().size(), 2, "Each bundle should have 2 entries.");
+        }
+
+
+        // 5. Execute a set of deletes in parallel.
+        concurrentUpdates = new ArrayList<>();
+
+        for (Future<Bundle> future : futureResults) {
+            concurrentUpdates.add(new Delete(future.get()));
+        }
+        futureResults = executor.invokeAll(concurrentUpdates);
+        assertEquals(futureResults.size(), maxThreads);
+        for (Future<Bundle> future : futureResults) {
+            assertEquals(future.get().getEntry().size(), 1, "Each bundle should have 1 entry.");
+        }
+    }
+
+    private class Add implements Callable<Bundle> {
+        private Bundle bundle;
+        private Entry entry;
+
+        Add(Bundle bundle, Entry entry) {
+            this.bundle = bundle;
+            this.entry = entry;
+        }
+
+        @Override
+        public Bundle call() throws Exception {
+            return FHIRPathUtil.add(bundle, "Bundle", "entry", entry);
+        }
+    }
+
+    private class Insert implements Callable<Bundle> {
+        private Bundle bundle;
+        private Entry entry;
+
+        Insert(Bundle bundle, Entry entry) {
+            this.bundle = bundle;
+            this.entry = entry;
+        }
+
+        @Override
+        public Bundle call() throws Exception {
+            return FHIRPathUtil.insert(bundle, "Bundle.entry", 0, entry);
+        }
+    }
+
+    private class Replace implements Callable<Bundle> {
+        private Bundle bundle;
+        private Entry entry;
+
+        Replace(Bundle bundle, Entry entry) {
+            this.bundle = bundle;
+            this.entry = entry;
+        }
+
+        @Override
+        public Bundle call() throws Exception {
+            return FHIRPathUtil.replace(bundle, "Bundle.entry[0]", entry);
+        }
+    }
+
+    private class Move implements Callable<Bundle> {
+        private Bundle bundle;
+
+        Move(Bundle bundle) {
+            this.bundle = bundle;
+        }
+
+        @Override
+        public Bundle call() throws Exception {
+            return FHIRPathUtil.move(bundle, "Bundle.entry", 0, 1);
+        }
+    }
+
+    private class Delete implements Callable<Bundle> {
+        private Bundle bundle;
+
+        Delete(Bundle bundle) {
+            this.bundle = bundle;
+        }
+
+        @Override
+        public Bundle call() throws Exception {
+            return FHIRPathUtil.delete(bundle, "Bundle.entry[0]");
+        }
     }
 }

--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -51,6 +51,8 @@ import net.jcip.annotations.NotThreadSafe;
 /**
  * A validator that uses conformance resources from the {@link com.ibm.fhir.registry.FHIRRegistry}
  * to validate resource instances against the base specification and, optionally, extended profiles.
+ *
+ * The static factory method {@link #validator()} is threadsafe, but the created instances are not.
  */
 @NotThreadSafe
 public class FHIRValidator {

--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -46,6 +46,13 @@ import com.ibm.fhir.profile.ProfileSupport;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.validation.exception.FHIRValidationException;
 
+import net.jcip.annotations.NotThreadSafe;
+
+/**
+ * A validator that uses conformance resources from the {@link com.ibm.fhir.registry.FHIRRegistry}
+ * to validate resource instances against the base specification and, optionally, extended profiles.
+ */
+@NotThreadSafe
 public class FHIRValidator {
     private static final Logger log = Logger.getLogger(FHIRValidator.class.getName());
 


### PR DESCRIPTION
FHIRPathUtil was using a shared static FHIRPathEvaluator but this is not
thread-safe. Now we construct a new evaluator for each request.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>