### PR TITLE
issue #2266 - avoid reflection while instantiating XML factories

### DIFF
--- a/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
+++ b/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
@@ -1,7 +1,3 @@
 # disable writing to trace.log by only sending trace data to console
 com.ibm.ws.logging.trace.format=BASIC
 com.ibm.ws.logging.trace.file.name=stdout
-
-javax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl
-javax.xml.stream.XMLOutputFactory=com.sun.xml.internal.stream.XMLOutputFactoryImpl
-javax.xml.stream.XMLTransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl

--- a/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
+++ b/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
@@ -1,3 +1,7 @@
 # disable writing to trace.log by only sending trace data to console
 com.ibm.ws.logging.trace.format=BASIC
 com.ibm.ws.logging.trace.file.name=stdout
+
+javax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl
+javax.xml.stream.XMLOutputFactory=com.sun.xml.internal.stream.XMLOutputFactoryImpl
+javax.xml.stream.XMLTransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/XMLSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/XMLSupport.java
@@ -27,6 +27,14 @@ public final class XMLSupport {
     public static final String FHIR_NS_URI = "http://hl7.org/fhir";
     public static final String XHTML_NS_URI = "http://www.w3.org/1999/xhtml";
 
+    private static final String PROP_XML_INPUT_FACTORY = "javax.xml.stream.XMLInputFactory";
+    private static final String PROP_XML_OUTPUT_FACTORY = "javax.xml.stream.XMLOutputFactory";
+    private static final String PROP_TRANSFORMER_FACTORY = "javax.xml.stream.XMLTransformerFactory";
+
+    private static final String XML_INPUT_FACTORY_IMPL = "com.sun.xml.internal.stream.XMLInputFactoryImpl";
+    private static final String XML_OUTPUT_FACTORY_IMPL = "com.sun.xml.internal.stream.XMLOutputFactoryImpl";
+    private static final String TRANSFORMER_FACTORY_IMPL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
+
     private static final XMLInputFactory XML_INPUT_FACTORY = createXMLInputFactory();
     private static final XMLOutputFactory XML_OUTPUT_FACTORY = createXMLOutputFactory();
     private static final TransformerFactory TRANSFORMER_FACTORY = createTransformerFactory();
@@ -182,7 +190,15 @@ public final class XMLSupport {
 
     private static XMLInputFactory createXMLInputFactory() {
         try {
+            boolean isSet = System.getProperty(PROP_XML_INPUT_FACTORY) != null;
+            if (!isSet) {
+                System.setProperty(PROP_XML_INPUT_FACTORY, XML_INPUT_FACTORY_IMPL);
+            }
             XMLInputFactory factory = XMLInputFactory.newFactory();
+            if (!isSet) {
+                System.clearProperty(PROP_XML_INPUT_FACTORY);
+            }
+
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             return factory;
@@ -193,7 +209,16 @@ public final class XMLSupport {
 
     private static XMLOutputFactory createXMLOutputFactory() {
         try {
-            return XMLOutputFactory.newFactory();
+            boolean isSet = System.getProperty(PROP_XML_OUTPUT_FACTORY) != null;
+            if (!isSet) {
+                System.setProperty(PROP_XML_OUTPUT_FACTORY, XML_OUTPUT_FACTORY_IMPL);
+            }
+            XMLOutputFactory factory = XMLOutputFactory.newFactory();
+            if (!isSet) {
+                System.clearProperty(PROP_XML_OUTPUT_FACTORY);
+            }
+
+            return factory;
         } catch (Exception e) {
             throw new Error(e);
         }
@@ -201,7 +226,15 @@ public final class XMLSupport {
 
     private static TransformerFactory createTransformerFactory() {
         try {
+            boolean isSet = System.getProperty(PROP_TRANSFORMER_FACTORY) != null;
+            if (!isSet) {
+                System.setProperty(PROP_TRANSFORMER_FACTORY, TRANSFORMER_FACTORY_IMPL);
+            }
             TransformerFactory factory = TransformerFactory.newInstance();
+            if (!isSet) {
+                System.clearProperty(PROP_TRANSFORMER_FACTORY);
+            }
+
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return factory;
         } catch (Exception e) {

--- a/fhir-model/src/main/java/com/ibm/fhir/model/util/XMLSupport.java
+++ b/fhir-model/src/main/java/com/ibm/fhir/model/util/XMLSupport.java
@@ -27,10 +27,6 @@ public final class XMLSupport {
     public static final String FHIR_NS_URI = "http://hl7.org/fhir";
     public static final String XHTML_NS_URI = "http://www.w3.org/1999/xhtml";
 
-    private static final String XML_INPUT_FACTORY_IMPL = "com.sun.xml.internal.stream.XMLInputFactoryImpl";
-    private static final String XML_OUTPUT_FACTORY_IMPL = "com.sun.xml.internal.stream.XMLOutputFactoryImpl";
-    private static final String TRANSFORMER_FACTORY_IMPL = "com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl";
-
     private static final XMLInputFactory XML_INPUT_FACTORY = createXMLInputFactory();
     private static final XMLOutputFactory XML_OUTPUT_FACTORY = createXMLOutputFactory();
     private static final TransformerFactory TRANSFORMER_FACTORY = createTransformerFactory();
@@ -186,7 +182,7 @@ public final class XMLSupport {
 
     private static XMLInputFactory createXMLInputFactory() {
         try {
-            XMLInputFactory factory = (XMLInputFactory) Class.forName(XML_INPUT_FACTORY_IMPL).getConstructor().newInstance();
+            XMLInputFactory factory = XMLInputFactory.newFactory();
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
             return factory;
@@ -197,7 +193,7 @@ public final class XMLSupport {
 
     private static XMLOutputFactory createXMLOutputFactory() {
         try {
-            return (XMLOutputFactory) Class.forName(XML_OUTPUT_FACTORY_IMPL).getConstructor().newInstance();
+            return XMLOutputFactory.newFactory();
         } catch (Exception e) {
             throw new Error(e);
         }
@@ -205,7 +201,7 @@ public final class XMLSupport {
 
     private static TransformerFactory createTransformerFactory() {
         try {
-            TransformerFactory factory = (TransformerFactory) Class.forName(TRANSFORMER_FACTORY_IMPL).getConstructor().newInstance();
+            TransformerFactory factory = TransformerFactory.newInstance();
             factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             return factory;
         } catch (Exception e) {


### PR DESCRIPTION
The javadocs say that these system properties are the first things consulted.
I think we shied away from relying on system properties for proper functionality in the past,
but with Java 17 around the corner it would be nice to remove the reflection here before it breaks.

If we drop java 8 support, we could possibly just use these methods instead:
* https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/stream/XMLInputFactory.html#newDefaultFactory()
* https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/stream/XMLOutputFactory.html#newDefaultFactory()
* https://docs.oracle.com/en/java/javase/11/docs/api/java.xml/javax/xml/transform/TransformerFactory.html#newDefaultInstance()

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>