### PR TITLE
issue 2680 Allow control of the clock

### DIFF
--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/cadf/CadfReporterStep.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/cadf/CadfReporterStep.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -173,7 +174,7 @@ public final class CadfReporterStep {
             if (rTime != null) {
                 this.reporterTime = rTime;
             } else {
-                this.reporterTime = Instant.now().atZone(ZoneId.of("UTC"));
+                this.reporterTime = Instant.now(ClockFactory.getDefaultClock()).atZone(ZoneId.of("UTC"));
             }
         }
 

--- a/fhir-core/src/main/java/com/ibm/fhir/core/clock/ClockFactory.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/clock/ClockFactory.java
@@ -1,0 +1,28 @@
+/*
+ * (C) Copyright IBM Corp. 2019, 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.core.clock;
+
+import java.time.Clock;
+
+/**
+ * Allows controlling the current date and time during tests.
+ */
+public class ClockFactory {
+    private static Clock FIXED_CLOCK = null;
+    
+    public static Clock getDefaultClock() {
+        if (FIXED_CLOCK != null) {
+            return FIXED_CLOCK;
+        } else {
+            return Clock.systemUTC();
+        }
+    }
+    
+    public static void setDefaultClock(Clock clock) {
+        FIXED_CLOCK = clock;
+    }
+}

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/DateTime.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import javax.annotation.Generated;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.ValidationSupport;
 import com.ibm.fhir.model.visitor.Visitor;
@@ -95,7 +96,7 @@ public class DateTime extends Element {
      * Factory method for creating a DateTime that represents the current DateTime
      */
     public static DateTime now() {
-        return DateTime.builder().value(ZonedDateTime.now()).build();
+        return DateTime.builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock())).build();
     }
 
     /**
@@ -106,7 +107,7 @@ public class DateTime extends Element {
      */
     public static DateTime now(ZoneOffset offset) {
         Objects.requireNonNull(offset, "offset");
-        return DateTime.builder().value(ZonedDateTime.now(offset)).build();
+        return DateTime.builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock().withZone(offset))).build();
     }
 
     @Override

--- a/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/type/Instant.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 
 import javax.annotation.Generated;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.ValidationSupport;
 import com.ibm.fhir.model.visitor.Visitor;
@@ -84,7 +85,7 @@ public class Instant extends Element {
      * Factory method for creating a Instant that represents the current Instant
      */
     public static Instant now() {
-        return Instant.builder().value(ZonedDateTime.now()).build();
+        return Instant.builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock())).build();
     }
 
     /**
@@ -95,7 +96,7 @@ public class Instant extends Element {
      */
     public static Instant now(ZoneOffset offset) {
         Objects.requireNonNull(offset, "offset");
-        return Instant.builder().value(ZonedDateTime.now(offset)).build();
+        return Instant.builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock().withZone(offset))).build();
     }
 
     @Override

--- a/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/evaluator/FHIRPathEvaluator.java
@@ -59,6 +59,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 
@@ -259,7 +260,7 @@ public class FHIRPathEvaluator {
     }
 
     private void setDateTimeConstants(EvaluationContext evaluationContext) {
-        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime now = ZonedDateTime.now(ClockFactory.getDefaultClock());
         evaluationContext.setExternalConstant("now", singleton(dateTimeValue(now)));
         evaluationContext.setExternalConstant("today", singleton(dateValue(LocalDate.from(now))));
         evaluationContext.setExternalConstant("timeOfDay", singleton(timeValue(LocalTime.from(now))));

--- a/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/date/DateTimeHandler.java
@@ -24,6 +24,7 @@ import java.time.temporal.TemporalAccessor;
 import java.time.zone.ZoneRules;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.util.ModelSupport;
@@ -123,7 +124,7 @@ public class DateTimeHandler {
 
         if (prefix == Prefix.AP) {
             Instant cur = generateValue(value, originalString);
-            Instant now = java.time.Instant.now();
+            Instant now = java.time.Instant.now(ClockFactory.getDefaultClock());
             response = generateLowerBoundApproximation(now, cur);
         } else {
             response = generateValue(value, originalString);
@@ -149,25 +150,25 @@ public class DateTimeHandler {
             // YEAR - 1
             Year year = (Year) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock()))).toInstant();
         } else if (value instanceof YearMonth) {
             // Month - 1
             // Grab the values for Year/Month Value
             YearMonth ym = (YearMonth) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock()))).toInstant();
         } else if (value instanceof LocalDate) {
             // LocalDate - YYYY-MM-DD
             LocalDate ld = (LocalDate) value;
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ld.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
             local    = local.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock()))).toInstant();
         } else if (value instanceof LocalDateTime) {
             // LocalDate - YYYY-MM-DD HH
             LocalDateTime local = (LocalDateTime) value;
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock()))).toInstant();
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime zdt = (ZonedDateTime) value;
             response = zdt.toInstant();
