### PR TITLE
WHFFHIR-207 Write to a protected directory that is not needed, and fails when running SchemaTool/Db2 with a restricted user in openshift

### DIFF
--- a/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
+++ b/fhir-install/src/main/docker/ibm-fhir-schematool/run.sh
@@ -190,7 +190,6 @@ function _call_db2 {
         ${SSL_STANZA} \
         --db-type db2 \
         ${INPUT} 2>&1 | tee ${SCHEMA_TOOL_LOCATION}/workarea/out.log
-    echo "$?" > response_code
     set +x
 }
 


### PR DESCRIPTION
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>