### PR TITLE
issue #2673 - Set the resourceTypeSummary at the end of each file export

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/common/BulkDataUtils.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/common/BulkDataUtils.java
@@ -40,6 +40,7 @@ import com.ibm.cloud.objectstorage.services.s3.model.S3Object;
 import com.ibm.cloud.objectstorage.services.s3.model.S3ObjectInputStream;
 import com.ibm.cloud.objectstorage.services.s3.model.UploadPartRequest;
 import com.ibm.cloud.objectstorage.services.s3.model.UploadPartResult;
+import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
 import com.ibm.fhir.core.util.URLSupport;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -390,6 +391,25 @@ public class BulkDataUtils {
                         new String(Base64.getDecoder().decode(dataSourcesInfo), StandardCharsets.UTF_8)))) {
             JsonArray dataSourceArray = reader.readArray();
             return dataSourceArray;
+        }
+    }
+
+    /**
+     * Update the chunkData with the stats from the newly finished upload.
+     * The data is added to the summary from the chunkData's currentUploadResourceNum.
+     *
+     * @param fhirResourceType
+     * @param chunkData
+     */
+    public static void updateSummary(String fhirResourceType, ExportTransientUserData chunkData) {
+        if (chunkData.getResourceTypeSummary() == null) {
+            chunkData.setResourceTypeSummary(fhirResourceType + "[" + chunkData.getCurrentUploadResourceNum());
+        } else {
+            chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "," + chunkData.getCurrentUploadResourceNum());
+        }
+
+        if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
+            chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
         }
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
@@ -26,6 +26,7 @@ import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.specialized.AppendBlobClient;
+import com.ibm.fhir.bulkdata.common.BulkDataUtils;
 import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
@@ -259,17 +260,7 @@ public class AzureProvider implements Provider {
 
         if (chunkData.isFinishCurrentUpload()) {
             // Partition status for the exported resources, e.g, Patient[1000,1000,200]
-            if (chunkData.getResourceTypeSummary() == null) {
-                chunkData.setResourceTypeSummary(fhirResourceType + "[" + chunkData.getCurrentUploadResourceNum());
-                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
-                }
-            } else {
-                chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "," + chunkData.getCurrentUploadResourceNum());
-                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
-                }
-            }
+            BulkDataUtils.updateSummary(fhirResourceType, chunkData);
 
             ConfigurationAdapter config = ConfigurationFactory.getInstance();
             long resourceCountThreshold = config.getCoreAzureObjectResourceCountThreshold();

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -194,14 +194,20 @@ public class FileProvider implements Provider {
         chunkData.getBufferStream().writeTo(out);
         chunkData.getBufferStream().reset();
 
-        StringBuilder output = new StringBuilder();
-        output.append(fhirResourceType);
-        output.append('[');
-        output.append(chunkData.getCurrentUploadResourceNum());
-        output.append(']');
-        chunkData.setResourceTypeSummary(output.toString());
-
         if (chunkData.isFinishCurrentUpload()) {
+            // Partition status for the exported resources, e.g, Patient[1000,1000,200]
+            if (chunkData.getResourceTypeSummary() == null) {
+                chunkData.setResourceTypeSummary(fhirResourceType + "[" + chunkData.getCurrentUploadResourceNum());
+                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
+                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
+                }
+            } else {
+                chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "," + chunkData.getCurrentUploadResourceNum());
+                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
+                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
+                }
+            }
+
             out.close();
             out = null;
             chunkData.setPartNum(1);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.bulkdata.common.BulkDataUtils;
 import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
 import com.ibm.fhir.bulkdata.jbatch.export.data.ExportTransientUserData;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
@@ -196,17 +197,7 @@ public class FileProvider implements Provider {
 
         if (chunkData.isFinishCurrentUpload()) {
             // Partition status for the exported resources, e.g, Patient[1000,1000,200]
-            if (chunkData.getResourceTypeSummary() == null) {
-                chunkData.setResourceTypeSummary(fhirResourceType + "[" + chunkData.getCurrentUploadResourceNum());
-                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
-                }
-            } else {
-                chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "," + chunkData.getCurrentUploadResourceNum());
-                if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                    chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
-                }
-            }
+            BulkDataUtils.updateSummary(fhirResourceType, chunkData);
 
             out.close();
             out = null;

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
@@ -459,18 +459,8 @@ public class S3Provider implements Provider {
         parquetWriter.writeParquet(resources, itemName);
 
         // Partition status for the exported resources, e.g, Patient[1000,1000,200]
-        if (chunkData.getResourceTypeSummary() == null) {
-            chunkData.setResourceTypeSummary(fhirResourceType + "[" + chunkData.getCurrentUploadResourceNum());
-            if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
-            }
-        } else {
-            chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "," + chunkData.getCurrentUploadResourceNum());
-            if (chunkData.getPageNum() >= chunkData.getLastPageNum()) {
-                chunkData.setResourceTypeSummary(chunkData.getResourceTypeSummary() + "]");
+        BulkDataUtils.updateSummary(fhirResourceType, chunkData);
 
-            }
-        }
         if (chunkData.getPageNum() < chunkData.getLastPageNum()) {
             chunkData.setPartNum(1);
             chunkData.setUploadId(null);


### PR DESCRIPTION
Now the FileProvider follows the same pattern as the S3Provider...we
update the resourceTypeSummary at the end of each "currentUpload".

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>