### PR TITLE
Minor Fixes

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2121,6 +2121,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/storageProviders/<source>/auth/connection`|string|For Azure Blob Service, the connection string is used|
 |`fhirServer/bulkdata/storageProviders/<source>/operationOutcomeProvider`|string| the default storage provider used to output Operation Outcomes (file, s3 only)|
 |`fhirServer/bulkdata/storageProviders/<source>/accessType`|string| The s3 access type, `host` or `path` (s3 only) [Link](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)|
+|`fhirServer/bulkdata/storageProviders/<source>/requiresAccessToken`|boolean|controls the `$bulkdata-status` response to indicate Bulk Data storageprovider requires an accessToken using `requiresAccessToken`.|
 |`fhirServer/operations/erase/enabled`|boolean|Enables the $erase operation|
 |`fhirServer/operations/erase/allowedRoles`|list|The list of allowed roles, allowed entries are: `FHIRUsers` every authenticated user, `FHIROperationAdmin` which is authenticated `FHIRAdmin` users|
 
@@ -2250,6 +2251,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/bulkdata/storageProviders/<source>/presigned`|false|
 |`fhirServer/bulkdata/storageProviders/<source>/create`|false|
 |`fhirServer/bulkdata/storageProviders/<source>/accessType`|`path`|
+|`fhirServer/bulkdata/storageProviders/<source>/requiresAccessToken`|false|
 |`fhirServer/operations/erase/enabled`|false|
 |`fhirServer/operations/erase/allowedRoles`|empty, all roles|
 
