### PR TITLE
Introduce EncodingVisitor and remove redundant resource type checking in AbstractOperation

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/visitor/EncodingVisitor.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/visitor/EncodingVisitor.java
@@ -1,0 +1,92 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.model.visitor;
+
+import org.owasp.encoder.Encode;
+
+import com.ibm.fhir.model.builder.Builder;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Element;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.Xhtml;
+
+/**
+ * Encodes the string elements of the visited resource for use within a given context.
+ * The XHTML narrative text is left unencoded as this content is validated elsewhere in the model.
+ */
+public class EncodingVisitor<T extends Resource> extends CopyingVisitor<T> {
+    /**
+     * The context for which the string elements should be encoded.
+     * These roughly align with the OWASP Encoder types, but they are duplicated here because
+     * the OWASP encoder library doesn't make it easy to pass the encoder type at runtime.
+     */
+    public enum EncodingContext {
+        HTML,
+        HTML_CONTENT,
+        HTML_ATTRIBUTE,
+        JAVA,
+        JAVASCRIPT
+    }
+
+    private final EncodingContext context;
+
+    /**
+     * @param context the context for which to encode
+     */
+    public EncodingVisitor(EncodingContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public boolean visit(java.lang.String elementName, int elementIndex, Xhtml xhtml) {
+        // visit the id and extensions but not the value so that we avoid replacing the XHTML content
+        visit("id", xhtml.getId());
+        for (Extension extension : xhtml.getExtension()) {
+            extension.accept(this);
+        }
+        return false;
+    }
+
+    @Override
+    public void visit(java.lang.String elementName, java.lang.String value) {
+        if(value == null) {
+            return;
+        }
+
+        String newValue = encode(value);
+        // we can compare the string identity because the OWASP encoder has an optimization
+        // that returns the exact string that was passed when there is no encoding needed
+        if (newValue == value) {
+            return;
+        }
+
+        Builder<?> builder = getBuilder();
+        if (builder instanceof com.ibm.fhir.model.type.String.Builder) {
+            ((com.ibm.fhir.model.type.String.Builder) builder).value(newValue);
+            markDirty();
+        } else if (builder instanceof Extension.Builder && "url".equals(elementName)) {
+            ((Extension.Builder) getBuilder()).url(newValue);
+            markDirty();
+        } else if (builder instanceof Element.Builder && "id".equals(elementName)) {
+            ((Element.Builder) getBuilder()).id(newValue);
+            markDirty();
+        } else {
+            throw new UnsupportedOperationException("Encoding is not yet support for element '" + elementName + "' of builder "+ builder.getClass().getName());
+        }
+    }
+
+    private java.lang.String encode(java.lang.String string) {
+        switch(context) {
+        case JAVA:          return Encode.forJava(string);
+        case JAVASCRIPT:    return Encode.forJavaScript(string);
+        case HTML_CONTENT:  return Encode.forHtmlContent(string);
+        case HTML_ATTRIBUTE:return Encode.forHtmlAttribute(string);
+        case HTML:
+        default:
+            return Encode.forHtml(string);
+        }
+    }
+}

--- a/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/CopyingVisitorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/CopyingVisitorTest.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.model.test;
+package com.ibm.fhir.model.visitor.test;
 
 import static org.testng.Assert.assertEquals;
 
@@ -33,25 +33,25 @@ import com.ibm.fhir.model.visitor.CopyingVisitor;
 public class CopyingVisitorTest {
     public static void main(java.lang.String[] args) throws Exception {
         java.lang.String id = UUID.randomUUID().toString();
-        
+
         Meta meta = Meta.builder().versionId(Id.of("1"))
                 .lastUpdated(Instant.now(ZoneOffset.UTC))
                 .build();
-        
+
         String given = String.builder().value("John")
                 .extension(Extension.builder()
                     .url("http://www.ibm.com/someExtension")
                     .value(String.of("value and extension"))
                     .build())
                 .build();
-        
+
         String otherGiven = String.builder()
                 .extension(Extension.builder()
                     .url("http://www.ibm.com/someExtension")
                     .value(String.of("extension only"))
                     .build())
                 .build();
-        
+
         HumanName name = HumanName.builder()
                 .id("someId")
                 .given(given)
@@ -59,11 +59,11 @@ public class CopyingVisitorTest {
                 .given(String.of("value no extension"))
                 .family(String.of("Doe"))
                 .build();
-        
+
         Reference providerRef = Reference.builder()
                 .reference(String.of("urn:uuid:" + UUID.randomUUID()))
                 .build();
-                
+
         Patient patient = Patient.builder()
                 .id(id)
                 .active(Boolean.TRUE)
@@ -73,7 +73,7 @@ public class CopyingVisitorTest {
                 .birthDate(Date.of(LocalDate.now()))
                 .generalPractitioner(providerRef)
                 .build();
-        
+
         testCopy(patient);
     }
 
@@ -81,14 +81,14 @@ public class CopyingVisitorTest {
         CopyingVisitor<Resource> visitor = new CopyingVisitor<Resource>();
         resource.accept(visitor);
         Resource result = visitor.getResult();
-        
+
         StringWriter writer1 = new StringWriter();
         FHIRGenerator.generator(Format.JSON, true).generate(resource, writer1);
         StringWriter writer2 = new StringWriter();
         FHIRGenerator.generator(Format.JSON, true).generate(result, writer2);
         assertEquals(writer2.toString(), writer1.toString());
-        
+
         assertEquals(result, resource);
     }
-    
+
 }

--- a/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/EncodingVisitorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/EncodingVisitorTest.java
@@ -1,0 +1,80 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.model.visitor.test;
+
+import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertFalse;
+
+import java.io.StringWriter;
+import java.util.Collections;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.generator.FHIRGenerator;
+import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.Narrative;
+import com.ibm.fhir.model.type.Xhtml;
+import com.ibm.fhir.model.type.code.NarrativeStatus;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.model.visitor.EncodingVisitor;
+import com.ibm.fhir.model.visitor.EncodingVisitor.EncodingContext;
+
+public class EncodingVisitorTest {
+    private static OperationOutcome oo;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        oo = TestUtil.getMinimalResource(ResourceType.OPERATION_OUTCOME);
+        Issue issue = oo.getIssue().get(0).toBuilder()
+                .extension(Extension.builder()
+                    .id("\" onload=\"alert('test1')")
+                    .url("http://example.com/evil")
+                    .value(string("<script>alert('powned')</script>"))
+                    .build())
+                .details(CodeableConcept.builder()
+                    .text(string("<body onload=alert('powned2')>"))
+                    .build())
+                .diagnostics(string("<META HTTP-EQUIV=\"refresh\"\n"
+                        + "CONTENT=\"0;url=data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg\">"))
+                .build();
+
+        oo = oo.toBuilder()
+                .text(Narrative.builder()
+                    .id("\" onmouseover=\"alert('Wufff!')")
+                    .extension(Collections.singleton(Extension.builder()
+                        .url("http://example.com/evil")
+                        .value(string("<script>alert('powned')</script>"))
+                        .build()))
+                    .status(NarrativeStatus.EMPTY)
+                    .div(Xhtml.from("Narrative text is tested elsewhere"))
+                    .build())
+                .issue(Collections.singleton(issue))
+                .build();
+    }
+
+    @Test
+    public void testEscape() throws Exception {
+        EncodingVisitor<OperationOutcome> v = new EncodingVisitor<>(EncodingContext.HTML_CONTENT);
+        oo.accept(v);
+
+        OperationOutcome result = v.getResult();
+
+        StringWriter writer = new StringWriter();
+        FHIRGenerator.generator(Format.JSON, true).generate(result, writer);
+        System.out.println(writer);
+
+        String resultSansXhtml = writer.toString()
+                .replace("<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\">", "")
+                .replace("</div>", "");
+        assertFalse(resultSansXhtml.contains("<"));
+    }
+}

--- a/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/PathAwareVisitorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/PathAwareVisitorTest.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.model.test;
+package com.ibm.fhir.model.visitor.test;
 
 import java.time.LocalDate;
 import java.time.ZoneOffset;

--- a/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
+++ b/fhir-provider/src/main/java/com/ibm/fhir/provider/FHIRProvider.java
@@ -95,7 +95,7 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
                         buildResponse(
                                 buildOperationOutcome(Collections.singletonList(
                                         buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.INVALID,
-                                                "FHIRProvider: " + encMsg, e.getPath()))),
+                                                "FHIRProvider: " + encMsg, Encode.forHtml(e.getPath())))),
                                 getMediaType(acceptHeader));
                 throw new WebApplicationException(response);
             } else {
@@ -122,11 +122,12 @@ public class FHIRProvider implements MessageBodyReader<Resource>, MessageBodyWri
             // log the error but don't throw because that seems to block to original IOException from bubbling for some reason
             log.log(Level.WARNING, "an error occurred during resource serialization", e);
             if (RuntimeType.SERVER.equals(runtimeType)) {
+                String encMsg = Encode.forHtml(e.getMessage());
                 Response response =
                         buildResponse(
                                 buildOperationOutcome(Collections.singletonList(
                                         buildOperationOutcomeIssue(IssueSeverity.FATAL, IssueType.EXCEPTION,
-                                                "FHIRProvider: " + Encode.forHtml(e.getMessage()), Encode.forHtml(e.getPath())))),
+                                                "FHIRProvider: " + encMsg, Encode.forHtml(e.getPath())))),
                                 mediaType);
                 throw new WebApplicationException(response);
             }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ServerSpecTest.java
