### PR TITLE
update db2 reindex constraint violation

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/db2/Db2ResourceReferenceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/db2/Db2ResourceReferenceDAO.java
@@ -149,14 +149,9 @@ public class Db2ResourceReferenceDAO extends ResourceReferenceDAO {
                 ps.setInt(a++, tv.getCodeSystemId());
             }
 
-            try {
-                ps.executeUpdate();
-            } catch (SQLException x) {
-                logger.throwing("Db2ResourceReferenceDAO", "doCommonTokenValuesUpsert", x);
-                logger.fine("Retrying the execution in case of synchronization issues");
-                ps.executeUpdate();
-            }
+            ps.executeUpdate();
         } catch (SQLException x) {
+            logger.throwing(Db2ResourceReferenceDAO.class.getSimpleName(), "doCommonTokenValuesUpsert", x);
             StringBuilder values = new StringBuilder();
             for (CommonTokenValue tv: tokenValues) {
                 if (values.length() > 0) {
@@ -169,7 +164,7 @@ public class Db2ResourceReferenceDAO extends ResourceReferenceDAO {
                 values.append("}");
             }
 
-            logger.log(Level.SEVERE, insert.toString() + "; [" + values.toString() + "]", x);
+            logger.log(Level.SEVERE, "Unable to upsert to common_token_values [" + insert.toString() + ";] [" + values.toString() + "]", x);
             throw getTranslator().translate(x);
         }
     }


### PR DESCRIPTION
- Remove an incorrect retry
- optimize the  db2 specific reindexing to retry when SQL Constraint on Common Token values.
 
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>