### PR TITLE
Issue #2516, #2518 - FHIRPath updates

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/ConformsToFunction.java
@@ -88,7 +88,6 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
                 return SINGLETON_TRUE;
             }
 
-
             if (!ProfileSupport.isApplicable(structureDefinition, modelClass)) {
                 // the profile (or base definition) is not applicable to type: modelClass
                 generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.INVALID, "Conformance check failed: profile (or base definition) '" + url + "' is not applicable to type: " + ModelSupport.getTypeName(modelClass), node.path());
@@ -100,13 +99,35 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
                 return SINGLETON_TRUE;
             }
 
-            if (node.isResourceNode() && evaluationContext.hasConstraint() &&
-                    ProfileSupport.hasResourceAssertedProfile(node.asResourceNode().resource(), structureDefinition)) {
+            if (hasCachedFunctionResult(evaluationContext, context, arguments)) {
+                Collection<FHIRPathNode> result = getCachedFunctionResult(evaluationContext, context, arguments);
+
+                if (result.isEmpty()) {
+                    log.finest("Non-empty (boolean) function result computation is in progress");
+
+                    // non-empty (boolean) function result computation is in progress
+                    return SINGLETON_TRUE;
+                }
+
+                if (log.isLoggable(Level.FINEST)) {
+                    log.finest("Cached non-empty (boolean) function result: " + result);
+                }
+
+                // return cached non-empty (boolean) function result
+                return result;
+            }
+
+            // cache empty function result to indicate that non-empty (boolean) function result computation is in progress
+            cacheFunctionResult(evaluationContext, context, arguments, empty());
+
+            if (node.isResourceNode() && evaluationContext.hasConstraint() && ProfileSupport.hasResourceAssertedProfile(node.asResourceNode().resource(), structureDefinition)) {
                 // optimization
                 if (log.isLoggable(Level.FINEST)) {
                     log.finest("Skipping constraint evaluation for profile '" + url + "'");
                 }
-                return SINGLETON_TRUE;
+
+                // cache and return non-empty (boolean) function result
+                return cacheFunctionResult(evaluationContext, context, arguments, SINGLETON_TRUE);
             }
 
             // save parent constraint reference
@@ -130,7 +151,8 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
                         // restore parent constraint reference
                         evaluationContext.setConstraint(parentConstraint);
 
-                        return SINGLETON_FALSE;
+                        // cache and return non-empty (boolean) function result
+                        return cacheFunctionResult(evaluationContext, context, arguments, SINGLETON_FALSE);
                     }
                 } catch (FHIRPathException e) {
                     log.log(Level.WARNING, "An unexpected error occurred while evaluating the following expression: " + constraint.expression(), e);
@@ -144,6 +166,7 @@ public class ConformsToFunction extends FHIRPathAbstractFunction {
             generateIssue(evaluationContext, IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, "Conformance check was not performed: profile (or base definition) '" + url + "' is not supported", node.path());
         }
 
-        return SINGLETON_TRUE;
+        // cache and return non-empty (boolean) function result
+        return cacheFunctionResult(evaluationContext, context, arguments, SINGLETON_TRUE);
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/FHIRPathAbstractFunction.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -67,5 +67,18 @@ public abstract class FHIRPathAbstractFunction implements FHIRPathFunction {
     @Override
     public int hashCode() {
         return Objects.hash(getName(), getMinArity(), getMaxArity());
+    }
+
+    protected Collection<FHIRPathNode> getCachedFunctionResult(EvaluationContext evaluationContext, Collection<FHIRPathNode> context, List<Collection<FHIRPathNode>> arguments) {
+        return evaluationContext.getCachedFunctionResult(getName(), context, arguments);
+    }
+
+    protected Collection<FHIRPathNode> cacheFunctionResult(EvaluationContext evaluationContext, Collection<FHIRPathNode> context, List<Collection<FHIRPathNode>> arguments, Collection<FHIRPathNode> result) {
+        evaluationContext.cacheFunctionResult(getName(), context, arguments, result);
+        return result;
+    }
+
+    protected boolean hasCachedFunctionResult(EvaluationContext evaluationContext, Collection<FHIRPathNode> context, List<Collection<FHIRPathNode>> arguments) {
+        return evaluationContext.hasCachedFunctionResult(getName(), context, arguments);
     }
 }

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/ResolveInternalFragmentReferenceTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/ResolveInternalFragmentReferenceTest.java
@@ -1,0 +1,67 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.path.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.path.evaluator.FHIRPathEvaluator.SINGLETON_TRUE;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collection;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
+import com.ibm.fhir.model.resource.Bundle.Entry.Request;
+import com.ibm.fhir.model.resource.HealthcareService;
+import com.ibm.fhir.model.resource.Organization;
+import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.BundleType;
+import com.ibm.fhir.model.type.code.HTTPVerb;
+import com.ibm.fhir.path.FHIRPathNode;
+import com.ibm.fhir.path.FHIRPathResourceNode;
+import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
+import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
+
+public class ResolveInternalFragmentReferenceTest {
+    @Test
+    public void testResolveInternalFragmentReference() throws Exception {
+        Bundle bundle = Bundle.builder()
+                .type(BundleType.TRANSACTION)
+                .entry(Entry.builder()
+                    .resource(Organization.builder()
+                        .id("1")
+                        .name(string("Test Organization"))
+                        .contained(HealthcareService.builder()
+                            .providedBy(Reference.builder()
+                                .reference(string("#"))
+                                .build())
+                            .build(),
+                            Organization.builder()
+                                .id("parentOrg")
+                                .name(string("Parent Organization"))
+                            .build())
+                        .partOf(Reference.builder()
+                            .reference(string("#parentOrg"))
+                            .build())
+                        .build())
+                    .request(Request.builder()
+                        .method(HTTPVerb.PUT)
+                        .url(Uri.of("Organization/1"))
+                        .build())
+                    .build())
+                .build();
+
+        EvaluationContext evaluationContext = new EvaluationContext(bundle);
+        FHIRPathResourceNode resourceNode = evaluationContext.getTree().getNode("Bundle.entry[0].resource.contained[0]").asResourceNode();
+
+        Collection<FHIRPathNode> result = FHIRPathEvaluator.evaluator().evaluate(evaluationContext, "providedBy.exists() and providedBy.resolve().partOf.resolve().is(Organization)", resourceNode);
+
+        assertEquals(result, SINGLETON_TRUE);
+    }
+}

--- a/fhir-registry/src/main/java/com/ibm/fhir/registry/util/FHIRRegistryResourceProviderAdapter.java
+++ b/fhir-registry/src/main/java/com/ibm/fhir/registry/util/FHIRRegistryResourceProviderAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.registry.util;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.registry.resource.FHIRRegistryResource;
+import com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider;
+
+public class FHIRRegistryResourceProviderAdapter implements FHIRRegistryResourceProvider {
+    @Override
+    public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
+        return null;
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getProfileResources(String type) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<FHIRRegistryResource> getSearchParameterResources(String type) {
+        return Collections.emptyList();
+    }
+}

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ConformsToLoopTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/ConformsToLoopTest.java
@@ -1,0 +1,166 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.validation.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.countErrors;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.hasErrors;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.resource.Organization;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.StructureDefinition;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.type.ElementDefinition;
+import com.ibm.fhir.model.type.ElementDefinition.Constraint;
+import com.ibm.fhir.model.type.Id;
+import com.ibm.fhir.model.type.Meta;
+import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.ConstraintSeverity;
+import com.ibm.fhir.model.type.code.TypeDerivationRule;
+import com.ibm.fhir.path.function.ConformsToFunction;
+import com.ibm.fhir.registry.FHIRRegistry;
+import com.ibm.fhir.registry.resource.FHIRRegistryResource;
+import com.ibm.fhir.registry.util.FHIRRegistryResourceProviderAdapter;
+import com.ibm.fhir.validation.FHIRValidator;
+
+public class ConformsToLoopTest {
+    @BeforeClass
+    public void beforeClass() throws Exception {
+        configureLogging();
+
+        StructureDefinition structureDefinition = FHIRRegistry.getInstance().getResource("http://hl7.org/fhir/StructureDefinition/Organization", StructureDefinition.class);
+
+        List<ElementDefinition> element = new ArrayList<>(structureDefinition.getSnapshot().getElement());
+        element.set(indexOf(structureDefinition, "Organization"), addConstraints(getElementDefinition(structureDefinition, "Organization"),
+            Constraint.builder()
+                .key(Id.of("test-1"))
+                .severity(ConstraintSeverity.ERROR)
+                .human(string("The organization SHALL conform to the TestOrganization profile"))
+                .expression(string("conformsTo('http://ibm.com/fhir/StructureDefinition/TestOrganization')"))
+                .source(Canonical.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+                .build(),
+            Constraint.builder()
+                .key(Id.of("test-2"))
+                .severity(ConstraintSeverity.ERROR)
+                .human(string("The organization name length SHALL be greater than 9 characters"))
+                .expression(string("name.length() > 9"))
+                .source(Canonical.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+                .build()));
+        element.set(indexOf(structureDefinition, "Organization.partOf"), addConstraints(getElementDefinition(structureDefinition, "Organization.partOf"), Constraint.builder()
+            .key(Id.of("test-3"))
+            .human(string("The partOf reference SHALL resolve to an organization that conforms the TestOrganization profile"))
+            .expression(string("resolve().conformsTo('http://ibm.com/fhir/StructureDefinition/TestOrganization')"))
+            .source(Canonical.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+            .severity(ConstraintSeverity.ERROR)
+            .build()));
+
+        StructureDefinition profile = structureDefinition.toBuilder()
+            .url(Uri.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+            .baseDefinition(Canonical.of("http://hl7.org/fhir/StructureDefinition/Organization"))
+            .derivation(TypeDerivationRule.CONSTRAINT)
+            .snapshot(structureDefinition.getSnapshot().toBuilder()
+                .element(element)
+                .build())
+            .build();
+
+        FHIRRegistry.getInstance().addProvider(new FHIRRegistryResourceProviderAdapter() {
+            @Override
+            public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
+                if ("http://ibm.com/fhir/StructureDefinition/TestOrganization".equals(url)) {
+                    return FHIRRegistryResource.from(profile);
+                }
+                return null;
+            }
+        });
+    }
+
+    @Test
+    public void testConformsToLoop1() throws Exception {
+        Organization organization = Organization.builder()
+            .name(string("Test Organization"))
+            .contained(Organization.builder()
+                .meta(Meta.builder()
+                    .profile(Canonical.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+                    .build())
+                .name(string("Child Test Organization"))
+                .partOf(Reference.builder()
+                    .reference(string("#"))
+                    .build())
+                .build())
+            .build();
+        List<Issue> issues = FHIRValidator.validator().validate(organization, true, "http://ibm.com/fhir/StructureDefinition/TestOrganization");
+        assertFalse(hasErrors(issues));
+    }
+
+    @Test
+    public void testConformsToLoop2() throws Exception {
+        Organization organization = Organization.builder()
+            .name(string("Test Organization"))
+            .contained(Organization.builder()
+                .meta(Meta.builder()
+                    .profile(Canonical.of("http://ibm.com/fhir/StructureDefinition/TestOrganization"))
+                    .build())
+                .name(string("invalid"))
+                .partOf(Reference.builder()
+                    .reference(string("#"))
+                    .build())
+                .build())
+            .build();
+        List<Issue> issues = FHIRValidator.validator().validate(organization, true, "http://ibm.com/fhir/StructureDefinition/TestOrganization");
+        assertTrue(hasErrors(issues));
+        assertEquals(countErrors(issues), 1);
+    }
+
+    private ElementDefinition addConstraints(ElementDefinition elementDefinition, Constraint... constraints) {
+        return elementDefinition.toBuilder()
+            .constraint(elementDefinition.getConstraint())
+            .constraint(constraints)
+            .build();
+    }
+
+    private void configureLogging() {
+        Logger logger = Logger.getLogger(ConformsToFunction.class.getName());
+        logger.setLevel(Level.FINEST);
+        Handler handler = new ConsoleHandler();
+        handler.setLevel(Level.FINEST);
+        logger.addHandler(handler);
+    }
+
+    private ElementDefinition getElementDefinition(StructureDefinition structureDefinition, String path) {
+        for (ElementDefinition elementDefinition : structureDefinition.getSnapshot().getElement()) {
+            if (elementDefinition.getPath().getValue().equals(path)) {
+                return elementDefinition;
+            }
+        }
+        return null;
+    }
+
+    private int indexOf(StructureDefinition structureDefinition, String path) {
+        for (int i = 0; i < structureDefinition.getSnapshot().getElement().size(); i++) {
+            ElementDefinition elementDefinition = structureDefinition.getSnapshot().getElement().get(i);
+            if (elementDefinition.getPath().getValue().equals(path)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
1. update ResolveFunction.resolveInternalFragmentReference 
2. introduce function result caching in evaluation context

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>