### PR TITLE
issue #2184 - support getting all the common token value ids in one go

### DIFF
--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/query/expression/StringStatementRenderer.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/query/expression/StringStatementRenderer.java
@@ -92,7 +92,7 @@ public class StringStatementRenderer implements StatementRenderer<String> {
 
         if (groupByClause != null) {
             if (this.pretty) {
-                result.append(NEWLINE).append("    ");
+                result.append(NEWLINE).append("   ");
             }
             result.append(SPACE).append(groupByClause.toString());
         }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/cache/CommonTokenValuesCacheImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/cache/CommonTokenValuesCacheImpl.java
@@ -394,35 +394,6 @@ public class CommonTokenValuesCacheImpl implements ICommonTokenValuesCache {
         return result;
     }
 
-    public List<Long> resolveCommonTokenValueIdsPreservingOrder(List<CommonTokenValue> tokenValues, List<Integer> misses) {
-        List<Long> result = new ArrayList<>();
-
-        LinkedHashMap<CommonTokenValue,Long> valMap = commonTokenValues.get();
-
-        for (int i = 0; i < tokenValues.size(); i++) {
-            CommonTokenValue token = tokenValues.get(i);
-
-            Long tokenValueId = valMap != null ? valMap.get(token) : null;
-            if (tokenValueId == null) {
-                // not found in the local cache, try the shared cache
-                synchronized (tokenValuesCache) {
-                    tokenValueId = tokenValuesCache.get(token);
-                }
-
-                if (tokenValueId != null) {
-                    // add to the local cache so we can find it again without locking
-                    addTokenValue(token, tokenValueId);
-                } else {
-                    misses.add(i);
-                }
-            }
-
-            result.add(tokenValueId);
-        }
-
-        return result;
-    }
-
     @Override
     public Set<Long> resolveCommonTokenValueIds(Collection<CommonTokenValue> tokenValues, Set<CommonTokenValue> misses) {
         Set<Long> result = new HashSet<>();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ICommonTokenValuesCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ICommonTokenValuesCache.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.persistence.jdbc.dao.api;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.ibm.fhir.persistence.jdbc.dao.impl.ResourceProfileRec;
 import com.ibm.fhir.persistence.jdbc.dao.impl.ResourceTokenValueRec;
@@ -36,7 +37,7 @@ public interface ICommonTokenValuesCache {
      * Lookup all the database values we have cached for the code-system names
      * in the given collection. Put any objects with cache misses into the corresponding
      * miss lists (so that we know which records we need to generate inserts for)
-     * @param xrefs
+     * @param tokenValues
      * @param misses the objects we couldn't find in the cache
      */
     void resolveCodeSystems(Collection<ResourceTokenValueRec> tokenValues,
@@ -115,6 +116,14 @@ public interface ICommonTokenValuesCache {
      * @return
      */
     Long getCommonTokenValueId(String codeSystem, String tokenValue);
+
+    /**
+     * Get the database common_token_value_ids for the given list of token values.
+     * @param tokenValues
+     * @param misses the set of the CommonTokenValue objects we couldn't find in the cache
+     * @return
+     */
+    Set<Long> resolveCommonTokenValueIds(Collection<CommonTokenValue> tokenValues, Set<CommonTokenValue> misses);
 
     /**
      * Get the cached database id for the given canonical url

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/IResourceReferenceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/IResourceReferenceDAO.java
@@ -8,10 +8,12 @@ package com.ibm.fhir.persistence.jdbc.dao.api;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.jdbc.dao.impl.ResourceProfileRec;
 import com.ibm.fhir.persistence.jdbc.dao.impl.ResourceTokenValueRec;
+import com.ibm.fhir.persistence.jdbc.dto.CommonTokenValue;
 import com.ibm.fhir.persistence.jdbc.dto.CommonTokenValueResult;
 
 /**
@@ -60,6 +62,14 @@ public interface IResourceReferenceDAO {
      * @return the matching id from common_token_values.common_token_value_id or null if not found
      */
     CommonTokenValueResult readCommonTokenValueId(String codeSystem, String tokenValue);
+
+    /**
+     * Find database ids for a set of common token values
+     * @param tokenValues
+     * @return a non-null, possibly-empty set of ids from common_token_values.common_token_value_id;
+     *      CommonTokenValues with no corresponding record will be omitted from the set
+     */
+    Set<CommonTokenValueResult> readCommonTokenValueIds(Collection<CommonTokenValue> tokenValues);
 
     /**
      * Fetch the list of matching common_token_value_id records for the given tokenValue.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/JDBCIdentityCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/JDBCIdentityCache.java
@@ -6,9 +6,12 @@
 
 package com.ibm.fhir.persistence.jdbc.dao.api;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.jdbc.dto.CommonTokenValue;
 
 /**
  * Provides access to all the identity information we need when processing
@@ -64,8 +67,19 @@ public interface JDBCIdentityCache {
      * a cache, or the database if not found in the cache.
      * @param codeSystem
      * @param tokenValue
+     * @return The common token value id or null if it doesn't exist
      */
     Long getCommonTokenValueId(String codeSystem, String tokenValue);
+
+    /**
+     * Get the common_token_value_ids for the given tokenValues. Reads from
+     * a cache, or the database if not found in the cache.
+     * CommonTokenValues with no corresponding record in the database will
+     * be omitted from the result set.
+     * @param tokenValues
+     * @return A non-null, possibly-empty set of common token value ids
+     */
+    Set<Long> getCommonTokenValueIds(Collection<CommonTokenValue> tokenValues);
 
     /**
      * Get a list of matching common_token_value_id values. Implementations may decide

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/JDBCIdentityCacheImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/impl/JDBCIdentityCacheImpl.java
@@ -164,43 +164,6 @@ public class JDBCIdentityCacheImpl implements JDBCIdentityCache {
         return result;
     }
 
-//    public List<Long> getCommonTokenValueIdsPreservingOrder(List<CommonTokenValue> tokenValues) {
-//        List<Integer> misses = new ArrayList<>();
-//        List<Long> result = cache.getResourceReferenceCache().resolveCommonTokenValueIds(tokenValues, misses);
-//
-//        if (misses.isEmpty()) {
-//            return result;
-//        }
-//
-//        Map<CommonTokenValue,Integer> valueAndIndex = new LinkedHashMap<>();
-//        for (Integer missIndex : misses) {
-//            CommonTokenValue commonTokenValue = tokenValues.get(missIndex);
-//
-//            if (logger.isLoggable(Level.FINE)) {
-//                logger.fine("Cache miss. Fetching common_token_value_id from database: " + commonTokenValue);
-//            }
-//            valueAndIndex.put(commonTokenValue, missIndex);
-//        }
-//        Set<CommonTokenValueResult> readCommonTokenValueIds = resourceReferenceDAO.readCommonTokenValueIds(valueAndIndex.keySet());
-
-//        if (result == null) {
-//
-//            CommonTokenValueResult dto = resourceReferenceDAO.readCommonTokenValueId(codeSystem, tokenValue);
-//            if (dto != null) {
-//                // Value exists in the database, so we can add this to our cache. Note that we still
-//                // choose to add it the thread-local cache - this avoids any locking. The values will
-//                // be promoted to the shared cache at the end of the transaction. This avoids unnecessary
-//                // contention.
-//                result = dto.getCommonTokenValueId();
-//                if (logger.isLoggable(Level.FINE)) {
-//                    logger.fine("Adding common_token_value_id to cache: '" + codeSystem + "|" + tokenValue + "' = " + result);
-//                }
-//                cache.getResourceReferenceCache().addCodeSystem(codeSystem, dto.getCodeSystemId());
-//                cache.getResourceReferenceCache().addTokenValue(new CommonTokenValue(dto.getCodeSystemId(), tokenValue), result);
-//            }
-//        return result;
-//    }
-
     @Override
     public Set<Long> getCommonTokenValueIds(Collection<CommonTokenValue> tokenValues) {
         Set<CommonTokenValue> misses = new HashSet<>();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceReferenceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceReferenceDAO.java
@@ -61,18 +61,19 @@ public class DerbyResourceReferenceDAO extends ResourceReferenceDAO {
 
         Set<CommonTokenValueResult> result = new HashSet<>();
 
-        String SQL = ""
-                + "SELECT c.token_value, c.code_system_id, c.common_token_value_id "
-                + "  FROM common_token_values c"
-                + " WHERE ";
+        StringBuilder select = new StringBuilder()
+                .append("SELECT c.token_value, c.code_system_id, c.common_token_value_id ")
+                .append("  FROM common_token_values c")
+                .append(" WHERE ");
 
         String delim = "";
         for (CommonTokenValue ctv : tokenValues) {
-            SQL += delim + "(c.token_value = ? AND c.code_system_id = " + ctv.getCodeSystemId() + ")";
+            select.append(delim);
+            select.append("(c.token_value = ? AND c.code_system_id = " + ctv.getCodeSystemId() + ")");
             delim = " OR ";
         }
 
-        try (PreparedStatement ps = getConnection().prepareStatement(SQL)) {
+        try (PreparedStatement ps = getConnection().prepareStatement(select.toString())) {
             Iterator<CommonTokenValue> iterator = tokenValues.iterator();
             for (int i = 1; i <= tokenValues.size(); i++) {
                 ps.setString(i, iterator.next().getTokenValue());
@@ -83,7 +84,7 @@ public class DerbyResourceReferenceDAO extends ResourceReferenceDAO {
                 result.add(new CommonTokenValueResult(rs.getString(1), rs.getInt(2), rs.getLong(3)));
             }
         } catch (SQLException x) {
-            logger.log(Level.SEVERE, SQL, x);
+            logger.log(Level.SEVERE, select.toString(), x);
             throw getTranslator().translate(x);
         }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValue.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValue.java
@@ -11,18 +11,18 @@ package com.ibm.fhir.persistence.jdbc.dto;
  * DTO representing a record in COMMON_TOKEN_VALUES
  */
 public class CommonTokenValue {
-    
+
     private final int codeSystemId;
-    
+
     // tokenValue can be null
     private final String tokenValue;
-    
+
     public CommonTokenValue(int codeSystemId, String tokenValue) {
         if (codeSystemId < 0) {
             // Called before the code-system record was created (or fetched from) the database
             throw new IllegalArgumentException("Invalid codeSystemId argument");
         }
-        
+
         this.codeSystemId = codeSystemId;
         this.tokenValue = tokenValue;
     }
@@ -40,12 +40,12 @@ public class CommonTokenValue {
     public String getTokenValue() {
         return tokenValue;
     }
-    
+
     @Override
     public int hashCode() {
         return Integer.hashCode(codeSystemId) * 37 + (tokenValue == null ? 7 : tokenValue.hashCode());
     }
-    
+
     @Override
     public boolean equals(Object other) {
         if (other instanceof CommonTokenValue) {
@@ -57,5 +57,10 @@ public class CommonTokenValue {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "[codeSystemId=" + codeSystemId + ", tokenValue=" + tokenValue + "]";
     }
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValue.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValue.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020
+ * (C) Copyright IBM Corp. 2020, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +17,11 @@ public class CommonTokenValue {
     // tokenValue can be null
     private final String tokenValue;
 
+    /**
+     * Construct a common token value from a codeSystemId and tokenValue
+     * @param codeSystemId
+     * @param tokenValue
+     */
     public CommonTokenValue(int codeSystemId, String tokenValue) {
         if (codeSystemId < 0) {
             // Called before the code-system record was created (or fetched from) the database

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValueResult.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValueResult.java
@@ -12,26 +12,20 @@ package com.ibm.fhir.persistence.jdbc.dto;
  * corresponding code system id
  */
 public class CommonTokenValueResult {
-    private final int codeSystemId;
     private final String tokenValue;
+    private final int codeSystemId;
     private final long commonTokenValueId;
 
     /**
      * Public constructor
+     * @param tokenValue
      * @param codeSystemId
      * @param commonTokenValueId
      */
-    public CommonTokenValueResult(int codeSystemId, String tokenValue, long commonTokenValueId) {
-        this.codeSystemId = codeSystemId;
+    public CommonTokenValueResult(String tokenValue, int codeSystemId, long commonTokenValueId) {
         this.tokenValue = tokenValue;
+        this.codeSystemId = codeSystemId;
         this.commonTokenValueId = commonTokenValueId;
-    }
-
-    /**
-     * @return the commonTokenValueId
-     */
-    public long getCommonTokenValueId() {
-        return commonTokenValueId;
     }
 
     /**
@@ -39,6 +33,13 @@ public class CommonTokenValueResult {
      */
     public String getTokenValue() {
         return tokenValue;
+    }
+
+    /**
+     * @return the commonTokenValueId
+     */
+    public long getCommonTokenValueId() {
+        return commonTokenValueId;
     }
 
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValueResult.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dto/CommonTokenValueResult.java
@@ -13,6 +13,7 @@ package com.ibm.fhir.persistence.jdbc.dto;
  */
 public class CommonTokenValueResult {
     private final int codeSystemId;
+    private final String tokenValue;
     private final long commonTokenValueId;
 
     /**
@@ -20,8 +21,9 @@ public class CommonTokenValueResult {
      * @param codeSystemId
      * @param commonTokenValueId
      */
-    public CommonTokenValueResult(int codeSystemId, long commonTokenValueId) {
+    public CommonTokenValueResult(int codeSystemId, String tokenValue, long commonTokenValueId) {
         this.codeSystemId = codeSystemId;
+        this.tokenValue = tokenValue;
         this.commonTokenValueId = commonTokenValueId;
     }
 
@@ -30,6 +32,13 @@ public class CommonTokenValueResult {
      */
     public long getCommonTokenValueId() {
         return commonTokenValueId;
+    }
+
+    /**
+     * @return the tokenValue
+     */
+    public String getTokenValue() {
+        return tokenValue;
     }
 
     /**


### PR DESCRIPTION
Added:
* getCommonTokenValueIds to JDBCIdentityCache
* resolveCommonTokenValueIds to ICommonTokenValuesCache
* readCommonTokenValueIds to ResourceReferenceDAO

Updated SearchQueryRenderer to use this mechanism in two cases:
* getReferenceFilter for reference params without the `:identifier` modifier (including compartment params)
* getTokenFilter for token params with the IN, ABOVE, BELOW, and NOT-IN modifiers

Also includes cleanup in getReferenceFilter and populateCodesSubSegment (used by getTokenFilter):
* removal of code in getReferenceFilter for handling modifier that we don't support for reference params
* removal of code that uses the token ref view for token filters...I believe that the IN, ABOVE, BELOW, and NOT-IN cases can be handled with COMMON_TOKEN_VALUES now

Needs testing on Db2.