### PR TITLE
Issue #2582, #2583 - general refactoring / clean-up

### DIFF
--- a/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
+++ b/fhir-validation/src/main/java/com/ibm/fhir/validation/FHIRValidator.java
@@ -326,9 +326,7 @@ public class FHIRValidator {
                 } else if (!ProfileSupport.isApplicable(profile, resourceType)) {
                     issues.add(issue(IssueSeverity.ERROR, IssueType.INVALID, "Profile '" + url + "' is not applicable to resource type: " + resourceType.getSimpleName(), resourceNode));
                 }
-                if (failFast && hasErrors(issues)) {
-                    aborted = true;
-                }
+                aborted = failFast && hasErrors(issues);
             }
         }
 

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -124,8 +124,8 @@ public class FHIRValidatorTest {
                 .build();
         List<Issue> issues = FHIRValidator.validator().validate(patient);
         assertEquals(issues.size(), 2);
-        assertEquals(issues.get(1).getSeverity(), IssueSeverity.WARNING);
-        assertEquals(issues.get(1).getCode(), IssueType.NOT_SUPPORTED);
+        assertEquals(issues.get(0).getSeverity(), IssueSeverity.WARNING);
+        assertEquals(issues.get(0).getCode(), IssueType.NOT_SUPPORTED);
     }
 
     @Test


### PR DESCRIPTION
- Moved `validateProfileReferences(...)` method from `FHIRValidator` to `FHIRValidator.ValidatingNodeVisitor`
- Updated main `FHIRValidator.validate(...)` method / entry point to be more consistent with main `FHIRPathEvaluator.evaluate(...)` method / entry point
- Updated main `FHIRValidator.ValidatingNodeVisitor.validate(...)` method to be more consistent with `FHIRPathEvaluator.EvaluatingVisitor.evaluate(...)` method
- Updated `ValidatingNodeVisitor.validate(FHIRPathElementNode)` and `ValidatingNodeVisitor.validate(FHIRPathResourceNode)` methods to be more consistent in structure

Signed-off-by: John T.E. Timm <johntimm@us.ibm.com>