### PR TITLE
minor javadoc updates

### DIFF
--- a/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRJsonParser.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRJsonParser.java
@@ -62,6 +62,20 @@ public class FHIRJsonParser extends FHIRAbstractParser {
         return parseAndFilter(in, null);
     }
 
+    /**
+     * Read a resource from the passed InputStream and filter its top-level elements to the collection of elementsToInclude.
+     * This method does not close the passed InputStream.
+     * 
+     * @param <T>
+     *     The resource type to read
+     * @param in
+     *     An input stream with the JSON contents of a FHIR resource
+     * @param elementsToInclude
+     *     The top-level elements to include or null to indicate that no filter should be applied
+     * @return
+     * @throws FHIRParserException
+     *     if the resource could not be parsed for any reason
+     */
     public <T extends Resource> T parseAndFilter(InputStream in, Collection<java.lang.String> elementsToInclude) throws FHIRParserException {
         try (JsonReader jsonReader = JSON_READER_FACTORY.createReader(nonClosingInputStream(in), StandardCharsets.UTF_8)) {
             JsonObject jsonObject = jsonReader.readObject();
@@ -78,6 +92,20 @@ public class FHIRJsonParser extends FHIRAbstractParser {
         return parseAndFilter(reader, null);
     }
 
+    /**
+     * Read a resource using the passed Reader and filter its top-level elements to the collection of elementsToInclude.
+     * This method does not close the passed InputStream.
+     * 
+     * @param <T>
+     *     The resource type to read
+     * @param reader
+     *     A reader with the JSON contents of a FHIR resource
+     * @param elementsToInclude
+     *     The top-level elements to include or null to indicate that no filter should be applied
+     * @return
+     * @throws FHIRParserException
+     *     if the resource could not be parsed for any reason
+     */
     public <T extends Resource> T parseAndFilter(Reader reader, Collection<java.lang.String> elementsToInclude) throws FHIRParserException {
         try (JsonReader jsonReader = JSON_READER_FACTORY.createReader(nonClosingReader(reader))) {
             JsonObject jsonObject = jsonReader.readObject();
@@ -89,10 +117,35 @@ public class FHIRJsonParser extends FHIRAbstractParser {
         }
     }
 
+    /**
+     * Read a resource from a JsonObject. This method does not close the passed InputStream.
+     * 
+     * @param <T>
+     *     The resource type to read
+     * @param jsonObject
+     *     A JsonObject with the contents of a FHIR resource
+     * @return
+     * @throws FHIRParserException
+     *     if the resource could not be parsed for any reason
+     */
     public <T extends Resource> T parse(JsonObject jsonObject) throws FHIRParserException {
         return parseAndFilter(jsonObject, null);
     }
 
+    /**
+     * Read a resource from a JsonObject and filter its top-level elements to the collection of elementsToInclude.
+     * This method does not close the passed InputStream.
+     * 
+     * @param <T>
+     *     The resource type to read
+     * @param jsonObject
+     *     A JsonObject with the contents of a FHIR resource
+     * @param elementsToInclude
+     *     The top-level elements to include or null to indicate that no filter should be applied
+     * @return
+     * @throws FHIRParserException
+     *     if the resource could not be parsed for any reason
+     */
     @SuppressWarnings("unchecked")
     public <T extends Resource> T parseAndFilter(JsonObject jsonObject, Collection<java.lang.String> elementsToInclude) throws FHIRParserException {
         try {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRParser.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/parser/FHIRParser.java
@@ -30,8 +30,7 @@ public interface FHIRParser {
      * @param <T> The resource type to read
      * @param in
      * @return
-     * @throws FHIRParserException
-     * @throws ClassCastException If the InputStream contains a FHIR resource type that cannot be cast to the requested type
+     * @throws FHIRParserException if the resource could not be parsed for any reason
      */
     <T extends Resource> T parse(InputStream in) throws FHIRParserException;
 
@@ -41,8 +40,7 @@ public interface FHIRParser {
      * @param <T> The resource type to read
      * @param reader
      * @return
-     * @throws FHIRParserException
-     * @throws ClassCastException If the InputStream contains a FHIR resource type that cannot be cast to the requested type
+     * @throws FHIRParserException if the resource could not be parsed for any reason
      */
     <T extends Resource> T parse(Reader reader) throws FHIRParserException;
 

--- a/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
+++ b/fhir-tools/src/main/java/com/ibm/fhir/tools/CodeGenerator.java
@@ -2992,6 +2992,16 @@ public class CodeGenerator {
         .end();
         cb.newLine();
 
+        cb.javadocStart()
+            .javadoc("Read a resource from the passed InputStream and filter its top-level elements to the collection of elementsToInclude.")
+            .javadoc("This method does not close the passed InputStream.")
+            .javadoc("")
+            .javadocParam("<T>", "The resource type to read")
+            .javadocParam("in", "An input stream with the JSON contents of a FHIR resource")
+            .javadocParam("elementsToInclude", "The top-level elements to include or null to indicate that no filter should be applied")
+            .javadocReturn("")
+            .javadocThrows("FHIRParserException", "if the resource could not be parsed for any reason")
+            .javadocEnd();
         // public <T extends Resource> T parseAndFilter(InputStream in, java.util.List<java.lang.String> elementsToInclude) throws FHIRException
         cb.method(mods("public"), "<T extends Resource> T", "parseAndFilter", params("InputStream in", "Collection<java.lang.String> elementsToInclude"), throwsExceptions("FHIRParserException"))
             ._try("JsonReader jsonReader = JSON_READER_FACTORY.createReader(nonClosingInputStream(in), StandardCharsets.UTF_8)")
@@ -3012,6 +3022,16 @@ public class CodeGenerator {
         .end();
         cb.newLine();
 
+        cb.javadocStart()
+            .javadoc("Read a resource using the passed Reader and filter its top-level elements to the collection of elementsToInclude.")
+            .javadoc("This method does not close the passed InputStream.")
+            .javadoc("")
+            .javadocParam("<T>", "The resource type to read")
+            .javadocParam("reader", "A reader with the JSON contents of a FHIR resource")
+            .javadocParam("elementsToInclude", "The top-level elements to include or null to indicate that no filter should be applied")
+            .javadocReturn("")
+            .javadocThrows("FHIRParserException", "if the resource could not be parsed for any reason")
+            .javadocEnd();
         // public <T extends Resource> T parseAndFilter(Reader reader, java.util.List<java.lang.String> elementsToInclude) throws FHIRException
         cb.method(mods("public"), "<T extends Resource> T", "parseAndFilter", params("Reader reader", "Collection<java.lang.String> elementsToInclude"), throwsExceptions("FHIRParserException"))
             ._try("JsonReader jsonReader = JSON_READER_FACTORY.createReader(nonClosingReader(reader))")
@@ -3025,11 +3045,29 @@ public class CodeGenerator {
         .end();
         cb.newLine();
 
+        cb.javadocStart()
+            .javadoc("Read a resource from a JsonObject. This method does not close the passed InputStream.")
+            .javadoc("")
+            .javadocParam("<T>", "The resource type to read")
+            .javadocParam("jsonObject", "A JsonObject with the contents of a FHIR resource")
+            .javadocReturn("")
+            .javadocThrows("FHIRParserException", "if the resource could not be parsed for any reason")
+            .javadocEnd();
         cb.method(mods("public"), "<T extends Resource> T", "parse", args("JsonObject jsonObject"), throwsExceptions("FHIRParserException"))
             ._return("parseAndFilter(jsonObject, null)")
         .end();
         cb.newLine();
 
+        cb.javadocStart()
+            .javadoc("Read a resource from a JsonObject and filter its top-level elements to the collection of elementsToInclude.")
+            .javadoc("This method does not close the passed InputStream.")
+            .javadoc("")
+            .javadocParam("<T>", "The resource type to read")
+            .javadocParam("jsonObject", "A JsonObject with the contents of a FHIR resource")
+            .javadocParam("elementsToInclude", "The top-level elements to include or null to indicate that no filter should be applied")
+            .javadocReturn("")
+            .javadocThrows("FHIRParserException", "if the resource could not be parsed for any reason")
+            .javadocEnd();
         // public <T extends Resource> T parseAndFilter(JsonObject jsonObject, java.util.List<java.lang.String> elementsToInclude)
         cb.annotation("SuppressWarnings", quote("unchecked"));
         cb.method(mods("public"), "<T extends Resource> T", "parseAndFilter", params("JsonObject jsonObject", "Collection<java.lang.String> elementsToInclude"), throwsExceptions("FHIRParserException"))


### PR DESCRIPTION
* remove throws declaration from FHIRParser.parse javadoc...its always
wrapped in a FHIRParserException
* add javadoc for FHIRJsonParser parse(JsonObject) and parseAndFilter
methods

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>