@@ -2412,6 +2414,7 @@ must restart the server for that change to take effect.
 |`fhirServer/bulkdata/storageProviders/<source>/auth/connection`|Y|Y|
 |`fhirServer/bulkdata/storageProviders/<source>/operationOutcomeProvider`|Y|Y|
 |`fhirServer/bulkdata/storageProviders/<source>/accessType`|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/requiresAccessToken`|Y|Y|
 |`fhirServer/operations/erase/enabled`|Y|Y|
 |`fhirServer/operations/erase/allowedRoles`|Y|Y|
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/listener/StepChunkListener.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/listener/StepChunkListener.java
@@ -15,6 +15,8 @@ import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.ibm.cloud.objectstorage.services.s3.model.AmazonS3Exception;
+
 /**
  * Enables Logging for the Given Step
  */
@@ -39,6 +41,12 @@ public class StepChunkListener implements ChunkListener {
         long jobExecutionId = jobCtx.getInstanceId();
         logger.log(Level.SEVERE, "StepChunkListener: job[" + jobCtx.getJobName() + "/" + jobExecutionId + "/" + stepExecutionId + "] --- " + ex.getMessage(), ex);
         logger.throwing("StepChunkListener", "onError", ex);
+        if (ex instanceof AmazonS3Exception) {
+            AmazonS3Exception s3ex = (AmazonS3Exception) ex;
+            if ("NoSuchBucket".equals(s3ex.getErrorCode())) {
+                jobCtx.setExitStatus("NO_SUCH_BUCKET");
+            }
+        }
     }
 
     @Override

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRDocumentOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRDocumentOperationTest.java
@@ -47,7 +47,7 @@ public class FHIRDocumentOperationTest extends FHIRServerTestBase {
     private Condition savedCreatedCondition = null;
     private AllergyIntolerance savedCreatedAllergyIntolerance = null;
     private Composition savedCreatedComposition = null;
-    
+
     private static final boolean DEBUG = false;
 
     @Test(groups = { "fhir-operation" })
@@ -179,7 +179,7 @@ public class FHIRDocumentOperationTest extends FHIRServerTestBase {
         TestUtil.assertResourceEquals(allergyIntolerance, responseAllergyIntolerance);
     }
 
-    @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testCreateObservation", 
+    @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testCreateObservation",
             "testCreateCondition", "testCreateAllergyIntolerance" })
     public void testCreateComposition() throws Exception {
         String practitionerId = savedCreatedPractitioner.getId();
@@ -207,6 +207,17 @@ public class FHIRDocumentOperationTest extends FHIRServerTestBase {
         savedCreatedComposition = responseComposition;
 
         TestUtil.assertResourceEquals(composition, responseComposition);
+    }
+
+    @Test(groups = { "fhir-operation" })
+    public void testCompositionDoesNotExist() throws Exception {
+        WebTarget target = getWebTarget();
+
+        String compositionId = "DOES-NOT-EXIST";
+
+        Response response = target.path("Composition/" + compositionId + "/$document").queryParam("persist", "true")
+                .request().get(Response.class);
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
     }
 
     private Composition buildComposition(String practitionerId, String patientId, String observationId,

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
@@ -217,6 +218,154 @@ public class FHIRPatchTest extends FHIRServerTestBase {
                 .add(Json.createObjectBuilder()
                         .add("op", "remove")
                         .add("path", "/activeFudge67891234!/1235~###&?")
+                    .build())
+                .build();
+
+        Entity<JsonArray> patchEntity = Entity.entity(array, FHIRMediaType.APPLICATION_JSON_PATCH);
+        response = target.path("Patient/" + patient.getId())
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .method("PATCH", patchEntity, Response.class);
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test(groups = { "fhir-patch" })
+    public void testJSONPatchOperationWithCopy() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = buildPatient();
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient/" + patient.getId()).request().put(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // create a copy of the patient and update it using the model API
+        Patient.Builder patientBuilder = patient.toBuilder();
+        patientBuilder.active(null);
+
+        // https://datatracker.ietf.org/doc/html/rfc6902#section-4.5
+        // ‘[{“op”:“copy”,“from”:“/name/0/given/0",“path”:“/name/0/given/1"}]
+        JsonArray array = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add("op", "copy")
+                        .add("from", "/name/0/given/0")
+                        .add("path", "/name/0/given/1")
+                    .build())
+                .build();
+
+        Entity<JsonArray> patchEntity = Entity.entity(array, FHIRMediaType.APPLICATION_JSON_PATCH);
+        response = target.path("Patient/" + patient.getId())
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .method("PATCH", patchEntity, Response.class);
+        assertResponse(response, Response.Status.OK.getStatusCode());
+    }
+
+    @Test(groups = { "fhir-patch" })
+    public void testJSONPatchOperationWithCopyOutOfRangeOfNext() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = buildPatient();
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient/" + patient.getId()).request().put(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // create a copy of the patient and update it using the model API
+        Patient.Builder patientBuilder = patient.toBuilder();
+        patientBuilder.active(null);
+
+        // https://datatracker.ietf.org/doc/html/rfc6902#section-4.5
+        // ‘[{“op”:“copy”,“from”:“/name/0/given/0",“path”:“/name/0/given/1"}]
+        // Note there is only an array of size 1 (the value is only 2)
+        JsonArray array = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add("op", "copy")
+                        .add("from", "/name/0/given/0")
+                        .add("path", "/name/0/given/3")
+                    .build())
+                .build();
+
+        Entity<JsonArray> patchEntity = Entity.entity(array, FHIRMediaType.APPLICATION_JSON_PATCH);
+        response = target.path("Patient/" + patient.getId())
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .method("PATCH", patchEntity, Response.class);
+        assertResponse(response, Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    @Test(groups = { "fhir-patch" })
+    public void testJSONPatchOperationWithMove() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = buildPatient();
+        patient = patient.toBuilder()
+                .name(HumanName.builder()
+                        .given(string("One"), string("Two"), string("Three"))
+                        .family(string("Doe"))
+                    .build())
+                .build();
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient/" + patient.getId()).request().put(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // create a copy of the patient and update it using the model API
+        Patient.Builder patientBuilder = patient.toBuilder();
+        patientBuilder.active(null);
+
+        // https://datatracker.ietf.org/doc/html/rfc6902#section-4.4
+        // [{“op”:“move”,“from”:“/name/0/given/0",“path”:“/name/0/given/1"}]
+        JsonArray array = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add("op", "move")
+                        .add("from", "/name/1/given/0")
+                        .add("path", "/name/1/given/2")
+                    .build())
+                .build();
+
+        Entity<JsonArray> patchEntity = Entity.entity(array, FHIRMediaType.APPLICATION_JSON_PATCH);
+        response = target.path("Patient/" + patient.getId())
+                .request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .method("PATCH", patchEntity, Response.class);
+        assertResponse(response, Response.Status.OK.getStatusCode());
+
+        // Next, call the 'read' API to retrieve the new patient and verify it.
+        response = target.path("Patient/" + patient.getId()).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+        assertResponse(response, Response.Status.OK.getStatusCode());
+        Patient responsePatient = response.readEntity(Patient.class);
+        assertEquals("Two,Three,One",
+            responsePatient.getName().get(1).getGiven().stream().map(m -> m.getValue()).collect(Collectors.joining(",")));
+    }
+
+    @Test(groups = { "fhir-patch" })
+    public void testJSONPatchOperationWithMoveBadLocation() throws Exception {
+        WebTarget target = getWebTarget();
+
+        // Build a new Patient and then call the 'create' API.
+        Patient patient = buildPatient();
+        patient = patient.toBuilder()
+                .name(HumanName.builder()
+                        .given(string("Fred"), string("John"), string("Joe"))
+                        .family(string("Doe"))
+                    .build())
+                .build();
+
+        Entity<Patient> entity = Entity.entity(patient, FHIRMediaType.APPLICATION_FHIR_JSON);
+        Response response = target.path("Patient/" + patient.getId()).request().put(entity, Response.class);
+        assertResponse(response, Response.Status.CREATED.getStatusCode());
+
+        // create a copy of the patient and update it using the model API
+        Patient.Builder patientBuilder = patient.toBuilder();
+        patientBuilder.active(null);
+
+        // https://datatracker.ietf.org/doc/html/rfc6902#section-4.4
+        // [{“op”:“move”,“from”:“/name/0/given/0",“path”:“/name/0/given/4"}]
+        JsonArray array = Json.createArrayBuilder()
+                .add(Json.createObjectBuilder()
+                        .add("op", "move")
+                        .add("from", "/name/1/given/0")
+                        .add("path", "/name/1/given/4")
                     .build())
                 .build();
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -478,7 +478,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             if (ior.getPrevResource() != null) {
                 performVersionAwareUpdateCheck(ior.getPrevResource(), ifMatchValue);
 
-                if (skippableUpdate && !isDeleted) {
+                // In the case of a patch, we should not be updating meaninglessly.
+                if ((skippableUpdate || patch != null) && !isDeleted) {
                     ResourceFingerprintVisitor fingerprinter = new ResourceFingerprintVisitor();
                     ior.getPrevResource().accept(fingerprinter);
                     SaltHash baseline = fingerprinter.getSaltAndHash();

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/OperationConstants.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/OperationConstants.java
@@ -55,6 +55,7 @@ public class OperationConstants {
     public static final List<String> STOPPED_STATUS = Collections.unmodifiableList(Arrays.asList("STOPPED"));
 
     public static final String FAILED_BAD_SOURCE = "FAILED_BAD_SOURCE";
+    public static final String NO_SUCH_BUCKET = "NO_SUCH_BUCKET";
 
     // Import
     public static final String PARAM_INPUT_FORMAT = "inputFormat";

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -354,7 +354,7 @@ public class BulkDataClient {
                 if (OperationConstants.FAILED_BAD_SOURCE.equals(bulkExportJobExecutionResponse.getExitStatus())) {
                     throw export.buildOperationException("A bad source input was used during a call to $import", IssueType.INVALID);
                 } else if (OperationConstants.NO_SUCH_BUCKET.equals(bulkExportJobExecutionResponse.getExitStatus())) {
-                    throw export.buildOperationException("No such bucket exists for the storageProvider", IssueType.EXCEPTION);
+                    throw export.buildOperationException("No such bucket exists for the storageProvider", IssueType.NO_STORE);
                 } else {
                     throw export.buildOperationException("The job has failed", IssueType.EXCEPTION);
                 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -683,7 +683,10 @@ public class BulkDataClient {
         String request = response.getJobParameters().getIncomingUrl();
         log.fine(response.getJobName());
         result.setRequest(request);
-        result.setRequiresAccessToken(false);
+
+        // Per the storageProvider setting the output to indicate that the use of an access token is required.
+        boolean requireAccessToken = adapter.getStorageProviderUsesRequestAccessToken(source);
+        result.setRequiresAccessToken(requireAccessToken);
 
         // Outputs lastUpdatedTime as yyyy-MM-dd'T'HH:mm:ss
         String lastUpdatedTime = response.getLastUpdatedTime();
@@ -734,6 +737,10 @@ public class BulkDataClient {
                 }
             }
             result.setOutput(outputList);
+
+            // Errors need to be added.
+            List<PollingLocationResponse.Output> errors = Collections.emptyList();
+            result.setError(errors);
         }
         // Export that has no data exported
         else if ("COMPLETED".equals(exitStatus) && !"bulkimportchunkjob".equals(response.getJobName())) {
@@ -745,6 +752,9 @@ public class BulkDataClient {
             }
             List<PollingLocationResponse.Output> outputs = Collections.emptyList();
             result.setOutput(outputs);
+
+            List<PollingLocationResponse.Output> errors = Collections.emptyList();
+            result.setError(errors);
         }
         // Import Jobs
         else if ("bulkimportchunkjob".equals(response.getJobName())) {

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -353,6 +353,8 @@ public class BulkDataClient {
                  */
                 if (OperationConstants.FAILED_BAD_SOURCE.equals(bulkExportJobExecutionResponse.getExitStatus())) {
                     throw export.buildOperationException("A bad source input was used during a call to $import", IssueType.INVALID);
+                } else if (OperationConstants.NO_SUCH_BUCKET.equals(bulkExportJobExecutionResponse.getExitStatus())) {
+                    throw export.buildOperationException("No such bucket exists for the storageProvider", IssueType.INVALID);
                 } else {
                     throw export.buildOperationException("The job has failed", IssueType.EXCEPTION);
                 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -354,7 +354,7 @@ public class BulkDataClient {
                 if (OperationConstants.FAILED_BAD_SOURCE.equals(bulkExportJobExecutionResponse.getExitStatus())) {
                     throw export.buildOperationException("A bad source input was used during a call to $import", IssueType.INVALID);
                 } else if (OperationConstants.NO_SUCH_BUCKET.equals(bulkExportJobExecutionResponse.getExitStatus())) {
-                    throw export.buildOperationException("No such bucket exists for the storageProvider", IssueType.INVALID);
+                    throw export.buildOperationException("No such bucket exists for the storageProvider", IssueType.EXCEPTION);
                 } else {
                     throw export.buildOperationException("The job has failed", IssueType.EXCEPTION);
                 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/ConfigurationAdapter.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/ConfigurationAdapter.java
@@ -535,4 +535,12 @@ public interface ConfigurationAdapter {
      * @return
      */
     S3HostStyle getS3HostStyleByStorageProvider(String provider);
+
+    /**
+     * reports back to the client if the StorageProvider supports requestAccessTokens
+     *
+     * @param provider
+     * @return
+     */
+    boolean getStorageProviderUsesRequestAccessToken(String provider);
 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
@@ -171,4 +171,9 @@ public class V2ConfigurationImpl extends AbstractSystemConfigurationImpl {
         String type = FHIRConfigHelper.getStringProperty("fhirServer/bulkdata/core/systemExportImpl", "fast");
         return "fast".equals(type);
     }
+
+    @Override
+    public boolean getStorageProviderUsesRequestAccessToken(String provider) {
+        return FHIRConfigHelper.getBooleanProperty("fhirServer/bulkdata/storageProviders/" + provider + "/requiresAccessToken", Boolean.FALSE);
+    }
 }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
@@ -26,7 +26,6 @@ import com.ibm.fhir.model.util.JsonSupport;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
-import jakarta.json.JsonReaderFactory;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonGeneratorFactory;
 
@@ -35,8 +34,6 @@ import jakarta.json.stream.JsonGeneratorFactory;
  * This response object is intent for the polling location.
  */
 public class PollingLocationResponse {
-    private static final JsonReaderFactory JSON_READER_FACTORY = Json.createReaderFactory(null);
-
     public static final OperationOutcome EMPTY_RESULTS_DURING_EXPORT = OperationOutcome.builder()
             .issue(Issue.builder()
                 .severity(IssueSeverity.INFORMATION)

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -29,6 +29,7 @@ import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
+import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.server.operation.spi.AbstractOperation;
 import com.ibm.fhir.server.operation.spi.FHIROperationContext;
@@ -51,7 +52,7 @@ public class DocumentOperation extends AbstractOperation {
 
             Resource resource = resourceHelper.doRead("Composition", logicalId, false, false, null).getResource();
             if (resource == null) {
-                throw new FHIROperationException("Could not find composition with id: " + logicalId);
+                throw FHIROperationUtil.buildExceptionWithIssue("Could not find composition with id: " + logicalId, IssueType.INVALID);
             }
 
             composition = (Composition) resource;
@@ -70,7 +71,6 @@ public class DocumentOperation extends AbstractOperation {
                     }
 
                     if (persist) {
-                        // FHIRResourceHelper resourceHelper = (FHIRResourceHelper) operationContext.getProperty(FHIROperationContext.PROPNAME_RESOURCE_HELPER;
                         FHIRRestOperationResponse response = resourceHelper.doCreate("Bundle", bundle, null, false);
                         // Use the responded bundle to create response to client.
                         bundle = (Bundle)response.getResource();
@@ -79,7 +79,6 @@ public class DocumentOperation extends AbstractOperation {
                     }
                 }
             }
-
 
             return FHIROperationUtil.getOutputParameters(bundle);
         } catch (FHIROperationException e) {


### PR DESCRIPTION
- Bulk Export Status #2715
	- Added a default Error
- Bulk Export Status Report #2714
	- Added property for requiresAccessToken
- Composition reports a 500 when it's a bad user request #2717
	- Mutate 500 to 400 in $document
	- Add Test for $document when bad request
- add patch integration tests for Move and Copy to additionally confirm behaviors 
-  For the JSON Patch path for the test option, it is not handled correctly #2720 
     - Skippable updates enabled for patch scenarios 
-  bulkdata preflight checks should verify output provider config #2709 
     - put into an exception handling due to virtualhost and api host handling. 
 
Signed-off-by: Paul Bastide <pbastide@us.ibm.com>