### PR TITLE
issue #2669 - validate request scopes before read, vread, history, and search

### DIFF
--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -115,7 +115,6 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
 
         FHIRSearchContext searchContext = event.getSearchContextImpl();
         if (searchContext != null) {
-
             Set<String> patientIdFromToken = getPatientIdFromToken(jwt);
 
             // Determine if compartment search


### PR DESCRIPTION
In addition to checking the scopes for each resource on the way out (via
the afterX methods), we now check that the requested interaction is
permitted by the passed scopes on the way in (the beforeX methods).
Two reasons:
1. We prevent some unnecessary work for invalid requests
2. We prevent leaking info about the presence/absence of resourceTypes
for which a given application has not been granted access

The request scopes are already checked before create, update, and
delete.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>