### PR TITLE
issue #2550 - add default system for `|<code>` searches

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/JDBCConstants.java
@@ -115,9 +115,6 @@ public class JDBCConstants {
     // Db2 optimization hints
     public static final String SEARCH_REOPT = "search.reopt";
 
-    // Default code_system_id value
-    public static final String DEFAULT_TOKEN_SYSTEM = "default-token-system";
-
     /**
      * Calendar object to use while inserting Timestamp objects into the database.
      */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterDAOImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterDAOImpl.java
@@ -14,8 +14,8 @@ import java.util.logging.Logger;
 
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 import com.ibm.fhir.persistence.jdbc.connection.FHIRDbFlavor;
 import com.ibm.fhir.persistence.jdbc.dao.api.CodeSystemDAO;
 import com.ibm.fhir.persistence.jdbc.dao.api.ParameterDAO;
@@ -318,7 +318,7 @@ public class ParameterDAOImpl extends FHIRDbDAOImpl implements ParameterDAO {
 
         try {
             if (myCodeSystemName == null || myCodeSystemName.isEmpty()) {
-                myCodeSystemName = JDBCConstants.DEFAULT_TOKEN_SYSTEM;
+                myCodeSystemName = FHIRConstants.DEFAULT_TOKEN_SYSTEM;
             }
             codeSystemId = getCodeSystemIdFromCaches(myCodeSystemName);
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/ParameterVisitorBatchDAO.java
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 import com.ibm.fhir.persistence.jdbc.dao.api.IResourceReferenceDAO;
 import com.ibm.fhir.persistence.jdbc.dao.api.JDBCIdentityCache;
 import com.ibm.fhir.persistence.jdbc.dto.CompositeParmVal;
@@ -624,7 +624,7 @@ public class ParameterVisitorBatchDAO implements ExtractedParameterValueVisitor,
             rec = new ResourceTokenValueRec(parameterNameId, resourceType, resourceTypeId, logicalResourceId, refResourceType, refLogicalId, refVersion, this.currentCompositeId, isSystemParam);
         } else {
             // stored as a token with the default system
-            rec = new ResourceTokenValueRec(parameterNameId, resourceType, resourceTypeId, logicalResourceId, JDBCConstants.DEFAULT_TOKEN_SYSTEM, refLogicalId, this.currentCompositeId, isSystemParam);
+            rec = new ResourceTokenValueRec(parameterNameId, resourceType, resourceTypeId, logicalResourceId, FHIRConstants.DEFAULT_TOKEN_SYSTEM, refLogicalId, this.currentCompositeId, isSystemParam);
         }
 
         if (this.transactionData != null) {

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/QuantityParmVal.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/QuantityParmVal.java
@@ -8,8 +8,8 @@ package com.ibm.fhir.persistence.jdbc.dto;
 
 import java.math.BigDecimal;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 
 /**
  * This class defines the Data Transfer Object representing a row in the X_QUANTITY_VALUES tables.
@@ -51,7 +51,7 @@ public class QuantityParmVal implements ExtractedParameterValue {
 
     public String getValueSystem() {
         if (valueSystem == null) {
-            return JDBCConstants.DEFAULT_TOKEN_SYSTEM;
+            return FHIRConstants.DEFAULT_TOKEN_SYSTEM;
         }
         return valueSystem;
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/TokenParmVal.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/TokenParmVal.java
@@ -1,13 +1,13 @@
 /*
- * (C) Copyright IBM Corp. 2017,2021
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.persistence.jdbc.dto;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 
 /**
  * This class defines the Data Transfer Object representing a row in the X_TOKEN_VALUES tables.
@@ -32,17 +32,19 @@ public class TokenParmVal implements ExtractedParameterValue {
         return getResourceType() + "[" + getName() + ", " + getValueSystem() + ", " + getValueCode() + "]";
     }
 
+    @Override
     public void setName(String name) {
         this.name = name;
     }
 
+    @Override
     public String getName() {
         return name;
     }
 
     public String getValueSystem() {
         if (valueSystem == null) {
-            return JDBCConstants.DEFAULT_TOKEN_SYSTEM;
+            return FHIRConstants.DEFAULT_TOKEN_SYSTEM;
         }
         return valueSystem;
     }
@@ -59,10 +61,12 @@ public class TokenParmVal implements ExtractedParameterValue {
         this.valueCode = valueCode;
     }
 
+    @Override
     public String getResourceType() {
         return resourceType;
     }
 
+    @Override
     public void setResourceType(String resourceType) {
         this.resourceType = resourceType;
     }
@@ -70,6 +74,7 @@ public class TokenParmVal implements ExtractedParameterValue {
     /**
      * We know our type, so we can call the correct method on the visitor
      */
+    @Override
     public void accept(ExtractedParameterValueVisitor visitor) throws FHIRPersistenceException {
         visitor.visit(this);
     }
@@ -77,6 +82,7 @@ public class TokenParmVal implements ExtractedParameterValue {
     /**
      * @return the base
      */
+    @Override
     public String getBase() {
         return base;
     }
@@ -84,6 +90,7 @@ public class TokenParmVal implements ExtractedParameterValue {
     /**
      * @param base the base to set
      */
+    @Override
     public void setBase(String base) {
         this.base = base;
     }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterExtractionTest.java
@@ -23,6 +23,7 @@ import java.util.TimeZone;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.model.type.Address;
 import com.ibm.fhir.model.type.Age;
@@ -56,7 +57,6 @@ import com.ibm.fhir.model.type.code.PublicationStatus;
 import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.type.code.SearchParamType;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceProcessorException;
-import com.ibm.fhir.persistence.jdbc.JDBCConstants;
 import com.ibm.fhir.persistence.jdbc.dto.CompositeParmVal;
 import com.ibm.fhir.persistence.jdbc.dto.DateParmVal;
 import com.ibm.fhir.persistence.jdbc.dto.ExtractedParameterValue;
@@ -385,7 +385,7 @@ public class ParameterExtractionTest {
         assertEquals(((TokenParmVal) params.get(0)).getValueSystem(), SAMPLE_URI);
         assertEquals(((TokenParmVal) params.get(1)).getName(), SEARCH_PARAM_CODE_VALUE + SearchConstants.TEXT_MODIFIER_SUFFIX);
         assertEquals(((TokenParmVal) params.get(1)).getValueCode(), SAMPLE_NORMALIZED_TEXT_STRING + "a");
-        assertEquals(((TokenParmVal) params.get(1)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((TokenParmVal) params.get(1)).getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(((TokenParmVal) params.get(2)).getName(), SEARCH_PARAM_CODE_VALUE);
         assertEquals(((TokenParmVal) params.get(2)).getValueCode(), "b");
         assertEquals(((TokenParmVal) params.get(2)).getValueSystem(), SAMPLE_URI);
@@ -394,10 +394,10 @@ public class ParameterExtractionTest {
         assertEquals(((TokenParmVal) params.get(3)).getValueSystem(), SAMPLE_URI);
         assertEquals(((TokenParmVal) params.get(4)).getName(), SEARCH_PARAM_CODE_VALUE + SearchConstants.TEXT_MODIFIER_SUFFIX);
         assertEquals(((TokenParmVal) params.get(4)).getValueCode(), SAMPLE_NORMALIZED_TEXT_STRING + "c");
-        assertEquals(((TokenParmVal) params.get(4)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((TokenParmVal) params.get(4)).getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(((TokenParmVal) params.get(5)).getName(), SEARCH_PARAM_CODE_VALUE + SearchConstants.TEXT_MODIFIER_SUFFIX);
         assertEquals(((TokenParmVal) params.get(5)).getValueCode(), SAMPLE_NORMALIZED_TEXT_STRING);
-        assertEquals(((TokenParmVal) params.get(5)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((TokenParmVal) params.get(5)).getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
     }
 
     @Test
@@ -421,7 +421,7 @@ public class ParameterExtractionTest {
         assertEquals(((TokenParmVal) params.get(0)).getValueSystem(), SAMPLE_URI);
         assertEquals(((TokenParmVal) params.get(1)).getName(), SEARCH_PARAM_CODE_VALUE + SearchConstants.TEXT_MODIFIER_SUFFIX);
         assertEquals(((TokenParmVal) params.get(1)).getValueCode(), SAMPLE_NORMALIZED_TEXT_STRING);
-        assertEquals(((TokenParmVal) params.get(1)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((TokenParmVal) params.get(1)).getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
     }
 
     @Test
@@ -522,7 +522,7 @@ public class ParameterExtractionTest {
         assertEquals(tokenParmVal.getValueCode(), "codea");
         tokenParmVal = (TokenParmVal) cParmVal.getComponent().get(1);
         assertEquals(tokenParmVal.getName(), SearchUtil.makeCompositeSubCode(compositeCode, SearchConstants.OF_TYPE_MODIFIER_COMPONENT_VALUE));
-        assertEquals(tokenParmVal.getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(tokenParmVal.getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(tokenParmVal.getValueCode(), "abc123");
 
         cParmVal = (CompositeParmVal) params.get(2);
@@ -530,11 +530,11 @@ public class ParameterExtractionTest {
         assertEquals(cParmVal.getComponent().size(), 2, "Number of extracted components");
         tokenParmVal = (TokenParmVal) cParmVal.getComponent().get(0);
         assertEquals(tokenParmVal.getName(), SearchUtil.makeCompositeSubCode(compositeCode, SearchConstants.OF_TYPE_MODIFIER_COMPONENT_TYPE));
-        assertEquals(tokenParmVal.getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(tokenParmVal.getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(tokenParmVal.getValueCode(), "codeb");
         tokenParmVal = (TokenParmVal) cParmVal.getComponent().get(1);
         assertEquals(tokenParmVal.getName(), SearchUtil.makeCompositeSubCode(compositeCode, SearchConstants.OF_TYPE_MODIFIER_COMPONENT_VALUE));
-        assertEquals(tokenParmVal.getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(tokenParmVal.getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(tokenParmVal.getValueCode(), "abc123");
     }
 
@@ -631,7 +631,7 @@ public class ParameterExtractionTest {
         List<ExtractedParameterValue> params = parameterBuilder.getResult();
         assertEquals(params.size(), 1, "Number of extracted parameters");
         assertEquals(((QuantityParmVal) params.get(0)).getValueNumber().intValue(), 1);
-        assertEquals(((QuantityParmVal) params.get(0)).getValueSystem(), JDBCConstants.DEFAULT_TOKEN_SYSTEM);
+        assertEquals(((QuantityParmVal) params.get(0)).getValueSystem(), FHIRConstants.DEFAULT_TOKEN_SYSTEM);
         assertEquals(((QuantityParmVal) params.get(0)).getValueCode(), "");
     }
 

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -1389,7 +1389,11 @@ public class SearchUtil {
                 } else if (Modifier.TEXT.equals(modifier)) {
                     parameterValue.setValueCode(unescapeSearchParm(v));
                 } else if (parts.length == 2) {
-                    parameterValue.setValueSystem(unescapeSearchParm(parts[0]));
+                    if (parts[0].isEmpty()) {
+                        parameterValue.setValueSystem(FHIRConstants.DEFAULT_TOKEN_SYSTEM);
+                    } else {
+                        parameterValue.setValueSystem(unescapeSearchParm(parts[0]));
+                    }
                     parameterValue.setValueCode(unescapeSearchParm(parts[1]));
                 } else if (parts.length == 1 && v.endsWith("|") && v.indexOf("|") == v.length()-1) {
                     // Only a system was specified (uri followed by a single '|')


### PR DESCRIPTION
When we store a token value without a system, we end up using a special
placeholder system instead of saving NULL.

With this PR, we will now use that system when we search for system-less
codes.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>