### PR TITLE
add caching to TestUtil.getMinimalResource and standardize on this

### DIFF
--- a/fhir-model/src/test/java/com/ibm/fhir/model/util/test/ResourceFingerprintVisitorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/util/test/ResourceFingerprintVisitorTest.java
@@ -20,7 +20,6 @@ import com.ibm.fhir.model.type.Id;
 import com.ibm.fhir.model.type.Identifier;
 import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.code.IdentifierUse;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.util.SaltHash;
 import com.ibm.fhir.model.visitor.ResourceFingerprintVisitor;
 
@@ -30,7 +29,7 @@ import com.ibm.fhir.model.visitor.ResourceFingerprintVisitor;
 public class ResourceFingerprintVisitorTest {
     @Test
     public void testEqualResources() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
 
         ResourceFingerprintVisitor resourceFingerprintVisitor = new ResourceFingerprintVisitor();
         patient.accept(resourceFingerprintVisitor);
@@ -63,7 +62,7 @@ public class ResourceFingerprintVisitorTest {
 
     @Test
     public void testUnequalResources_add() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
 
         ResourceFingerprintVisitor resourceFingerprintVisitor = new ResourceFingerprintVisitor();
         patient.accept(resourceFingerprintVisitor);
@@ -81,7 +80,7 @@ public class ResourceFingerprintVisitorTest {
 
     @Test
     public void testUnequalResources_remove() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
 
         ResourceFingerprintVisitor resourceFingerprintVisitor = new ResourceFingerprintVisitor();
         patient.accept(resourceFingerprintVisitor);
@@ -97,7 +96,7 @@ public class ResourceFingerprintVisitorTest {
 
     @Test
     public void testUnequalResources_reorder() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .identifier(Identifier.builder()
                     .use(IdentifierUse.USUAL)
@@ -127,7 +126,7 @@ public class ResourceFingerprintVisitorTest {
 
     @Test
     public void testIgnoredPaths() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
 
         ResourceFingerprintVisitor resourceFingerprintVisitor = new ResourceFingerprintVisitor();
         patient.accept(resourceFingerprintVisitor);
@@ -148,7 +147,7 @@ public class ResourceFingerprintVisitorTest {
 
     @Test
     public void testUnequalResources_extension() throws Exception {
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
 
         ResourceFingerprintVisitor resourceFingerprintVisitor = new ResourceFingerprintVisitor();
         patient.accept(resourceFingerprintVisitor);

--- a/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/EncodingVisitorTest.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/visitor/test/EncodingVisitorTest.java
@@ -24,7 +24,6 @@ import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.Narrative;
 import com.ibm.fhir.model.type.Xhtml;
 import com.ibm.fhir.model.type.code.NarrativeStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.visitor.EncodingVisitor;
 import com.ibm.fhir.model.visitor.EncodingVisitor.EncodingContext;
 
@@ -33,7 +32,7 @@ public class EncodingVisitorTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        oo = TestUtil.getMinimalResource(ResourceType.OPERATION_OUTCOME);
+        oo = TestUtil.getMinimalResource(OperationOutcome.class);
         Issue issue = oo.getIssue().get(0).toBuilder()
                 .extension(Extension.builder()
                     .id("\" onload=\"alert('test1')")

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -214,26 +214,26 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
         Observation savedObservation;
 
         Observation.Builder observationBuilder =
-                ((Observation) TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json")).toBuilder();
+                ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
 
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         savedPatient = persistence.create(getDefaultPersistenceContext(), patient).getResource();
         observationBuilder.subject(buildReference(savedPatient));
         observationBuilder.performer(buildReference(savedPatient));
 
-        Device device = TestUtil.readExampleResource("json/ibm/minimal/Device-1.json");
+        Device device = TestUtil.getMinimalResource(Device.class);
         savedDevice = persistence.create(getDefaultPersistenceContext(), device).getResource();
         observationBuilder.device(buildReference(savedDevice));
 
-        Encounter encounter = TestUtil.readExampleResource("json/ibm/minimal/Encounter-1.json");
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         savedEncounter = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
         observationBuilder.encounter(buildReference(savedEncounter));
 
-        Practitioner practitioner = TestUtil.readExampleResource("json/ibm/minimal/Practitioner-1.json");
+        Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
         savedPractitioner = persistence.create(getDefaultPersistenceContext(), practitioner).getResource();
         observationBuilder.performer(buildReference(savedPractitioner));
 
-        RelatedPerson relatedPerson = TestUtil.readExampleResource("json/ibm/minimal/RelatedPerson-1.json");
+        RelatedPerson relatedPerson = TestUtil.getMinimalResource(RelatedPerson.class);
         savedRelatedPerson = persistence.create(getDefaultPersistenceContext(), relatedPerson).getResource();
         observationBuilder.performer(buildReference(savedRelatedPerson));
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
 
     @Override
     public Basic getBasicResource() throws Exception {
-        Basic basic = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic basic = TestUtil.getMinimalResource(Basic.class);
 
         Coding tag =
                 Coding.builder()

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceEventTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,37 +34,37 @@ public class FHIRPersistenceEventTest {
         assertFalse(pe.isStandardResourceType());
         assertNull(pe.getPersistenceImpl());
     }
-    
+
     @Test
     public void testSimpleProps() throws Exception {
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         Map<String, Object> properties = new HashMap<>();
-        
+
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "id1");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "v1");
-        
+
         FHIRPersistenceEvent pe = new FHIRPersistenceEvent(patient, properties);
         assertNotNull(pe.getFhirResource());
         assertEquals("Patient", pe.getFhirResourceType());
         assertEquals("id1", pe.getFhirResourceId());
         assertEquals("v1", pe.getFhirVersionId());
     }
-    
+
     @Test
     public void testReplicationContext() throws Exception {
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         Map<String, Object> properties = new HashMap<>();
-        
+
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "id1");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "v1");
-        
+
         FHIRPersistenceEvent pe = new FHIRPersistenceEvent(patient, properties);
         assertNotNull(pe.getFhirResource());
         assertEquals("Patient", pe.getFhirResourceType());
         assertEquals("id1", pe.getFhirResourceId());
         assertEquals("v1", pe.getFhirVersionId());
-        
+
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractChangesTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractChangesTest.java
@@ -43,7 +43,7 @@ public abstract class AbstractChangesTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         FHIRRequestContext.get().setTenantId("all");
 
-        Basic resource = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic resource = TestUtil.getMinimalResource(Basic.class);
 
         Basic.Builder resource1Builder = resource.toBuilder();
         Basic.Builder resource2Builder = resource.toBuilder();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
@@ -61,29 +61,29 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         checkReferenceTypes = FHIRModelConfig.getCheckReferenceTypes();
         FHIRModelConfig.setCheckReferenceTypes(false);
-        Observation.Builder observationBuilder = ((Observation) TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json")).toBuilder();
-        Observation.Builder observation2Builder = ((Observation) TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json")).toBuilder();
+        Observation.Builder observationBuilder = ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
+        Observation.Builder observation2Builder = ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
 
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         savedPatient = persistence.create(getDefaultPersistenceContext(), patient).getResource();
         observationBuilder.subject(buildReference(savedPatient));
         observationBuilder.performer(buildReference(savedPatient));
         // a logical ID-only reference to a patient
         observation2Builder.subject(Reference.builder().reference(string(savedPatient.getId())).build());
 
-        Device device = TestUtil.readExampleResource("json/ibm/minimal/Device-1.json");
+        Device device = TestUtil.getMinimalResource(Device.class);
         savedDevice = persistence.create(getDefaultPersistenceContext(), device).getResource();
         observationBuilder.device(buildReference(savedDevice));
 
-        Encounter encounter = TestUtil.readExampleResource("json/ibm/minimal/Encounter-1.json");
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         savedEncounter = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
         observationBuilder.encounter(buildReference(savedEncounter));
 
-        Practitioner practitioner = TestUtil.readExampleResource("json/ibm/minimal/Practitioner-1.json");
+        Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
         savedPractitioner = persistence.create(getDefaultPersistenceContext(), practitioner).getResource();
         observationBuilder.performer(buildReference(savedPractitioner));
 
-        RelatedPerson relatedPerson = TestUtil.readExampleResource("json/ibm/minimal/RelatedPerson-1.json");
+        RelatedPerson relatedPerson = TestUtil.getMinimalResource(RelatedPerson.class);
         savedRelatedPerson = persistence.create(getDefaultPersistenceContext(), relatedPerson).getResource();
         observationBuilder.performer(buildReference(savedRelatedPerson));
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -20,8 +20,8 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.resource.Device;
 import com.ibm.fhir.model.resource.Device.UdiCarrier;
-import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
@@ -38,18 +38,18 @@ import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundExcepti
 public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
     protected String deviceId1;
     protected String deviceId2;
-    
+
     @BeforeClass
     public void createResources() throws Exception {
-        Device device = TestUtil.readExampleResource("json/ibm/minimal/Device-1.json");
-        
+        Device device = TestUtil.getMinimalResource(Device.class);
+
         Device device1 = persistence.create(getDefaultPersistenceContext(), device).getResource();
         assertNotNull(device1.getId());
         assertNotNull(device1.getMeta());
         assertNotNull(device1.getMeta().getVersionId().getValue());
         assertEquals("1", device1.getMeta().getVersionId().getValue());
         this.deviceId1 = device1.getId();
-        
+
         Device device2 = persistence.create(getDefaultPersistenceContext(), device).getResource();
         assertNotNull(device2.getId());
         assertNotNull(device2.getMeta());
@@ -57,68 +57,68 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
         assertEquals("1", device2.getMeta().getVersionId().getValue());
         this.deviceId2 = device2.getId();
     }
-    
+
     @Test(expectedExceptions = FHIRPersistenceResourceNotFoundException.class)
     public void testDeleteInvalidDevice() throws Exception {
-        
+
         SingleResourceResult<Device> result = persistence.delete(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
         assertNull(result.getResource());
     }
-    
+
     @Test
     public void testReadInvalidDevice() throws Exception {
-        
+
         SingleResourceResult<Device> result = persistence.read(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
         assertNull(result.getResource());
     }
-    
+
     @Test
     public void testDeleteValidDevice() throws Exception {
-        
+
         persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId1);
     }
-    
-    @Test(dependsOnMethods = { "testDeleteValidDevice" }, 
+
+    @Test(dependsOnMethods = { "testDeleteValidDevice" },
                     expectedExceptions = FHIRPersistenceResourceDeletedException.class)
     public void testReadDeletedDevice() throws Exception {
-        
+
         persistence.read(getDefaultPersistenceContext(), Device.class, this.deviceId1);
-     
+
     }
-    
+
     @Test(dependsOnMethods = { "testDeleteValidDevice" })
     public void testVReadNonDeletedDevice() throws Exception {
-    
+
         // Retrieve version 1 of the resource. It should NOT be indicated as deleted in the history context.
         Device device = persistence.vread(getDefaultPersistenceContext(), Device.class, this.deviceId1, "1").getResource();
         assertNotNull(device);
         assertEquals(this.deviceId1, device.getId());
         assertEquals("1",device.getMeta().getVersionId().getValue());
-                
+
     }
-    
+
     @Test(dependsOnMethods = { "testDeleteValidDevice" },
             expectedExceptions = FHIRPersistenceResourceDeletedException.class)
     public void testVReadDeletedDevice() throws Exception {
-            
+
         // Retrieve version 2 which IS logically deleted.
         persistence.vread(getDefaultPersistenceContext(), Device.class, this.deviceId1, "2");
     }
-    
+
     @Test(dependsOnMethods = { "testDeleteValidDevice" })
     public void testSearchDeletedDevice() throws Exception {
         List<Resource> resources = runQueryTest(Device.class, "model", "eq:delete-test-model");
         assertNotNull(resources);
         assertTrue(resources.size() == 0);
     }
-    
+
     @Test(dependsOnMethods = { "testDeleteValidDevice" })
     public void testHistoryDeletedDevice() throws Exception {
         FHIRHistoryContext historyContext = FHIRPersistenceContextFactory.createHistoryContext();
         FHIRPersistenceContext context = this.getPersistenceContextForHistory(historyContext);
         Map<String, List<Integer>> deletedResources;
         List<Integer> deletedVersions;
-        
+
         List<Device> resources = persistence.history(context, Device.class, this.deviceId1).getResource();
         assertNotNull(resources);
         assertTrue(resources.size() == 2);
@@ -130,32 +130,32 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
         assertEquals(1,deletedVersions.size());
         assertEquals(new Integer(2),deletedVersions.get(0));
     }
-    
+
     @Test(dependsOnMethods = { "testDeleteValidDevice" })
     public void testReDeleteValidDevice() throws Exception {
-        
+
         persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId1);
     }
-    
+
     @Test
-    public void testUpdateDeletedDevice() throws Exception { 
-        
+    public void testUpdateDeletedDevice() throws Exception {
+
         FHIRHistoryContext historyContext = FHIRPersistenceContextFactory.createHistoryContext();
         FHIRPersistenceContext context = this.getPersistenceContextForHistory(historyContext);
         Map<String, List<Integer>> deletedResources;
         List<Integer> deletedVersions;
         String updatedUdiValue = "updated-udi-value";
-        
+
         // Read previously created device
         Device device = persistence.read(getDefaultPersistenceContext(), Device.class, this.deviceId2).getResource();
-        
+
         // Delete previously created device
         persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId2);
-        
+
         // Then update deleted device
         device = device.toBuilder().udiCarrier(UdiCarrier.builder().deviceIdentifier(string(updatedUdiValue)).build()).build();
         persistence.update(getDefaultPersistenceContext(), deviceId2, device);
-        
+
         // Verify device history
         List<Device> resources = persistence.history(context, Device.class, this.deviceId2).getResource();
         assertNotNull(resources);
@@ -167,9 +167,9 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
         deletedVersions = deletedResources.get(this.deviceId2);
         assertEquals(1,deletedVersions.size());
         assertEquals(new Integer(2),deletedVersions.get(0));
-        
+
         // Verify latest device
-        Device latestDeviceVersion = (Device)resources.get(0);
+        Device latestDeviceVersion = resources.get(0);
         assertEquals(updatedUdiValue,latestDeviceVersion.getUdiCarrier().get(0).getDeviceIdentifier().getValue());
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractEraseTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractEraseTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
         // We need the all so we can set the Erase on all tables
         FHIRRequestContext.get().setTenantId("all");
 
-        Basic resource = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic resource = TestUtil.getMinimalResource(Basic.class);
         allTypesBuilder = resource.toBuilder();
 
         // Number

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractExportTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractExportTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2019, 2020
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -45,7 +45,7 @@ public abstract class AbstractExportTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         FHIRRequestContext.get().setTenantId("all");
 
-        Basic resource = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic resource = TestUtil.getMinimalResource(Basic.class);
 
         Basic.Builder resource1Builder = resource.toBuilder();
         Basic.Builder resource2Builder = resource.toBuilder();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
@@ -68,12 +68,12 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
     public void createResources() throws Exception {
         checkReferenceTypes = FHIRModelConfig.getCheckReferenceTypes();
         FHIRModelConfig.setCheckReferenceTypes(false);
-        Organization org = TestUtil.readExampleResource("json/ibm/minimal/Organization-1.json");
-        Encounter encounter = TestUtil.readExampleResource("json/ibm/minimal/Encounter-1.json");
-        Observation observation = TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json");
-        Patient patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
-        Device device = TestUtil.readExampleResource("json/ibm/minimal/Device-1.json");
-        DeviceRequest deviceRequest = TestUtil.readExampleResource("json/ibm/minimal/DeviceRequest-1.json");
+        Organization org = TestUtil.getMinimalResource(Organization.class);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
+        Observation observation = TestUtil.getMinimalResource(Observation.class);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
+        Device device = TestUtil.getMinimalResource(Device.class);
+        DeviceRequest deviceRequest = TestUtil.getMinimalResource(DeviceRequest.class);
 
         // an Organization that will be referenced by a Patient
         savedOrg1 = persistence.create(getDefaultPersistenceContext(), org).getResource();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractMultiResourceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractMultiResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018,2019
+ * (C) Copyright IBM Corp. 2018, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,26 +29,26 @@ import com.ibm.fhir.persistence.SingleResourceResult;
  */
 public abstract class AbstractMultiResourceTest extends AbstractPersistenceTest {
     String commonId = UUID.randomUUID().toString();
-    
+
     /**
-     * Create two different resources with the same id 
+     * Create two different resources with the same id
      */
     @BeforeClass
     public void createResources() throws Exception {
-        
-        Encounter encounter = TestUtil.readExampleResource("json/ibm/minimal/Encounter-1.json");
-        
+
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
+
         // Update the id on the resource
         encounter = encounter.toBuilder().id(commonId).build();
-        
+
         encounter = persistence.update(getDefaultPersistenceContext(), commonId, encounter).getResource();
         assertNotNull(encounter);
         assertNotNull(encounter.getId());
         assertNotNull(encounter.getMeta());
         assertNotNull(encounter.getMeta().getVersionId().getValue());
         assertEquals("1", encounter.getMeta().getVersionId().getValue());
-        
-        Observation observation = TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json");
+
+        Observation observation = TestUtil.getMinimalResource(Observation.class);
 
         // update the id on the resource
         observation = observation.toBuilder().id(commonId).build();
@@ -58,43 +58,43 @@ public abstract class AbstractMultiResourceTest extends AbstractPersistenceTest 
         assertNotNull(observation.getMeta());
         assertNotNull(observation.getMeta().getVersionId().getValue());
         assertEquals("1", observation.getMeta().getVersionId().getValue());
-    } 
-    
+    }
+
     /**
      * Tests a normal read when a different resource type has the same id
      */
     @Test
     public void testRead() throws Exception {
         SingleResourceResult<? extends Resource> result;
-        
+
         result = persistence.read(getDefaultPersistenceContext(), Encounter.class, commonId);
         assertTrue(result.isSuccess());
         assertNotNull(result.getResource());
         assertTrue(result.getResource() instanceof Encounter);
-        
+
         result = persistence.read(getDefaultPersistenceContext(), Observation.class, commonId);
         assertTrue(result.isSuccess());
         assertNotNull(result.getResource());
         assertTrue(result.getResource() instanceof Observation);
     }
-    
+
     /**
      * Tests searching by id when a different resource type has the same id
      */
     @Test
     public void testSearchById() throws Exception {
         List<Resource> resources;
-        
+
         resources = runQueryTest(Encounter.class, "_id", commonId);
         assertNotNull(resources);
         assertTrue(resources.size() == 1);
         assertTrue(resources.get(0) instanceof Encounter);
-        
+
         resources = runQueryTest(Observation.class, "_id", commonId);
         assertNotNull(resources);
         assertTrue(resources.size() == 1);
         assertTrue(resources.get(0) instanceof Observation);
-        
+
         resources = runQueryTest(Resource.class, "_id", commonId);
         assertNotNull(resources);
         assertTrue(resources.size() == 2);

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPagingTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPagingTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractPagingTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         FHIRRequestContext.get().setTenantId("all");
 
-        Basic resource = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic resource = TestUtil.getMinimalResource(Basic.class);
 
         Basic.Builder resource1Builder = resource.toBuilder();
         Basic.Builder resource2Builder = resource.toBuilder();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractReverseChainTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractReverseChainTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.model.config.FHIRModelConfig;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.Device;
 import com.ibm.fhir.model.resource.Encounter;
 import com.ibm.fhir.model.resource.Observation;
@@ -39,7 +38,6 @@ import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.code.ObservationStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
 
 /**
  *  This class tests the persistence layer support for the FHIR _has search parameter.
@@ -72,11 +70,11 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         checkReferenceTypes = FHIRModelConfig.getCheckReferenceTypes();
         FHIRModelConfig.setCheckReferenceTypes(false);
-        Organization org = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
-        Encounter encounter = TestUtil.getMinimalResource(ResourceType.ENCOUNTER, Format.JSON);
-        Observation observation = TestUtil.getMinimalResource(ResourceType.OBSERVATION, Format.JSON);
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
-        Device device = TestUtil.getMinimalResource(ResourceType.DEVICE, Format.JSON);
+        Organization org = TestUtil.getMinimalResource(Organization.class);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
+        Observation observation = TestUtil.getMinimalResource(Observation.class);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
+        Device device = TestUtil.getMinimalResource(Device.class);
 
         // Organizations that will be referenced by a Patient
         savedOrg1 = org.toBuilder().active(com.ibm.fhir.model.type.Boolean.of(true)).build();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSortTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSortTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractSortTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         FHIRRequestContext.get().setTenantId("all");
         
-        Basic resource = TestUtil.readExampleResource("json/ibm/minimal/Basic-1.json");
+        Basic resource = TestUtil.getMinimalResource(Basic.class);
         
         Basic.Builder resource1Builder = resource.toBuilder();
         Basic.Builder resource2Builder = resource.toBuilder();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/test/InterceptorTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/test/InterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016,2019
+ * (C) Copyright IBM Corp. 2016, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,14 +44,14 @@ public class InterceptorTest {
         mgr = FHIRPersistenceInterceptorMgr.getInstance();
         assertNotNull(mgr);
 
-        patient = TestUtil.readExampleResource("json/ibm/minimal/Patient-1.json");
+        patient = TestUtil.getMinimalResource(Patient.class);
 
         // Inject a new family name of "Exception" to trigger errors from MyInterceptor
         badPatient = patient.toBuilder()
                             .name(Collections.emptyList()) // clear existing names
                             .name(HumanName.builder().family(com.ibm.fhir.model.type.String.of("Exception")).build())
                             .build();
-        
+
         // Quick check to make sure we've set up the test correctly
         assertEquals("Exception", badPatient.getName().get(0).getFamily().getValue());
     }
@@ -61,9 +61,9 @@ public class InterceptorTest {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeCreateEvent(event);
-        
+
         assertTrue(event.isStandardResourceType());
         assertEquals(1, MyInterceptor.getBeforeCreateCount());
     }
@@ -73,7 +73,7 @@ public class InterceptorTest {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterCreateEvent(event);
         mgr.fireAfterCreateEvent(event);
         mgr.fireAfterCreateEvent(event);
@@ -81,36 +81,36 @@ public class InterceptorTest {
 
         assertEquals(4, MyInterceptor.getAfterCreateCount());
     }
-    
+
     @Test
     public void testBeforeRead() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeReadEvent(event);
-        
+
         assertTrue(event.isStandardResourceType());
         assertEquals(1, MyInterceptor.getBeforeReadCount());
     }
-    
+
     @Test
     public void testAfterRead() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient1");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterReadEvent(event);
         mgr.fireAfterReadEvent(event);
         mgr.fireAfterReadEvent(event);
         mgr.fireAfterReadEvent(event);
-        
+
         assertFalse(event.isStandardResourceType());
         assertEquals(4, MyInterceptor.getAfterReadCount());
     }
-    
+
     @Test
     public void testBeforeVread() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
@@ -118,13 +118,13 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "1");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeVreadEvent(event);
-        
+
         assertTrue(event.isStandardResourceType());
         assertEquals(1, MyInterceptor.getBeforeVreadCount());
     }
-    
+
     @Test
     public void testAfterVread() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
@@ -132,64 +132,64 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "1");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterVreadEvent(event);
         mgr.fireAfterVreadEvent(event);
-        
+
         assertFalse(event.isStandardResourceType());
         assertEquals(2, MyInterceptor.getAfterVreadCount());
     }
-    
+
     @Test
     public void testBeforeHistory() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeHistoryEvent(event);
-        
+
         assertTrue(event.isStandardResourceType());
         assertEquals(1, MyInterceptor.getBeforeHistoryCount());
     }
-    
+
     @Test
     public void testAfterHistory() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient1");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterHistoryEvent(event);
         mgr.fireAfterHistoryEvent(event);
         mgr.fireAfterHistoryEvent(event);
-        
+
         assertFalse(event.isStandardResourceType());
         assertEquals(3, MyInterceptor.getAfterHistoryCount());
     }
-    
+
     @Test
     public void testBeforeSearch() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeSearchEvent(event);
-        
+
         assertTrue(event.isStandardResourceType());
         assertEquals(1, MyInterceptor.getBeforeSearchCount());
     }
-    
+
     @Test
     public void testAfterSearch() throws Exception {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient1");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterSearchEvent(event);
         mgr.fireAfterSearchEvent(event);
         mgr.fireAfterSearchEvent(event);
-        
+
         assertFalse(event.isStandardResourceType());
         assertEquals(3, MyInterceptor.getAfterSearchCount());
     }
@@ -200,7 +200,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireBeforeUpdateEvent(event);
         mgr.fireBeforeUpdateEvent(event);
 
@@ -213,7 +213,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(patient, properties);
-        
+
         mgr.fireAfterUpdateEvent(event);
 
         assertEquals(1, MyInterceptor.getAfterUpdateCount());
@@ -273,7 +273,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, properties);
-        
+
         mgr.fireBeforeReadEvent(event);
     }
 
@@ -283,7 +283,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(badPatient, properties);
-        
+
         mgr.fireAfterReadEvent(event);
     }
 
@@ -294,7 +294,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "1");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, properties);
-        
+
         mgr.fireBeforeVreadEvent(event);
     }
 
@@ -305,7 +305,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         properties.put(FHIRPersistenceEvent.PROPNAME_VERSION_ID, "1");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(badPatient, properties);
-        
+
         mgr.fireAfterVreadEvent(event);
     }
 
@@ -315,7 +315,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, properties);
-        
+
         mgr.fireBeforeHistoryEvent(event);
     }
 
@@ -325,7 +325,7 @@ public class InterceptorTest {
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_ID, "123");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(badPatient, properties);
-        
+
         mgr.fireAfterHistoryEvent(event);
     }
 
@@ -334,7 +334,7 @@ public class InterceptorTest {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, properties);
-        
+
         mgr.fireBeforeSearchEvent(event);
     }
 
@@ -343,7 +343,7 @@ public class InterceptorTest {
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Exception");
         FHIRPersistenceEvent event = new FHIRPersistenceEvent(badPatient, properties);
-        
+
         mgr.fireAfterSearchEvent(event);
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
@@ -469,7 +469,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         // This test takes advantage of a issue with the 4.0.1 spec (https://jira.hl7.org/browse/FHIR-25173)
         // to verify that supplemental warnings that are added by the persistence layer will make it to the response
         WebTarget target = getWebTarget();
-        Immunization resource = TestUtil.readExampleResource("json/ibm/minimal/Immunization-1.json");
+        Immunization resource = TestUtil.getMinimalResource(Immunization.class);
         // 1. Add narrative text to avoid dom-6 (A resource should have narrative for robust management)
         // 2. Set occurrence to a String to get the searchparameter warning added by the persistence layer
         resource = resource.toBuilder()

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/DeleteTest.java
@@ -432,7 +432,7 @@ public class DeleteTest extends FHIRServerTestBase {
         final String TESTNAME = "testConditionalDeleteTwoResource";
 
         // Create 2 observations with the same tag (in a single request)
-        Observation obs = TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json");
+        Observation obs = TestUtil.getMinimalResource(Observation.class);
         obs = obs.toBuilder()
                 .meta(Meta.builder()
                     .tag(Coding.builder().code(Code.of(TESTNAME)).build())
@@ -458,7 +458,7 @@ public class DeleteTest extends FHIRServerTestBase {
         final String TESTNAME = "testConditionalDeleteElevenResource";
 
         // Create 11 observations with the same tag (in a single request)
-        Observation obs = TestUtil.readExampleResource("json/ibm/minimal/Observation-1.json");
+        Observation obs = TestUtil.getMinimalResource(Observation.class);
         obs = obs.toBuilder()
                 .meta(Meta.builder()
                     .tag(Coding.builder().code(Code.of(TESTNAME)).build())

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchChainTest.java
@@ -20,7 +20,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Encounter;
@@ -32,7 +31,6 @@ import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
-import com.ibm.fhir.model.type.code.ResourceType;
 
 /**
  * The tests execute the chained behavior in order to exercise reference chains.
@@ -103,7 +101,7 @@ public class SearchChainTest extends FHIRServerTestBase {
                 .reference(com.ibm.fhir.model.type.String.of("Patient/" + patientId + "/_history/2")).build();
 
         // Build a new Procedure and then call the 'create' API.
-        Encounter encounter = TestUtil.getMinimalResource(ResourceType.ENCOUNTER, Format.JSON);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         encounter = encounter.toBuilder().subject(reference).build();
 
         // Call the 'create' API.

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchIncludeTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchIncludeTest.java
@@ -25,7 +25,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Organization;
@@ -46,7 +45,6 @@ import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.LinkType;
 import com.ibm.fhir.model.type.code.ProcedureStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.type.code.SearchEntryMode;
 
 /**
@@ -69,7 +67,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Organization.
-        Organization organization = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
+        Organization organization = TestUtil.getMinimalResource(Organization.class);
         organization = organization.toBuilder()
                 .name(of(tag))
                 .build();
@@ -92,7 +90,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Practitioner and then call the 'create' API.
-        Practitioner practitioner = TestUtil.getMinimalResource(ResourceType.PRACTITIONER, Format.JSON);
+        Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
         practitioner = practitioner.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -123,7 +121,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -154,7 +152,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.FEMALE)
                 .name(HumanName.builder()
@@ -188,7 +186,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.UNKNOWN)
                 .name(HumanName.builder()
@@ -222,7 +220,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())
@@ -250,7 +248,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())
@@ -279,7 +277,7 @@ public class SearchIncludeTest extends FHIRServerTestBase {
 
         // Build a new Procedure and add subject reference to patient
         // and partOf and reasonReference references to another procedure.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchRevIncludeTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchRevIncludeTest.java
@@ -33,7 +33,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Encounter;
 import com.ibm.fhir.model.resource.NutritionOrder;
@@ -62,7 +61,6 @@ import com.ibm.fhir.model.type.code.LinkType;
 import com.ibm.fhir.model.type.code.NutritionOrderIntent;
 import com.ibm.fhir.model.type.code.NutritionOrderStatus;
 import com.ibm.fhir.model.type.code.ProcedureStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.type.code.SearchEntryMode;
 
 /**
@@ -89,7 +87,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Organization.
-        Organization organization = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
+        Organization organization = TestUtil.getMinimalResource(Organization.class);
         organization = organization.toBuilder()
                 .name(of(tag))
                 .build();
@@ -112,7 +110,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Practitioner and then call the 'create' API.
-        Practitioner practitioner = TestUtil.getMinimalResource(ResourceType.PRACTITIONER, Format.JSON);
+        Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
         practitioner = practitioner.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -143,7 +141,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -174,7 +172,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.FEMALE)
                 .name(HumanName.builder()
@@ -208,7 +206,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -240,7 +238,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())
@@ -268,7 +266,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())
@@ -296,7 +294,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add performer reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .performer(Performer.builder().actor(Reference.builder().reference(of("Patient/" + patient2Id)).build()).build())
@@ -323,7 +321,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient1Id)).build())
@@ -351,7 +349,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
 
         // Build a new Procedure and add subject reference to patient
         // and partOf and reasonReference references to another procedure.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient3Id)).build())
@@ -380,7 +378,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Encounter and add subject reference to patient.
-        Encounter encounter = TestUtil.getMinimalResource(ResourceType.ENCOUNTER, Format.JSON);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         encounter = encounter.toBuilder()
                 .status(EncounterStatus.FINISHED)
                 .subject(Reference.builder().reference(of("Patient/" + patient2Id)).build())
@@ -402,7 +400,7 @@ public class SearchRevIncludeTest extends FHIRServerTestBase {
     @Test(groups = { "server-search-revinclude" }, dependsOnMethods = {"testCreatePatient3"})
     public void testCreateNutritionOrders() throws Exception {
         // Build a new NutritionOrder and add reference to patient.
-        NutritionOrder nutritionOrder = TestUtil.getMinimalResource(ResourceType.NUTRITION_ORDER, Format.JSON);
+        NutritionOrder nutritionOrder = TestUtil.getMinimalResource(NutritionOrder.class);
         nutritionOrder = nutritionOrder.toBuilder()
                 .status(NutritionOrderStatus.ACTIVE)
                 .intent(NutritionOrderIntent.DIRECTIVE)

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchReverseChainTest.java
@@ -24,7 +24,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Encounter;
 import com.ibm.fhir.model.resource.Endpoint;
@@ -52,7 +51,6 @@ import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.ContactPointSystem;
 import com.ibm.fhir.model.type.code.EncounterStatus;
 import com.ibm.fhir.model.type.code.ProcedureStatus;
-import com.ibm.fhir.model.type.code.ResourceType;
 
 /**
  * The tests execute the reverse chained behavior in order to exercise reference chains.
@@ -77,7 +75,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
        // Build a new Endpoint.
-        Endpoint endpoint = TestUtil.getMinimalResource(ResourceType.ENDPOINT, Format.JSON);
+        Endpoint endpoint = TestUtil.getMinimalResource(Endpoint.class);
         endpoint = endpoint.toBuilder().name(of(tag)).build();
 
         // Call the 'create' API.
@@ -110,7 +108,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Organization.
-        Organization organization = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
+        Organization organization = TestUtil.getMinimalResource(Organization.class);
         organization = organization.toBuilder()
                 .name(of(tag))
                 .endpoint(Reference.builder().reference(of("Endpoint/" + endpointId)).build())
@@ -134,7 +132,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
        // Build a new Organization.
-        Organization organization = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
+        Organization organization = TestUtil.getMinimalResource(Organization.class);
         organization = organization.toBuilder()
                 .name(of(tag))
                 .endpoint(Reference.builder().reference(of("Endpoint/" + endpointId)).build())
@@ -158,7 +156,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.MALE)
                 .name(HumanName.builder()
@@ -192,7 +190,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Patient and then call the 'create' API.
-        Patient patient = TestUtil.getMinimalResource(ResourceType.PATIENT, Format.JSON);
+        Patient patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .gender(AdministrativeGender.FEMALE)
                 .name(HumanName.builder()
@@ -226,7 +224,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(Reference.builder().reference(of("Patient/" + patient1Id)).build())
@@ -256,7 +254,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         Reference reference = Reference.builder().reference(of("Patient/" + patient2Id)).build();
 
         // Build a new Procedure and add subject reference to patient.
-        Procedure procedure = TestUtil.getMinimalResource(ResourceType.PROCEDURE, Format.JSON);
+        Procedure procedure = TestUtil.getMinimalResource(Procedure.class);
         procedure = procedure.toBuilder()
                 .status(ProcedureStatus.COMPLETED)
                 .subject(reference)
@@ -284,7 +282,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Encounter and add reason-reference reference to procedure.
-        Encounter encounter = TestUtil.getMinimalResource(ResourceType.ENCOUNTER, Format.JSON);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         encounter = encounter.toBuilder()
                 .status(EncounterStatus.FINISHED)
                 .reasonReference(Reference.builder().reference(of("Procedure/" + procedure1Id)).build())
@@ -312,7 +310,7 @@ public class SearchReverseChainTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Encounter and add reason-reference reference to procedure.
-        Encounter encounter = TestUtil.getMinimalResource(ResourceType.ENCOUNTER, Format.JSON);
+        Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
         encounter = encounter.toBuilder()
                 .status(EncounterStatus.FINISHED)
                 .reasonReference(Reference.builder().reference(of("Procedure/" + procedure2Id)).build())

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchTest.java
@@ -33,7 +33,6 @@ import com.ibm.fhir.client.FHIRParameters;
 import com.ibm.fhir.client.FHIRRequestHeader;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
-import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.resource.AllergyIntolerance;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Entry;
@@ -62,7 +61,6 @@ import com.ibm.fhir.model.type.Quantity;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.AdministrativeGender;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.util.FHIRUtil;
 
 public class SearchTest extends FHIRServerTestBase {
@@ -104,7 +102,7 @@ public class SearchTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
 
         // Build a new Organization and then call the 'create' API.
-        Organization organization = TestUtil.getMinimalResource(ResourceType.ORGANIZATION, Format.JSON);
+        Organization organization = TestUtil.getMinimalResource(Organization.class);
 
         organization = organization.toBuilder().name(com.ibm.fhir.model.type.String.of("test")).build();
         Entity<Organization> entity =

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -80,9 +80,9 @@ public class AuthzPolicyEnforcementTest {
 
         interceptor = new AuthzPolicyEnforcementPersistenceInterceptor();
 
-        Provenance provenanceBase = TestUtil.getMinimalResource(ResourceType.PROVENANCE);
+        Provenance provenanceBase = TestUtil.getMinimalResource(Provenance.class);
 
-        patient = TestUtil.getMinimalResource(ResourceType.PATIENT);
+        patient = TestUtil.getMinimalResource(Patient.class);
         patient = patient.toBuilder()
                 .id(PATIENT_ID)
                 .build();
@@ -93,7 +93,7 @@ public class AuthzPolicyEnforcementTest {
                     .build())
                 .build();
 
-        observation = TestUtil.getMinimalResource(ResourceType.OBSERVATION);
+        observation = TestUtil.getMinimalResource(Observation.class);
         observation = observation.toBuilder()
                 .id(OBSERVATION_ID)
                 .subject(Reference.builder().reference(string("Patient/" + PATIENT_ID)).build())
@@ -106,7 +106,7 @@ public class AuthzPolicyEnforcementTest {
                     .build())
                 .build();
 
-        condition = TestUtil.getMinimalResource(ResourceType.CONDITION);
+        condition = TestUtil.getMinimalResource(Condition.class);
         condition = condition.toBuilder()
                 .subject(Reference.builder()
                     .reference(string("Patient/" + CONDITION_ID + "/_history/1"))
@@ -271,7 +271,7 @@ public class AuthzPolicyEnforcementTest {
         FHIRRequestContext.get().setHttpHeaders(buildRequestHeaders("patient/Patient.read patient/Observation.read patient/Practitioner.read"));
         Practitioner practitioner = null;
         try {
-            practitioner = TestUtil.readExampleResource("json/ibm/minimal/Practitioner-1.json");
+            practitioner = TestUtil.getMinimalResource(Practitioner.class);
         } catch (Exception e) {
             fail("Practitioner resource could not be created");
         }

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
@@ -19,7 +19,6 @@ import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Reference;
-import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
 import com.ibm.fhir.persistence.MultiResourceResult;
@@ -49,7 +48,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
         this.observation = observation;
 
 
-        encounter_not_in_patient_compartment = TestUtil.getMinimalResource(ResourceType.ENCOUNTER);
+        encounter_not_in_patient_compartment = TestUtil.getMinimalResource(Encounter.class);
         encounter_in_patient_compartment = encounter_not_in_patient_compartment.toBuilder()
                 .id(ENCOUNTER_ID_GOOD)
                 .subject(Reference.builder()


### PR DESCRIPTION
Our object model is immutable and so its safe to re-use the same
resources across all the tests. This could avoid I/O, parse, and parse
validation time each time its re-used.

I had originally designed TestUtil.getMinimalResource to accept a single
argument of type ResourceType. However, I've always regretted that
because the generic type is more useful if it can be gleaned from an
input argument of type class<T extends Resource> instead of forcing java
to try figuring it out based on the call context.

Finally, we had quite a few search tests that were using the 
`getMinimalResourceType(ResourceType, Format.JSON)` variant.
However, which format the resource we're reading from the examples jar
is in is quite irrelevant to the actual tests, so now these will use the single
argument flavor (which supports this new caching behavior).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>