### PR TITLE
issue #2526 - deprecate the /Resource and /DomainResource endpoints

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
@@ -18,9 +18,6 @@ import java.net.URI;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -49,6 +46,10 @@ import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.ObservationStatus;
 import com.ibm.fhir.model.util.FHIRUtil;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
 
 /**
  * This class tests the REST API's compliance with the FHIR spec in terms of status code and OperationOutcome responses,
@@ -427,7 +428,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("BogusResourceType/1").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'BogusResourceType' is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;BogusResourceType&#39; is not a valid resource type.");
     }
 
     // Test: retrieve non-existent Patient.
@@ -463,7 +464,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("BogusResourceType/1/_history/1").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'BogusResourceType' is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;BogusResourceType&#39; is not a valid resource type.");
     }
 
     // Test: retrieve invalid version.
@@ -499,7 +500,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("Bogus/123456789ABCDEF/_history").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'Bogus' is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;Bogus&#39; is not a valid resource type.");
     }
 
     @Test(groups = { "server-spec" }, dependsOnMethods={"testCreatePatient"})
@@ -557,7 +558,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("NotAResourceType").queryParam("notasearchparameter", "foo").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'NotAResourceType' is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;NotAResourceType&#39; is not a valid resource type.");
     }
 
     @Test(groups = { "server-spec" }, dependsOnMethods={"testCreatePatient"})

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -69,6 +69,7 @@ public class Create extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             ior = helper.doCreate(type, resource, ifNoneExist);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Delete.java
@@ -56,6 +56,7 @@ public class Delete extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             ior = helper.doDelete(type, id, null);
@@ -93,6 +94,7 @@ public class Delete extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             String searchQueryString = httpServletRequest.getQueryString();
             if (searchQueryString == null || searchQueryString.isEmpty()) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -41,6 +41,7 @@ import com.ibm.fhir.config.FHIRConfigHelper;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
+import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
@@ -48,10 +49,13 @@ import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.FHIRUtil;
+import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
@@ -115,6 +119,19 @@ public class FHIRResource {
             String msg =
                     "The FHIR Server web application cannot process requests because it did not initialize correctly";
             throw buildRestException(msg, IssueType.EXCEPTION);
+        }
+    }
+
+    /**
+     * This method will do a quick check of the {type} URL parameter. If the type is not a valid FHIR resource type, then
+     * we'll throw an error to short-circuit the current in-progress REST API invocation.
+     */
+    protected void checkType(String type) throws FHIROperationException {
+        if (!ModelSupport.isResourceType(type)) {
+            throw buildUnsupportedResourceTypeException(type);
+        }
+        if (!ModelSupport.isConcreteResourceType(type)) {
+            log.warning("Use of abstract resource types like '" + type + "' in FHIR URLs is deprecated and will be removed in a future release");
         }
     }
 
