### PR TITLE
Upgrade azure-storage-blob dependency to fix build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,10 @@ Connect with us through https://chat.fhir.org/ or open an [issue](https://github
 ## Setup
 The IBM FHIR Server is built with Maven and requires Java 8 or higher.  To build the project from the root directory, please execute:
 
-> mvn clean install -f fhir-parent/pom.xml
+```
+mvn clean install -f fhir-examples
+mvn clean install -f fhir-parent
+```
 
 ## Testing
 To ensure a working build, please run the full build from the root of the project before submitting your pull request.

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -558,7 +558,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-storage-blob</artifactId>
-                <version>12.6.0</version>
+                <version>12.13.0</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
Fixes https://github.com/IBM/FHIR/issues/2690

Also add an extra line to CONTRIBUTING.md. Without first compiling the fhir-examples folder, the remaining build fails.