### PR TITLE
Per Testing with Azure Provider and Fix Skippable Logic

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -289,7 +289,7 @@ public class ChunkWriter extends AbstractItemWriter {
      */
     public OperationOutcome conditionalFingerprintUpdate(ImportTransientUserData chunkData, boolean skip, Map<String, SaltHash> localCache, FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, Resource resource) throws FHIRPersistenceException {
         OperationOutcome oo;
-        if (!skip) {
+        if (skip) {
             // Key is scoped to the ResourceType.
             String key = resourceType + "/" + logicalId;
             SaltHash oldBaseLine = localCache.get(key);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
@@ -359,7 +359,7 @@ public class AzureProvider implements Provider {
             line = reader.readLine();
 
             try (ByteArrayInputStream bais = new ByteArrayInputStream(compLine.getBytes())) {
-                LOG.fine(() -> "Azure Resource [R] " + compLine);
+                LOG.finer(() -> "Azure Resource [R] " + compLine);
                 resources.add(FHIRParser.parser(Format.JSON).parse(bais));
             } catch (FHIRParserException fpe) {
                 // We're on the last line, so there might be more

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
@@ -9,15 +9,14 @@ package com.ibm.fhir.bulkdata.provider.impl;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobClientBuilder;
@@ -35,6 +34,7 @@ import com.ibm.fhir.bulkdata.provider.Provider;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.OperationOutcome;
@@ -140,6 +140,10 @@ public class AzureProvider implements Provider {
         try {
             initializeBlobClient(workItem);
             long size = client.getProperties().getBlobSize();
+            // Only null when we are using the AzureTransformer
+            if (transientUserData != null) {
+                transientUserData.setImportFileSize(size);
+            }
             LOG.fine(() -> workItem + " [" + size + "]");
             return size;
         } catch (Exception e) {
@@ -181,8 +185,25 @@ public class AzureProvider implements Provider {
         if (!client.exists().booleanValue()) {
             aClient.create();
         }
+
+        byte[] payload = new byte[4194303];
+        int len = in.read(payload, 0, 4194303);
+        while (len != -1) {
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Start Loop with '" + len + "'");
+            }
+            byte[] tmpPayload = payload;
+            if (len < 4194303) {
+                tmpPayload = Arrays.copyOfRange(payload, 0, len);
+            }
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(tmpPayload)) {
+                aClient.appendBlock(bais, len);
+            }
+            len = in.read(payload, 0, 4194303);
+        }
+        LOG.fine(() -> "Finished Loop");
+
         // Append a new line.
-        aClient.appendBlock(in, size);
         try (ByteArrayInputStream bais = new ByteArrayInputStream(NEWLINE)) {
             aClient.appendBlock(bais, NEWLINE.length);
         }
@@ -190,7 +211,7 @@ public class AzureProvider implements Provider {
 
     @Override
     public void writeResources(String mediaType, List<ReadResultDTO> dtos) throws Exception {
-        String workItem = cosBucketPathPrefix + "/" + fhirResourceType + "_" + chunkData.getUploadCount() + ".ndjson";
+        workItem = cosBucketPathPrefix + "/" + fhirResourceType + "_" + chunkData.getUploadCount() + ".ndjson";
 
         initializeBlobClient(workItem);
 
@@ -198,9 +219,28 @@ public class AzureProvider implements Provider {
         if (!client.exists().booleanValue()) {
             aClient.create();
         }
-        aClient.appendBlock(
-            new ByteArrayInputStream(chunkData.getBufferStream().toByteArray()),
-                chunkData.getBufferStream().size());
+
+        byte[] baos = chunkData.getBufferStream().toByteArray();
+        int current = 0;
+        for (int i = 0; i <= (Math.ceil(baos.length/4194303)); i++) {
+            int payloadLength = 4194303;
+            if (payloadLength + current > baos.length) {
+                payloadLength = baos.length - current;
+            }
+            byte[] payload = new byte[payloadLength];
+            for (int j = 0; j < payloadLength; j++) {
+                payload[j] = baos[current];
+                current++;
+            }
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Byte Progress: current='" + current + "' total='" + baos.length + "' payload='" + payload.length);
+            }
+            aClient.appendBlock(
+                new ByteArrayInputStream(payload),
+                    payload.length);
+        }
+
+        LOG.fine(() -> "Export Write is finished");
 
         chunkData.getBufferStream().reset();
 
@@ -230,75 +270,137 @@ public class AzureProvider implements Provider {
         }
     }
 
-    /*
-     * We process the BlobRange as a window
-     */
     @Override
     public void readResources(long numOfLinesToSkip, String workItem) throws FHIRException {
+        resources = new ArrayList<>();
         initializeBlobClient(workItem);
         this.workItem = workItem;
 
         boolean complete = false;
         int window = 0;
 
-        // 200 means 2000M! has been retrieved, our maximum single resource size.
+        // We process the BlobRange as a window of 100K up to 20000 windows.
+        // 20000 windows X 100K means 2000M! has been retrieved, our maximum single resource size.
+        // We increment the window after the processing of the current BlobRange.
         StringBuilder previous = new StringBuilder();
-        while (!complete && window < 200) {
+        while (!complete && window < 20000) {
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Window [" + window + "]");
+            }
+            // Figure out the range that is needed
+            long actualRange = 100000L;
+            boolean endOfFile = (currentBytes + actualRange) > this.transientUserData.getImportFileSize();
+            if (endOfFile) {
+                actualRange = this.transientUserData.getImportFileSize() - currentBytes;
+                LOG.fine(() -> "Hit the end of the file size='" + this.transientUserData.getImportFileSize() + "' rest='" + (this.transientUserData.getImportFileSize() - currentBytes) + "' currentBytes='" + currentBytes + "'");
+                if (actualRange == 0) {
+                    break;
+                }
+            }
+
+            // Assemble the BlobRequestConditions and BlobRange
             BlobRequestConditions options = new BlobRequestConditions();
-            BlobRange range = new BlobRange(currentBytes, 10000L);
+            BlobRange range = new BlobRange(currentBytes, actualRange);
+
             // Now we need to calculate where we left off in the download, and adjust the resume point.
             try (InputStream in = client.openInputStream(range, options);
                     CountInputStreamReader counter = new CountInputStreamReader(in);
                     BufferedReader reader = new BufferedReader(counter)) {
-
-                List<String> lines = reader.lines().collect(Collectors.toList());
-                int idx = 1;
-                for (String line : lines) {
-                    idx++;
-                    String compLine = previous + line;
-
-                    try (ByteArrayInputStream bais = new ByteArrayInputStream(compLine.getBytes())) {
-                        resources.add(FHIRParser.parser(Format.JSON).parse(bais));
-                        if (LOG.isLoggable(Level.FINE)) {
-                            LOG.fine("Azure Resource [R] " + compLine);
-                        }
-                        // There is no reason to reset compLine as we're now stopping this proccessing block.
-                        // previous, baos are all going to go out of scope.
-                        if (window > 0) {
-                            // Doesn't need to be closed per JavaDocs
-                            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                            baos.write(line.getBytes());
-                            currentBytes += baos.size();
-                            complete = true;
-                            break;
-                        }
-                    } catch(FHIRParserException fpe) {
-                        // We're on the last line, so there might be more
-                        if (idx -1 == lines.size()) {
-                            previous.append(line);
-                        } else {
-                            parseFailures++;
-                            OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue("Failed to Process " + this.transientUserData.getNumOfProcessedResources() + idx, IssueType.EXCEPTION);
-                            OperationOutcome oo = OperationOutcome.builder().issue(ooi).build();
-                            FHIRGenerator.generator(Format.JSON).generate(oo, this.transientUserData.getBufferStreamForImportError());
-                            this.transientUserData.getBufferStreamForImportError().write("\r\n".getBytes());
-                        }
-                    }
-                }
-                if (!complete) {
-                    currentBytes += counter.getLength();
-                    window++;
-                }
-
-                // Set so we can move the window forward.
-                this.transientUserData.setCurrentBytes(currentBytes);
+                complete = processLines(counter, reader, window, endOfFile, previous);
                 LOG.fine(() -> "Number of bytes read are: '" + currentBytes + "'");
             } catch (IOException e) {
                 LOG.throwing("AzureProvider", "readResources", e);
                 LOG.severe("Problem accessing backend on Azure" + e.getMessage());
                 throw new FHIRException("Problem accessing backend Container or Blob on Azure", e);
             }
+
+            // No more processing when we are at the end of the file
+            if (endOfFile) {
+                transientUserData.setCurrentBytes(this.transientUserData.getImportFileSize());
+                break;
+            }
+
+            window++;
         }
+    }
+
+    /**
+     * processes the lines in the ndjson file.
+     * @param counter
+     * @param reader
+     * @param window
+     * @param endOfFile
+     * @param previous
+     * @return
+     * @throws FHIRGeneratorException
+     * @throws IOException
+     */
+    public boolean processLines(CountInputStreamReader counter, BufferedReader reader, int window, boolean endOfFile, StringBuilder previous) throws FHIRGeneratorException, IOException {
+        boolean complete = false;
+        int idx = 0;
+
+        String tmpLine = "";
+
+        String line = reader.readLine();
+        while (line != null) {
+            idx++;
+            // Only when we're on the first line do we want to prefix it
+            String compLine;
+
+            if (idx == 1) {
+                compLine = previous + line;
+            } else {
+                compLine = line;
+            }
+
+            tmpLine = line;
+            line = reader.readLine();
+
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(compLine.getBytes())) {
+                LOG.fine(() -> "Azure Resource [R] " + compLine);
+                resources.add(FHIRParser.parser(Format.JSON).parse(bais));
+            } catch (FHIRParserException fpe) {
+                // We're on the last line, so there might be more
+                // We may need to combine multiple windows retrieved from the source (up to 2GB)
+                if (line == null) {
+                    if (LOG.isLoggable(Level.FINE)) {
+                        LOG.fine("Azure Resource [PARTIAL] '" + tmpLine + "' Previous: '" + previous + "'");
+                    }
+                    previous.append(tmpLine);
+                } else {
+                    addParseFailure(idx);
+                }
+            }
+        }
+
+        if (window > 0 && idx != 1 && currentBytes < transientUserData.getImportFileSize()) {
+            // Important here, we're on the Nth window, and need to look back to find the last unparsed
+            // and subtract it
+            complete = true;
+            currentBytes += counter.getLength() - tmpLine.getBytes().length;
+        } else {
+            currentBytes += counter.getLength();
+        }
+
+        // Set so we can move the window forward.
+        transientUserData.setCurrentBytes(currentBytes);
+        return complete || endOfFile;
+    }
+
+    /**
+     * logs the parse failures.
+     *
+     * @param idx
+     * @throws FHIRGeneratorException
+     * @throws IOException
+     */
+    public void addParseFailure(int idx) throws FHIRGeneratorException, IOException {
+        parseFailures++;
+        OperationOutcome.Issue ooi = FHIRUtil.buildOperationOutcomeIssue("Failed to Process "
+                + this.transientUserData.getNumOfProcessedResources() + idx, IssueType.EXCEPTION);
+        OperationOutcome oo = OperationOutcome.builder().issue(ooi).build();
+        FHIRGenerator.generator(Format.JSON).generate(oo, this.transientUserData.getBufferStreamForImportError());
+        this.transientUserData.getBufferStreamForImportError().write("\r\n".getBytes());
     }
 
     /**
@@ -386,7 +488,6 @@ public class AzureProvider implements Provider {
 
         this.cosBucketPathPrefix = cosBucketPathPrefix;
         this.fhirResourceType = fhirResourceType;
-
         this.chunkData = transientUserData;
     }
 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/AzurePreflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/AzurePreflight.java
@@ -1,0 +1,68 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.operation.bulkdata.config.preflight.impl;
+
+import java.util.List;
+
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.operation.bulkdata.OperationConstants;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
+import com.ibm.fhir.operation.bulkdata.model.type.Input;
+import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
+import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
+import com.ibm.fhir.operation.bulkdata.util.BulkDataExportUtil;
+
+/**
+ * Verifies the Export/Import is valid for Azure
+ */
+public class AzurePreflight extends NopPreflight {
+    private static final BulkDataExportUtil export = new BulkDataExportUtil();
+
+    public AzurePreflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType, String format) {
+        super(source, outcome, inputs, exportType, format);
+    }
+
+    @Override
+    public void preflight() throws FHIROperationException {
+        super.preflight();
+        validate(getSource());
+        validate(getOutcome());
+    }
+
+
+    /**
+     * validates the azure provider is properly configured.
+     *
+     * @param source
+     * @throws FHIROperationException
+     */
+    public void validate(String source) throws FHIROperationException {
+        ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
+        if (adapter.isStorageProviderAuthTypeConnectionString(source)) {
+            String conn = adapter.getStorageProviderAuthTypeConnectionString(source);
+            if (conn == null || conn.isEmpty()) {
+                throw export.buildOperationException("bad configuration for the Azure Blob Container's connection configuration", IssueType.EXCEPTION);
+            }
+        } else {
+            throw export.buildOperationException("Failed to specify the source or outcome container's authentication mechanism", IssueType.EXCEPTION);
+        }
+
+        // Used to get the Azure Container
+        if (adapter.getStorageProviderBucketName(source) == null || adapter.getStorageProviderBucketName(source).isEmpty()) {
+            throw export.buildOperationException("bad configuration for the basic configuration with bucketname", IssueType.EXCEPTION);
+        }
+    }
+
+    @Override
+    public void checkStorageAllowed(StorageDetail storageDetail) throws FHIROperationException {
+        if (storageDetail != null && !StorageType.AZURE.value().equals(storageDetail.getType())){
+            throw util.buildExceptionWithIssue("Azure: Configuration not set to import from storageDetail '" + getSource() + "'", IssueType.INVALID);
+        }
+    }
+}


### PR DESCRIPTION
- Increase the BlobRange size for Read Speed
- Add Preflight Checks for Azure
- Improve handling of the edge of an $Import read window for Azure Blobs
- Add AzureProviderMain tests for driving tests from local

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>