### PR TITLE
Issue 1822 -     Add Vacuum Setting support for PostgreSQL

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/api/IDatabaseAdapter.java
@@ -16,6 +16,7 @@ import com.ibm.fhir.database.utils.model.OrderedColumnDef;
 import com.ibm.fhir.database.utils.model.PrimaryKeyDef;
 import com.ibm.fhir.database.utils.model.Privilege;
 import com.ibm.fhir.database.utils.model.Table;
+import com.ibm.fhir.database.utils.model.With;
 
 /**
  * Abstraction of the SQL to use for a given database. This allows us to hide as
@@ -74,9 +75,10 @@ public interface IDatabaseAdapter {
      * @param primaryKey
      * @param identity
      * @param tablespaceName
+     * @param withs
      */
     public void createTable(String schemaName, String name, String tenantColumnName, List<ColumnBase> columns,
-            PrimaryKeyDef primaryKey, IdentityDef identity, String tablespaceName);
+            PrimaryKeyDef primaryKey, IdentityDef identity, String tablespaceName, List<With> withs);
 
     /**
      * Add a new column to an existing table

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -135,6 +135,7 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
      * @param columns
      * @param pkDef
      * @param tablespaceName
+     * @param withs the list of table metadata parameters
      * @return
      */
     protected String buildCreateTableStatement(String schema, String name, List<ColumnBase> columns, PrimaryKeyDef pkDef, IdentityDef identity, String tablespaceName, List<With> withs) {

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -470,12 +470,10 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
         if (this.connectionProvider != null) {
             try (Connection c = connectionProvider.getConnection()) {
                 stmt.run(getTranslator(), c);
-            }
-            catch (SQLException x) {
+            } catch (SQLException x) {
                 throw translator.translate(x);
             }
-        }
-        else {
+        } else {
             this.target.runStatement(getTranslator(), stmt);
         }
     }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/common/CommonDatabaseAdapter.java
@@ -36,6 +36,7 @@ import com.ibm.fhir.database.utils.model.PrimaryKeyDef;
 import com.ibm.fhir.database.utils.model.Privilege;
 import com.ibm.fhir.database.utils.model.Table;
 import com.ibm.fhir.database.utils.model.Tenant;
+import com.ibm.fhir.database.utils.model.With;
 import com.ibm.fhir.database.utils.tenant.AddTenantDAO;
 import com.ibm.fhir.database.utils.tenant.AddTenantKeyDAO;
 import com.ibm.fhir.database.utils.tenant.CreateOrReplaceViewDAO;
@@ -136,7 +137,7 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
      * @param tablespaceName
      * @return
      */
