### PR TITLE
issue-2712 NPE when using a JsonPatch Remove on an already removed Field

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -459,13 +459,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     newResource = patch.apply(ior.getPrevResource());
                 } catch (FHIRPatchException e) {
                     String msg = "Invalid patch: " + e.getMessage();
+                    String path = e.getPath() != null ? e.getPath() : "<no-path>";
                     throw new FHIROperationException(msg, e).withIssue(Issue.builder()
                             .severity(IssueSeverity.ERROR)
                             .code(IssueType.INVALID)
                             .details(CodeableConcept.builder()
                                     .text(string(msg))
                                     .build())
-                            .expression(string(e.getPath()))
+                            .expression(string(path))
                             .build());
                 }
             }


### PR DESCRIPTION
When running a FHIR Patch operation using JsonPatch on a field

**Response**
Payload: {"resourceType":"OperationOutcome","id":"c0-a8-56-16-0a786fde-71f2-4de1-b932-db54b0ad5c35","issue":[{"severity":"error","code":"invalid","details":{"text":"Invalid patch: Non-existing name/value pair in the object for key active"},"expression":["<no-path>"]}]}

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>