### PR TITLE
Update fhir-ig-us-core to US-Core STU4 #2586

### DIFF
--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/ConstraintGeneratorTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/ConstraintGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,7 +10,7 @@ import static com.ibm.fhir.path.util.FHIRPathUtil.compile;
 
 import org.testng.annotations.Test;
 
-import com.ibm.fhir.ig.us.core.USCoreResourceProvider;
+import com.ibm.fhir.ig.us.core.USCoreSTU3ResourceProvider;
 import com.ibm.fhir.model.annotation.Constraint;
 import com.ibm.fhir.model.resource.StructureDefinition;
 import com.ibm.fhir.model.type.Extension;
@@ -20,14 +20,36 @@ import com.ibm.fhir.registry.resource.FHIRRegistryResource;
 import com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider;
 
 public class ConstraintGeneratorTest {
+
     @Test
-    public static void testConstraintGenerator() throws Exception {
-        FHIRRegistryResourceProvider provider = new USCoreResourceProvider();
+    public static void testConstraintGeneratorSTU3() throws Exception {
+        FHIRRegistryResourceProvider provider = new USCoreSTU3ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
                 String url = registryResource.getUrl();
                 System.out.println(url);
-                Class<?> type = ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
+                Class<?> type =
+                        ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
+                for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {
+                    System.out.println("    " + constraint);
+                    if (!Constraint.LOCATION_BASE.equals(constraint.location())) {
+                        compile(constraint.location());
+                    }
+                    compile(constraint.expression());
+                }
+            }
+        }
+    }
+
+    @Test
+    public static void testConstraintGeneratorSTU4() throws Exception {
+        FHIRRegistryResourceProvider provider = new USCoreSTU3ResourceProvider();
+        for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
+            if (StructureDefinition.class.equals(registryResource.getResourceType())) {
+                String url = registryResource.getUrl();
+                System.out.println(url);
+                Class<?> type =
+                        ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
                 for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {
                     System.out.println("    " + constraint);
                     if (!Constraint.LOCATION_BASE.equals(constraint.location())) {


### PR DESCRIPTION
- Move pre-4.9.0 USCore to STU3 Provider
- Add STU4 package and STU4 Provider
- Format All parts of package with Pretty Print
- Add VersionComparatorTool to show differences

- Errors:
	us-core-pulse-oximetry

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>