-    protected String buildCreateTableStatement(String schema, String name, List<ColumnBase> columns, PrimaryKeyDef pkDef, IdentityDef identity, String tablespaceName) {
+    protected String buildCreateTableStatement(String schema, String name, List<ColumnBase> columns, PrimaryKeyDef pkDef, IdentityDef identity, String tablespaceName, List<With> withs) {
         StringBuilder result = new StringBuilder();
         result.append("CREATE TABLE ");
         result.append(getQualifiedName(schema, name));
@@ -161,6 +162,17 @@ public abstract class CommonDatabaseAdapter implements IDatabaseAdapter, IDataba
             result.append(')');
         }
         result.append(')');
+
+        // Creates WITH (fillfactor=70, key2=val2);
+        if (withs != null && !withs.isEmpty()) {
+            StringBuilder builder = new StringBuilder(" WITH (");
+            builder.append(
+                withs.stream()
+                    .map(with -> with.buildWithComponent())
+                    .collect(Collectors.joining(",")));
+            builder.append(")");
+            result.append(builder.toString());
+        }
 
         if (tablespaceName != null) {
             DataDefinitionUtil.assertValidName(tablespaceName);

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/db2/Db2Adapter.java
@@ -40,6 +40,7 @@ import com.ibm.fhir.database.utils.model.IdentityDef;
 import com.ibm.fhir.database.utils.model.IntColumn;
 import com.ibm.fhir.database.utils.model.PrimaryKeyDef;
 import com.ibm.fhir.database.utils.model.Table;
+import com.ibm.fhir.database.utils.model.With;
 import com.ibm.fhir.database.utils.transaction.TransactionFactory;
 
 /**
@@ -69,7 +70,7 @@ public class Db2Adapter extends CommonDatabaseAdapter {
 
     @Override
     public void createTable(String schemaName, String name, String tenantColumnName, List<ColumnBase> columns, PrimaryKeyDef primaryKey,
-            IdentityDef identity, String tablespaceName) {
+            IdentityDef identity, String tablespaceName, List<With> withs) {
 
         // With DB2 we can implement support for multi-tenancy, which we do by injecting a MT_ID column
         // to the definition and partitioning on that column
@@ -93,7 +94,7 @@ public class Db2Adapter extends CommonDatabaseAdapter {
         // Now append all the actual columns we want in the table
         cols.addAll(columns);
 
-        String ddl = buildCreateTableStatement(schemaName, name, cols, primaryKey, identity, tablespaceName);
+        String ddl = buildCreateTableStatement(schemaName, name, cols, primaryKey, identity, tablespaceName, With.EMPTY);
 
         // Our multi-tenant tables are range-partitioned as part of our data isolation strategy
         // We reserve partition 0. Real tenant partitions start at 1...

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/derby/DerbyAdapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/PhysicalDataModel.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/PhysicalDataModel.java
@@ -233,6 +233,10 @@ public class PhysicalDataModel implements IDataModel {
             .forEach(obj -> obj.visit(v));
     }
 
+    /**
+     * Visits all objects in the data model
+     * @param v
+     */
     public void visit(DataModelVisitor v) {
         // visit every object
         this.allObjects.forEach(obj -> obj.visit(v));

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/Table.java
@@ -47,6 +47,9 @@ public class Table extends BaseObject {
     // The column to use when making this table multi-tenant (if supported by the the target)
     private final String tenantColumnName;
 
+    // The With parameters on the table
+    private final List<With> withs;
+
     /**
      * Public constructor
      *
@@ -68,7 +71,7 @@ public class Table extends BaseObject {
     public Table(String schemaName, String name, int version, String tenantColumnName, Collection<ColumnBase> columns, PrimaryKeyDef pk,
             IdentityDef identity, Collection<IndexDef> indexes, Collection<ForeignKeyConstraint> fkConstraints,
             SessionVariableDef accessControlVar, Tablespace tablespace, List<IDatabaseObject> dependencies, Map<String,String> tags,
-            Collection<GroupPrivilege> privileges, List<Migration> migrations) {
+            Collection<GroupPrivilege> privileges, List<Migration> migrations, List<With> withs) {
         super(schemaName, name, DatabaseObjectType.TABLE, version, migrations);
         this.tenantColumnName = tenantColumnName;
         this.columns.addAll(columns);
@@ -78,6 +81,7 @@ public class Table extends BaseObject {
         this.fkConstraints.addAll(fkConstraints);
         this.accessControlVar = accessControlVar;
         this.tablespace = tablespace;
+        this.withs = withs;
 
         // Adds all dependencies which aren't null.
         // The only circumstances where it is null is when it is self referencial (an FK on itself).
@@ -114,7 +118,7 @@ public class Table extends BaseObject {
     @Override
     public void apply(IDatabaseAdapter target) {
         final String tsName = this.tablespace == null ? null : this.tablespace.getName();
-        target.createTable(getSchemaName(), getObjectName(), this.tenantColumnName, this.columns, this.primaryKey, this.identity, tsName);
+        target.createTable(getSchemaName(), getObjectName(), this.tenantColumnName, this.columns, this.primaryKey, this.identity, tsName, this.withs);
 
         // Now add any indexes associated with this table
         for (IndexDef idx: this.indexes) {
@@ -223,6 +227,9 @@ public class Table extends BaseObject {
 
         // Privileges to be granted on this table
         private List<GroupPrivilege> privileges = new ArrayList<>();
+
+        // With metadata on the Table
+        private List<With> withs = new ArrayList<>();
 
         /**
          * Private constructor to force creation through factory method
@@ -685,7 +692,7 @@ public class Table extends BaseObject {
             // Our schema objects are immutable by design, so all initialization takes place
             // through the constructor
             return new Table(getSchemaName(), getObjectName(), this.version, this.tenantColumnName, buildColumns(), this.primaryKey, this.identity, this.indexes.values(),
-                    this.fkConstraints.values(), this.accessControlVar, this.tablespace, allDependencies, tags, privileges, migrations);
+                    this.fkConstraints.values(), this.accessControlVar, this.tablespace, allDependencies, tags, privileges, migrations, withs);
 
         }
 
@@ -803,6 +810,15 @@ public class Table extends BaseObject {
             super.addMigration(migration);
             return this;
         }
+
+        /**
+         * adds with parameters (key-values) to the table definition.
+         * @param withs
+         */
+        public Builder addWiths(List<With> withs) {
+            this.withs.addAll(withs);
+            return this;
+        }
     }
 
     /**
@@ -814,24 +830,16 @@ public class Table extends BaseObject {
         return target.doesTableExist(getSchemaName(), getObjectName());
     }
 
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.database.utils.model.IDatabaseObject#visit(com.ibm.fhir.database.utils.model.DataModelVisitor)
-     */
     @Override
     public void visit(DataModelVisitor v) {
         v.visited(this);
-
         this.fkConstraints.forEach(fk -> v.visited(this, fk));
     }
 
-    /* (non-Javadoc)
-     * @see com.ibm.fhir.database.utils.model.IDatabaseObject#visitReverse(com.ibm.fhir.database.utils.model.DataModelVisitor)
-     */
     @Override
     public void visitReverse(DataModelVisitor v) {
         // visit the child objects first when going in reverse
         this.fkConstraints.forEach(fk -> v.visited(this, fk));
-
         v.visited(this);
     }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/With.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/model/With.java
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.database.utils.model;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * WITH to set metadata on the table: WITH (fillfactor=70)
+ */
+public class With {
+
+    public static final List<With> EMPTY = Collections.emptyList();
+    private String name = null;
+    private String value = null;
+
+    /**
+     * @param name
+     * @param value
+     */
+    public With(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * builds the sql component 'WITH'
+     * @return
+     */
+    public String buildWithComponent() {
+        return name + "=" + value;
+    }
+
+    /**
+     * creates a with statement
+     * @param key
+     * @param value
+     */
+    public static With with(String key, String value) {
+        return new With(key, value);
+    }
+}

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresAdapter.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresAdapter.java
@@ -35,6 +35,7 @@ import com.ibm.fhir.database.utils.model.OrderedColumnDef;
 import com.ibm.fhir.database.utils.model.PrimaryKeyDef;
 import com.ibm.fhir.database.utils.model.Privilege;
 import com.ibm.fhir.database.utils.model.Table;
+import com.ibm.fhir.database.utils.model.With;
 
 /**
  * A PostgreSql database target
@@ -93,7 +94,7 @@ public class PostgresAdapter extends CommonDatabaseAdapter {
 
     @Override
     public void createTable(String schemaName, String name, String tenantColumnName, List<ColumnBase> columns, PrimaryKeyDef primaryKey,
-            IdentityDef identity, String tablespaceName) {
+            IdentityDef identity, String tablespaceName, List<With> withs) {
 
         // PostgreSql doesn't support partitioning, so we ignore tenantColumnName
         if (tenantColumnName != null) {
@@ -101,7 +102,7 @@ public class PostgresAdapter extends CommonDatabaseAdapter {
         }
 
         // We also ignore tablespace for PostgreSql
-        String ddl = buildCreateTableStatement(schemaName, name, columns, primaryKey, identity, null);
+        String ddl = buildCreateTableStatement(schemaName, name, columns, primaryKey, identity, null, withs);
         runStatement(ddl);
     }
 

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
@@ -96,17 +96,17 @@ public class PostgresVacuumSettingDAO implements IDatabaseStatement {
                 throw translator.translate(x);
             }
 
-            // Build the SQL
-            StringBuilder builder = new StringBuilder();
-            builder.append("alter table ")
-                .append(schema).append(".").append(tableName)
-                .append(" SET ( ")
-                .append(
-                    generateWiths(processSettings1, processSettings2, processSettings3).stream()
-                        .map(with -> with.buildWithComponent())
-                        .collect(Collectors.joining(",")))
-                .append(" )");
             if (processSettings1 || processSettings2 || processSettings3) {
+                // Build the SQL
+                StringBuilder builder = new StringBuilder();
+                builder.append("alter table ")
+                    .append(schema).append(".").append(tableName)
+                    .append(" SET ( ")
+                    .append(
+                        generateWiths(processSettings1, processSettings2, processSettings3).stream()
+                            .map(with -> with.buildWithComponent())
+                            .collect(Collectors.joining(",")))
+                    .append(" )");
                 final String statement1 = builder.toString();
 
                 LOG.fine(() -> "Updating the table vacuum settings " + statement1);

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 
 import com.ibm.fhir.database.utils.api.IDatabaseStatement;
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
+import com.ibm.fhir.database.utils.model.DbType;
 
 /**
  * Per the Performance Guide, this DAO implements VACUUM setting changes.
@@ -49,70 +50,72 @@ public class PostgresVacuumSettingDAO implements IDatabaseStatement {
 
     @Override
     public void run(IDatabaseTranslator translator, Connection c) {
-        boolean processSettings1a = true;
-        boolean processSettings1b = true;
-        boolean processSettings2 = true;
-        LOG.fine(() -> "Checking the table vacuum settings");
-        final String statement0 = "select (reloptions)::VARCHAR "
-                + "from pg_class "
-                + "join pg_namespace on pg_namespace.oid = pg_class.relnamespace "
-                + "where relname = LOWER('" + tableName + "') "
-                + "and pg_namespace.nspname = LOWER('" + schema + "')";
-        try (PreparedStatement ps = c.prepareStatement(statement0)) {
-            ps.execute();
-            ResultSet rs = ps.getResultSet();
-            if (rs.next()) {
-                String settings = rs.getString(1);
-                if (!rs.wasNull()) {
-                    String[] sar = settings
-                                .replace("{", "")
-                                .replace("}", "")
-                                .split(",");
-                    for (String setting : sar) {
-                        String[] kv = setting.split("=");
-                        if ("autovacuum_vacuum_scale_factor".equals(kv[0]) && vacuumScaleFactor == Double.parseDouble(kv[1])) {
-                            processSettings1a = false;
-                        } else if ("autovacuum_vacuum_threshold".equals(kv[0]) && vacuumThreshold == Integer.parseInt(kv[1])) {
-                            processSettings1b = false;
-                        } else if ("autovacuum_vacuum_cost_limit".equals(kv[0]) && vacuumCostLimit == Integer.parseInt(kv[1])) {
-                            processSettings2 = false;
+        if (translator.getType() == DbType.POSTGRESQL) {
+            boolean processSettings1a = true;
+            boolean processSettings1b = true;
+            boolean processSettings2 = true;
+            LOG.fine(() -> "Checking the table vacuum settings");
+            final String statement0 = "select (reloptions)::VARCHAR "
+                    + "from pg_class "
+                    + "join pg_namespace on pg_namespace.oid = pg_class.relnamespace "
+                    + "where relname = LOWER('" + tableName + "') "
+                    + "and pg_namespace.nspname = LOWER('" + schema + "')";
+            try (PreparedStatement ps = c.prepareStatement(statement0)) {
+                ps.execute();
+                ResultSet rs = ps.getResultSet();
+                if (rs.next()) {
+                    String settings = rs.getString(1);
+                    if (!rs.wasNull()) {
+                        String[] sar = settings
+                                    .replace("{", "")
+                                    .replace("}", "")
+                                    .split(",");
+                        for (String setting : sar) {
+                            String[] kv = setting.split("=");
+                            if ("autovacuum_vacuum_scale_factor".equals(kv[0]) && vacuumScaleFactor == Double.parseDouble(kv[1])) {
+                                processSettings1a = false;
+                            } else if ("autovacuum_vacuum_threshold".equals(kv[0]) && vacuumThreshold == Integer.parseInt(kv[1])) {
+                                processSettings1b = false;
+                            } else if ("autovacuum_vacuum_cost_limit".equals(kv[0]) && vacuumCostLimit == Integer.parseInt(kv[1])) {
+                                processSettings2 = false;
+                            }
                         }
                     }
                 }
-            }
-        } catch (SQLException x) {
-            throw translator.translate(x);
-        }
-
-        if (processSettings1a || processSettings1b) {
-            // -- Lower the trigger threshold for starting work
-            // alter table fhirdata.logical_resources SET (autovacuum_vacuum_scale_factor = 0.01,
-            // autovacuum_vacuum_threshold=1000);
-            final String statement1 = "alter table " + schema + "." + tableName
-                    + " SET (autovacuum_vacuum_scale_factor = " + vacuumScaleFactor + ", autovacuum_vacuum_threshold=" + vacuumThreshold + ")";
-
-            LOG.fine(() -> "Updating the table " + schema + "." + tableName + " [" + vacuumScaleFactor + "," + vacuumThreshold + "]");
-            try (PreparedStatement ps = c.prepareStatement(statement1)) {
-                ps.execute();
             } catch (SQLException x) {
                 throw translator.translate(x);
             }
-        }
 
-        if (processSettings2) {
-            // -- Increase the amount of work vacuuming completes before taking a breather (default is typically 200)
-            // alter table fhirdata.logical_resources SET (autovacuum_vacuum_cost_limit=2000);
-            final String statement2 = "alter table " + schema + "." + tableName + " SET (autovacuum_vacuum_cost_limit=" + vacuumCostLimit + ")";
-            LOG.fine(() -> "Updating the table autovacuum_vacuum_cost_limit " + schema + "." + tableName + " [" + vacuumCostLimit + "]");
-            try (PreparedStatement ps = c.prepareStatement(statement2)) {
-                ps.execute();
-            } catch (SQLException x) {
-                throw translator.translate(x);
+            if (processSettings1a || processSettings1b) {
+                // -- Lower the trigger threshold for starting work
+                // alter table fhirdata.logical_resources SET (autovacuum_vacuum_scale_factor = 0.01,
+                // autovacuum_vacuum_threshold=1000);
+                final String statement1 = "alter table " + schema + "." + tableName
+                        + " SET (autovacuum_vacuum_scale_factor = " + vacuumScaleFactor + ", autovacuum_vacuum_threshold=" + vacuumThreshold + ")";
+
+                LOG.fine(() -> "Updating the table " + schema + "." + tableName + " [" + vacuumScaleFactor + "," + vacuumThreshold + "]");
+                try (PreparedStatement ps = c.prepareStatement(statement1)) {
+                    ps.execute();
+                } catch (SQLException x) {
+                    throw translator.translate(x);
+                }
             }
-        }
 
-        if (processSettings1a || processSettings1b || processSettings2) {
-            LOG.info("Completed update for the autovacuum on table '" + schema + "." + tableName + "'");
+            if (processSettings2) {
+                // -- Increase the amount of work vacuuming completes before taking a breather (default is typically 200)
+                // alter table fhirdata.logical_resources SET (autovacuum_vacuum_cost_limit=2000);
+                final String statement2 = "alter table " + schema + "." + tableName + " SET (autovacuum_vacuum_cost_limit=" + vacuumCostLimit + ")";
+                LOG.fine(() -> "Updating the table autovacuum_vacuum_cost_limit " + schema + "." + tableName + " [" + vacuumCostLimit + "]");
+                try (PreparedStatement ps = c.prepareStatement(statement2)) {
+                    ps.execute();
+                } catch (SQLException x) {
+                    throw translator.translate(x);
+                }
+            }
+
+            if (processSettings1a || processSettings1b || processSettings2) {
+                LOG.info("Completed update for the autovacuum on table '" + schema + "." + tableName + "'");
+            }
         }
     }
 }

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/PostgresVacuumSettingDAO.java
@@ -1,0 +1,118 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.database.utils.postgres;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+
+import com.ibm.fhir.database.utils.api.IDatabaseStatement;
+import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
+
+/**
+ * Per the Performance Guide, this DAO implements VACUUM setting changes.
+ * https://ibm.github.io/FHIR/guides/FHIRPerformanceGuide/#412-tuning-auto-vacuum
+ */
+public class PostgresVacuumSettingDAO implements IDatabaseStatement {
+
+    private static final Logger LOG = Logger.getLogger(PostgresVacuumSettingDAO.class.getName());
+
+    private String schema = null;
+    private String tableName = null;
+
+    private int vacuumCostLimit = 0;
+    private double vacuumScaleFactor = 0.0;
+    private int vacuumThreshold = 0;
+
+    /**
+     * sets up the vacuum setting for Postgres
+     *
+     * @param schema
+     * @param tableName
+     * @param vacuumCostLimit
+     * @param vacuumScaleFactor
+     * @param vacuumThreshold
+     */
+    public PostgresVacuumSettingDAO(String schema, String tableName, int vacuumCostLimit, double vacuumScaleFactor, int vacuumThreshold) {
+        this.schema = schema;
+        this.tableName = tableName;
+        this.vacuumCostLimit = vacuumCostLimit;
+        this.vacuumScaleFactor = vacuumScaleFactor;
+        this.vacuumThreshold = vacuumThreshold;
+    }
+
+    @Override
+    public void run(IDatabaseTranslator translator, Connection c) {
+        boolean processSettings1a = true;
+        boolean processSettings1b = true;
+        boolean processSettings2 = true;
+        LOG.fine(() -> "Checking the table vacuum settings");
+        final String statement0 = "select (reloptions)::VARCHAR "
+                + "from pg_class "
+                + "join pg_namespace on pg_namespace.oid = pg_class.relnamespace "
+                + "where relname = LOWER('" + tableName + "') "
+                + "and pg_namespace.nspname = LOWER('" + schema + "')";
+        try (PreparedStatement ps = c.prepareStatement(statement0)) {
+            ps.execute();
+            ResultSet rs = ps.getResultSet();
+            if (rs.next()) {
+                String settings = rs.getString(1);
+                if (!rs.wasNull()) {
+                    String[] sar = settings
+                                .replace("{", "")
+                                .replace("}", "")
+                                .split(",");
+                    for (String setting : sar) {
+                        String[] kv = setting.split("=");
+                        if ("autovacuum_vacuum_scale_factor".equals(kv[0]) && vacuumScaleFactor == Double.parseDouble(kv[1])) {
+                            processSettings1a = false;
+                        } else if ("autovacuum_vacuum_threshold".equals(kv[0]) && vacuumThreshold == Integer.parseInt(kv[1])) {
+                            processSettings1b = false;
+                        } else if ("autovacuum_vacuum_cost_limit".equals(kv[0]) && vacuumCostLimit == Integer.parseInt(kv[1])) {
+                            processSettings2 = false;
+                        }
+                    }
+                }
+            }
+        } catch (SQLException x) {
+            throw translator.translate(x);
+        }
+
+        if (processSettings1a || processSettings1b) {
+            // -- Lower the trigger threshold for starting work
+            // alter table fhirdata.logical_resources SET (autovacuum_vacuum_scale_factor = 0.01,
+            // autovacuum_vacuum_threshold=1000);
+            final String statement1 = "alter table " + schema + "." + tableName
+                    + " SET (autovacuum_vacuum_scale_factor = " + vacuumScaleFactor + ", autovacuum_vacuum_threshold=" + vacuumThreshold + ")";
+
+            LOG.fine(() -> "Updating the table " + schema + "." + tableName + " [" + vacuumScaleFactor + "," + vacuumThreshold + "]");
+            try (PreparedStatement ps = c.prepareStatement(statement1)) {
+                ps.execute();
+            } catch (SQLException x) {
+                throw translator.translate(x);
+            }
+        }
+
+        if (processSettings2) {
+            // -- Increase the amount of work vacuuming completes before taking a breather (default is typically 200)
+            // alter table fhirdata.logical_resources SET (autovacuum_vacuum_cost_limit=2000);
+            final String statement2 = "alter table " + schema + "." + tableName + " SET (autovacuum_vacuum_cost_limit=" + vacuumCostLimit + ")";
+            LOG.fine(() -> "Updating the table autovacuum_vacuum_cost_limit " + schema + "." + tableName + " [" + vacuumCostLimit + "]");
+            try (PreparedStatement ps = c.prepareStatement(statement2)) {
+                ps.execute();
+            } catch (SQLException x) {
+                throw translator.translate(x);
+            }
+        }
+
+        if (processSettings1a || processSettings1b || processSettings2) {
+            LOG.info("Completed update for the autovacuum on table '" + schema + "." + tableName + "'");
+        }
+    }
+}

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/VacuumSettingsTableDataModelVisitor.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/VacuumSettingsTableDataModelVisitor.java
@@ -1,0 +1,119 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.database.utils.postgres;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.ibm.fhir.database.utils.model.AlterSequenceStartWith;
+import com.ibm.fhir.database.utils.model.AlterTableIdentityCache;
+import com.ibm.fhir.database.utils.model.CreateIndex;
+import com.ibm.fhir.database.utils.model.DataModelVisitor;
+import com.ibm.fhir.database.utils.model.ForeignKeyConstraint;
+import com.ibm.fhir.database.utils.model.FunctionDef;
+import com.ibm.fhir.database.utils.model.ProcedureDef;
+import com.ibm.fhir.database.utils.model.RowArrayType;
+import com.ibm.fhir.database.utils.model.RowType;
+import com.ibm.fhir.database.utils.model.Sequence;
+import com.ibm.fhir.database.utils.model.SessionVariableDef;
+import com.ibm.fhir.database.utils.model.Table;
+import com.ibm.fhir.database.utils.model.Tablespace;
+
+/**
+ * Manages setting the Vacuum Settings on the Physical Data Model
+ */
+public class VacuumSettingsTableDataModelVisitor implements DataModelVisitor {
+    private static final Set<String> SKIP = new HashSet<>(Arrays.asList(
+        "COMMON_TOKEN_VALUES", "COMMON_CANONICAL_VALUES",
+        "TENANTS", "TENANT_KEYS", "PARAMETER_NAMES", "CODE_SYSTEMS"));
+
+    private PostgresAdapter adapter = null;
+    private String schema = null;
+
+    private int vacuumCostLimit = 0;
+    private double vacuumScaleFactor = 0.0;
+    private int vacuumThreshold = 0;
+
+    public VacuumSettingsTableDataModelVisitor(PostgresAdapter adapter, String schema, int vacuumCostLimit, double vacuumScaleFactor, int vacuumThreshold) {
+        this.adapter = adapter;
+        this.schema = schema;
+        this.vacuumCostLimit = vacuumCostLimit;
+        this.vacuumScaleFactor = vacuumScaleFactor;
+        this.vacuumThreshold = vacuumThreshold;
+    }
+    @Override
+    public void visited(Table tbl) {
+        String tableName = tbl.getObjectName().toUpperCase();
+        if (!(tableName.endsWith("_RESOURCES") && !tableName.contains("LOGICAL_RESOURCES"))
+                && !SKIP.contains(tableName)) {
+            PostgresVacuumSettingDAO alterVacuumSettings =
+                    new PostgresVacuumSettingDAO(schema, tbl.getObjectName(), vacuumCostLimit, vacuumScaleFactor, vacuumThreshold);
+            adapter.runStatement(alterVacuumSettings);
+        }
+    }
+
+    @Override
+    public void visited(Table fromChildTable, ForeignKeyConstraint fk) {
+        // NOP
+    }
+
+    @Override
+    public void nop() {
+        // NOP
+    }
+
+    @Override
+    public void visited(ProcedureDef procedureDef) {
+        // NOP
+    }
+
+    @Override
+    public void visited(RowArrayType rowArrayType) {
+        // NOP
+    }
+
+    @Override
+    public void visited(RowType rowType) {
+        // NOP
+    }
+
+    @Override
+    public void visited(Sequence sequence) {
+        // NOP
+    }
+
+    @Override
+    public void visited(SessionVariableDef sessionVariableDef) {
+        // NOP
+    }
+
+    @Override
+    public void visited(Tablespace tablespace) {
+        // NOP
+    }
+
+    @Override
+    public void visited(FunctionDef functionDef) {
+        // NOP
+    }
+
+    @Override
+    public void visited(AlterSequenceStartWith alterSequence) {
+        // NOP
+    }
+
+    @Override
+    public void visited(AlterTableIdentityCache alterTable) {
+        // NOP
+    }
+
+    @Override
+    public void visited(CreateIndex createIndex) {
+        //NOP
+    }
+}

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/VacuumSettingsTableDataModelVisitor.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/postgres/VacuumSettingsTableDataModelVisitor.java
@@ -28,6 +28,7 @@ import com.ibm.fhir.database.utils.model.Tablespace;
  * Manages setting the Vacuum Settings on the Physical Data Model
  */
 public class VacuumSettingsTableDataModelVisitor implements DataModelVisitor {
+    // These tables are skipped as they are not often UPDATED.
     private static final Set<String> SKIP = new HashSet<>(Arrays.asList(
         "COMMON_TOKEN_VALUES", "COMMON_CANONICAL_VALUES",
         "TENANTS", "TENANT_KEYS", "PARAMETER_NAMES", "CODE_SYSTEMS"));
@@ -49,6 +50,7 @@ public class VacuumSettingsTableDataModelVisitor implements DataModelVisitor {
     @Override
     public void visited(Table tbl) {
         String tableName = tbl.getObjectName().toUpperCase();
+        // The Table pattern is to skip <RESOURCETYPE>_RESOURCES and not LOGICAL_RESOURCES
         if (!(tableName.endsWith("_RESOURCES") && !tableName.contains("LOGICAL_RESOURCES"))
                 && !SKIP.contains(tableName)) {
             PostgresVacuumSettingDAO alterVacuumSettings =

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -11,8 +11,6 @@ The executable command line interface (cli) version of this module can be downlo
 
 To create the Db2 database and database user, use the following commands:
 
-
-
 1. If necessary on your system, create the User
 ``` shell
 groupadd -g 1002 fhir
@@ -115,6 +113,8 @@ For PostgreSQL:
 --update-schema
 --db-type postgresql
 ```
+
+When updating the postgres schema, the autovacuum settings are configured.
 
 ### Grant privileges to data access user (Db2 only)
 
@@ -366,6 +366,33 @@ java -jar ./fhir-persistence-schema-${VERSION}-cli.jar \
 --prop-file db2.properties
 --grant-to FHIRSERVER
 --target DATA FHIRDATA_2ND
+```
+
+## Adjust the Vacuum Settings for PostgreSQL Tables only
+Since 4.9.0, the IBM FHIR Server has implemented support for modifying the [autovacuum](https://www.postgresql.org/docs/12/runtime-config-autovacuum.html). Per [4.1.2. Tuning Auto-vacuum](https://ibm.github.io/FHIR/guides/FHIRPerformanceGuide/#412-tuning-auto-vacuum) the schema tool modifies `autovacuum_vacuum_cost_limit`, `autovacuum_vacuum_scale_factor` and `autovacuum_vacuum_threshold`.
+
+### Specific Tables
+To update a specific tables settings, you can run with  `--vacuum-table-name`.
+
+```
+java -jar ./fhir-persistence-schema-${VERSION}-cli.jar \
+--db-type postgresql --prop db.host=localhost --prop db.port=5432 \
+--prop db.database=fhirdb --schema-name fhirdata \
+--prop user=fhiradmin --prop password=passw0rd \
+--update-vacuum --vacuum-cost-limit 2000 --vacuum-threshold 1000 \
+--vacuum-scale-factor 0.01 --vacuum-table-name LOGICAL_RESOURCES
+```
+
+### All Tables in a Schema
+To update all tables in a schema, you can run without the table parameter. If you omit any value, the  defaults are picked as described in the Performance guide.
+
+```
+java -jar ./fhir-persistence-schema-${VERSION}-cli.jar \
+--db-type postgresql --prop db.host=localhost --prop db.port=5432 \
+--prop db.database=fhirdb --schema-name fhirdata \
+--prop user=fhiradmin --prop password=passw0rd \
+--update-vacuum --vacuum-cost-limit 2000 --vacuum-threshold 1000 \
+--vacuum-scale-factor 0.01
 ```
 
 ## Advanced SSL Configuration with Postgres

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
@@ -2005,6 +2005,7 @@ public class Main {
     public void updateVacuumSettings() {
         if (dbType != DbType.POSTGRESQL) {
             logger.severe("Updating the vacuum settings is only supported on postgres and the setting is for '" + dbType + "'");
+            return;
         }
 
         // Create the Physical Data Model

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
@@ -60,7 +60,10 @@ import com.ibm.fhir.database.utils.model.PhysicalDataModel;
 import com.ibm.fhir.database.utils.model.Table;
 import com.ibm.fhir.database.utils.model.Tenant;
 import com.ibm.fhir.database.utils.pool.PoolConnectionProvider;
+import com.ibm.fhir.database.utils.postgres.PostgresAdapter;
 import com.ibm.fhir.database.utils.postgres.PostgresTranslator;
+import com.ibm.fhir.database.utils.postgres.PostgresVacuumSettingDAO;
+import com.ibm.fhir.database.utils.postgres.VacuumSettingsTableDataModelVisitor;
 import com.ibm.fhir.database.utils.tenant.AddTenantKeyDAO;
 import com.ibm.fhir.database.utils.tenant.DeleteTenantKeyDAO;
 import com.ibm.fhir.database.utils.tenant.GetTenantDAO;
@@ -104,6 +107,7 @@ import com.ibm.fhir.task.core.service.TaskService;
  * This utility also includes an option to exercise the tenant partitioning code.
  */
 public class Main {
+
     private static final Logger logger = Logger.getLogger(Main.class.getName());
     private static final int EXIT_OK = 0; // validation was successful
     private static final int EXIT_BAD_ARGS = 1; // invalid CLI arguments
@@ -157,6 +161,13 @@ public class Main {
     // The database user we will grant tenant data access privileges to
     private String grantTo;
 
+    // Action flag related to Vacuuming:
+    private boolean updateVacuum = false;
+    private String vacuumTableName = null;
+    private int vacuumCostLimit = 2000;
+    private int vacuumThreshold = 1000;
+    private double vacuumScaleFactor = 0.01;
+
     // The database type being populated (default: Db2)
     private DbType dbType = DbType.DB2;
     private IDatabaseTranslator translator = new Db2Translator();
@@ -193,7 +204,7 @@ public class Main {
     private PoolConnectionProvider connectionPool;
     private ITransactionProvider transactionProvider;
 
-    //-----------------------------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------------------------
     // The following method is related to the common methods and functions
     /**
      * @return a created connection to the selected database
@@ -233,10 +244,14 @@ public class Main {
 
     /**
      * builds the common model based on the flags passed in
+     *
      * @param pdm
-     * @param fhirSchema - true indicates if the fhir model is added to the Physical Data Model
-     * @param oauthSchema - true indicates if the oauth model is added to the Physical Data Model
-     * @param javaBatchSchema - true indicates if the model is added to the Physical Data Model
+     * @param fhirSchema
+     *            - true indicates if the fhir model is added to the Physical Data Model
+     * @param oauthSchema
+     *            - true indicates if the oauth model is added to the Physical Data Model
+     * @param javaBatchSchema
+     *            - true indicates if the model is added to the Physical Data Model
      */
     protected void buildCommonModel(PhysicalDataModel pdm, boolean fhirSchema, boolean oauthSchema, boolean javaBatchSchema) {
         if (fhirSchema) {
@@ -285,8 +300,7 @@ public class Main {
      * @param collector
      * @param vhs
      */
-    protected void applyModel(PhysicalDataModel pdm, IDatabaseAdapter adapter, ITaskCollector collector,
-            VersionHistoryService vhs) {
+    protected void applyModel(PhysicalDataModel pdm, IDatabaseAdapter adapter, ITaskCollector collector, VersionHistoryService vhs) {
         logger.info("Collecting model update tasks");
         pdm.collect(collector, adapter, this.transactionProvider, vhs);
 
@@ -306,6 +320,7 @@ public class Main {
 
     /**
      * specific feature to check if it is compatible.
+     *
      * @return
      */
     protected boolean checkCompatibility() {
@@ -360,7 +375,7 @@ public class Main {
     protected void updateSchema() {
         // Build/update the FHIR-related tables as well as the stored procedures
         PhysicalDataModel pdm = new PhysicalDataModel();
-        buildCommonModel(pdm, updateFhirSchema, updateOauthSchema,updateJavaBatchSchema);
+        buildCommonModel(pdm, updateFhirSchema, updateOauthSchema, updateJavaBatchSchema);
 
         // The objects are applied in parallel, which relies on each object
         // expressing its dependencies correctly. Changes are only applied
@@ -377,7 +392,8 @@ public class Main {
         CreateVersionHistory.createTableIfNeeded(schema.getAdminSchemaName(), adapter);
 
         // Current version history for the data schema
-        VersionHistoryService vhs = new VersionHistoryService(schema.getAdminSchemaName(), schema.getSchemaName(), schema.getOauthSchemaName(), schema.getJavaBatchSchemaName());
+        VersionHistoryService vhs =
+                new VersionHistoryService(schema.getAdminSchemaName(), schema.getSchemaName(), schema.getOauthSchemaName(), schema.getJavaBatchSchemaName());
         vhs.setTransactionProvider(transactionProvider);
         vhs.setTarget(adapter);
         vhs.init();
@@ -391,7 +407,7 @@ public class Main {
 
         // If the db is multi-tenant, we populate the resource types and parameter names in allocate-tenant.
         // Otherwise, if its a new schema, populate the resource types and parameters names (codes) now
-        if (!MULTITENANT_FEATURE_ENABLED.contains(dbType) && newDb ) {
+        if (!MULTITENANT_FEATURE_ENABLED.contains(dbType) && newDb) {
             populateResourceTypeAndParameterNameTableEntries(null);
         }
 
@@ -421,8 +437,9 @@ public class Main {
      *           DerbyBootstrapper.populateResourceTypeAndParameterNameTableEntries
      *           and DerbyFhirDatabase.populateResourceTypeAndParameterNameTableEntries
      *           The reason is there are three different ways of managing the transaction.
-     * @param tenantId the mt_id that is used to setup the partition.
-     *                 passing in null signals not multi-tenant.
+     * @param tenantId
+     *            the mt_id that is used to setup the partition.
+     *            passing in null signals not multi-tenant.
      */
     protected void populateResourceTypeAndParameterNameTableEntries(Integer tenantId) {
         try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
@@ -501,6 +518,7 @@ public class Main {
      * Add part of the schema drop process, we first kill all
      * the foreign key constraints. The rest of the drop is
      * performed in a second transaction.
+     *
      * @param pdm
      */
     private void dropForeignKeyConstraints(PhysicalDataModel pdm, String tagGroup, String tag) {
@@ -522,7 +540,7 @@ public class Main {
         }
     }
 
-    //-----------------------------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------------------------
     // The following method is related to the Stored Procedures and Functions feature
     /**
      * Update the stored procedures used by FHIR to insert records
@@ -553,7 +571,8 @@ public class Main {
                     tx.setRollbackOnly();
                     throw x;
                 }
-                // Reminder: Don't fall into the trap, let the connectionPool and Transaction Management handle the transaction commit.
+                // Reminder: Don't fall into the trap, let the connectionPool and Transaction Management handle the
+                // transaction commit.
             } catch (SQLException x) {
                 tx.setRollbackOnly();
                 throw translator.translate(x);
@@ -561,7 +580,7 @@ public class Main {
         }
     }
 
-    //-----------------------------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------------------------
     // The following method is related to the Privilege feature
     /**
      * Grant the minimum required set of privileges on the FHIR schema objects
@@ -583,8 +602,7 @@ public class Main {
 
         // Build/update the tables as well as the stored procedures
         PhysicalDataModel pdm = new PhysicalDataModel();
-        buildCommonModel(pdm, updateFhirSchema || grantFhirSchema, updateOauthSchema || grantOauthSchema,
-            updateJavaBatchSchema || grantJavaBatchSchema);
+        buildCommonModel(pdm, updateFhirSchema || grantFhirSchema, updateOauthSchema || grantOauthSchema, updateJavaBatchSchema || grantJavaBatchSchema);
 
         final IDatabaseAdapter adapter = getDbAdapter(dbType, connectionPool);
         try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
@@ -603,13 +621,14 @@ public class Main {
     /**
      * Do we want to build the multitenant variant of the schema (currently only supported
      * by DB2)
+     *
      * @return
      */
     protected boolean isMultitenant() {
         return MULTITENANT_FEATURE_ENABLED.contains(this.dbType);
     }
 
-    //-----------------------------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------------------------
     // The following methods are related to Multi-Tenant only.
     /**
      * Add a new tenant key so that we can rotate the values (add a
@@ -622,7 +641,7 @@ public class Main {
         }
 
         // Only if the Tenant Key file is provided as a parameter is it not null.
-        // in  this case we want special behavior.
+        // in this case we want special behavior.
         if (tenantKeyFileUtil.keyFileExists(tenantKeyFileName)) {
             tenantKey = this.tenantKeyFileUtil.readTenantFile(tenantKeyFileName);
         } else {
@@ -645,8 +664,7 @@ public class Main {
                 if (tenant != null) {
                     // Attach the new tenant key to the tenant:
                     AddTenantKeyDAO adder =
-                            new AddTenantKeyDAO(schema.getAdminSchemaName(), tenant.getTenantId(), tenantKey, tenantSalt,
-                                    FhirSchemaConstants.TENANT_SEQUENCE);
+                            new AddTenantKeyDAO(schema.getAdminSchemaName(), tenant.getTenantId(), tenantKey, tenantSalt, FhirSchemaConstants.TENANT_SEQUENCE);
                     adapter.runStatement(adder);
                 } else {
                     throw new IllegalArgumentException("Tenant does not exist: " + addKeyForTenant);
@@ -663,8 +681,7 @@ public class Main {
             logger.info("New tenant key: " + addKeyForTenant + " [key=" + tenantKey + "]");
         } else {
             // Loaded from File
-            logger.info(
-                    "New tenant key from file: " + addKeyForTenant + " [tenantKeyFileName=" + tenantKeyFileName + "]");
+            logger.info("New tenant key from file: " + addKeyForTenant + " [tenantKeyFileName=" + tenantKeyFileName + "]");
             if (!tenantKeyFileUtil.keyFileExists(tenantKeyFileName)) {
                 tenantKeyFileUtil.writeTenantFile(tenantKeyFileName, tenantKey);
             }
@@ -675,9 +692,12 @@ public class Main {
     /**
      * checks if tenant name and tenant key exists.
      *
-     * @param adapter    the db2 adapter as this is a db2 feature only now
-     * @param tenantName the tenant's name
-     * @param tenantKey  tenant key
+     * @param adapter
+     *            the db2 adapter as this is a db2 feature only now
+     * @param tenantName
+     *            the tenant's name
+     * @param tenantKey
+     *            tenant key
      */
     protected void checkIfTenantNameAndTenantKeyExists(Db2Adapter adapter, String tenantName, String tenantKey) {
         try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
@@ -699,8 +719,7 @@ public class Main {
                         throw new IllegalArgumentException("Problem checking the results");
                     }
                 } catch (SQLException e) {
-                    throw new IllegalArgumentException(
-                            "Exception when querying backend to verify tenant key and tenant name", e);
+                    throw new IllegalArgumentException("Exception when querying backend to verify tenant key and tenant name", e);
                 }
             } catch (DataAccessException x) {
                 // Something went wrong, so mark the transaction as failed
@@ -725,7 +744,7 @@ public class Main {
         // activities related to this tenant, such as setting the tenant context.
         if (tenantKeyFileUtil.keyFileExists(tenantKeyFileName)) {
             // Only if the Tenant Key file is provided as a parameter is it not null.
-            // in  this case we want special behavior.
+            // in this case we want special behavior.
             tenantKey = this.tenantKeyFileUtil.readTenantFile(tenantKeyFileName);
         } else {
             tenantKey = getRandomKey();
@@ -753,8 +772,7 @@ public class Main {
         try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
             try {
                 tenantId =
-                        adapter.allocateTenant(schema.getAdminSchemaName(), schema.getSchemaName(), tenantName, tenantKey, tenantSalt,
-                                FhirSchemaConstants.TENANT_SEQUENCE);
+                        adapter.allocateTenant(schema.getAdminSchemaName(), schema.getSchemaName(), tenantName, tenantKey, tenantSalt, FhirSchemaConstants.TENANT_SEQUENCE);
 
                 // The tenant-id is important because this is also used to identify the partition number
                 logger.info("Tenant Id[" + tenantName + "] = [" + tenantId + "]");
@@ -818,19 +836,19 @@ public class Main {
 
         // Scan over the list to see if the tenant we are working with
         // already exists
-        for (TenantInfo ti: tenants) {
+        for (TenantInfo ti : tenants) {
             if (ti.getTenantName().equals(this.tenantName)) {
                 if (ti.getTenantSchema() == null) {
                     // The schema is empty so no chance of adding tenants
                     throw new IllegalArgumentException("Schema '" + schema.getSchemaName() + "'"
-                        + " for tenant '" + ti.getTenantName() + "'"
-                        + " does not contain a valid IBM FHIR Server schema");
+                            + " for tenant '" + ti.getTenantName() + "'"
+                            + " does not contain a valid IBM FHIR Server schema");
                 } else if (!ti.getTenantSchema().equalsIgnoreCase(schema.getSchemaName())) {
                     // The given schema name doesn't match where we think this tenant
                     // should be located, so throw an error before any damage is done
                     throw new IllegalArgumentException("--schema-name argument '" + schema.getSchemaName()
-                    + "' does not match schema '" + ti.getTenantSchema() + "' for tenant '"
-                    + ti.getTenantName() + "'");
+                            + "' does not match schema '" + ti.getTenantSchema() + "' for tenant '"
+                            + ti.getTenantName() + "'");
                 }
             }
         }
@@ -842,6 +860,7 @@ public class Main {
      * looking up the schema from one of the tables we know should exist. The schema
      * name may therefore be null if the tenant record (in FHIR_ADMIN.TENANTS) exists,
      * but all the tables from that schema have been dropped.
+     *
      * @return
      */
     protected List<TenantInfo> getTenantList() {
@@ -883,7 +902,7 @@ public class Main {
 
         // make sure the list is sorted by tenantId. Lambdas really do clean up this sort of code
         tenants.sort((TenantInfo left, TenantInfo right) -> left.getTenantId() < right.getTenantId() ? -1 : left.getTenantId() > right.getTenantId() ? 1 : 0);
-        for (TenantInfo ti: tenants) {
+        for (TenantInfo ti : tenants) {
             // For issue 1847 we only want to process for the named data schema if one is provided
             // If no -schema-name arg is given, we process all tenants.
             if (ti.getTenantSchema() != null && (!schema.isOverrideDataSchema() || schema.matchesDataSchema(ti.getTenantSchema()))) {
@@ -914,7 +933,7 @@ public class Main {
 
                 System.out.println(TenantInfo.getHeader());
                 tenants.forEach(System.out::println);
-            } catch(UndefinedNameException x) {
+            } catch (UndefinedNameException x) {
                 System.out.println("The FHIR_ADMIN schema appears not to be deployed with the TENANTS table");
             } catch (DataAccessException x) {
                 // Something went wrong, so mark the transaction as failed
@@ -941,7 +960,7 @@ public class Main {
         // Part of Bring your own Tenant Key
         if (tenantKeyFileName != null) {
             // Only if the Tenant Key file is provided as a parameter is it not null.
-            // in  this case we want special behavior.
+            // in this case we want special behavior.
             tenantKey = this.tenantKeyFileUtil.readTenantFile(tenantKeyFileName);
         }
 
@@ -1023,7 +1042,7 @@ public class Main {
             // the schema used for this tenant in the database
             if (!tenantSchema.equalsIgnoreCase(schema.getSchemaName())) {
                 throw new IllegalArgumentException("--schema-name '" + schema.getSchemaName() + "' argument does not match tenant schema: '"
-                    + tenantSchema + "'");
+                        + tenantSchema + "'");
             }
         }
 
@@ -1034,6 +1053,7 @@ public class Main {
      * Mark the tenant so that it can no longer be accessed (this prevents
      * the SET_TENANT method from authenticating the tenantName/tenantKey
      * pair, so the SV_TENANT_ID variable never gets set).
+     *
      * @return the TenantInfo associated with the tenant
      */
     protected TenantInfo freezeTenant() {
@@ -1043,7 +1063,6 @@ public class Main {
 
         TenantInfo result = getTenantInfo();
         Db2Adapter adapter = new Db2Adapter(connectionPool);
-
 
         logger.info("Marking tenant for drop: " + tenantName);
         try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
@@ -1062,40 +1081,39 @@ public class Main {
         return result;
     }
 
-
     /**
      * Deallocate this tenant, dropping all the related partitions. This needs to be
      * idempotent because there are steps which must be run in separate transactions
      * (due to how Db2 handles detaching partitions). This is further complicated by
      * referential integrity constraints in the schema. See:
-     *  - https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.partition.doc/doc/t0021576.html
+     * - https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.partition.doc/doc/t0021576.html
      *
      * The workaround described in the above link is:
-     *   // Change the RI constraint to informational:
-     *   1. ALTER TABLE child ALTER FOREIGN KEY fk NOT ENFORCED;
+     * // Change the RI constraint to informational:
+     * 1. ALTER TABLE child ALTER FOREIGN KEY fk NOT ENFORCED;
      *
-     *   2. ALTER TABLE parent DETACH PARTITION p0 INTO TABLE pdet;
+     * 2. ALTER TABLE parent DETACH PARTITION p0 INTO TABLE pdet;
      *
-     *   3. SET INTEGRITY FOR child OFF;
+     * 3. SET INTEGRITY FOR child OFF;
      *
-     *   // Change the RI constraint back to enforced:
-     *   4. ALTER TABLE child ALTER FOREIGN KEY fk ENFORCED;
+     * // Change the RI constraint back to enforced:
+     * 4. ALTER TABLE child ALTER FOREIGN KEY fk ENFORCED;
      *
-     *   5. SET INTEGRITY FOR child ALL IMMEDIATE UNCHECKED;
-     *   6.   Assuming that the CHILD table does not have any dependencies on partition P0,
-     *   7.   and that no updates on the CHILD table are permitted until this UOW is complete,
-     *        no RI violation is possible during this UOW.
+     * 5. SET INTEGRITY FOR child ALL IMMEDIATE UNCHECKED;
+     * 6. Assuming that the CHILD table does not have any dependencies on partition P0,
+     * 7. and that no updates on the CHILD table are permitted until this UOW is complete,
+     * no RI violation is possible during this UOW.
      *
-     *   COMMIT WORK;
+     * COMMIT WORK;
      *
-     *   Unfortunately, #7 above essentially requires that all writes cease until the
-     *   UOW is completed and the integrity is enabled again on all the child (leaf)
-     *   tables. Of course, this could be relaxed if the application is trusted not
-     *   to mess up the referential integrity...which we know to be true for the
-     *   FHIR server persistence layer.
+     * Unfortunately, #7 above essentially requires that all writes cease until the
+     * UOW is completed and the integrity is enabled again on all the child (leaf)
+     * tables. Of course, this could be relaxed if the application is trusted not
+     * to mess up the referential integrity...which we know to be true for the
+     * FHIR server persistence layer.
      *
-     *   If the risk is deemed too high, tenant removal should be performed in a
-     *   maintenance window.
+     * If the risk is deemed too high, tenant removal should be performed in a
+     * maintenance window.
      */
     protected void dropTenant() {
         if (!MULTITENANT_FEATURE_ENABLED.contains(dbType)) {
@@ -1138,6 +1156,7 @@ public class Main {
      * Drop any tables which have previously been detached. Once all tables have been
      * dropped, we go on to drop the tablespace. If the tablespace drop is successful,
      * we know the cleanup is complete so we can update the tenant status accordingly
+     *
      * @param pdm
      * @param tenantInfo
      */
@@ -1168,9 +1187,9 @@ public class Main {
                 } catch (DataAccessException x) {
                     boolean error = x instanceof DataAccessException && x.getCause() instanceof SQLException
                             && (((SQLException) x.getCause()).getErrorCode() == -282);
-                    if (error && wait++ <= 30){
+                    if (error && wait++ <= 30) {
                         retry = true;
-                        logger.warning("Waiting on async dettach dependency to finish - count '"+ wait + "'");
+                        logger.warning("Waiting on async dettach dependency to finish - count '" + wait + "'");
                         try {
                             Thread.sleep(2000);
                         } catch (InterruptedException e) {
@@ -1205,11 +1224,11 @@ public class Main {
      * to have to go through this, because the child table partition will be
      * detached before the parent anyway, so theoretically this workaround
      * shouldn't be necessary.
-     *   ALTER TABLE child ALTER FOREIGN KEY fk NOT ENFORCED;
-     *   ALTER TABLE parent DETACH PARTITION p0 INTO TABLE pdet;
-     *   SET INTEGRITY FOR child OFF;
-     *   ALTER TABLE child ALTER FOREIGN KEY fk ENFORCED;
-     *   SET INTEGRITY FOR child ALL IMMEDIATE UNCHECKED;
+     * ALTER TABLE child ALTER FOREIGN KEY fk NOT ENFORCED;
+     * ALTER TABLE parent DETACH PARTITION p0 INTO TABLE pdet;
+     * SET INTEGRITY FOR child OFF;
+     * ALTER TABLE child ALTER FOREIGN KEY fk ENFORCED;
+     * SET INTEGRITY FOR child ALL IMMEDIATE UNCHECKED;
      */
     protected void detachTenantPartitions(PhysicalDataModel pdm, TenantInfo tenantInfo) {
         Db2Adapter adapter = new Db2Adapter(connectionPool);
@@ -1277,7 +1296,7 @@ public class Main {
         int tenantId = tenantInfo.getTenantId();
 
         // Only if the Tenant Key file is provided as a parameter is it not null.
-        // in  this case we want special behavior.
+        // in this case we want special behavior.
         if (tenantKeyFileUtil.keyFileExists(tenantKeyFileName)) {
             tenantKey = this.tenantKeyFileUtil.readTenantFile(tenantKeyFileName);
         }
@@ -1298,7 +1317,7 @@ public class Main {
         }
     }
 
-    //-----------------------------------------------------------------------------------------------------------------
+    // -----------------------------------------------------------------------------------------------------------------
     // The following methods are related to parsing arguments and action selection
     /**
      * Parse the command-line arguments, building up the environment and
@@ -1354,7 +1373,7 @@ public class Main {
                             } else {
                                 throw new IllegalArgumentException("Missing value for argument at posn: " + i);
                             }
-                        } else if (tmp.startsWith("OAUTH")){
+                        } else if (tmp.startsWith("OAUTH")) {
                             this.grantOauthSchema = true;
                             if (nextIdx < args.length && !args[nextIdx].startsWith("--")) {
                                 schema.setOauthSchemaName(args[nextIdx]);
@@ -1362,7 +1381,7 @@ public class Main {
                             } else {
                                 throw new IllegalArgumentException("Missing value for argument at posn: " + i);
                             }
-                        } else if (tmp.startsWith("DATA")){
+                        } else if (tmp.startsWith("DATA")) {
                             this.grantFhirSchema = true;
                             if (nextIdx < args.length && !args[nextIdx].startsWith("--")) {
                                 schema.setSchemaName(args[nextIdx]);
@@ -1467,7 +1486,7 @@ public class Main {
                 this.createJavaBatchSchema = true;
                 break;
             case "--create-schema-fhir":
-                this.createFhirSchema =  true;
+                this.createFhirSchema = true;
                 if (nextIdx < args.length && !args[nextIdx].startsWith("--")) {
                     schema.setSchemaName(args[nextIdx]);
                     i++;
@@ -1519,6 +1538,37 @@ public class Main {
                 if (++i < args.length) {
                     // properties are given as name=value
                     addProperty(args[i]);
+                } else {
+                    throw new IllegalArgumentException("Missing value for argument at posn: " + i);
+                }
+                break;
+            case "--update-vacuum":
+                updateVacuum = true;
+                break;
+            case "--vacuum-cost-limit":
+                if (++i < args.length) {
+                    this.vacuumCostLimit = Integer.parseInt(args[i]);
+                } else {
+                    throw new IllegalArgumentException("Missing value for argument at posn: " + i);
+                }
+                break;
+            case "--vacuum-threshold":
+                if (++i < args.length) {
+                    this.vacuumThreshold = Integer.parseInt(args[i]);
+                } else {
+                    throw new IllegalArgumentException("Missing value for argument at posn: " + i);
+                }
+                break;
+            case "--vacuum-scale-factor":
+                if (++i < args.length) {
+                    this.vacuumScaleFactor = Double.parseDouble(args[i]);
+                } else {
+                    throw new IllegalArgumentException("Missing value for argument at posn: " + i);
+                }
+                break;
+            case "--vacuum-table-name":
+                if (++i < args.length) {
+                    this.vacuumTableName = args[i];
                 } else {
                     throw new IllegalArgumentException("Missing value for argument at posn: " + i);
                 }
@@ -1654,7 +1704,7 @@ public class Main {
         if (MULTITENANT_FEATURE_ENABLED.contains(dbType)) {
             // Process each tenant one-by-one
             List<TenantInfo> tenants = getTenantList();
-            for (TenantInfo ti: tenants) {
+            for (TenantInfo ti : tenants) {
 
                 // If no --schema-name override was specified, we process all tenants, otherwise we
                 // process only tenants which belong to the override schema name
@@ -1671,7 +1721,7 @@ public class Main {
         if (MULTITENANT_FEATURE_ENABLED.contains(dbType)) {
             // Process each tenant one-by-one
             List<TenantInfo> tenants = getTenantList();
-            for (TenantInfo ti: tenants) {
+            for (TenantInfo ti : tenants) {
 
                 // If no --schema-name override was specified, we process all tenants, otherwise we
                 // process only tenants which belong to the override schema name
@@ -1686,6 +1736,7 @@ public class Main {
 
     /**
      * Get the list of resource types to drive resource-by-resource operations
+     *
      * @return the full list of FHIR R4 resource types, or a subset of names if so configured
      */
     private Set<String> getResourceTypes() {
@@ -1695,9 +1746,7 @@ public class Main {
             // Should simplify FhirSchemaGenerator and always pass in this list. When switching
             // over to false, migration is required to drop the tables no longer required.
             final boolean includeAbstractResourceTypes = true;
-            result = ModelSupport.getResourceTypes(includeAbstractResourceTypes).stream()
-                    .map(Class::getSimpleName)
-                    .collect(Collectors.toSet());
+            result = ModelSupport.getResourceTypes(includeAbstractResourceTypes).stream().map(Class::getSimpleName).collect(Collectors.toSet());
         } else {
             result = this.resourceTypeSubset;
         }
@@ -1707,6 +1756,7 @@ public class Main {
 
     /**
      * Get the list of resource types from the database.
+     *
      * @param adapter
      * @param schemaName
      * @return
@@ -1727,6 +1777,7 @@ public class Main {
 
     /**
      * Migrate the IS_DELETED data for the given tenant
+     *
      * @param ti
      */
     private void dataMigrationForV0010(TenantInfo ti) {
@@ -1736,7 +1787,7 @@ public class Main {
         Set<String> resourceTypes = getResourceTypes();
 
         // Process each update in its own transaction so we don't stress the tx log space
-        for (String resourceTypeName: resourceTypes) {
+        for (String resourceTypeName : resourceTypes) {
             try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
                 try {
                     SetTenantIdDb2 setTenantId = new SetTenantIdDb2(schema.getAdminSchemaName(), ti.getTenantId());
@@ -1766,7 +1817,7 @@ public class Main {
         Set<String> resourceTypes = getResourceTypes();
 
         // Process each resource type in its own transaction to avoid pressure on the tx log
-        for (String resourceTypeName: resourceTypes) {
+        for (String resourceTypeName : resourceTypes) {
             try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
                 try {
                     // only process tables which have been converted to the V0010 schema but
@@ -1775,7 +1826,8 @@ public class Main {
                     // has to be done after the transaction in which the alter table was performed.
                     GetXXLogicalResourceNeedsMigration needsMigrating = new GetXXLogicalResourceNeedsMigration(schema.getSchemaName(), resourceTypeName);
                     if (adapter.runStatement(needsMigrating)) {
-                        logger.info("V0010-V0012 Migration: Updating " + resourceTypeName + "_LOGICAL_RESOURCES denormalized columns in schema " + schema.getSchemaName());
+                        logger.info("V0010-V0012 Migration: Updating " + resourceTypeName + "_LOGICAL_RESOURCES denormalized columns in schema "
+                                + schema.getSchemaName());
                         InitializeLogicalResourceDenorms cmd = new InitializeLogicalResourceDenorms(schema.getSchemaName(), resourceTypeName);
                         adapter.runStatement(cmd);
                     }
@@ -1790,6 +1842,7 @@ public class Main {
 
     /**
      * Migrate the LOGICAL_RESOURCE IS_DELETED and LAST_UPDATED data for the given tenant
+     *
      * @param ti
      */
     private void dataMigrationForV0014(TenantInfo ti) {
@@ -1799,14 +1852,14 @@ public class Main {
         List<ResourceType> resourceTypes = getResourceTypesList(adapter, schema.getSchemaName());
 
         // Process each update in its own transaction so we don't over-stress the tx log space
-        for (ResourceType resourceType: resourceTypes) {
+        for (ResourceType resourceType : resourceTypes) {
             try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
                 try {
                     SetTenantIdDb2 setTenantId = new SetTenantIdDb2(schema.getAdminSchemaName(), ti.getTenantId());
                     adapter.runStatement(setTenantId);
 
                     logger.info("V0014 Migration: Updating " + "LOGICAL_RESOURCES.IS_DELETED and LAST_UPDATED for " + resourceType.toString()
-                        + " for tenant '" + ti.getTenantName() + "', schema '" + ti.getTenantSchema() + "'");
+                            + " for tenant '" + ti.getTenantName() + "', schema '" + ti.getTenantSchema() + "'");
 
                     dataMigrationForV0014(adapter, ti.getTenantSchema(), resourceType);
                 } catch (DataAccessException x) {
@@ -1826,7 +1879,7 @@ public class Main {
         List<ResourceType> resourceTypes = getResourceTypesList(adapter, schema.getSchemaName());
 
         // Process each resource type in its own transaction to avoid pressure on the tx log
-        for (ResourceType resourceType: resourceTypes) {
+        for (ResourceType resourceType : resourceTypes) {
             try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
                 try {
                     dataMigrationForV0014(adapter, schema.getSchemaName(), resourceType);
@@ -1853,7 +1906,8 @@ public class Main {
         if (adapter.runStatement(needsMigrating)) {
             logger.info("V0014 Migration: Updating LOGICAL_RESOURCES.IS_DELETED and LAST_UPDATED for schema '"
                     + schemaName + "' and resource type '" + resourceType.toString() + "'");
-            MigrateV0014LogicalResourceIsDeletedLastUpdated cmd = new MigrateV0014LogicalResourceIsDeletedLastUpdated(schemaName, resourceType.getName(), resourceType.getId());
+            MigrateV0014LogicalResourceIsDeletedLastUpdated cmd =
+                    new MigrateV0014LogicalResourceIsDeletedLastUpdated(schemaName, resourceType.getName(), resourceType.getId());
             adapter.runStatement(cmd);
         }
     }
@@ -1862,11 +1916,10 @@ public class Main {
      * Backfill the RESOURCE_CHANGE_LOG table if it is empty
      */
     protected void backfillResourceChangeLog() {
-
         if (MULTITENANT_FEATURE_ENABLED.contains(dbType)) {
             // Process each tenant one-by-one
             List<TenantInfo> tenants = getTenantList();
-            for (TenantInfo ti: tenants) {
+            for (TenantInfo ti : tenants) {
 
                 // If no --schema-name override was specified, we process all tenants, otherwise we
                 // process only tenants which belong to the override schema name
@@ -1912,9 +1965,9 @@ public class Main {
                 GetResourceChangeLogEmpty isEmpty = new GetResourceChangeLogEmpty(schema.getSchemaName());
                 if (adapter.runStatement(isEmpty)) {
                     // change log is empty, so we need to backfill it with data
-                    for (String resourceTypeName: resourceTypes) {
+                    for (String resourceTypeName : resourceTypes) {
                         logger.info("Backfilling RESOURCE_CHANGE_LOG with " + resourceTypeName
-                            + " resources for tenant '" + ti.getTenantName() + "', schema '" + ti.getTenantSchema() + "'");
+                                + " resources for tenant '" + ti.getTenantName() + "', schema '" + ti.getTenantSchema() + "'");
                         BackfillResourceChangeLogDb2 backfill = new BackfillResourceChangeLogDb2(schema.getSchemaName(), resourceTypeName);
                         adapter.runStatement(backfill);
                     }
@@ -1932,16 +1985,57 @@ public class Main {
     /**
      * Backfill the RESOURCE_CHANGE_LOG table for all the resource types. Non-multi-tenant
      * implementation
+     *
      * @param adapter
      */
     private void doBackfill(IDatabaseAdapter adapter) {
         Set<String> resourceTypes = getResourceTypes();
 
-        for (String resourceTypeName: resourceTypes) {
+        for (String resourceTypeName : resourceTypes) {
             logger.info("Backfilling RESOURCE_CHANGE_LOG with " + resourceTypeName
-                + " resources for schema '" + schema.getSchemaName() + "'");
+                    + " resources for schema '" + schema.getSchemaName() + "'");
             BackfillResourceChangeLog backfill = new BackfillResourceChangeLog(schema.getSchemaName(), resourceTypeName);
             adapter.runStatement(backfill);
+        }
+    }
+
+    /**
+     * updates the vacuum settings for postgres.
+     */
+    public void updateVacuumSettings() {
+        if (dbType != DbType.POSTGRESQL) {
+            logger.severe("Updating the vacuum settings is only supported on postgres and the setting is for '" + dbType + "'");
+        }
+
+        // Create the Physical Data Model
+        PhysicalDataModel pdm = new PhysicalDataModel();
+        buildCommonModel(pdm, true, false, false);
+
+        // Setup the Connection Pool
+        configureConnectionPool();
+        PostgresAdapter adapter = new PostgresAdapter(connectionPool);
+
+        try (ITransaction tx = TransactionFactory.openTransaction(connectionPool)) {
+            try {
+                if (vacuumTableName != null) {
+                    // If the vacuumTableName exists, then we try finding the table definition.
+                    Table table = pdm.findTable(schema.getSchemaName(), vacuumTableName);
+                    if (table == null) {
+                        logger.severe("Table [" + vacuumTableName + "] is not found, and no vacuum settings are able to be updated.");
+                        throw new IllegalArgumentException("Table [" + vacuumTableName + "] is not found, and no vacuum settings are able to be updated.");
+                    }
+                    PostgresVacuumSettingDAO alterVacuumSettings =
+                            new PostgresVacuumSettingDAO(schema.getSchemaName(), table.getObjectName(), vacuumCostLimit, vacuumScaleFactor, vacuumThreshold);
+                    adapter.runStatement(alterVacuumSettings);
+                } else {
+                    // Process all tables in the schema ... except for XX_RESOURCES and COMMON_TOKEN_VALUES and COMMON_CANONICAL_VALUES
+                    pdm.visit(new VacuumSettingsTableDataModelVisitor(adapter, schema.getSchemaName(), vacuumCostLimit, vacuumScaleFactor, vacuumThreshold));
+                }
+            } catch (DataAccessException x) {
+                // Something went wrong, so mark the transaction as failed
+                tx.setRollbackOnly();
+                throw x;
+            }
         }
     }
 
@@ -1973,6 +2067,8 @@ public class Main {
 
         if (addKeyForTenant != null) {
             addTenantKey();
+        } else if (updateVacuum) {
+            updateVacuumSettings();
         } else if (this.dropAdmin || this.dropFhirSchema || this.dropJavaBatchSchema || this.dropOauthSchema) {
             // only proceed with the drop if the user has provided additional confirmation
             if (this.confirmDrop) {
@@ -2056,13 +2152,11 @@ public class Main {
      * Log warning messages for deprecated tables.
      */
     private void logWarningMessagesForDeprecatedTables() {
-        List<String> deprecatedTables = Arrays.asList(
-            "DOMAINRESOURCE_DATE_VALUES", "DOMAINRESOURCE_LATLNG_VALUES", "DOMAINRESOURCE_LOGICAL_RESOURCES", "DOMAINRESOURCE_NUMBER_VALUES",
-            "DOMAINRESOURCE_QUANTITY_VALUES", "DOMAINRESOURCE_RESOURCE_TOKEN_REFS", "DOMAINRESOURCE_RESOURCES","DOMAINRESOURCE_STR_VALUES",
-            "RESOURCE_DATE_VALUES", "RESOURCE_LATLNG_VALUES", "RESOURCE_LOGICAL_RESOURCES", "RESOURCE_NUMBER_VALUES",
-            "RESOURCE_QUANTITY_VALUES", "RESOURCE_RESOURCE_TOKEN_REFS", "RESOURCE_RESOURCES", "RESOURCE_STR_VALUES");
+        List<String> deprecatedTables =
+                Arrays.asList("DOMAINRESOURCE_DATE_VALUES", "DOMAINRESOURCE_LATLNG_VALUES", "DOMAINRESOURCE_LOGICAL_RESOURCES", "DOMAINRESOURCE_NUMBER_VALUES", "DOMAINRESOURCE_QUANTITY_VALUES", "DOMAINRESOURCE_RESOURCE_TOKEN_REFS", "DOMAINRESOURCE_RESOURCES", "DOMAINRESOURCE_STR_VALUES", "RESOURCE_DATE_VALUES", "RESOURCE_LATLNG_VALUES", "RESOURCE_LOGICAL_RESOURCES", "RESOURCE_NUMBER_VALUES", "RESOURCE_QUANTITY_VALUES", "RESOURCE_RESOURCE_TOKEN_REFS", "RESOURCE_RESOURCES", "RESOURCE_STR_VALUES");
         for (String deprecatedTable : deprecatedTables) {
-            logger.warning("Table '" + deprecatedTable + "' will be dropped in a future release. No data should be written to this table. If any data exists in the table, that data should be deleted.");
+            logger.warning("Table '" + deprecatedTable
+                    + "' will be dropped in a future release. No data should be written to this table. If any data exists in the table, that data should be deleted.");
         }
     }
 

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirResourceTableGroup.java
@@ -199,7 +199,7 @@ public class FhirResourceTableGroup {
         // things sensible.
         Table.Builder builder = Table.builder(schemaName, tableName)
                 .setTenantColumnName(MT_ID)
-                .setVersion(FhirSchemaVersion.V0017.vid()) // V0011: is_deleted and last_updated, V0012: version_id
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID, false)
                 .addVarcharColumn(LOGICAL_ID, LOGICAL_ID_BYTES, false)
@@ -400,7 +400,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
         // Parameters are tied to the logical resource
         Table tbl = Table.builder(schemaName, tableName)
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 // .addBigIntColumn(             ROW_ID,      false) // Removed by issue-1683 - composites refactor
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
@@ -485,7 +485,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         // logical_resources (1) ---- (*) patient_resource_token_refs (*) ---- (0|1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(       PARAMETER_NAME_ID,    false)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,     true)
@@ -558,7 +558,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         // logical_resources (1) ---- (*) patient_resource_token_refs (*) ---- (0|1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(          CANONICAL_ID,    false)
                 .addBigIntColumn(   LOGICAL_RESOURCE_ID,    false)
@@ -601,7 +601,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         // logical_resources (1) ---- (*) patient_tags (*) ---- (0|1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,   false)
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,   false)
@@ -639,7 +639,7 @@ ALTER TABLE device_str_values ADD CONSTRAINT fk_device_str_values_rid  FOREIGN K
 
         // logical_resources (1) ---- (*) patient_security (*) ---- (0|1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,   false)
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,   false)
@@ -739,7 +739,7 @@ ALTER TABLE device_date_values ADD CONSTRAINT fk_device_date_values_r  FOREIGN K
         final String logicalResourcesTable = prefix + _LOGICAL_RESOURCES;
 
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
@@ -802,7 +802,7 @@ ALTER TABLE device_number_values ADD CONSTRAINT fk_device_number_values_r  FOREI
         final String logicalResourcesTable = prefix + _LOGICAL_RESOURCES;
 
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
@@ -872,7 +872,7 @@ ALTER TABLE device_latlng_values ADD CONSTRAINT fk_device_latlng_values_r  FOREI
 
         Table tbl = Table.builder(schemaName, tableName)
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addDoubleColumn(     LATITUDE_VALUE,       true)
@@ -941,7 +941,7 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
 
         Table tbl = Table.builder(schemaName, tableName)
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addVarcharColumn(              CODE, 255, false)
@@ -994,7 +994,7 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
         final int lib = LOGICAL_ID_BYTES;
 
         Table tbl = Table.builder(schemaName, LIST_LOGICAL_RESOURCE_ITEMS)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn( LOGICAL_RESOURCE_ID,      false)
@@ -1034,7 +1034,7 @@ ALTER TABLE device_quantity_values ADD CONSTRAINT fk_device_quantity_values_r  F
         // model with a foreign key to avoid order of insertion issues
 
         Table tbl = Table.builder(schemaName, PATIENT_CURRENT_REFS)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addTag(FhirSchemaTags.RESOURCE_TYPE, prefix)
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(         LOGICAL_RESOURCE_ID,      false)

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaGenerator.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaGenerator.java
@@ -516,7 +516,7 @@ public class FhirSchemaGenerator {
         final String IDX_LOGICAL_RESOURCES_LUPD = "IDX_" + LOGICAL_RESOURCES + "_LUPD";
 
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID, false)
                 .addIntColumn(RESOURCE_TYPE_ID, false)
@@ -651,7 +651,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (1) ---- (*) logical_resource_profiles (*) ---- (1) common_canonical_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0014
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes (Original Table at V0014)
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(         CANONICAL_ID,     false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,     false) // FK referencing LOGICAL_RESOURCES
@@ -696,7 +696,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (1) ---- (*) logical_resource_tags (*) ---- (1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0014
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes, original table created at version V0014
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,    false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,    false) // FK referencing LOGICAL_RESOURCES
@@ -733,7 +733,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (1) ---- (*) logical_resource_security (*) ---- (1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0016
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes, original table created at version V0016
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,    false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,    false) // FK referencing LOGICAL_RESOURCES
@@ -771,7 +771,7 @@ public class FhirSchemaGenerator {
 
         Table tbl = Table.builder(schemaName, tableName)
                 .setTenantColumnName(MT_ID)
-                .setVersion(FhirSchemaVersion.V0017.vid()) // Make sure this matches any migration
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .addBigIntColumn(RESOURCE_ID, false)
                 .addIntColumn(RESOURCE_TYPE_ID, false)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID, false)
@@ -817,7 +817,7 @@ public class FhirSchemaGenerator {
         // because it makes it very easy to find the most recent changes to resources associated with
         // a given patient (for example).
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     COMPARTMENT_NAME_ID,      false)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID,      false)
@@ -860,7 +860,7 @@ public class FhirSchemaGenerator {
         final int msb = MAX_SEARCH_STRING_BYTES;
 
         Table tbl = Table.builder(schemaName, STR_VALUES)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addVarcharColumn(         STR_VALUE, msb,  true)
@@ -903,7 +903,7 @@ public class FhirSchemaGenerator {
         final String logicalResourcesTable = LOGICAL_RESOURCES;
 
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addTimestampColumn(      DATE_START,6,    true)
@@ -1069,7 +1069,7 @@ public class FhirSchemaGenerator {
      */
     protected void addCodeSystems(PhysicalDataModel model) {
         codeSystemsTable = Table.builder(schemaName, CODE_SYSTEMS)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(      CODE_SYSTEM_ID,         false)
                 .addVarcharColumn(CODE_SYSTEM_NAME,    255, false)
@@ -1163,7 +1163,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (0|1) ---- (*) resource_token_refs
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0017.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid()) // V0017: Updated to support Postgres vacuum changes
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(       PARAMETER_NAME_ID,    false)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,     true) // support for null token value entries

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaGenerator.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaGenerator.java
@@ -104,6 +104,8 @@ import com.ibm.fhir.database.utils.model.Sequence;
 import com.ibm.fhir.database.utils.model.SessionVariableDef;
 import com.ibm.fhir.database.utils.model.Table;
 import com.ibm.fhir.database.utils.model.Tablespace;
+import com.ibm.fhir.database.utils.model.With;
+import com.ibm.fhir.database.utils.postgres.PostgresVacuumSettingDAO;
 import com.ibm.fhir.model.util.ModelSupport;
 
 /**
@@ -514,6 +516,7 @@ public class FhirSchemaGenerator {
         final String IDX_LOGICAL_RESOURCES_LUPD = "IDX_" + LOGICAL_RESOURCES + "_LUPD";
 
         Table tbl = Table.builder(schemaName, tableName)
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID, false)
                 .addIntColumn(RESOURCE_TYPE_ID, false)
@@ -531,7 +534,7 @@ public class FhirSchemaGenerator {
                 .addPrivileges(resourceTablePrivileges)
                 .addForeignKeyConstraint(FK + tableName + "_RTID", schemaName, RESOURCE_TYPES, RESOURCE_TYPE_ID)
                 .enableAccessControl(this.sessionVariable)
-                .setVersion(FhirSchemaVersion.V0015.vid())
+                .addWiths(addWiths()) // New Column for V0017
                 .addMigration(priorVersion -> {
                     List<IDatabaseStatement> statements = new ArrayList<>();
                     if (priorVersion == FhirSchemaVersion.V0001.vid()) {
@@ -573,7 +576,6 @@ public class FhirSchemaGenerator {
                         statements.add(new CreateIndexStatement(schemaName, IDX_LOGICAL_RESOURCES_LUPD, tableName, mtId, indexCols));
                     }
 
-
                     if (priorVersion < FhirSchemaVersion.V0015.vid()) {
                         // Add PARAM_HASH logical_resources
                         List<ColumnBase> cols = ColumnDefBuilder.builder()
@@ -582,7 +584,9 @@ public class FhirSchemaGenerator {
                         statements.add(new AddColumn(schemaName, tableName, cols.get(0)));
                     }
 
-
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
                     return statements;
                 })
                 .build(pdm);
@@ -618,6 +622,11 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    // Intentionally NOP
+                    return statements;
+                })
                 .build(pdm);
 
         // TODO should not need to add as a table and an object. Get the table to add itself?
@@ -642,7 +651,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (1) ---- (*) logical_resource_profiles (*) ---- (1) common_canonical_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0014.vid()) // table created at version V0014
+                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0014
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(         CANONICAL_ID,     false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,     false) // FK referencing LOGICAL_RESOURCES
@@ -655,6 +664,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         tbl.addTag(SCHEMA_GROUP_TAG, FHIRDATA_GROUP);
@@ -679,7 +696,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (1) ---- (*) logical_resource_tags (*) ---- (1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0014.vid()) // table created at version V0014
+                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0014
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,    false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,    false) // FK referencing LOGICAL_RESOURCES
@@ -690,6 +707,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         pdm.addTable(tbl);
@@ -704,12 +729,11 @@ public class FhirSchemaGenerator {
      * @return
      */
     public Table addLogicalResourceSecurity(PhysicalDataModel pdm) {
-
         final String tableName = LOGICAL_RESOURCE_SECURITY;
 
         // logical_resources (1) ---- (*) logical_resource_security (*) ---- (1) common_token_values
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0016.vid()) // table created at version V0016
+                .setVersion(FhirSchemaVersion.V0017.vid()) // table created at version V0016
                 .setTenantColumnName(MT_ID)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,    false) // FK referencing COMMON_CANONICAL_VALUES
                 .addBigIntColumn(  LOGICAL_RESOURCE_ID,    false) // FK referencing LOGICAL_RESOURCES
@@ -720,6 +744,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         pdm.addTable(tbl);
@@ -739,7 +771,7 @@ public class FhirSchemaGenerator {
 
         Table tbl = Table.builder(schemaName, tableName)
                 .setTenantColumnName(MT_ID)
-                .setVersion(FhirSchemaVersion.V0009.vid()) // Make sure this matches any migration
+                .setVersion(FhirSchemaVersion.V0017.vid()) // Make sure this matches any migration
                 .addBigIntColumn(RESOURCE_ID, false)
                 .addIntColumn(RESOURCE_TYPE_ID, false)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID, false)
@@ -751,6 +783,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         // TODO should not need to add as a table and an object. Get the table to add itself?
@@ -768,7 +808,6 @@ public class FhirSchemaGenerator {
      * @return Table the table that was added to the PhysicalDataModel
      */
     public Table addLogicalResourceCompartments(PhysicalDataModel pdm) {
-
         final String tableName = LOGICAL_RESOURCE_COMPARTMENTS;
 
         // note COMPARTMENT_LOGICAL_RESOURCE_ID represents the compartment (e.g. the Patient)
@@ -778,7 +817,7 @@ public class FhirSchemaGenerator {
         // because it makes it very easy to find the most recent changes to resources associated with
         // a given patient (for example).
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0006.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     COMPARTMENT_NAME_ID,      false)
                 .addBigIntColumn(LOGICAL_RESOURCE_ID,      false)
@@ -791,6 +830,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         // TODO should not need to add as a table and an object. Get the table to add itself?
@@ -813,6 +860,7 @@ public class FhirSchemaGenerator {
         final int msb = MAX_SEARCH_STRING_BYTES;
 
         Table tbl = Table.builder(schemaName, STR_VALUES)
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addVarcharColumn(         STR_VALUE, msb,  true)
@@ -827,6 +875,14 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, STR_VALUES, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(pdm);
 
         tbl.addTag(SCHEMA_GROUP_TAG, FHIRDATA_GROUP);
@@ -847,7 +903,7 @@ public class FhirSchemaGenerator {
         final String logicalResourcesTable = LOGICAL_RESOURCES;
 
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(2)
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(     PARAMETER_NAME_ID,      false)
                 .addTimestampColumn(      DATE_START,6,    true)
@@ -861,12 +917,16 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
                 .addMigration(priorVersion -> {
                     List<IDatabaseStatement> statements = new ArrayList<>();
                     if (priorVersion == 1) {
                         statements.add(new DropIndex(schemaName, IDX + tableName + "_PVR"));
                         statements.add(new DropIndex(schemaName, IDX + tableName + "_RPV"));
                         statements.add(new DropColumn(schemaName, tableName, DATE_VALUE_DROPPED_COLUMN));
+                    }
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
                     }
                     return statements;
                 })
@@ -879,7 +939,6 @@ public class FhirSchemaGenerator {
 
         return tbl;
     }
-
 
     /**
      * <pre>
@@ -896,7 +955,6 @@ public class FhirSchemaGenerator {
      * @param model
      */
     protected void addResourceTypes(PhysicalDataModel model) {
-
         resourceTypesTable = Table.builder(schemaName, RESOURCE_TYPES)
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(    RESOURCE_TYPE_ID,      false)
@@ -906,6 +964,11 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    // Intentionally a NOP
+                    return statements;
+                })
                 .build(model);
 
         // TODO Table should be immutable, so add support to the Builder for this
@@ -928,7 +991,7 @@ public class FhirSchemaGenerator {
         // The sessionVariable is used to enable access control on every table, so we
         // provide it as a dependency
         FhirResourceTableGroup frg = new FhirResourceTableGroup(model, this.schemaName, this.multitenant, sessionVariable,
-                this.procedureDependencies, this.fhirTablespace, this.resourceTablePrivileges);
+                this.procedureDependencies, this.fhirTablespace, this.resourceTablePrivileges, addWiths());
         for (String resourceType: this.resourceTypes) {
 
             resourceType = resourceType.toUpperCase().trim();
@@ -965,7 +1028,6 @@ public class FhirSchemaGenerator {
      * @param model
      */
     protected void addParameterNames(PhysicalDataModel model) {
-
         // The index which also used by the database to support the primary key constraint
         String[] prfIndexCols = {PARAMETER_NAME};
         String[] prfIncludeCols = {PARAMETER_NAME_ID};
@@ -979,6 +1041,11 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    // Intentionally a NOP
+                    return statements;
+                })
                 .build(model);
 
         this.parameterNamesTable.addTag(SCHEMA_GROUP_TAG, FHIRDATA_GROUP);
@@ -1001,8 +1068,8 @@ public class FhirSchemaGenerator {
      * @param model
      */
     protected void addCodeSystems(PhysicalDataModel model) {
-
         codeSystemsTable = Table.builder(schemaName, CODE_SYSTEMS)
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(      CODE_SYSTEM_ID,         false)
                 .addVarcharColumn(CODE_SYSTEM_NAME,    255, false)
@@ -1011,13 +1078,19 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, CODE_SYSTEMS, 2000, 0.01, 1000));
+                    }
+                    return statements;
+                })
                 .build(model);
 
         this.codeSystemsTable.addTag(SCHEMA_GROUP_TAG, FHIRDATA_GROUP);
         this.procedureDependencies.add(codeSystemsTable);
         model.addTable(codeSystemsTable);
         model.addObject(codeSystemsTable);
-
     }
 
     /**
@@ -1060,6 +1133,11 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addMigration(priorVersion -> {
+                    List<IDatabaseStatement> statements = new ArrayList<>();
+                    // Intentionally a NOP
+                    return statements;
+                })
                 .build(pdm);
 
         // TODO should not need to add as a table and an object. Get the table to add itself?
@@ -1085,7 +1163,7 @@ public class FhirSchemaGenerator {
 
         // logical_resources (0|1) ---- (*) resource_token_refs
         Table tbl = Table.builder(schemaName, tableName)
-                .setVersion(FhirSchemaVersion.V0009.vid())
+                .setVersion(FhirSchemaVersion.V0017.vid())
                 .setTenantColumnName(MT_ID)
                 .addIntColumn(       PARAMETER_NAME_ID,    false)
                 .addBigIntColumn(COMMON_TOKEN_VALUE_ID,     true) // support for null token value entries
@@ -1099,6 +1177,7 @@ public class FhirSchemaGenerator {
                 .setTablespace(fhirTablespace)
                 .addPrivileges(resourceTablePrivileges)
                 .enableAccessControl(this.sessionVariable)
+                .addWiths(addWiths()) // New Column for V0017
                 .addMigration(priorVersion -> {
                     // Replace the indexes initially defined in the V0006 version with better ones
                     List<IDatabaseStatement> statements = new ArrayList<>();
@@ -1125,6 +1204,9 @@ public class FhirSchemaGenerator {
                             new OrderedColumnDef(COMMON_TOKEN_VALUE_ID, OrderedColumnDef.Direction.ASC, null)
                             );
                         statements.add(new CreateIndexStatement(schemaName, IDX + tableName + "_LRPT", tableName, mtId, lrpt));
+                    }
+                    if (priorVersion < FhirSchemaVersion.V0017.vid()) {
+                        statements.add(new PostgresVacuumSettingDAO(schemaName, tableName, 2000, 0.01, 1000));
                     }
                     return statements;
                 })
@@ -1182,7 +1264,6 @@ public class FhirSchemaGenerator {
         pdm.addObject(alter);
     }
 
-
     /**
      * Add the sequence used by the new local/external references data model
      * @param pdm
@@ -1193,5 +1274,16 @@ public class FhirSchemaGenerator {
         procedureDependencies.add(seq);
         sequencePrivileges.forEach(p -> p.addToObject(seq));
         pdm.addObject(seq);
+    }
+
+    /**
+     * The defaults with addWiths
+     * @return
+     */
+    protected List<With> addWiths() {
+        return Arrays.asList(
+                With.with("autovacuum_vacuum_scale_factor", "0.01"),
+                With.with("autovacuum_vacuum_threshold", "1000"),
+                With.with("autovacuum_vacuum_cost_limit", "2000"));
     }
 }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
@@ -35,6 +35,7 @@ public enum FhirSchemaVersion {
     ,V0014(14, "whole-system search and canonical references", true)
     ,V0015(15, "issue-2155 add parameter hash to bypass update during reindex", true)
     ,V0016(16, "issue-1921 add dedicated common_token_values mapping table for security", true)
+    ,V0017(17, "issue-1822 add default settings for postgres vacuum tables", true)
     ;
 
     // The version number recorded in the VERSION_HISTORY

--- a/fhir-server-test/src/test/java/com/ibm/fhir/client/test/FHIRClientTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/client/test/FHIRClientTestBase.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2021
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,13 +36,14 @@ public abstract class FHIRClientTestBase {
     protected FHIRClient clientOAuth2 = null;
 
     public FHIRClientTestBase() {
+        // No Operation
     }
 
     /**
      * Do one-time setup to enable tests to run.
      */
     @BeforeClass
-    public void setUp() throws Exception {
+    public void setup() throws Exception {
         testProperties = TestUtil.readTestProperties("test.properties");
         testPropertiesOAuth2 = TestUtil.readTestProperties("test.oauth2.properties");
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
@@ -13,10 +13,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Properties;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonReaderFactory;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -28,6 +24,11 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.test.FHIRClientTestBase;
 import com.ibm.fhir.model.test.TestUtil;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 
 /**
  * OAuth 2.0 tests used to register a client and generate an access token
@@ -44,6 +45,7 @@ public class FHIROAuth2Test extends FHIRClientTestBase {
     private final String tokenURL = "https://localhost:9443/oauth2/endpoint/oauth2-provider/token";
 
 
+    @Override
     @BeforeClass
     public void setup() throws Exception {
         Properties testProperties = TestUtil.readTestProperties("test.properties");
@@ -98,7 +100,9 @@ public class FHIROAuth2Test extends FHIRClientTestBase {
         if (ON) {
             WebTarget endpoint = clientOAuth2.getWebTarget(tokenURL);
             Form form = new Form();
-            form.param("grant_type", "client_credentials").param("client_id", clientID.replaceAll("\"", "")).param("client_secret", clientSecret.replaceAll("\"", ""));
+            form.param("grant_type", "client_credentials")
+                .param("client_id", clientID.replaceAll("\"", ""))
+                .param("client_secret", clientSecret.replaceAll("\"", ""));
 
             Entity<Form> entity = Entity.form(form);
             Invocation.Builder builder = endpoint.request("application/json");

--- a/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
@@ -13,6 +13,10 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Properties;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -24,11 +28,6 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.test.FHIRClientTestBase;
 import com.ibm.fhir.model.test.TestUtil;
-
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonReaderFactory;
 
 /**
  * OAuth 2.0 tests used to register a client and generate an access token
@@ -45,7 +44,6 @@ public class FHIROAuth2Test extends FHIRClientTestBase {
     private final String tokenURL = "https://localhost:9443/oauth2/endpoint/oauth2-provider/token";
 
 
-    @Override
     @BeforeClass
     public void setup() throws Exception {
         Properties testProperties = TestUtil.readTestProperties("test.properties");
@@ -100,9 +98,7 @@ public class FHIROAuth2Test extends FHIRClientTestBase {
         if (ON) {
             WebTarget endpoint = clientOAuth2.getWebTarget(tokenURL);
             Form form = new Form();
-            form.param("grant_type", "client_credentials")
-                .param("client_id", clientID.replaceAll("\"", ""))
-                .param("client_secret", clientSecret.replaceAll("\"", ""));
+            form.param("grant_type", "client_credentials").param("client_id", clientID.replaceAll("\"", "")).param("client_secret", clientSecret.replaceAll("\"", ""));
 
             Entity<Form> entity = Entity.form(form);
             Invocation.Builder builder = endpoint.request("application/json");

--- a/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/client/test/oauth/FHIROAuth2Test.java
@@ -13,10 +13,6 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Properties;
 
-import jakarta.json.Json;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonReaderFactory;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -28,6 +24,11 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.client.test.FHIRClientTestBase;
 import com.ibm.fhir.model.test.TestUtil;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonReaderFactory;
 
 /**
  * OAuth 2.0 tests used to register a client and generate an access token
@@ -43,9 +44,8 @@ public class FHIROAuth2Test extends FHIRClientTestBase {
     private final String oidcRegURL = "https://localhost:9443/oidc/endpoint/oidc-provider/registration";
     private final String tokenURL = "https://localhost:9443/oauth2/endpoint/oauth2-provider/token";
 
-
     @BeforeClass
-    public void setup() throws Exception {
+    public void checkIfOn() throws Exception {
         Properties testProperties = TestUtil.readTestProperties("test.properties");
         ON = Boolean.parseBoolean(testProperties.getProperty("test.client.oauth.enabled", "false"));
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/Base64BinaryTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/Base64BinaryTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,8 +23,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
-import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.resource.AuditEvent;
 import com.ibm.fhir.model.resource.Binary;
 import com.ibm.fhir.model.resource.DocumentReference;
@@ -55,25 +53,26 @@ public class Base64BinaryTest extends FHIRServerTestBase {
 
         byte[] value = "Hello, World!".getBytes();
         Binary binary = Binary.builder()
-                .contentType(Code.of("text/plain")).data(Base64Binary.builder().value(value).build()).build();
+                .contentType(Code.of("text/plain"))
+                .data(Base64Binary.builder()
+                        .value(value)
+                        .build())
+                .build();
 
         Entity<Binary> entity = Entity.entity(binary, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Binary").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(binary, System.out);
-        }
+        printOutResource(DEBUG, binary);
 
         String binaryId = getLocationLogicalId(response);
+        addToResourceRegistry("Binary", binaryId);
 
         response = target.path("Binary/" + binaryId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Binary responseBinary = response.readEntity(Binary.class);
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(responseBinary, System.out);
-        }
+        printOutResource(DEBUG, responseBinary);
 
         String valueString = new String(responseBinary.getData().getValue());
 
@@ -109,19 +108,16 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         Response response = target.path("DocumentReference").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON).generate(docRef, System.out);
-        }
+        printOutResource(DEBUG, docRef);
 
         // Retrieve the DocumentReference
         String docRefId = getLocationLogicalId(response);
+        addToResourceRegistry("DocumentReference", docRefId);
         response = target.path("DocumentReference/" + docRefId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         DocumentReference responseDocRef = response.readEntity(DocumentReference.class);
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON).generate(responseDocRef, System.out);
-        }
+        printOutResource(DEBUG, responseDocRef);
 
         // Compare original and retrieved values.
         assertEquals(new String(responseDocRef.getContent().get(0).getAttachment().getData().getValue()), valueString);
@@ -160,19 +156,16 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         Response response = target.path("AuditEvent").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(auditEvent, System.out);
-        }
+        printOutResource(DEBUG, auditEvent);
 
         // Retrieve the AuditEvent
         String auditEventId = getLocationLogicalId(response);
+        addToResourceRegistry("AuditEvent", auditEventId);
         response = target.path("AuditEvent/" + auditEventId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         AuditEvent responseAuditEvent = response.readEntity(AuditEvent.class);
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(responseAuditEvent, System.out);
-        }
+        printOutResource(DEBUG, responseAuditEvent);
 
         Base64Binary base64Binary = (Base64Binary) responseAuditEvent.getEntity().get(0).getDetail().get(0).getValue();
 
@@ -213,9 +206,7 @@ public class Base64BinaryTest extends FHIRServerTestBase {
                         .build())
                 .build();
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(parameters, System.out);
-        }
+        printOutResource(DEBUG, parameters);
 
         // Persist the Parameters resource
         Entity<Parameters> entity = Entity.entity(parameters, FHIRMediaType.APPLICATION_FHIR_JSON);
@@ -224,13 +215,12 @@ public class Base64BinaryTest extends FHIRServerTestBase {
 
         // Retrieve the Parameters
         String parametersId = getLocationLogicalId(response);
+        addToResourceRegistry("Parameters", parametersId);
         response = target.path("Parameters/" + parametersId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Parameters responseParameters = response.readEntity(Parameters.class);
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(responseParameters, System.out);
-        }
+        printOutResource(DEBUG, responseParameters);
 
         Base64Binary base64Binary = (Base64Binary) responseParameters.getParameter().get(0).getValue();
         Signature signature = (Signature) responseParameters.getParameter().get(2).getValue();
@@ -239,7 +229,6 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         assertEquals(new String(base64Binary.getValue()), valueParameterString);
         assertEquals(new String(signature.getData().getValue()), valueSignatureString);
     }
-
 
     @Test(enabled = true, groups = { "server-binary" })
     public void testCreateAuditEventWithExtension() throws Exception {
@@ -273,19 +262,16 @@ public class Base64BinaryTest extends FHIRServerTestBase {
         Response response = target.path("AuditEvent").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(auditEvent, System.out);
-        }
+        printOutResource(DEBUG, auditEvent);
 
         // Retrieve the AuditEvent
         String auditEventId = getLocationLogicalId(response);
+        addToResourceRegistry("AuditEvent", auditEventId);
         response = target.path("AuditEvent/" + auditEventId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         AuditEvent responseAuditEvent = response.readEntity(AuditEvent.class);
 
-        if (DEBUG) {
-            FHIRGenerator.generator(Format.JSON, false).generate(responseAuditEvent, System.out);
-        }
+        printOutResource(DEBUG, responseAuditEvent);
 
         // Compare original and retrieved values.
         assertEquals(new String(((Base64Binary) responseAuditEvent.getExtension().get(0).getValue()).getValue()),

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConditionalReferenceTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConditionalReferenceTest.java
@@ -38,11 +38,14 @@ public class ConditionalReferenceTest extends FHIRServerTestBase {
 
         WebTarget target = getWebTarget();
 
-        Response response = target.path("Patient").path("12345")
-                .request()
-                .put(Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON));
+        Response response = target
+                            .path("Patient")
+                            .path("12345")
+                            .request()
+                            .put(Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON));
         int status = response.getStatus();
         assertTrue(status == Response.Status.CREATED.getStatusCode() || status == Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Patient", "12345");
 
         patient = patient.toBuilder()
                 .id("54321")
@@ -57,6 +60,7 @@ public class ConditionalReferenceTest extends FHIRServerTestBase {
                 .put(Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON));
         status = response.getStatus();
         assertTrue(status == Response.Status.CREATED.getStatusCode() || status == Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Patient", "54321");
     }
 
     @Test(dependsOnMethods = { "testCreatePatients" })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConvertOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConvertOperationTest.java
@@ -1,3 +1,9 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.ibm.fhir.server.test;
 
 import static org.testng.Assert.assertNotNull;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -45,7 +45,6 @@ import com.ibm.fhir.model.util.ModelSupport;
 
 /**
  * This class tests delete interactions.
- *
  */
 public class DeleteTest extends FHIRServerTestBase {
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DuplicateResourceIdTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DuplicateResourceIdTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,9 +31,6 @@ import com.ibm.fhir.model.type.Reference;
  * more than one FHIR Resource can have the same logical id. This can happen
  * when the updateCreateEnabled option is set to true. A FHIR Client can create
  * different resources (via the update API) with the same logical id.
- * 
- * @author markd
- *
  */
 public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
@@ -44,12 +41,11 @@ public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
     /**
      * Creates a Device and a Contract resource, each with the same logical id.
-     * 
+     *
      * @throws Exception
      */
     @Test(groups = { "server-basic" })
     public void testCreateDupIdResources() throws Exception {
-
         String dupId = UUID.randomUUID().toString();
 
         FHIRResponse response;
@@ -89,7 +85,7 @@ public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
     /**
      * Tests the read API for resources with the same logical id.
-     * 
+     *
      * @throws Exception
      */
     @Test(enabled = true, groups = { "server-basic" }, dependsOnMethods = { "testCreateDupIdResources" })
@@ -113,7 +109,7 @@ public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
     /**
      * Tests the version read API for resources with the same logical id.
-     * 
+     *
      * @throws Exception
      */
     @Test(enabled = true, groups = { "server-basic" }, dependsOnMethods = { "testCreateDupIdResources" })
@@ -137,7 +133,7 @@ public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
     /**
      * Tests the search API for resources with the same logical id.
-     * 
+     *
      * @throws Exception
      */
     @Test(enabled = true, groups = { "server-basic" }, dependsOnMethods = { "testCreateDupIdResources" })
@@ -172,7 +168,7 @@ public class DuplicateResourceIdTest extends FHIRServerTestBase {
 
     /**
      * Tests the history API for resources with the same logical id.
-     * 
+     *
      * @throws Exception
      */
     @Test(enabled = true, groups = { "server-basic" }, dependsOnMethods = { "testCreateDupIdResources" })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRServerTestBase.java
@@ -165,18 +165,21 @@ public abstract class FHIRServerTestBase {
                 }
             }
         }
-
     }
 
     /**
      * prints out the resources
      * @param debug
      * @param res
-     * @throws FHIRGeneratorException
      */
-    public void printOutResource(boolean debug, Resource res) throws FHIRGeneratorException {
+    public void printOutResource(boolean debug, Resource res) {
         if (debug) {
-            FHIRGenerator.generator(Format.JSON, false).generate(res, System.out);
+            try {
+                FHIRGenerator.generator(Format.JSON, false).generate(res, System.out);
+            } catch (FHIRGeneratorException e) {
+                e.printStackTrace();
+                fail("unable to generate the fhir resource to JSON");
+            }
         }
     }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PlanDefinitionApplyOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/PlanDefinitionApplyOperationTest.java
@@ -48,7 +48,7 @@ import com.ibm.fhir.model.type.Coding;
  */
 public class PlanDefinitionApplyOperationTest extends FHIRServerTestBase {
 
-    public static Boolean DEBUG_APPLY = Boolean.TRUE;
+    public static Boolean DEBUG_APPLY = Boolean.FALSE;
     public static final String TEST_GROUP_NAME = "plan-defintion-apply-operation";
 
     // URL Pattern:

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -12,10 +12,7 @@ import static com.ibm.fhir.model.type.Uri.uri;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -34,9 +31,6 @@ import com.ibm.fhir.client.FHIRParameters;
 import com.ibm.fhir.client.FHIRRequestHeader;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
-import com.ibm.fhir.model.generator.FHIRGenerator;
-import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Bundle.Link;
@@ -92,10 +86,7 @@ public class SearchAllTest extends FHIRServerTestBase {
                                 .source(Uri.of("http://ibm.com/fhir/source/Source"))
                                 .build())
                         .build();
-
-        if (DEBUG_SEARCH) {
-            generateOutput(patient);
-        }
+        printOutResource(DEBUG_SEARCH, patient);
 
         Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Patient").request()
@@ -250,9 +241,7 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
 
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
 
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -266,9 +255,7 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
 
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
 
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -284,9 +271,7 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
 
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
 
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -396,26 +381,6 @@ public class SearchAllTest extends FHIRServerTestBase {
         Bundle bundle = response.getResource(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().isEmpty());
-    }
-
-    /*
-     * generates the output into a resource.
-     */
-    public static void generateOutput(Resource resource) {
-
-        try (StringWriter writer = new StringWriter();) {
-            FHIRGenerator.generator(Format.JSON, true).generate(resource, System.out);
-            System.out.println(writer.toString());
-        } catch (FHIRGeneratorException e) {
-
-            e.printStackTrace();
-            fail("unable to generate the fhir resource to JSON");
-
-        } catch (IOException e1) {
-            e1.printStackTrace();
-            fail("unable to generate the fhir resource to JSON (io problem) ");
-        }
-
     }
 
     @Test(groups = { "server-search-all" }, dependsOnMethods = { "testCreatePatient" })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchExtensionsTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchExtensionsTest.java
@@ -113,9 +113,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
 
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
@@ -134,9 +132,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() == 0);
     }
@@ -228,9 +224,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
 
         assertNotNull(bundle);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         // Testing the behavior specific to the URI patterns
@@ -247,9 +241,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
 
         assertNotNull(bundle);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() == 0);
 
         // Response should be empty as the URI value is not an exact match
@@ -265,9 +257,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
 
         assertNotNull(bundle);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() > 0);
     }
 
@@ -287,10 +277,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
         Bundle bundle = response.readEntity(Bundle.class);
 
         assertNotNull(bundle);
-
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
 
         assertTrue(bundle.getEntry().size() > 0);
     }
@@ -310,10 +297,7 @@ public class SearchExtensionsTest extends FHIRServerTestBase {
         Bundle bundle = response.readEntity(Bundle.class);
 
         assertNotNull(bundle);
-
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
 
         assertTrue(bundle.getEntry().size() == 0);
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -66,7 +66,6 @@ import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.util.FHIRUtil;
 
 public class SearchTest extends FHIRServerTestBase {
-
     private static final boolean DEBUG_SEARCH = false;
     private static final String PREFER_HEADER_RETURN_REPRESENTATION = "return=representation";
     private static final String PREFER_HEADER_NAME = "Prefer";
@@ -82,7 +81,7 @@ public class SearchTest extends FHIRServerTestBase {
     private String organizationId;
     private String carePlanId;
     private String conditionId;
-    private Patient patient4DuplicationTest = null;
+    private Patient patientForDuplicationTest = null;
     // Some of the tests run with tenant1 and datastore study1;
     // The others run with the default tenant and the default datastore.
     private final String tenantName = "tenant1";
@@ -686,9 +685,7 @@ public class SearchTest extends FHIRServerTestBase {
         Observation responseObservation =
                 response.readEntity(Observation.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responseObservation);
-        }
+        printOutResource(DEBUG_SEARCH, responseObservation);
 
         // use it for search
         observationId = responseObservation.getId();
@@ -843,13 +840,7 @@ public class SearchTest extends FHIRServerTestBase {
 
         boolean result = false;
         for (Bundle.Entry entry : bundle.getEntry()) {
-
-            if (DEBUG_SEARCH) {
-
-                SearchAllTest.generateOutput(entry.getResource());
-                System.out.println(result + " "
-                        + FHIRUtil.hasTag(entry.getResource(), subsettedTag));
-            }
+            printOutResource(DEBUG_SEARCH, entry.getResource());
 
             result = result
                     || FHIRUtil.hasTag(entry.getResource(), subsettedTag);
@@ -1156,17 +1147,17 @@ public class SearchTest extends FHIRServerTestBase {
     public void testSearchObservationCodeGTSystem() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("component-value-quantity", "gt123.0||mmHg")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("X-FHIR-DSID", dataStoreId)
-                .get();
+                target.path("Observation")
+                        .queryParam("component-value-quantity", "gt123.0||mmHg")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .header("X-FHIR-DSID", dataStoreId)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
+
         assertTrue(bundle.getEntry().size() >= 1);
         for (Entry entry : bundle.getEntry()) {
             Observation observation = ((Observation) entry.getResource());
@@ -1232,12 +1223,9 @@ public class SearchTest extends FHIRServerTestBase {
                 client._search("Observation", parameters, tenantHeader, dsHeader, preferStrictHeader);
         assertResponse(response.getResponse(), Response.Status.BAD_REQUEST.getStatusCode());
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(response.getResource(OperationOutcome.class));
-        }
-
-        assertExceptionOperationOutcome(response.getResource(OperationOutcome.class),
-                "Search parameter 'category' for resource type 'Observation' was not found.");
+        OperationOutcome oo = response.getResource(OperationOutcome.class);
+        printOutResource(DEBUG_SEARCH, oo);
+        assertExceptionOperationOutcome(oo, "Search parameter 'category' for resource type 'Observation' was not found.");
     }
 
     @Test(groups = { "server-search" }, dependsOnMethods = {"testCreateObservation" })
@@ -1398,13 +1386,14 @@ public class SearchTest extends FHIRServerTestBase {
     public void testSearchObservationWithSubjectIncluded_summary_text() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject", "Patient/"+ patientId)
-                .queryParam("_include", "Observation:subject")
-                .queryParam("_summary", "text")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("X-FHIR-DSID", dataStoreId)
-                .get();
+                target.path("Observation")
+                        .queryParam("subject", "Patient/"+ patientId)
+                        .queryParam("_include", "Observation:subject")
+                        .queryParam("_summary", "text")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .header("X-FHIR-DSID", dataStoreId)
+                        .get();
         assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
         assertExceptionOperationOutcome(response.readEntity(OperationOutcome.class),
                 "_include and _revinclude are not supported with '_summary=text'");
@@ -1464,14 +1453,13 @@ public class SearchTest extends FHIRServerTestBase {
                         .build())
                 .build();
 
-
         Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
         Response response = target.path("Patient").request()
                 .header(PREFER_HEADER_NAME, PREFER_HEADER_RETURN_REPRESENTATION)
                 .post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
-        patient4DuplicationTest = response.readEntity(Patient.class);
-        assertNotNull(patient4DuplicationTest);
+        patientForDuplicationTest = response.readEntity(Patient.class);
+        assertNotNull(patientForDuplicationTest);
 
     }
 
@@ -1504,7 +1492,7 @@ public class SearchTest extends FHIRServerTestBase {
             for (Bundle.Entry entry : bundle.getEntry()) {
                 lstRes.add(entry.getResource());
             }
-            assertTrue(isResourceInResponse(patient4DuplicationTest, lstRes));
+            assertTrue(isResourceInResponse(patientForDuplicationTest, lstRes));
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is
             // no duplicated resource in the search results, Just need to do the verification for the second run.
@@ -1544,7 +1532,7 @@ public class SearchTest extends FHIRServerTestBase {
             for (Bundle.Entry entry : bundle.getEntry()) {
                 lstRes.add(entry.getResource());
             }
-            assertTrue(isResourceInResponse(patient4DuplicationTest, lstRes));
+            assertTrue(isResourceInResponse(patientForDuplicationTest, lstRes));
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is
             // no duplicated resource in the search results, Just need to do the verification for the second run.
@@ -1583,7 +1571,7 @@ public class SearchTest extends FHIRServerTestBase {
             for (Bundle.Entry entry : bundle.getEntry()) {
                 lstRes.add(entry.getResource());
             }
-            assertTrue(isResourceInResponse(patient4DuplicationTest, lstRes));
+            assertTrue(isResourceInResponse(patientForDuplicationTest, lstRes));
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is
             // no duplicated resource in the search results, Just need to do the verification for the second run.
@@ -1622,7 +1610,7 @@ public class SearchTest extends FHIRServerTestBase {
             for (Bundle.Entry entry : bundle.getEntry()) {
                 lstRes.add(entry.getResource());
             }
-            assertTrue(isResourceInResponse(patient4DuplicationTest, lstRes));
+            assertTrue(isResourceInResponse(patientForDuplicationTest, lstRes));
         } else {
             // Just in case there are more than 1000 matches, then simply verify that there is
             // no duplicated resource in the search results, Just need to do the verification for the second run.
@@ -1667,9 +1655,7 @@ public class SearchTest extends FHIRServerTestBase {
         PractitionerRole responsePractitionerRole =
                 response.readEntity(PractitionerRole.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responsePractitionerRole);
-        }
+        printOutResource(DEBUG_SEARCH, responsePractitionerRole);
 
         // use it for search
         practitionerRoleId = responsePractitionerRole.getId();
@@ -1704,9 +1690,7 @@ public class SearchTest extends FHIRServerTestBase {
         Practitioner responsePractitioner =
                 response.readEntity(Practitioner.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responsePractitioner);
-        }
+        printOutResource(DEBUG_SEARCH, responsePractitioner);
 
         // use it for search
         practitionerId2 = responsePractitioner.getId();
@@ -1748,9 +1732,7 @@ public class SearchTest extends FHIRServerTestBase {
         AllergyIntolerance responseAllergyIntolerance =
                 response.readEntity(AllergyIntolerance.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responseAllergyIntolerance);
-        }
+        printOutResource(DEBUG_SEARCH, responseAllergyIntolerance);
 
         // use it for search
         allergyIntoleranceId = responseAllergyIntolerance.getId();
@@ -1790,9 +1772,7 @@ public class SearchTest extends FHIRServerTestBase {
         Provenance responseProvenance =
                 response.readEntity(Provenance.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responseProvenance);
-        }
+        printOutResource(DEBUG_SEARCH, responseProvenance);
 
         // use it for search
         provenanceId = responseProvenance.getId();
@@ -1804,13 +1784,13 @@ public class SearchTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("AllergyIntolerance")
-                .queryParam("patient", "Patient/" + patientId)
-                .queryParam("_include", "AllergyIntolerance:*:Patient", "AllergyIntolerance:*:Practitioner", "AllergyIntolerance:*:PractitionerRole")
-                .queryParam("_revinclude", "Provenance:*")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("X-FHIR-DSID", dataStoreId)
-                .get();
+                        .queryParam("patient", "Patient/" + patientId)
+                        .queryParam("_include", "AllergyIntolerance:*:Patient", "AllergyIntolerance:*:Practitioner", "AllergyIntolerance:*:PractitionerRole")
+                        .queryParam("_revinclude", "Provenance:*")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .header("X-FHIR-DSID", dataStoreId)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -2143,9 +2123,7 @@ public class SearchTest extends FHIRServerTestBase {
         Condition responseCondition =
                 response.readEntity(Condition.class);
 
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(responseCondition);
-        }
+        printOutResource(DEBUG_SEARCH, responseCondition);
 
         // use it for search
         conditionId = responseCondition.getId();
@@ -2164,9 +2142,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
         for (Entry entry : bundle.getEntry()) {
             Condition condition = ((Condition) entry.getResource());
@@ -2196,9 +2172,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
         for (Entry entry : bundle.getEntry()) {
             Condition condition = ((Condition) entry.getResource());
@@ -2231,9 +2205,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertEquals(bundle.getEntry().size(), 0);
     }
 
@@ -2251,9 +2223,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertEquals(bundle.getEntry().size(), 0);
     }
 
@@ -2270,9 +2240,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
@@ -2285,9 +2253,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().isEmpty());
 
         response =
@@ -2300,9 +2266,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
@@ -2315,9 +2279,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().isEmpty());
 
         response =
@@ -2330,9 +2292,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
@@ -2345,9 +2305,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
@@ -2360,9 +2318,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
@@ -2379,9 +2335,7 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
@@ -2394,24 +2348,20 @@ public class SearchTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
 
         response =
                 target.path("Condition")
-                .queryParam("evidence", "http://terminology.hl7.org/CodeSystem/v3-ObservationValue|")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("X-FHIR-DSID", dataStoreId)
-                .get();
+                    .queryParam("evidence", "http://terminology.hl7.org/CodeSystem/v3-ObservationValue|")
+                    .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                    .header("X-FHIR-TENANT-ID", tenantName)
+                    .header("X-FHIR-DSID", dataStoreId)
+                    .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        if (DEBUG_SEARCH) {
-            SearchAllTest.generateOutput(bundle);
-        }
+        printOutResource(DEBUG_SEARCH, bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SortingTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SortingTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.Observation.Component;
@@ -348,14 +349,7 @@ public class SortingTest extends FHIRServerTestBase {
 
         boolean result = false;
         for (Bundle.Entry entry : bundle.getEntry()) {
-
-            if (DEBUG_SEARCH) {
-
-                SearchAllTest.generateOutput(entry.getResource());
-                System.out.println(result + " "
-                        + FHIRUtil.hasTag(entry.getResource(), subsettedTag));
-            }
-
+            printOutResource(DEBUG_SEARCH, entry.getResource());
             result = result
                     || FHIRUtil.hasTag(entry.getResource(), subsettedTag);
         }
@@ -441,7 +435,7 @@ public class SortingTest extends FHIRServerTestBase {
     // Patient?gender=male&_sort=telecom
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
-    public void testSortTelecom() {
+    public void testSortTelecom() throws FHIRGeneratorException {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("Patient").queryParam("gender", "male").queryParam("_count", "50")
@@ -455,10 +449,7 @@ public class SortingTest extends FHIRServerTestBase {
         for (Bundle.Entry entry : bundle.getEntry()) {
             Patient patient = (Patient) entry.getResource();
             if (patient.getTelecom() != null && patient.getTelecom().size() > 0) {
-
-                if (DEBUG_SEARCH) {
-                    SearchAllTest.generateOutput(patient);
-                }
+                printOutResource(DEBUG_SEARCH, patient);
 
                 if (patient.getTelecom().get(0).getValue() != null) {
                     list.add(patient.getTelecom().get(0).getValue().getValue());
@@ -499,7 +490,7 @@ public class SortingTest extends FHIRServerTestBase {
     // Patient?_count=50&_sort=-family,birthdate
     @Test(groups = { "server-search" }, dependsOnMethods = { "testCreatePatient1",
             "testCreatePatient2", "testCreatePatient3", "testCreatePatient4", "testCreatePatient5" })
-    public void testSortTwoParameters() {
+    public void testSortTwoParameters() throws FHIRGeneratorException {
         WebTarget target = getWebTarget();
         Response response =
                 target.path("Patient").queryParam("_count", "50")
@@ -533,9 +524,7 @@ public class SortingTest extends FHIRServerTestBase {
                         currentBirthDate = null;
                     }
 
-                    if (DEBUG_SEARCH) {
-                        SearchAllTest.generateOutput(patient);
-                    }
+                    printOutResource(DEBUG_SEARCH, patient);
                     if (previousFamily != null && previousFamily.equals(currentFamily)) {
                         assertTrue(previousBirthDate == null || currentBirthDate == null
                                 || (getInstantFromPartial(previousBirthDate.getValue())
@@ -645,22 +634,16 @@ public class SortingTest extends FHIRServerTestBase {
         for (HumanName patientName : patient.getName()) {
             if (patientName.getUse() != null
                     && patientName.getUse().getValue().compareTo("usual") == 0) {
-                if (DEBUG_SEARCH) {
-                    // Only output when DEBUG_SEARCHging.
-                    SearchAllTest.generateOutput(patient);
-                }
+                printOutResource(DEBUG_SEARCH, patient);
 
                 System.out.println("Skipping usual type as there is no family name ");
 
             } else {
-                if (DEBUG_SEARCH) {
-                    SearchAllTest.generateOutput(patient);
-                }
+                printOutResource(DEBUG_SEARCH, patient);
 
                 if (patientName.getFamily() != null) {
                     patientFamilyNameList.add(patientName.getFamily().getValue());
                 }
-
             }
         }
         Collections.sort(patientFamilyNameList);
@@ -846,13 +829,7 @@ public class SortingTest extends FHIRServerTestBase {
 
         boolean result = false;
         for (Bundle.Entry entry : bundle.getEntry()) {
-
-            if (DEBUG_SEARCH) {
-
-                SearchAllTest.generateOutput(entry.getResource());
-                System.out.println(result + " "
-                        + FHIRUtil.hasTag(entry.getResource(), subsettedTag));
-            }
+            printOutResource(DEBUG_SEARCH, entry.getResource());
 
             result = result
                     || FHIRUtil.hasTag(entry.getResource(), subsettedTag);
@@ -919,13 +896,7 @@ public class SortingTest extends FHIRServerTestBase {
 
         boolean result = false;
         for (Bundle.Entry entry : bundle.getEntry()) {
-
-            if (DEBUG_SEARCH) {
-
-                SearchAllTest.generateOutput(entry.getResource());
-                System.out.println(result + " "
-                        + FHIRUtil.hasTag(entry.getResource(), subsettedTag));
-            }
+            printOutResource(DEBUG_SEARCH, entry.getResource());
 
             result = result
                     || FHIRUtil.hasTag(entry.getResource(), subsettedTag);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/everything/EverythingOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/everything/EverythingOperationTest.java
@@ -44,15 +44,14 @@ import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.server.test.FHIRServerTestBase;
-import com.ibm.fhir.server.test.profiles.ProfilesTestBase;
 
 /**
  * Tests the Everything Operation
  */
 public class EverythingOperationTest extends FHIRServerTestBase {
 
-    private static final String CLASSNAME = ProfilesTestBase.class.getName();
-    private static final Logger logger = Logger.getLogger(CLASSNAME);
+    private static final String CLASSNAME = EverythingOperationTest.class.getName();
+    private static final Logger LOG = Logger.getLogger(CLASSNAME);
 
     public static final String EXPRESSION_OPERATION = "rest.resource.operation.name";
 
@@ -78,7 +77,7 @@ public class EverythingOperationTest extends FHIRServerTestBase {
             Collection<String> listOfOperations = tmpResults.stream().map(x -> x.getValue().asStringValue().string()).collect(Collectors.toList());
 
             if (!listOfOperations.contains("everything")) {
-                logger.warning("Operation $everything not found on server");
+                LOG.warning("Operation $everything not found on server, Skipping integration test for $everything");
                 SKIP = true;
             } else {
                 SKIP = false;
@@ -96,7 +95,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" })
     public void testCreatePatientWithEverything() throws Exception {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Bundle patientBundle = TestUtil.readLocalResource("everything-operation/Antonia30_Acosta403.json");
@@ -122,7 +120,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testCreatePatientWithEverything" })
     public void testPatientEverything() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         // Get the patient ID and invoke the $everything operation on it
@@ -180,7 +177,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithCount() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/" + patientId + "/$everything").queryParam("_count", 1).request().get(Response.class);
@@ -195,7 +191,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" })
     public void testPatientEverythingAtTypeLevel() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/$everything").queryParam("_count", 1).request().get(Response.class);
@@ -206,7 +201,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithStartAndStop() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/" + patientId
@@ -222,7 +216,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithTypes() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/" + patientId + "/$everything").queryParam("_type", "CareTeam,CarePlan").request().get(Response.class);
@@ -237,7 +230,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithBadType() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response =
@@ -249,7 +241,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithSince() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/" + patientId
@@ -265,7 +256,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })
     public void testPatientEverythingWithFutureSince() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         LocalDateTime today = LocalDateTime.of(LocalDate.now(), LocalTime.now());
@@ -283,7 +273,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" })
     public void testPatientEverythingForNotExistingPatient() {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         Response response = getWebTarget().path("Patient/some-unknown-id/$everything").request().get(Response.class);
@@ -293,7 +282,6 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-operation" })
     public void testCreateAndDeletePatientVerifyDelete() throws Exception {
         if (SKIP) {
-            logger.warning("Skipping integration test for $everything");
             return;
         }
         WebTarget target = getWebTarget();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
@@ -88,7 +88,6 @@ public class EraseOperationTest extends FHIRServerTestBase {
             System.out.println("Done testing erase on " + resourceType + "/" + logicalId + "'");
             return 1;
         }
-
     }
 
     /**
@@ -113,12 +112,14 @@ public class EraseOperationTest extends FHIRServerTestBase {
             Resource r = FHIRParser.parser(Format.JSON).parse(example);
             WebTarget target = getWebTarget();
             Entity<Resource> entity = Entity.entity(r, FHIRMediaType.APPLICATION_FHIR_JSON);
-            Response response = target.path(resourceType).request().post(entity, Response.class);
-            assertResponse(response, Response.Status.CREATED.getStatusCode());
-            String id = getLocationLogicalId(response);
-            response = target.path(resourceType + "/" + id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
-            assertResponse(response, Response.Status.OK.getStatusCode());
-            return id;
+            try (Response response = target.path(resourceType).request().post(entity, Response.class)) {
+                assertResponse(response, Response.Status.CREATED.getStatusCode());
+                String id = getLocationLogicalId(response);
+                try (Response responseGet = target.path(resourceType + "/" + id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get()) {
+                    assertResponse(responseGet, Response.Status.OK.getStatusCode());
+                }
+                return id;
+            }
         }
     }
 
@@ -345,36 +346,39 @@ public class EraseOperationTest extends FHIRServerTestBase {
     private void checkResourceExists(String resourceType, String logicalId) {
         WebTarget target = getWebTarget();
         target = target.path("/" + resourceType + "/" + logicalId);
-        Response r = target.request(FHIRMediaType.APPLICATION_FHIR_JSON)
+        try (Response r = target.request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .header("X-FHIR-TENANT-ID", "default")
                 .header("X-FHIR-DSID", "default")
-                .get(Response.class);
-        assertEquals(r.getStatus(), Status.OK.getStatusCode());
+                .get(Response.class)) {
+            assertEquals(r.getStatus(), Status.OK.getStatusCode());
+        }
         if ("Patient".equals(resourceType)) {
-            r = getWebTarget().path("/" + resourceType)
+            try (Response r = getWebTarget().path("/" + resourceType)
                     .queryParam("_id", logicalId)
                     .queryParam("_tag", "6aAf1ugE47")
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .header("X-FHIR-TENANT-ID", "default")
                     .header("X-FHIR-DSID", "default")
-                    .get();
-            Bundle bundle = r.readEntity(Bundle.class);
-            assertNotNull(bundle);
-            assertFalse(bundle.getEntry().isEmpty());
-            assertEquals(bundle.getEntry().size(), 1);
+                    .get()) {
+                Bundle bundle = r.readEntity(Bundle.class);
+                assertNotNull(bundle);
+                assertFalse(bundle.getEntry().isEmpty());
+                assertEquals(bundle.getEntry().size(), 1);
+            }
         } else {
             // must  be structure definition
-            r = getWebTarget().path("/" + resourceType)
+            try (Response r = getWebTarget().path("/" + resourceType)
                     .queryParam("_id", logicalId)
                     .queryParam("kind", "resource")
                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                     .header("X-FHIR-TENANT-ID", "default")
                     .header("X-FHIR-DSID", "default")
-                    .get();
-            Bundle bundle = r.readEntity(Bundle.class);
-            assertNotNull(bundle);
-            assertFalse(bundle.getEntry().isEmpty());
-            assertEquals(bundle.getEntry().size(), 1);
+                    .get()) {
+                Bundle bundle = r.readEntity(Bundle.class);
+                assertNotNull(bundle);
+                assertFalse(bundle.getEntry().isEmpty());
+                assertEquals(bundle.getEntry().size(), 1);
+            }
         }
     }
 
@@ -927,30 +931,31 @@ public class EraseOperationTest extends FHIRServerTestBase {
 
         WebTarget target = getWebTarget();
         target = target.path("/");
-        Response r = target.request(FHIRMediaType.APPLICATION_FHIR_JSON)
+        try (Response r = target.request(FHIRMediaType.APPLICATION_FHIR_JSON)
                      .header("X-FHIR-TENANT-ID", "default")
                      .header("X-FHIR-DSID", "default")
-                     .post(entity, Response.class);
-        assertResponse(r, Status.OK.getStatusCode());
+                     .post(entity, Response.class)) {
+            assertResponse(r, Status.OK.getStatusCode());
 
-        Bundle responseBundle = r.readEntity(Bundle.class);
-        int countFail = 0;
-        int countSuccess = 0;
-        int countUnknown = 0;
-        for(Bundle.Entry entry : responseBundle.getEntry()) {
-            Bundle.Entry.Response response =  entry.getResponse();
-            if ("404".equals(response.getStatus().getValue())) {
-                // this should be hit when there is a
-                countFail++;
-            } else if ("200".equals(response.getStatus().getValue())) {
-                countSuccess++;
-            } else {
-                countUnknown++;
+            Bundle responseBundle = r.readEntity(Bundle.class);
+            int countFail = 0;
+            int countSuccess = 0;
+            int countUnknown = 0;
+            for(Bundle.Entry entry : responseBundle.getEntry()) {
+                Bundle.Entry.Response response =  entry.getResponse();
+                if ("404".equals(response.getStatus().getValue())) {
+                    // this should be hit when there is a
+                    countFail++;
+                } else if ("200".equals(response.getStatus().getValue())) {
+                    countSuccess++;
+                } else {
+                    countUnknown++;
+                }
             }
+            assertEquals(countFail, 1);
+            assertEquals(countSuccess, 1);
+            assertEquals(countUnknown, 0);
         }
-        assertEquals(countFail, 1);
-        assertEquals(countSuccess, 1);
-        assertEquals(countUnknown, 0);
     }
 
     /**
@@ -1398,7 +1403,6 @@ public class EraseOperationTest extends FHIRServerTestBase {
         eraseResource("Patient", id, false, "Deleting per Patient Request");
         checkResourceNoLongerExists("Patient", id);
     }
-
 
     public void loadExtraLargeBundle(Patient r, String id) {
         WebTarget target = getWebTarget();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/performance/SearchPerformanceTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/performance/SearchPerformanceTest.java
@@ -42,7 +42,6 @@ import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.SearchEntryMode;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.server.test.FHIRServerTestBase;
-import com.ibm.fhir.server.test.SearchAllTest;
 
 public class SearchPerformanceTest extends FHIRServerTestBase {
     private static final boolean DEBUG_SEARCH = false;
@@ -83,19 +82,21 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
             Entity<Patient> entity =
                     Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
             Response response =
-                    target.path("Patient").request()
-                    .header("X-FHIR-TENANT-ID", tenantName)
-                    .post(entity, Response.class);
+                    target.path("Patient")
+                            .request()
+                            .header("X-FHIR-TENANT-ID", tenantName)
+                            .post(entity, Response.class);
             assertResponse(response, Response.Status.CREATED.getStatusCode());
 
             // Get the patient's logical id value.
             patientId = getLocationLogicalId(response);
+            addToResourceRegistry("Patient", patientId);
 
             // Next, call the 'read' API to retrieve the new patient and verify it.
-            response = target.path("Patient/"
-                    + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                    .header("X-FHIR-TENANT-ID", tenantName)
-                    .get();
+            response = target.path("Patient/" + patientId)
+                                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                                .header("X-FHIR-TENANT-ID", tenantName)
+                                .get();
             assertResponse(response, Response.Status.OK.getStatusCode());
             Patient responsePatient = response.readEntity(Patient.class);
             TestUtil.assertResourceEquals(patient, responsePatient);
@@ -129,6 +130,7 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
 
             // Get the patient's logical id value.
             String observationId = getLocationLogicalId(response);
+            addToResourceRegistry("Observation", observationId);
 
             // Next, call the 'read' API to retrieve the new patient and verify it.
             response = target.path("Observation/"
@@ -140,9 +142,7 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
             Observation responseObservation =
                     response.readEntity(Observation.class);
 
-            if (DEBUG_SEARCH) {
-                SearchAllTest.generateOutput(responseObservation);
-            }
+            printOutResource(DEBUG_SEARCH, responseObservation);
 
             // use it for search
             observationId = responseObservation.getId();
@@ -150,63 +150,63 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         }
     }
 
-
     @Test(groups = { "server-search-performance" }, dependsOnMethods = {
     "testCreatePatientAndObservation" })
     public void testSearchPatientWithGivenName() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("given", "John")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("given", "John")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
-    @Test(groups = { "server-search-performance" }, dependsOnMethods = {
-    "testCreatePatientAndObservation" })
+    @Test(groups = { "server-search-performance" }, dependsOnMethods = { "testCreatePatientAndObservation" })
     public void testSearchPatientWithID() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("_id", patientId)
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("_id", patientId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
-    @Test(groups = { "server-search-performance" }, dependsOnMethods = {
-    "testCreatePatientAndObservation" })
+    @Test(groups = { "server-search-performance" }, dependsOnMethods = { "testCreatePatientAndObservation" })
     public void testSearchPatientWithBirthDate() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("birthdate", "1970-01-01")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("birthdate", "1970-01-01")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
 
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
-
 
     @Test(groups = { "server-search-performance" }, dependsOnMethods = {
     "testCreatePatientAndObservation" })
     public void testSearchPatientWithLTBirthDate() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("birthdate", "lt1971-01-01")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("birthdate", "lt1971-01-01")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
 
@@ -219,10 +219,11 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchPatientWithGTBirthDate() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("birthdate", "gt1950-08-13")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("birthdate", "gt1950-08-13")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
 
@@ -235,44 +236,44 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchPatientWithGender() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("gender", "male")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("gender", "male")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
 
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
-
 
     @Test(groups = { "server-search-performance" }, dependsOnMethods = {
     "testCreatePatientAndObservation" })
     public void testSearchObservationWithID() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("_id", observationId)
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("_id", observationId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
-
     @Test(groups = { "server-search-performance" }, dependsOnMethods = {
     "testCreatePatientAndObservation" })
     public void testSearchObservationWithSubject() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject", "Patient/"
-                        + patientId)
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("subject", "Patient/" + patientId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -284,11 +285,12 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchObservation() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("_count", "100")
-                .queryParam("_page", "1")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("_count", "100")
+                        .queryParam("_page", "1")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -300,14 +302,14 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchObservationWithSubjectIncluded() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject", "Patient/"
-                        + patientId)
-                .queryParam("_include", "Observation:subject")
-                .queryParam("_count", "100")
-                .queryParam("_page", "1")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("subject", "Patient/" + patientId)
+                        .queryParam("_include", "Observation:subject")
+                        .queryParam("_count", "100")
+                        .queryParam("_page", "1")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -326,8 +328,7 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         assertNotNull(observation);
         assertNotNull(patient);
         assertEquals(patientId, patient.getId());
-        assertEquals("Patient/"
-                + patientId, observation.getSubject().getReference().getValue());
+        assertEquals("Patient/" + patientId, observation.getSubject().getReference().getValue());
     }
 
     @SuppressWarnings("rawtypes")
@@ -337,14 +338,15 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
             throws Exception {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject", "Patient/"
-                        + patientId).queryParam("_include", "Observation:subject")
-                .queryParam("_elements", "status,category,subject")
-                .queryParam("_count", "100")
-                .queryParam("_page", "1")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("subject", "Patient/" + patientId)
+                        .queryParam("_include", "Observation:subject")
+                        .queryParam("_elements", "status,category,subject")
+                        .queryParam("_count", "100")
+                        .queryParam("_page", "1")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -356,14 +358,12 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         for (Bundle.Entry entry : bundle.getEntry()) {
 
             if (DEBUG_SEARCH) {
-
-                SearchAllTest.generateOutput(entry.getResource());
+                printOutResource(DEBUG_SEARCH, entry.getResource());
                 System.out.println(result + " "
                         + FHIRUtil.hasTag(entry.getResource(), subsettedTag));
             }
 
-            result = result
-                    || FHIRUtil.hasTag(entry.getResource(), subsettedTag);
+            result = result || FHIRUtil.hasTag(entry.getResource(), subsettedTag);
         }
         assertTrue(result);
 
@@ -418,10 +418,12 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchPatientWithObservationRevIncluded() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("_id", patientId).queryParam("_revinclude", "Observation:patient")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Patient")
+                        .queryParam("_id", patientId)
+                        .queryParam("_revinclude", "Observation:patient")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -440,8 +442,7 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         assertNotNull(observation);
         assertNotNull(patient);
         assertEquals(patientId, patient.getId());
-        assertEquals("Patient/"
-                + patientId, observation.getSubject().getReference().getValue());
+        assertEquals("Patient/" + patientId, observation.getSubject().getReference().getValue());
     }
 
     @Test(groups = { "server-search-performance" }, dependsOnMethods = {
@@ -455,43 +456,43 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         String targetUri = "Patient/" + patientId + "/Observation";
         Response response =
-                target.path(targetUri).request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path(targetUri)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
-
-    @Test(groups = { "server-search-performance" }, dependsOnMethods = {
-    "testCreatePatientAndObservation" })
+    @Test(groups = { "server-search-performance" }, dependsOnMethods = { "testCreatePatientAndObservation" })
     public void testSearchObservationWithPatient() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("patient", "Patient/"
-                        + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("patient", "Patient/" + patientId)
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
         assertTrue(bundle.getEntry().size() >= 1);
     }
 
-    @Test(groups = { "server-search-performance" }, dependsOnMethods = {
-    "testCreatePatientAndObservation" })
+    @Test(groups = { "server-search-performance" }, dependsOnMethods = { "testCreatePatientAndObservation" })
     public void testSearchObservationWithSubjectIncluded_summary_text() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject", "Patient/"+ patientId)
-                .queryParam("_include", "Observation:subject")
-                .queryParam("_summary", "text")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("Prefer", "handling=lenient")
-                .get();
+                target.path("Observation")
+                        .queryParam("subject", "Patient/"+ patientId)
+                        .queryParam("_include", "Observation:subject")
+                        .queryParam("_summary", "text")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .header("Prefer", "handling=lenient")
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -506,13 +507,14 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchPatientWithObservationRevIncluded_summary_text() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Patient").queryParam("_id", patientId)
-                .queryParam("_revinclude", "Observation:patient")
-                .queryParam("_summary", "text")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .header("Prefer", "handling=lenient")
-                .get();
+                target.path("Patient")
+                        .queryParam("_id", patientId)
+                        .queryParam("_revinclude", "Observation:patient")
+                        .queryParam("_summary", "text")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .header("Prefer", "handling=lenient")
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
@@ -526,10 +528,11 @@ public class SearchPerformanceTest extends FHIRServerTestBase {
     public void testSearchObservationWithPatientName() {
         WebTarget target = getWebTarget();
         Response response =
-                target.path("Observation").queryParam("subject:Patient.name", "john")
-                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
-                .header("X-FHIR-TENANT-ID", tenantName)
-                .get();
+                target.path("Observation")
+                        .queryParam("subject:Patient.name", "john")
+                        .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                        .header("X-FHIR-TENANT-ID", tenantName)
+                        .get();
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/CarinBlueButtonTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/CarinBlueButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,7 +19,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,12 +43,11 @@ import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
 
 /**
- * Tests using http://hl7.org/fhir/us/C4BB/2020Feb/Examples.html And the given profile.
+ * Carin for BlueButton (C4BB) Profile Integration Tests
  */
 public class CarinBlueButtonTest extends ProfilesTestBase {
-
     private static final String CLASSNAME = CarinBlueButtonTest.class.getName();
-    private static final Logger logger = Logger.getLogger(CLASSNAME);
+    private static final Logger LOG = Logger.getLogger(CLASSNAME);
 
     private String coverageId = null;
     private String careTeamId = null;
@@ -86,9 +84,8 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
     @Override
     public void setCheck(Boolean check) {
         this.skip = check;
-
         if (!skip) {
-            logger.info("Skipping Tests");
+            LOG.info("Skipping Tests");
         }
     }
 
@@ -146,8 +143,10 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         assertResponse(response, Response.Status.CREATED.getStatusCode());
         organizationId = getLocationLogicalId(response);
+
         response = target.path("Organization/" + organizationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Organization", organizationId);
     }
 
     public void loadOrganizationOrg1() throws Exception {
@@ -158,8 +157,10 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
         Response response = target.path("Organization").request().post(entity, Response.class);
         assertResponse(response, Response.Status.CREATED.getStatusCode());
         organizationOrg1Id = getLocationLogicalId(response);
+
         response = target.path("Organization/" + organizationOrg1Id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Organization", organizationOrg1Id);
     }
 
     public void loadOrganizationOrg45() throws Exception {
@@ -173,6 +174,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("Organization/" + organizationOrg45Id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Organization", organizationOrg45Id);
     }
 
     // Load Coverage Resources
@@ -191,6 +193,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
         // Next, call the 'read' API to retrieve the new Location and verify it.
         response = target.path("Coverage/" + coverageId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Coverage", coverageId);
     }
 
     // Load Patient Resources
@@ -206,6 +209,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
         // Next, call the 'read' API to retrieve the new Location and verify it.
         response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Patient", patientId);
     }
 
     // Load Provider Resources
@@ -220,6 +224,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("Practitioner/" + practitionerId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Practitioner", practitionerId);
     }
 
     // Load CareTeam Resources
@@ -234,6 +239,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("CareTeam/" + careTeamId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("CareTeam", careTeamId);
     }
 
     // Load Location Resources
@@ -249,6 +255,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Location", locationId);
     }
 
     // Load Explanation of Benefits Resources
@@ -264,6 +271,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("ExplanationOfBenefit/" + explanationOfBenefitInPatientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("ExplanationOfBenefit", explanationOfBenefitInPatientId);
     }
 
     public void loadExplanationOfBenefitsOutPatient() throws Exception {
@@ -278,6 +286,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsOutPatient).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("ExplanationOfBenefit", explanationOfBenefitsOutPatient);
     }
 
     public void loadExplanationOfBenefitsPharmacy() throws Exception {
@@ -292,6 +301,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsPharmacyId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("ExplanationOfBenefit", explanationOfBenefitsPharmacyId);
     }
 
     public void loadExplanationOfBenefitsProfessional() throws Exception {
@@ -306,6 +316,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsProfessionalId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("ExplanationOfBenefit", explanationOfBenefitsProfessionalId);
     }
 
     // ExplanationOfBenefit-EOBInpatient1.json
@@ -321,132 +332,29 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
 
         response = target.path("ExplanationOfBenefit/" + eobInpatientInstitutionalEx1id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("ExplanationOfBenefit", eobInpatientInstitutionalEx1id);
     }
+
     // Load Resources
     @BeforeClass
     public void loadResources() throws Exception {
-        if (!skip) {
-            loadLocation();
-            loadOrganization();
-            loadOrganizationOrg1();
-            loadOrganizationOrg45();
-            loadProvider();
-            loadCoverage();
-            loadPatient();
-            loadCareteam();
-            loadExplanationOfBenefitsInPatient();
-            loadExplanationOfBenefitsOutPatient();
-            loadExplanationOfBenefitsPharmacy();
-            loadExplanationOfBenefitsProfessional();
-            loadExplanationOfBenefitsInpatientInstitutionalEx1();
+        if (skip) {
+            return;
         }
-    }
 
-    // Delete Resources
-    public void deleteOrganization() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Organization/" + organizationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteOrganizationOrg1() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Organization/" + organizationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteOrganizationOrg45() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Organization/" + organizationOrg45Id).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Coverage Resources
-    public void deleteCoverage() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Coverage/" + coverageId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Patient Resources
-    public void deletePatient() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Patient/" + patientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Provider Resources
-    public void deleteProvider() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Practitioner/" + practitionerId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete CareTeam Resources
-    public void deleteCareteam() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("CareTeam/" + careTeamId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Location Resources
-    public void deleteLocation() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Location/" + locationId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Explanation of Benefits Resources
-    public void deleteExplanationOfBenefits1() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("ExplanationOfBenefit/" + explanationOfBenefitInPatientId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Explanation of Benefits Resources
-    public void deleteExplanationOfBenefits2() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsOutPatient).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Explanation of Benefits Resources
-    public void deleteExplanationOfBenefits3() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsPharmacyId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    // Delete Explanation of Benefits Resources
-    public void deleteExplanationOfBenefits4() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("ExplanationOfBenefit/" + explanationOfBenefitsProfessionalId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteExplanationOfBenefitsInpatientInstitutionalEx1() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("ExplanationOfBenefit/" + eobInpatientInstitutionalEx1id).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    @AfterClass
-    public void deleteResources() throws Exception {
-        if (!skip) {
-            deleteLocation();
-            deleteOrganization();
-            deleteOrganizationOrg1();
-            deleteOrganizationOrg45();
-            deleteCoverage();
-            deletePatient();
-            deleteProvider();
-            deleteCareteam();
-            deleteExplanationOfBenefits1();
-            deleteExplanationOfBenefits2();
-            deleteExplanationOfBenefits3();
-            deleteExplanationOfBenefits4();
-            deleteExplanationOfBenefitsInpatientInstitutionalEx1();
-        }
+        loadLocation();
+        loadOrganization();
+        loadOrganizationOrg1();
+        loadOrganizationOrg45();
+        loadProvider();
+        loadCoverage();
+        loadPatient();
+        loadCareteam();
+        loadExplanationOfBenefitsInPatient();
+        loadExplanationOfBenefitsOutPatient();
+        loadExplanationOfBenefitsPharmacy();
+        loadExplanationOfBenefitsProfessional();
+        loadExplanationOfBenefitsInpatientInstitutionalEx1();
     }
 
     @Test
@@ -548,6 +456,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("identifier", "AW123412341234123412341234123412");
+            parameters.searchParam("_id", explanationOfBenefitInPatientId);
             FHIRResponse response = client.search(ExplanationOfBenefit.class.getSimpleName(), parameters);
             assertSearchResponse(response, Response.Status.OK.getStatusCode());
             Bundle bundle = response.getResource(Bundle.class);
@@ -562,6 +471,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("identifier", "https://www.xxxplan.com/fhir/EOBIdentifier|AW123412341234123412341234123412");
+            parameters.searchParam("_id", explanationOfBenefitInPatientId);
             FHIRResponse response = client.search(ExplanationOfBenefit.class.getSimpleName(), parameters);
             assertSearchResponse(response, Response.Status.OK.getStatusCode());
             Bundle bundle = response.getResource(Bundle.class);
@@ -581,6 +491,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("service-date", "ge2019-10-01");
             parameters.searchParam("service-date", "le2019-11-01");
+            parameters.searchParam("_id", explanationOfBenefitsPharmacyId);
             FHIRResponse response = client.search(ExplanationOfBenefit.class.getSimpleName(), parameters);
             assertSearchResponse(response, Response.Status.OK.getStatusCode());
             Bundle bundle = response.getResource(Bundle.class);
@@ -597,6 +508,7 @@ public class CarinBlueButtonTest extends ProfilesTestBase {
             // https://github.com/IBM/FHIR/issues/1157
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/Patient1");
+            parameters.searchParam("_id", explanationOfBenefitInPatientId);
             FHIRResponse response = client.search(ExplanationOfBenefit.class.getSimpleName(), parameters);
             assertSearchResponse(response, Response.Status.OK.getStatusCode());
             Bundle bundle = response.getResource(Bundle.class);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciDrugFormularyTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciDrugFormularyTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -34,7 +33,7 @@ import com.ibm.fhir.model.test.TestUtil;
  */
 public class DavinciDrugFormularyTest extends ProfilesTestBase {
     private static final String CLASSNAME = DavinciDrugFormularyTest.class.getName();
-    private static final Logger logger = Logger.getLogger(CLASSNAME);
+    private static final Logger LOG = Logger.getLogger(CLASSNAME);
 
     private String listCoveragePlan3001 = null;
     private String listCoveragePlan3002 = null;
@@ -61,7 +60,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         this.skip = check;
 
         if (skip) {
-            logger.info("Skipping Tests");
+            LOG.info("Skipping Tests");
         }
     }
 
@@ -75,6 +74,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         listCoveragePlan3001 = getLocationLogicalId(response);
         response = target.path("List/" + listCoveragePlan3001).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("List", listCoveragePlan3001);
     }
 
     public void loadCoveragePlan2() throws Exception {
@@ -87,6 +87,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         listCoveragePlan3002 = getLocationLogicalId(response);
         response = target.path("List/" + listCoveragePlan3002).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("List", listCoveragePlan3002);
     }
 
     public void loadCoveragePlan3() throws Exception {
@@ -99,6 +100,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         listCoveragePlan3004t = getLocationLogicalId(response);
         response = target.path("List/" + listCoveragePlan3004t).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("List", listCoveragePlan3004t);
     }
 
     public void loadCoveragePlan4() throws Exception {
@@ -111,6 +113,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         listCoveragePlan1002 = getLocationLogicalId(response);
         response = target.path("List/" + listCoveragePlan1002).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("List", listCoveragePlan1002);
     }
 
     public void loadMedicationKnowledge1() throws Exception {
@@ -123,6 +126,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         medicationKnowledgeCmsip9 = getLocationLogicalId(response);
         response = target.path("MedicationKnowledge/" + medicationKnowledgeCmsip9).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("MedicationKnowledge", medicationKnowledgeCmsip9);
     }
 
     public void loadMedicationKnowledge2() throws Exception {
@@ -135,6 +139,7 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         medicationKnowledge1002 = getLocationLogicalId(response);
         response = target.path("MedicationKnowledge/" + medicationKnowledge1002).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("MedicationKnowledge", medicationKnowledge1002);
     }
 
     public void loadMedicationKnowledge3() throws Exception {
@@ -147,76 +152,22 @@ public class DavinciDrugFormularyTest extends ProfilesTestBase {
         medicationKnowledge3001 = getLocationLogicalId(response);
         response = target.path("MedicationKnowledge/" + medicationKnowledge3001).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("MedicationKnowledge", medicationKnowledge3001);
     }
 
     // Load Resources
     @BeforeClass
     public void loadResources() throws Exception {
-        if (!skip) {
-            loadCoveragePlan1();
-            loadCoveragePlan2();
-            loadCoveragePlan3();
-            loadCoveragePlan4();
-            loadMedicationKnowledge1();
-            loadMedicationKnowledge2();
-            loadMedicationKnowledge3();
+        if (skip) {
+            return;
         }
-    }
-
-    // Delete Resources
-    public void deleteCoveragePlan1() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("List/" + listCoveragePlan3001).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteCoveragePlan2() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("List/" + listCoveragePlan3002).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteCoveragePlan3() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("List/" + listCoveragePlan3004t).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteCoveragePlan4() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("List/" + listCoveragePlan1002).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteMedicationKnowledge1() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("MedicationKnowledge/" + medicationKnowledgeCmsip9).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteMedicationKnowledge2() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("MedicationKnowledge/" + medicationKnowledge1002).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteMedicationKnowledge3() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("MedicationKnowledge/" + medicationKnowledge3001).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    @AfterClass
-    public void deleteResources() throws Exception {
-        if (!skip) {
-            deleteCoveragePlan1();
-            deleteCoveragePlan2();
-            deleteCoveragePlan3();
-            deleteCoveragePlan4();
-            deleteMedicationKnowledge1();
-            deleteMedicationKnowledge2();
-            deleteMedicationKnowledge3();
-        }
+        loadCoveragePlan1();
+        loadCoveragePlan2();
+        loadCoveragePlan3();
+        loadCoveragePlan4();
+        loadMedicationKnowledge1();
+        loadMedicationKnowledge2();
+        loadMedicationKnowledge3();
     }
 
     @Test

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciHealthRecordExchangeTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciHealthRecordExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -32,7 +31,7 @@ import com.ibm.fhir.model.test.TestUtil;
  */
 public class DavinciHealthRecordExchangeTest extends ProfilesTestBase {
     private static final String CLASSNAME = DavinciHealthRecordExchangeTest.class.getName();
-    private static final Logger logger = Logger.getLogger(CLASSNAME);
+    private static final Logger LOG = Logger.getLogger(CLASSNAME);
 
     String coverageId = null;
 
@@ -58,7 +57,7 @@ public class DavinciHealthRecordExchangeTest extends ProfilesTestBase {
         this.skip = check;
 
         if (skip) {
-            logger.info("Skipping Tests for HREX");
+            LOG.info("Skipping Tests for HREX");
         }
     }
 
@@ -72,6 +71,7 @@ public class DavinciHealthRecordExchangeTest extends ProfilesTestBase {
         coverageId = getLocationLogicalId(response);
         response = target.path("Coverage/" + coverageId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
+        addToResourceRegistry("Coverage", coverageId);
     }
 
     // Load Resources
@@ -79,20 +79,6 @@ public class DavinciHealthRecordExchangeTest extends ProfilesTestBase {
     public void loadResources() throws Exception {
         if (!skip) {
             loadCoverage();
-        }
-    }
-
-    // Delete Resources
-    public void deleteCoverage() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Coverage/" + coverageId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    @AfterClass
-    public void deleteResources() throws Exception {
-        if (!skip) {
-            deleteCoverage();
         }
     }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/ProfilesTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/ProfilesTestBase.java
@@ -31,7 +31,6 @@ import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
 import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.server.test.FHIRServerTestBase;
-import com.ibm.fhir.server.test.SearchAllTest;
 
 /*
  * This class is not designed to run its own.  The class does the basic lift to check:
@@ -74,7 +73,7 @@ public abstract class ProfilesTestBase extends FHIRServerTestBase {
             assertTrue(listOfIds.contains(id));
         }
     }
-    
+
     public static void assertDoesNotContainsIds(Bundle bundle, String... ids) throws FHIRPathException {
         FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
         EvaluationContext evaluationContext = new EvaluationContext(bundle);
@@ -91,17 +90,17 @@ public abstract class ProfilesTestBase extends FHIRServerTestBase {
         assertNotNull(response);
         if (expectedStatusCode != response.getStatus()) {
             OperationOutcome operationOutcome = response.getResource(OperationOutcome.class);
-            SearchAllTest.generateOutput(operationOutcome);
+            printOutResource(true, operationOutcome);
         }
         assertEquals(expectedStatusCode, response.getStatus());
     }
-    
+
     public Bundle getEntityWithExtraWork(Response response, String method) throws Exception {
         Bundle responseBundle = response.readEntity(Bundle.class);
         commonWork(responseBundle,method);
         return responseBundle;
     }
-    
+
     public void commonWork(Bundle responseBundle, String method) throws Exception{
         assertNotNull(responseBundle);
         checkForIssuesWithValidation(responseBundle, true, false, false);

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreAllergyIntoleranceTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreAllergyIntoleranceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,7 +17,6 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -47,7 +46,7 @@ import com.ibm.fhir.model.type.code.NarrativeStatus;
  */
 public class USCoreAllergyIntoleranceTest extends ProfilesTestBase {
     private static final String CLASSNAME = USCoreAllergyIntoleranceTest.class.getName();
-    private static final Logger logger = Logger.getLogger(CLASSNAME);
+    private static final Logger LOG = Logger.getLogger(CLASSNAME);
 
     public Boolean skip = Boolean.TRUE;
 
@@ -69,7 +68,7 @@ public class USCoreAllergyIntoleranceTest extends ProfilesTestBase {
     public void setCheck(Boolean check) {
         this.skip = check;
         if (skip) {
-            logger.info("Skipping Tests for 'fhir-ig-us-core - AllergyIntolerance', the profiles don't exist");
+            LOG.info("Skipping Tests for 'fhir-ig-us-core - AllergyIntolerance', the profiles don't exist");
         }
     }
 
@@ -187,43 +186,16 @@ public class USCoreAllergyIntoleranceTest extends ProfilesTestBase {
     public void loadResources() throws Exception {
         if (!skip) {
             loadAllergyIntoleranceActive();
+            addToResourceRegistry("AllergyIntolerance", allergyIntoleranceIdActive);
+
             loadAllergyIntoleranceInactive();
+            addToResourceRegistry("AllergyIntolerance", allergyIntoleranceIdInactive);
+
             loadAllergyIntoleranceResolved();
+            addToResourceRegistry("AllergyIntolerance", allergyIntoleranceIdResolved);
+
             loadProvenanceForAllergyIntoleranceIdActive();
-        }
-    }
-
-    public void deleteAllergyIntoleranceActive() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("AllergyIntolerance/" + allergyIntoleranceIdActive).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteAllergyIntoleranceInactive() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("AllergyIntolerance/" + allergyIntoleranceIdInactive).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteAllergyIntoleranceResolved() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("AllergyIntolerance/" + allergyIntoleranceIdResolved).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    public void deleteProvenanceForAllergyIntoleranceIdActive() throws Exception {
-        WebTarget target = getWebTarget();
-        Response response = target.path("Provenance/" + provenanceId).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
-        assertResponse(response, Response.Status.OK.getStatusCode());
-    }
-
-    @AfterClass
-    public void deleteResources() throws Exception {
-        if (!skip) {
-            deleteAllergyIntoleranceActive();
-            deleteAllergyIntoleranceInactive();
-            deleteAllergyIntoleranceResolved();
-            deleteProvenanceForAllergyIntoleranceIdActive();
+            addToResourceRegistry("Provenance", provenanceId);
         }
     }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreConditionTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreConditionTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreConditionTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreConditionTest.java
@@ -8,10 +8,7 @@ package com.ibm.fhir.server.test.profiles;
 
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
@@ -27,9 +24,6 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.client.FHIRParameters;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
-import com.ibm.fhir.model.generator.FHIRGenerator;
-import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Condition;
 import com.ibm.fhir.model.test.TestUtil;
@@ -205,22 +199,7 @@ public class USCoreConditionTest extends ProfilesTestBase {
             assertSearchResponse(response, Response.Status.OK.getStatusCode());
             Bundle bundle = response.getResource(Bundle.class);
             assertNotNull(bundle);
-
-            try (StringWriter writer = new StringWriter();) {
-                FHIRGenerator.generator(Format.JSON, true).generate(bundle, System.out);
-                if (DEBUG) {
-                    System.out.println(writer.toString());
-                }
-                assertTrue(bundle.getEntry().size() == 0);
-            } catch (FHIRGeneratorException e) {
-
-                e.printStackTrace();
-                fail("unable to generate the fhir resource to JSON");
-
-            } catch (IOException e1) {
-                e1.printStackTrace();
-                fail("unable to generate the fhir resource to JSON (io problem) ");
-            }
+            assertTrue(bundle.getEntry().isEmpty());
         }
     }
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreMedicationRequestTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCoreMedicationRequestTest.java
@@ -26,15 +26,14 @@ import com.ibm.fhir.client.FHIRParameters;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.resource.Bundle;
-import com.ibm.fhir.model.resource.MedicationRequest;
 import com.ibm.fhir.model.resource.Bundle.Entry.Request;
+import com.ibm.fhir.model.resource.MedicationRequest;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Id;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.HTTPVerb;
-import com.ibm.fhir.server.test.SearchAllTest;
 
 /**
  * Tests the US Core 3.1.1 Profile with MedicationRequest.
@@ -91,7 +90,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             deleteMedicationRequest4();
         }
     }
-    
+
     public void loadBundle1() throws Exception {
         String resource = "json/profiles/fhir-ig-us-core/Bundle-uscore-mo3.json";
         WebTarget target = getWebTarget();
@@ -104,12 +103,12 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
                     .method(HTTPVerb.PUT)
                     .url(Uri.of(entry.getResource().getClass().getSimpleName() + "/" + entry.getResource().getId()))
                     .build();
-            
+
             Meta meta = Meta.builder()
                     .versionId(Id.of("" + System.currentTimeMillis()))
                     .build();
             entry.getResource().toBuilder().meta(meta).build();
-            
+
             Bundle.Entry tmpEntry = entry.toBuilder().request(request).build();
             output.add(tmpEntry);
         }
@@ -122,7 +121,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         String method = "loadBundle1";
         if (DEBUG) {
             Bundle responseBundle = getEntityWithExtraWork(response, method);
-            SearchAllTest.generateOutput(responseBundle);
+            printOutResource(DEBUG, responseBundle);
         }
 
         response = target.path("MedicationRequest/" + medicationRequestId3).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
@@ -153,7 +152,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         Response response = target.path("MedicationRequest/" + medicationRequestId1).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
         assertResponse(response, Response.Status.OK.getStatusCode());
     }
-    
+
     public void loadMedicationRequest2() throws Exception {
         String resource = "json/profiles/fhir-ig-us-core/MedicationRequest-uscore-mo2.json";
         WebTarget target = getWebTarget();
@@ -175,7 +174,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         Response response = target.path("MedicationRequest/" + medicationRequestId2).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
         assertResponse(response, Response.Status.OK.getStatusCode());
     }
-    
+
     public void loadMedicationRequest4() throws Exception {
         String resource = "json/profiles/fhir-ig-us-core/MedicationRequest-self-tylenol.json";
         WebTarget target = getWebTarget();
@@ -191,13 +190,13 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         response = target.path("MedicationRequest/" + medicationRequestId4).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
     }
-    
+
     public void deleteMedicationRequest4() throws Exception {
         WebTarget target = getWebTarget();
         Response response = target.path("MedicationRequest/" + medicationRequestId4).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
         assertResponse(response, Response.Status.OK.getStatusCode());
     }
-    
+
     public void deleteBundleEntry1() throws Exception {
         WebTarget target = getWebTarget();
         Response response = target.path("MedicationRequest/" + medicationRequestId3).request(FHIRMediaType.APPLICATION_FHIR_JSON).delete();
@@ -215,7 +214,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         // SHALL support searching using the combination of the patient and intent search parameters:
         // including support for composite OR search on intent (e.g.intent={system|}[code],{system|}[code],...)
         // GET [base]/MedicationRequest?patient=[reference]&intent=order,plan
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");
@@ -231,13 +230,13 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             assertDoesNotContainsIds(bundle, medicationRequestId4);
         }
     }
-    
+
     @Test
     public void testSearchByPatientWithMultipleIntents() throws Exception {
         // SHALL support searching using the combination of the patient and intent search parameters:
         // including support for composite OR search on intent (e.g.intent={system|}[code],{system|}[code],...)
         // GET [base]/MedicationRequest?patient=[reference]&intent=order,plan
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");
@@ -253,14 +252,14 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             assertContainsIds(bundle, medicationRequestId4);
         }
     }
-    
+
     @Test
     public void testSearchByPatientWithSingleIntentAndStatus() throws Exception {
         // SHALL support searching using the combination of the patient and intent and status search parameters:
         // including support for composite OR search on intent (e.g.intent={system|}[code],{system|}[code],...)
         // including support for composite OR search on status (e.g.status={system|}[code],{system|}[code],...)
         // GET [base]/MedicationRequest?patient=[reference]&intent=order,plan&status={system|}[code]{,{system|}[code],...}
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");
@@ -277,13 +276,13 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             assertDoesNotContainsIds(bundle, medicationRequestId4);
         }
     }
-    
+
     @Test
     public void testSearchByPatientWithSingleIntentAndEncounter() throws Exception {
         // SHOULD support searching using the combination of the patient and intent and encounter search parameters:
         // including support for composite OR search on intent (e.g.intent={system|}[code],{system|}[code],...)
         // GET [base]/MedicationRequest?patient=[reference]&intent=order,plan&encounter=[reference]
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");
@@ -300,11 +299,11 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             assertContainsIds(bundle, medicationRequestId4);
         }
     }
-    
+
     @Test
     public void testSearchByPatientWithSingleIntentWithInclude() throws Exception {
         // Tests the include
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");
@@ -322,7 +321,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
             assertContainsIds(bundle, medicationId3);
         }
     }
-    
+
     @Test
     public void testSearchByPatientWithSingleIntentWithIncludeAndAuthoredOn() throws Exception {
         // SHOULD support searching using the combination of the patient and intent and authoredon search parameters:
@@ -330,7 +329,7 @@ public class USCoreMedicationRequestTest extends ProfilesTestBase {
         // including support for these authoredon comparators: gt,lt,ge,le
         // including optional support for composite AND search on authoredon (e.g.authoredon=[date]&authoredon=[date]]&...)
         // GET [base]/MedicationRequest?patient=[reference]&intent=order,plan&authoredon={gt|lt|ge|le}[date]{&authoredon={gt|lt|ge|le}[date]&...}
-        
+
         if (!skip) {
             FHIRParameters parameters = new FHIRParameters();
             parameters.searchParam("patient", "Patient/example");

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCorePractitionerAndPractitionerRoleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/USCorePractitionerAndPractitionerRoleTest.java
@@ -35,7 +35,6 @@ import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.HTTPVerb;
-import com.ibm.fhir.server.test.SearchAllTest;
 
 /**
  * Tests the US Core 3.1.1 Profile with Practitioner and PractitionerRole
@@ -116,7 +115,7 @@ public class USCorePractitionerAndPractitionerRoleTest extends ProfilesTestBase 
         String method = "loadBundle1";
         if (DEBUG) {
             Bundle responseBundle = getEntityWithExtraWork(response, method);
-            SearchAllTest.generateOutput(responseBundle);
+            printOutResource(DEBUG, responseBundle);
         }
 
         response = target.path("Practitioner/" + practitionerId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/terminology/CodeSystemClearCacheOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/terminology/CodeSystemClearCacheOperationTest.java
@@ -36,10 +36,12 @@ public class CodeSystemClearCacheOperationTest extends TerminologyOperationTestB
     public static final String CODE_SYSTEM_URL = "http://ibm.com/fhir/CodeSystem/test";
     public static final String CODE_SYSTEM_VERSION = "1.0.0";
 
+    @Override
     @BeforeClass
     public void setup() throws Exception {
-        Response response = doPut("CodeSystem", CODE_SYSTEM_ID, "testdata/CodeSystem-test.json");
-        assertEquals(response.getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL);
+        try (Response response = doPut("CodeSystem", CODE_SYSTEM_ID, "testdata/CodeSystem-test.json")) {
+            assertEquals(response.getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL);
+        }
     }
 
     @Test(groups = { TEST_GROUP_NAME })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/terminology/TerminologyOperationTestBase.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/terminology/TerminologyOperationTestBase.java
@@ -12,7 +12,6 @@ import static org.testng.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.util.Properties;
 
-import jakarta.json.JsonObject;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -27,6 +26,8 @@ import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.server.test.FHIRServerTestBase;
+
+import jakarta.json.JsonObject;
 
 public abstract class TerminologyOperationTestBase extends FHIRServerTestBase {
 
@@ -48,6 +49,10 @@ public abstract class TerminologyOperationTestBase extends FHIRServerTestBase {
         Response response = getWebTarget().path(resourceType + "/" + id).request().put(entity, Response.class);
         String responseBody = response.readEntity(String.class);
         assertEquals(response.getStatusInfo().getFamily(), Response.Status.Family.SUCCESSFUL, responseBody);
+
+        // To support delete AFTER the IT is run.
+        String logicalId = getLocationLogicalId(response);
+        addToResourceRegistry(resourceType, logicalId);
         return response;
     }
 

--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <web-app id="WebApp_ID" version="3.1"
     xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    xsi:schemaLocation="https://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
     <display-name>IBM FHIR Server</display-name>
     <servlet>
         <servlet-name>FHIRRestServlet</servlet-name>


### PR DESCRIPTION
Add Vacuum Setting support for PostgreSQL

- Add V0017 to indicate Schema change
- Introduce WITH to the Java data model
- Update the Adapters to support WITH
- Add PostgresVacuumSettingDAO controls the setting of the default scale factor, the threshold and the limit per    https://ibm.github.io/FHIR/guides/FHIRPerformanceGuide/#412-tuning-auto-vacuum
- Add to the Data Definition in the schema generator
- Add a Helper Method/new command --update-vacuum to update the current  vacuum settings to a specific setting.

To check SQL settings:

    select relname, (reloptions)::VARCHAR
    from pg_class
    join pg_namespace on pg_namespace.oid = pg_class.relnamespace
    where relname = LOWER('STRUCTUREMAP_LOGICAL_RESOURCES')
    and pg_namespace.nspname = LOWER('TEST12345');

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>