### PR TITLE
Include slf4j binding in bulkdata webapp instead of with parquet deps

### DIFF
--- a/fhir-bulkdata-webapp/pom.xml
+++ b/fhir-bulkdata-webapp/pom.xml
@@ -1,17 +1,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <fhir.bulk.war.name>fhir-bulkdata-webapp</fhir.bulk.war.name>
     </properties>
-  
+
     <parent>
         <groupId>com.ibm.fhir</groupId>
         <artifactId>fhir-parent</artifactId>
         <version>4.9.0-SNAPSHOT</version>
         <relativePath>../fhir-parent</relativePath>
     </parent>
-      
+
     <modelVersion>4.0.0</modelVersion>
     <artifactId>fhir-bulkdata-webapp</artifactId>
 
@@ -59,13 +59,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
-        </dependency>
-        <dependency>
-            <!-- This is provided, yet never used. -->
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-server</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/fhir-bulkdata-webapp/pom.xml
+++ b/fhir-bulkdata-webapp/pom.xml
@@ -193,7 +193,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/fhir-bulkdata-webapp/src/main/sh/cache-parquet-deps.sh
+++ b/fhir-bulkdata-webapp/src/main/sh/cache-parquet-deps.sh
@@ -30,7 +30,6 @@ jersey-container-servlet-2.30.1.jar
 json4s-ast_2.12-3.7.0-M5.jar
 json4s-core_2.12-3.7.0-M5.jar
 json4s-jackson_2.12-3.7.0-M5.jar
-jul-to-slf4j-1.7.30.jar
 kryo-shaded-4.0.2.jar
 log4j-1.2.17.jar
 metrics-core-4.1.1.jar
@@ -43,7 +42,6 @@ parquet-format-2.4.0.jar
 parquet-hadoop-1.10.1.jar
 scala-reflect-2.12.10.jar
 scala-xml_2.12-1.2.0.jar
-slf4j-nop-1.7.32.jar
 spark-catalyst_2.12-3.1.2.jar
 spark-core_2.12-3.1.2.jar
 spark-hive_2.12-3.1.2.jar
@@ -61,7 +59,7 @@ xbean-asm7-shaded-4.15.jar)
 
 # Set the workspace
 if [ -z "${WORKSPACE}" ]
-then 
+then
     echo "WORKSPACE NOT SET - e.g. 'export WORKSPACE=~/git/wffh/2021/FHIR'"
 fi
 
@@ -86,9 +84,6 @@ mkdir -p deps/
 # Get STOCATOR
 curl -o cache-repo/stocator-1.1.3.jar -L https://repo1.maven.org/maven2/com/ibm/stocator/stocator/1.1.3/stocator-1.1.3.jar
 
-# Get SLF47 (notice NOP)
-curl -o cache-repo/slf4j-nop-1.7.32.jar -L https://repo1.maven.org/maven2/org/slf4j/slf4j-nop/1.7.32/slf4j-nop-1.7.32.jar
-
 # Get Guava
 curl -o cache-repo/guava-14.0.1.jar -L https://repo1.maven.org/maven2/com/google/guava/guava/14.0.1/guava-14.0.1.jar
 
@@ -112,7 +107,7 @@ curl -L -o cache-repo/spark-tags_2.12-3.1.2.jar https://repo1.maven.org/maven2/o
 curl -L -o cache-repo/spark-unsafe_2.12-3.1.2.jar https://repo1.maven.org/maven2/org/apache/spark/spark-unsafe_2.12/3.1.2/spark-unsafe_2.12-3.1.2.jar
 
 for JAR in ${JARS[@]}
-do 
+do
     if [ ! -f cache-repo/${JAR} ]
     then
         echo "NOT_FOUND: ${JAR}"


### PR DESCRIPTION
I also removed the unused fhir-server "provided" dependency. This should prevent us from accidentally using classes from fhir-server within the fhir-bulkdata-webapp... the two webapps have isolated classloaders and so its not right to say fhir-server is a provided dependency.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>