@@ -428,5 +445,20 @@ public class FHIRResource {
      */
     protected URI toUri(String uriString) throws URISyntaxException {
         return new URI(uriString);
+    }
+
+    protected FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName) {
+        String msg = "'" + resourceTypeName + "' is not a valid resource type.";
+        Issue issue = OperationOutcome.Issue.builder()
+                .severity(IssueSeverity.FATAL)
+                .code(IssueType.NOT_SUPPORTED.toBuilder()
+                        .extension(Extension.builder()
+                            .url(FHIRConstants.EXT_BASE + "not-supported-detail")
+                            .value(Code.of("resource"))
+                            .build())
+                        .build())
+                .details(CodeableConcept.builder().text(string(Encode.forHtml(msg))).build())
+                .build();
+        return new FHIROperationException(msg).withIssue(issue);
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/History.java
@@ -53,6 +53,7 @@ public class History extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             bundle = helper.doHistory(type, id, uriInfo.getQueryParameters(), getRequestUri());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -200,6 +200,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =
@@ -245,6 +246,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =
@@ -304,6 +306,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =
@@ -350,6 +353,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =
@@ -397,6 +401,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =
@@ -444,6 +449,7 @@ public class Operation extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(resourceTypeName);
             checkAndVerifyOperationAllowed(operationName);
 
             FHIROperationContext operationContext =

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -14,9 +14,6 @@ import java.util.logging.Logger;
 
 import javax.annotation.security.RolesAllowed;
 import javax.enterprise.context.RequestScoped;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonPatch;
-import jakarta.json.JsonValue;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
@@ -46,6 +43,10 @@ import com.ibm.fhir.server.operation.spi.FHIRRestOperationResponse;
 import com.ibm.fhir.server.util.FHIRRestHelper;
 import com.ibm.fhir.server.util.RestAuditLogger;
 
+import jakarta.json.JsonArray;
+import jakarta.json.JsonPatch;
+import jakarta.json.JsonValue;
+
 @Path("/")
 @Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
@@ -73,6 +74,7 @@ public class Patch extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRPatch patch = createPatch(array);
 
@@ -125,6 +127,7 @@ public class Patch extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRPatch patch;
             try {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -60,6 +60,8 @@ public class Read extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
+
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
             long modifiedSince = parseIfModifiedSince();
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -67,6 +67,7 @@ public class Search extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
@@ -115,6 +116,7 @@ public class Search extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -63,6 +63,7 @@ public class Update extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             ior = helper.doUpdate(type, id, resource, ifMatch, null, onlyIfModified);
@@ -116,6 +117,7 @@ public class Update extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
 
             String searchQueryString = httpServletRequest.getQueryString();
             if (searchQueryString == null || searchQueryString.isEmpty()) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/VRead.java
@@ -56,6 +56,8 @@ public class VRead extends FHIRResource {
 
         try {
             checkInitComplete();
+            checkType(type);
+
             MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1958,6 +1958,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         } else if (pathTokens.length == 3) {
             if ("_history".equals(pathTokens[2])) {
                 // This is a 'history' request.
+                checkResourceType(pathTokens[0]);
                 resource = doHistory(pathTokens[0], pathTokens[1], queryParams, absoluteUri);
             } else {
                 // This is a compartment based search

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -101,7 +101,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             FHIRRestOperationResponse response = helper.doCreate("Patient", patient, null, false);
-            assertEquals(ALL_OK, response.getOperationOutcome());
+            assertEquals(response.getOperationOutcome(), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
         }
@@ -128,7 +128,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, false);
-            assertEquals(ALL_OK, response.getOperationOutcome());
+            assertEquals(response.getOperationOutcome(), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
         }
@@ -155,7 +155,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             FHIRRestOperationResponse response = helper.doCreate("Encounter", encounter, null, false);
-            assertEquals(ALL_OK, response.getOperationOutcome());
+            assertEquals(response.getOperationOutcome(), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
         }
@@ -186,11 +186,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Patient'",
-                issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.size(), 1);
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Patient'");
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -219,11 +219,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Encounter'",
-                issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.size(), 1);
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Encounter'");
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -259,11 +259,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Procedure'",
-                issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.size(), 1);
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Procedure'");
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -299,11 +299,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Procedure'",
-                issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.size(), 1);
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Procedure'");
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -326,11 +326,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -404,11 +404,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'read' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -428,11 +428,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'read' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -452,11 +452,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'read' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -476,11 +476,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'read' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -500,11 +500,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -578,11 +578,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'vread' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -602,11 +602,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'vread' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -626,11 +626,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'vread' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -650,11 +650,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'vread' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -674,11 +674,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -752,11 +752,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'history' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -776,11 +776,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'history' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -800,11 +800,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'history' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -824,11 +824,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'history' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -848,11 +848,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -926,11 +926,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'search' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -950,11 +950,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'search' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -974,11 +974,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'search' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -998,11 +998,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'search' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1022,11 +1022,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -1139,11 +1139,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'update' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1172,11 +1172,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'update' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1205,11 +1205,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'update' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1245,11 +1245,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'update' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1272,11 +1272,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -1296,11 +1296,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'patch' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1320,11 +1320,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'patch' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1344,11 +1344,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'patch' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1368,11 +1368,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'patch' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1392,11 +1392,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -1413,7 +1413,7 @@ public class InteractionValidationConfigTest {
         try {
             FHIRRestOperationResponse response = helper.doDelete("Patient", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("Deleted 1 Patient resource(s) with the following id(s): 1",
                 issues.get(0).getDetails().getText().getValue());
             assertEquals(IssueSeverity.INFORMATION, issues.get(0).getSeverity());
@@ -1436,7 +1436,7 @@ public class InteractionValidationConfigTest {
         try {
             FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("Deleted 1 Encounter resource(s) with the following id(s): 1",
                 issues.get(0).getDetails().getText().getValue());
             assertEquals(IssueSeverity.INFORMATION, issues.get(0).getSeverity());
@@ -1459,7 +1459,7 @@ public class InteractionValidationConfigTest {
         try {
             FHIRRestOperationResponse response = helper.doDelete("Encounter", "1", null);
             List<Issue> issues = response.getOperationOutcome().getIssue();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("Deleted 1 Encounter resource(s) with the following id(s): 1",
                 issues.get(0).getDetails().getText().getValue());
             assertEquals(IssueSeverity.INFORMATION, issues.get(0).getSeverity());
@@ -1485,11 +1485,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'delete' is not allowed for resource type 'Patient'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1509,11 +1509,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'delete' is not allowed for resource type 'Encounter'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1533,11 +1533,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'delete' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1557,11 +1557,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested interaction of type 'delete' is not allowed for resource type 'Procedure'",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1581,11 +1581,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
+            assertEquals(issues.size(), 1);
             assertEquals("The requested resource type 'Practitioner' is not found",
                 issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.NOT_FOUND, issues.get(0).getCode());
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
     }
 
@@ -1648,9 +1648,9 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             Bundle bundle = helper.doBundle(requestBundle, false);
-            assertEquals(2, bundle.getEntry().size());
+            assertEquals(bundle.getEntry().size(), 2);
             for (Entry bundleEntry : bundle.getEntry()) {
-                assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
+                assertEquals(bundleEntry.getResource().as(OperationOutcome.class), ALL_OK);
             }
         } catch (FHIROperationException e) {
             fail();
@@ -1720,11 +1720,11 @@ public class InteractionValidationConfigTest {
         } catch (FHIROperationException e) {
             // Validate results
             List<Issue> issues = e.getIssues();
-            assertEquals(1, issues.size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Patient'",
-                issues.get(0).getDetails().getText().getValue());
-            assertEquals(IssueSeverity.ERROR, issues.get(0).getSeverity());
-            assertEquals(IssueType.BUSINESS_RULE, issues.get(0).getCode());
+            assertEquals(issues.size(), 1);
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Patient'");
+            assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
+            assertEquals(issues.get(0).getCode(), IssueType.BUSINESS_RULE);
         }
     }
 
@@ -1787,9 +1787,9 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             Bundle bundle = helper.doBundle(requestBundle, false);
-            assertEquals(2, bundle.getEntry().size());
+            assertEquals(bundle.getEntry().size(), 2);
             for (Entry bundleEntry : bundle.getEntry()) {
-                assertEquals(ALL_OK, bundleEntry.getResource().as(OperationOutcome.class));
+                assertEquals(bundleEntry.getResource().as(OperationOutcome.class), ALL_OK);
             }
         } catch (FHIROperationException e) {
             fail();
@@ -1855,10 +1855,10 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
             Bundle bundle = helper.doBundle(requestBundle, false);
-            assertEquals(2, bundle.getEntry().size());
-            assertEquals("The requested interaction of type 'create' is not allowed for resource type 'Patient'",
-                bundle.getEntry().get(0).getResource().as(OperationOutcome.class).getIssue().get(0).getDetails().getText().getValue());
-            assertEquals(ALL_OK, bundle.getEntry().get(1).getResource().as(OperationOutcome.class));
+            assertEquals(bundle.getEntry().size(), 2);
+            assertEquals(bundle.getEntry().get(0).getResource().as(OperationOutcome.class).getIssue().get(0).getDetails().getText().getValue(),
+                    "The requested interaction of type 'create' is not allowed for resource type 'Patient'");
+            assertEquals(bundle.getEntry().get(1).getResource().as(OperationOutcome.class), ALL_OK);
         } catch (FHIROperationException e) {
             fail();
         }


### PR DESCRIPTION
Because we use "Resource" as the resource type for whole-system search
and whole-system history interactions, it wasn't as simple as just
checking for abstract types in FHIRRestHelper.validateInteraction().
Instead, I now check that the type in the request path is valid directly
from the JAX-RS endpoints / bundle entry processing.
This has the additional benefit of catching URL path errors up front,
avoiding almost all work associated with this type of bad request.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>