### PR TITLE
issue #2666 - fix for currentUploadSize tracking

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/export/system/resource/SystemExportResourceHandler.java
@@ -43,6 +43,8 @@ public class SystemExportResourceHandler {
             throw new Exception(msg);
         }
 
+        long priorSize = chunkData.getBufferStream().size();
+
         for (Resource res : resources) {
             try {
                 // No need to fill buffer for parquet because we're letting spark write to COS;
@@ -66,8 +68,9 @@ public class SystemExportResourceHandler {
                 throw e;
             }
         }
+
         chunkData.addCurrentUploadResourceNum(resSubTotal);
-        chunkData.addCurrentUploadSize(chunkData.getBufferStream().size());
+        chunkData.addCurrentUploadSize(chunkData.getBufferStream().size() - priorSize);
         chunkData.addTotalResourcesNum(resSubTotal);
         if (logger.isLoggable(Level.FINE)) {
             logger.fine("fillChunkDataBuffer: Processed resources - " + resSubTotal + "; Bufferred data size - "


### PR DESCRIPTION
Previously, we added the entire size of the buffer after each page of
results was read. This leads us to think that we have a lot more data
than we actually do. Now we will add only the new bytes.

This change fixes the over-counting but also started causing us to hit transaction timeouts.
It especially happens if you use an `_elements` filter because the search queries take just as long
but the size of the resources is much smaller and so we need many more resources to reach our
partUploadTriggerSizeMB for the checkpoint.

In the short term, it should be possible to either:
A. increase the transaction timeout (so we can gather more bytes before the timeout occurs); and/or
B. decrease the partUploadTriggerSizeMB (our default is 10 but we can go as low as 5 for S3)

In the longer term, we should possibly consolidate this implementation with the "fast export" one,
or at least use a similar approach. That one uses a maxChunkReadTime to decide when to stop reading.
However, that one also has the luxury of being fast and so we should be able to gather enough bytes
for a multiPartUpload for any moderately sized transaction timeout.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>