@@ -428,7 +428,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("BogusResourceType/1").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;BogusResourceType&#39; is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'BogusResourceType' is not a valid resource type.");
     }
 
     // Test: retrieve non-existent Patient.
@@ -464,7 +464,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("BogusResourceType/1/_history/1").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;BogusResourceType&#39; is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'BogusResourceType' is not a valid resource type.");
     }
 
     // Test: retrieve invalid version.
@@ -500,7 +500,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("Bogus/123456789ABCDEF/_history").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;Bogus&#39; is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'Bogus' is not a valid resource type.");
     }
 
     @Test(groups = { "server-spec" }, dependsOnMethods={"testCreatePatient"})
@@ -558,7 +558,7 @@ public class ServerSpecTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("NotAResourceType").queryParam("notasearchparameter", "foo").request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
-        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "&#39;NotAResourceType&#39; is not a valid resource type.");
+        assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class), "'NotAResourceType' is not a valid resource type.");
     }
 
     @Test(groups = { "server-spec" }, dependsOnMethods={"testCreatePatient"})

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/AbstractOperation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/AbstractOperation.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.owasp.encoder.Encode;
-
 import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationDefinition;
@@ -205,7 +203,7 @@ public abstract class AbstractOperation implements FHIROperation {
                             .value(Code.of("resource"))
                             .build())
                         .build())