@@ -216,7 +217,7 @@ public class DateTimeHandler {
             Year year = (Year) value;
             year = year.plus(1, ChronoUnit.YEARS);
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, year.getValue());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now()))
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock())))
                     .toInstant().minus(TICK, ChronoUnit.NANOS);
 
         } else if (value instanceof YearMonth) {
@@ -225,7 +226,7 @@ public class DateTimeHandler {
             ym = ym.plusMonths(1);
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ym.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ym.getMonthValue());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now()))
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock())))
                     .toInstant().minus(TICK, ChronoUnit.NANOS);
         } else if (value instanceof LocalDate) {
             // LocalDate - YYYY-MM-DD
@@ -234,7 +235,7 @@ public class DateTimeHandler {
             LocalDateTime local = REFERENCE_DATE.with(ChronoField.YEAR, ld.getYear());
             local    = local.with(ChronoField.MONTH_OF_YEAR, ld.getMonthValue());
             local    = local.with(ChronoField.DAY_OF_MONTH, ld.getDayOfMonth());
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now()))
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock())))
                     .toInstant().minus(TICK, ChronoUnit.NANOS);
         } else if (value instanceof LocalDateTime) {
             // LocalDate - YYYY-MM-DD
@@ -253,7 +254,7 @@ public class DateTimeHandler {
 
             // ELSE -> HH:MM:SS.XXXXX
             // The point is treated as exact.
-            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now())).toInstant();
+            response = ZonedDateTime.of(local, defaultOffsetRules.getOffset(Instant.now(ClockFactory.getDefaultClock()))).toInstant();
 
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime zdt = (ZonedDateTime) value;
@@ -284,7 +285,7 @@ public class DateTimeHandler {
         if (prefix != null && Prefix.AP.compareTo(prefix) == 0 && response != null) {
             // Take the ChronoUnits into consideration with +/- 10%
             // And now we're at the upper bound of a range, and taking 10% from there.
-            response = generateUpperBoundApproximation(Instant.now(), response);
+            response = generateUpperBoundApproximation(Instant.now(ClockFactory.getDefaultClock()), response);
         }
 
         return response;

--- a/fhir-search/src/main/java/com/ibm/fhir/search/group/characteristic/PatientAgeCharacteristicProcessor.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/group/characteristic/PatientAgeCharacteristicProcessor.java
@@ -10,6 +10,7 @@ import java.time.ZonedDateTime;
 
 import javax.ws.rs.core.MultivaluedMap;
 
+import com.ibm.fhir.core.clock.ClockFactory;
 import com.ibm.fhir.model.resource.Group.Characteristic;
 import com.ibm.fhir.model.type.Quantity;
 import com.ibm.fhir.model.type.code.QuantityComparator;
@@ -30,7 +31,7 @@ public class PatientAgeCharacteristicProcessor implements CharacteristicProcesso
 
             if (age.getUnit() != null && "years".equals(age.getUnit().getValue())) {
                 String val = fromQuantityComparator(comparator, exclude);
-                ZonedDateTime zdt = ZonedDateTime.now().minusYears(age.getValue().getValue().intValue());
+                ZonedDateTime zdt = ZonedDateTime.now(ClockFactory.getDefaultClock()).minusYears(age.getValue().getValue().intValue());
                 queryParams.add("birthdate", val + zdt.getYear());
             }
         }

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -1836,7 +1836,7 @@ public class CodeGenerator {
                 .javadoc("Factory method for creating a " + className + " that represents the current DateTime")
                 .javadocEnd();
             cb.method(mods("public", "static"), className, "now")
-                ._return(className + ".builder().value(ZonedDateTime.now()).build()")
+                ._return(className + ".builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock())).build()")
             .end().newLine();
 
             cb.javadocStart()
@@ -1846,7 +1846,7 @@ public class CodeGenerator {
                 .javadocEnd();
             cb.method(mods("public", "static"), className, "now", params("ZoneOffset offset"))
                 .invoke("Objects", "requireNonNull", args("offset","\"offset\""))
-                ._return(className + ".builder().value(ZonedDateTime.now(offset)).build()")
+                ._return(className + ".builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock().withZone(offset))).build()")
             .end().newLine();
         }
 
@@ -1875,7 +1875,7 @@ public class CodeGenerator {
                 .javadoc("Factory method for creating a " + className + " that represents the current Instant")
                 .javadocEnd();
             cb.method(mods("public", "static"), className, "now")
-                ._return(className + ".builder().value(ZonedDateTime.now()).build()")
+                ._return(className + ".builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock())).build()")
             .end().newLine();
 
             cb.javadocStart()
@@ -1885,7 +1885,7 @@ public class CodeGenerator {
                 .javadocEnd();
             cb.method(mods("public", "static"), className, "now", params("ZoneOffset offset"))
                 .invoke("Objects", "requireNonNull", args("offset","\"offset\""))
-                ._return(className + ".builder().value(ZonedDateTime.now(offset)).build()")
+                ._return(className + ".builder().value(ZonedDateTime.now(ClockFactory.getDefaultClock().withZone(offset))).build()")
             .end().newLine();
         }
 
@@ -2283,6 +2283,7 @@ public class CodeGenerator {
             imports.add("java.time.ZonedDateTime");
             imports.add("java.time.temporal.ChronoUnit");
             imports.add("com.ibm.fhir.model.util.ModelSupport");
+            imports.add("com.ibm.fhir.core.clock.ClockFactory");
         }
 
         if (isTime(structureDefinition)) {

--- a/operation/fhir-operation-reindex/src/main/java/com/ibm/fhir/operation/reindex/ReindexOperation.java
+++ b/operation/fhir-operation-reindex/src/main/java/com/ibm/fhir/operation/reindex/ReindexOperation.java
@@ -85,6 +85,8 @@ public class ReindexOperation extends AbstractOperation {
         }
 
         try {
+            // Deliberately not using ClockFactory.getDefaultClock() here for time fixing.
+            // This timestamp is used for database maintenance purposes and does not show up in user data.
             Instant tstamp = Instant.now();
             List<Long> indexIds = null;
             int resourceCount = 10;

--- a/operation/fhir-operation-reindex/src/main/java/com/ibm/fhir/operation/reindex/RetrieveIndexOperation.java
+++ b/operation/fhir-operation-reindex/src/main/java/com/ibm/fhir/operation/reindex/RetrieveIndexOperation.java
@@ -84,6 +84,8 @@ public class RetrieveIndexOperation extends AbstractOperation {
             String indexIdsString = "";
             int count = MAX_COUNT;
             Long afterIndexId = null;
+            // Deliberately not using ClockFactory.getDefaultClock() here for time fixing.
+            // This timestamp is used for database maintenance purposes and does not show up in user data.
             Instant notModifiedAfter = Instant.now();
             String resourceTypeName = resourceType != null ? resourceType.getSimpleName() : null;
 


### PR DESCRIPTION
Fixes https://github.com/IBM/FHIR/issues/2680

This is useful for system tests in order to produce predictable outputs,
and to test boundary conditions around clock changes.

This should expose a new HTTP endpoint `/.clock`. GET requests will return the system's current date and time, PUT and DELETE requests will allow the operator to set or clear the current date and time, so long as the configuration permits a mutable clock. This switch should typically not be enabled in a production server.

PR is draft as I'm still testing, but I welcome early feedback on the approach. 

Typically I would prefer to use the dependency injection system over static functions, but a larger change is required to introduce dependency injection throughout the application to make this possible, see https://github.com/IBM/FHIR/issues/2687.