-                .details(CodeableConcept.builder().text(string(Encode.forHtml(msg))).build())
+                .details(CodeableConcept.builder().text(string(msg)).build())
                 .build();
         return new FHIROperationException(msg).withIssue(issue);
     }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/AbstractOperation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/AbstractOperation.java
@@ -6,23 +6,15 @@
 
 package com.ibm.fhir.server.operation.spi;
 
-import static com.ibm.fhir.model.type.String.string;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationDefinition;
 import com.ibm.fhir.model.resource.OperationOutcome;
-import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.type.Code;
-import com.ibm.fhir.model.type.CodeableConcept;
-import com.ibm.fhir.model.type.Extension;
-import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.OperationParameterUse;
 import com.ibm.fhir.model.type.code.ResourceType;
@@ -176,14 +168,6 @@ public abstract class AbstractOperation implements FHIROperation {
     }
 
     private void validateResourceType(FHIROperationContext operationContext, Class<? extends Resource> resourceType) throws FHIROperationException {
-        if (resourceType == null) {
-            String actualPath = "null-path";
-            Object val = operationContext.getProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER);
-            if (val instanceof java.lang.String) {
-                actualPath = (String) val;
-            }
-            throw buildUnsupportedResourceTypeException(actualPath);
-        }
         String resourceTypeName = resourceType.getSimpleName();
         List<String> resourceTypeNames = getResourceTypeNames();
         if ((isAbstractResourceTypesDisallowed() && !ModelSupport.isConcreteResourceType(resourceTypeName)) ||
@@ -191,21 +175,6 @@ public abstract class AbstractOperation implements FHIROperation {
             String msg = "Resource type: '" + resourceTypeName + "' is not allowed for operation: '" + getName() + "'";
             throw buildExceptionWithIssue(msg, IssueType.INVALID);
         }
-    }
-
-    private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName) {
-        String msg = "'" + resourceTypeName + "' is not a valid resource type.";
-        Issue issue = OperationOutcome.Issue.builder()
-                .severity(IssueSeverity.FATAL)
-                .code(IssueType.NOT_SUPPORTED.toBuilder()
-                        .extension(Extension.builder()
-                            .url(FHIRConstants.EXT_BASE + "not-supported-detail")
-                            .value(Code.of("resource"))
-                            .build())
-                        .build())
-                .details(CodeableConcept.builder().text(string(msg)).build())
-                .build();
-        return new FHIROperationException(msg).withIssue(issue);
     }
 
     protected void validateOutputParameters(Parameters result) throws FHIROperationException {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIROperationContext.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/operation/spi/FHIROperationContext.java
@@ -68,11 +68,6 @@ public class FHIROperationContext {
      * The property is of the Response
      */
     public static final String PROPNAME_RESPONSE = "RESPONSE";
-    
-    /**
-     * The property is of the Path Parameter
-     */
-    public static final String PROPNAME_PATH_PARAMETER = "PATH_PARAMETER";
 
     /**
      * The property is of the Http Request object

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -210,7 +210,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
@@ -256,7 +255,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, null, null, operationName,
@@ -316,7 +314,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
@@ -363,7 +360,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, null, operationName,
@@ -411,7 +407,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.GET);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,
@@ -459,7 +454,6 @@ public class Operation extends FHIRResource {
             operationContext.setProperty(FHIROperationContext.PROPNAME_SECURITY_CONTEXT, securityContext);
             operationContext.setProperty(FHIROperationContext.PROPNAME_HTTP_REQUEST, httpServletRequest);
             operationContext.setProperty(FHIROperationContext.PROPNAME_METHOD_TYPE, HttpMethod.POST);
-            operationContext.setProperty(FHIROperationContext.PROPNAME_PATH_PARAMETER, resourceTypeName);
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl());
             Resource result = helper.doInvoke(operationContext, resourceTypeName, logicalId, versionId, operationName,

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1501,7 +1501,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     private FHIROperationException buildUnsupportedResourceTypeException(String resourceTypeName) {
-        String msg = "'" + resourceTypeName + "' is not a valid resource type.";
+        String msg = "'" + Encode.forHtml(resourceTypeName) + "' is not a valid resource type.";
         Issue issue = OperationOutcome.Issue.builder()
                 .severity(IssueSeverity.FATAL)
                 .code(IssueType.NOT_SUPPORTED.toBuilder()


### PR DESCRIPTION
Initially, I thought we could use this EncodingVisitor to encode all string 
fields from OperationOutcome resources that we construct (before returning
them to the client).
However, after further discussion, I think we'll tackle that under #2596 by
encoding the content more selectively.

Additionally, I removed some redundant resource type checking from AbstractOperation.
Now that we ensure that the resource type is valid prior to invoking the
operation, there's no need for having this check in AbstractOperation
and therefor also no need to have the PROPNAME_PATH_PARAMETER in the
OperationContext.

I left the PR open because I still think the EncodingVisitor could be generically useful (and
because some of the other cleanup in here still seems worthwhile to me).