### PR TITLE
Deprecate our old static jdbc caches for future removal

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -109,8 +109,11 @@ public class FHIRConfiguration {
     public static final String PROPERTY_PERSISTENCE_FACTORY = "fhirServer/persistence/factoryClassname";
     public static final String PROPERTY_DATASOURCES = "fhirServer/persistence/datasources";
     public static final String PROPERTY_JDBC_ENABLE_READ_ONLY_REPLICAS = "fhirServer/persistence/jdbc/enableReadOnlyReplicas";
+    @Deprecated
     public static final String PROPERTY_JDBC_ENABLE_CODE_SYSTEMS_CACHE = "fhirServer/persistence/jdbc/enableCodeSystemsCache";
+    @Deprecated
     public static final String PROPERTY_JDBC_ENABLE_PARAMETER_NAMES_CACHE = "fhirServer/persistence/jdbc/enableParameterNamesCache";
+    @Deprecated
     public static final String PROPERTY_JDBC_ENABLE_RESOURCE_TYPES_CACHE = "fhirServer/persistence/jdbc/enableResourceTypesCache";
     public static final String PROPERTY_JDBC_EXTERNAL_REF_SYSTEM_CACHE_SIZE = "fhirServer/persistence/jdbc/externalRefSystemCacheSize";
     public static final String PROPERTY_JDBC_EXTERNAL_REF_VALUE_CACHE_SIZE = "fhirServer/persistence/jdbc/externalRefValueCacheSize";
@@ -123,7 +126,7 @@ public class FHIRConfiguration {
     public static final String PROPERTY_USE_STORED_COMPARTMENT_PARAM = "fhirServer/search/useStoredCompartmentParam";
     @Deprecated
     public static final String PROPERTY_SEARCH_ENABLE_OPT_QUERY_BUILDER = "fhirServer/search/enableOptQueryBuilder";
-    
+
     public static final String PROPERTY_SEARCH_ENABLE_LEGACY_WHOLE_SYSTEM_SEARCH_PARAMS = "fhirServer/search/enableLegacyWholeSystemSearchParams";
 
     // bulkdata

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterDAO.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -13,7 +13,7 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDBConnectException
 import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessException;
 
 /**
- * This Data Access Object interface defines methods for creating, updating, 
+ * This Data Access Object interface defines methods for creating, updating,
  * and retrieving rows in the IBM FHIR Server parameter-related tables.
  */
 public interface ParameterDAO extends FHIRDbDAO {
@@ -25,7 +25,7 @@ public interface ParameterDAO extends FHIRDbDAO {
      * @throws FHIRPersistenceDataAccessException
      */
     Map<String,Integer> readAllSearchParameterNames() throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException;
-    
+
     /**
      * Reads all rows in the Code_Systems table and returns the data as a Map
      * @return Map<String, Long> - A map containing key=system-name, value=system-id
@@ -33,7 +33,7 @@ public interface ParameterDAO extends FHIRDbDAO {
      * @throws FHIRPersistenceDataAccessException
      */
     Map<String,Integer> readAllCodeSystems() throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException;
-    
+
     /**
      * Reads the id associated with the name of the passed Parameter from the Parameter_Names table. If the id for the passed name is not present
      * in the database, an id is generated, persisted, and returned.
@@ -72,7 +72,7 @@ public interface ParameterDAO extends FHIRDbDAO {
      */
     Integer readCodeSystemId(String systemName) throws FHIRPersistenceDBConnectException, FHIRPersistenceDataAccessException;
 
-    
+
     /**
      * Acquire and return the id associated with the passed parameter name.
      * @param parameterName The name of a valid FHIR search parameter.
@@ -96,6 +96,7 @@ public interface ParameterDAO extends FHIRDbDAO {
      * @param codeSystemId The id corresponding to the code system name.
      * @throws FHIRPersistenceException
      */
+    @Deprecated
     void addCodeSystemsCacheCandidate(String codeSystemName, Integer codeSystemId) throws FHIRPersistenceException;
 
     /**

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterNameDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/ParameterNameDAO.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,14 +14,14 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessExceptio
  * This Data Access Object interface defines APIs specific to parameter_names table.
  */
 public interface ParameterNameDAO {
-    
+
     /**
      * Reads all rows in the Parameter_Names table and returns the data as a Map
      * @return A map containing key=parameter-name, value=parameter-name-id
      * @throws FHIRPersistenceDataAccessException
      */
     Map<String,Integer> readAllSearchParameterNames() throws FHIRPersistenceDataAccessException;
-       
+
     /**
      * Reads the id associated with the name of the passed Parameter from the Parameter_Names table. If the id for the passed name is not present
      * in the database, an id is generated, persisted, and returned.
@@ -30,7 +30,7 @@ public interface ParameterNameDAO {
      * @throws FHIRPersistenceDataAccessException
      */
     int readOrAddParameterNameId(String parameterName) throws FHIRPersistenceDataAccessException;
-    
+
     /**
      * Read the parameter_name_id for the given parameterName
      * @param parameterName  A valid FHIR search parameter name.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1848,6 +1848,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
      * Calls some cache analysis methods and aggregates the output into a single String.
      * @return
      */
+    @Deprecated
     private String performCacheDiagnostics() {
 
         StringBuffer diags = new StringBuffer();
@@ -2130,7 +2131,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 // These references are stored as tokens and are used by the search query builder
                 // for compartment-based searches
                 addCompartmentParams(allParameters, fhirResource);
-                
+
                 // If this is a definitional resource, augment the extracted parameter list with a composite
                 // parameter that will be used for canonical searches. It will contain the url and version
                 // values.
@@ -2237,7 +2238,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
     protected void addCanonicalCompositeParam(List<ExtractedParameterValue> allParameters) throws FHIRSearchException {
         StringParmVal urlParm = null;
         TokenParmVal versionParm = null;
-        
+
         // Look for url and version parameters
         for (ExtractedParameterValue parameter : allParameters) {
             if (parameter.getName().equals(SearchConstants.URL) && parameter instanceof StringParmVal) {
@@ -2246,7 +2247,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 versionParm = (TokenParmVal) parameter;
             }
         }
-        
+
         // If we found a url parameter, create the composite parameter. The version parameter
         // can be null.
         if (urlParm != null) {
@@ -2274,13 +2275,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             vp.setVersion(cp.getVersion());
             vp.setValueString(versionParm != null ? versionParm.getValueCode() : null);
             cp.addComponent(vp);
-            
+
             if (log.isLoggable(Level.FINE)) {
                 log.fine("Adding canonical composite parameter: [" + cp.getResourceType() + "] " +
                             up.getName() + " = " + up.getValueString() + ", " +
                             vp.getName() + " = " + vp.getValueString());
             }
-            
+
             allParameters.add(cp);
         }
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/ParameterTransactionDataImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/ParameterTransactionDataImpl.java
@@ -51,6 +51,7 @@ public class ParameterTransactionDataImpl implements TransactionData {
      * Public constructor
      * @param datasourceId
      * @param impl
+     * @param userTransaction
      */
     public ParameterTransactionDataImpl(String datasourceId, FHIRPersistenceJDBCImpl impl, UserTransaction userTransaction) {
         this.datasourceId = datasourceId;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCache.java
@@ -19,10 +19,11 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessExceptio
 /**
  * This class provides a static cache for FHIR Systems that are part of Token type Search parameters.
  */
+@Deprecated
 public class CodeSystemsCache {
-    private static final String CLASSNAME = CodeSystemsCache.class.getName(); 
+    private static final String CLASSNAME = CodeSystemsCache.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
-    
+
     private static boolean enabled = true;
 
     /**
@@ -30,19 +31,19 @@ public class CodeSystemsCache {
      * mapping of system-name to system-id.
      */
     private static ConcurrentHashMap<String,ConcurrentHashMap<String,Integer>> codeSystemIdMaps = new ConcurrentHashMap<>();
-    
+
     /**
-     * Retrieves the id for the passed system, for the current tenant-datastore. 
+     * Retrieves the id for the passed system, for the current tenant-datastore.
      * If not found, null is returned.
      * @param parameter The name of a code system
      * @return Integer The id corresponding to the passed code system
      */
     public static Integer getCodeSystemId(String systemName) {
-        
+
         String tenantDatastoreCacheName = getCacheNameForTenantDatastore();
         Integer systemId = null;
         String encodedSysName = SqlParameterEncoder.encode(systemName);
-        
+
         if (enabled) {
             ConcurrentHashMap<String,Integer> currentDsMap = codeSystemIdMaps.putIfAbsent(tenantDatastoreCacheName, new ConcurrentHashMap<String,Integer>());
             if (currentDsMap == null) {
@@ -53,19 +54,19 @@ public class CodeSystemsCache {
         }
         return systemId;
     }
-    
+
     /**
      * Adds the passed code system name and id to the current tenant-datastore cache.
-     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to. 
+     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to.
      * @param systemName A valid code system name.
      * @param systemId The id associated with the passed code system name.
      */
     public static void putCodeSystemId(String tenantDatastoreCacheName, String systemName, Integer systemId) {
-        
+
         ConcurrentHashMap<String,Integer> currentDsMap;
         Integer tempValue;
         String encodedSysName = SqlParameterEncoder.encode(systemName);
-        
+
         if (enabled) {
             currentDsMap = codeSystemIdMaps.putIfAbsent(tenantDatastoreCacheName, new ConcurrentHashMap<String,Integer>());
             if (currentDsMap == null) {
@@ -78,66 +79,66 @@ public class CodeSystemsCache {
             }
         }
     }
-    
+
     /**
      * Adds the passed code system name/id pairs to the the current tenant-datastore cache.
-     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to. 
+     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to.
      * @param newParameters A Map containing code system name/id pairs.
      */
     public static void putCodeSystemIds(String tenantDatastoreCacheName, Map<String, Integer> newCodeSystems) {
-        
+
         if (enabled) {
             for (Map.Entry<String, Integer> entry : newCodeSystems.entrySet()) {
                  putCodeSystemId(tenantDatastoreCacheName, entry.getKey(), entry.getValue());
             }
         }
     }
-    
+
     /**
      * Returns a String containing a combination of the current tenantId and datastoreId.
      * @return
      */
     public static String getCacheNameForTenantDatastore() {
-        
+
         StringBuilder cacheName = new StringBuilder();
         cacheName.append(FHIRRequestContext.get().getTenantId())
                  .append("~")
                  .append(FHIRRequestContext.get().getDataStoreId());
         return cacheName.toString();
     }
-    
+
     /**
-     * 
+     *
      * @return String - A formatted representation of the entire cache managed by this class.
      */
     public static String dumpCacheContents() {
-        
+
         return CacheUtil.dumpCacheContents("CodeSystemsCache", codeSystemIdMaps);
     }
-    
+
     /**
      * Determines and reports any discrepancies between the current thread's Code Systems cache and the contents of the database CODE_SYSTEMS table.
      * @param dao A Parameter DAO instance
      * @return String - A report detailing cache/db discrepancies.
      */
     public static String reportCacheDiscrepancies(ParameterDAO dao) {
-        
+
         String tenantDatstoreCacheName = getCacheNameForTenantDatastore();
         Map<String, Integer> dbMap;
         ConcurrentHashMap<String,Integer> cachedMap = codeSystemIdMaps.get(tenantDatstoreCacheName);
         String discrepancies = "";
-        
+
         if (enabled) {
             try {
                 dbMap = dao.readAllCodeSystems();
                 discrepancies = CacheUtil.reportCacheDiscrepancies("CodeSystemsCache", cachedMap, dbMap);
-            } 
+            }
             catch (FHIRPersistenceDBConnectException | FHIRPersistenceDataAccessException e) {
                 log.log(Level.SEVERE, "Failure obtaining  all code systems." , e);
                 discrepancies = CacheUtil.NEWLINE + "Could not report on CodeSystems cache discrepancies." + CacheUtil.NEWLINE;
             }
         }
-        
+
         return discrepancies;
     }
 
@@ -146,7 +147,7 @@ public class CodeSystemsCache {
     }
 
     public static void setEnabled(boolean newEnabled) {
-        
+
         if (newEnabled != enabled) {
             synchronized(CodeSystemsCache.class) {
                 enabled = newEnabled;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCacheUpdater.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/CodeSystemsCacheUpdater.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 /**
  * This cache update writes its Code Systems cache candidates to the CodeSystemsCache upon a transaction commit.
  */
+@Deprecated
 public class CodeSystemsCacheUpdater extends CacheUpdater {
     private static final String CLASSNAME = CodeSystemsCacheUpdater.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
@@ -20,14 +21,14 @@ public class CodeSystemsCacheUpdater extends CacheUpdater {
         super(tenantDatastoreCacheName, newCacheCandidates);
     }
 
-    
+
     @Override
     public void commitCacheCandidates() {
         final String METHODNAME = "commitCacheCandidates";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         CodeSystemsCache.putCodeSystemIds(this.getTenantDatastoreCacheName(), this.getCacheCandidates());
-        
+
         log.exiting(CLASSNAME, METHODNAME);
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterNamesCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterNamesCache.java
@@ -19,10 +19,11 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessExceptio
 /**
  * This class provides a static cache for FHIR Search Parameter names.
  */
+@Deprecated
 public class ParameterNamesCache {
-    private static final String CLASSNAME = ParameterNamesCache.class.getName(); 
+    private static final String CLASSNAME = ParameterNamesCache.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
-    
+
     private static boolean enabled = true;
 
     /**
@@ -30,21 +31,21 @@ public class ParameterNamesCache {
      * mapping of parameter-name to parameter-name-id.
      */
     private static ConcurrentHashMap<String,ConcurrentHashMap<String,Integer>> parameterNameIdMaps = new ConcurrentHashMap<>();
-    
+
     /**
-     * Retrieves the id for the name contained in the passed Parameter, for the current tenant-datastore. 
+     * Retrieves the id for the name contained in the passed Parameter, for the current tenant-datastore.
      * If not found, null is returned.
      * @param parameterName A valid FHIR search parameter name.
      * @return Integer The id corresponding to the parameter name.
-     * @throws FHIRPersistenceDataAccessException 
-     * @throws FHIRPersistenceDBConnectException 
+     * @throws FHIRPersistenceDataAccessException
+     * @throws FHIRPersistenceDBConnectException
      */
     public static Integer getParameterNameId(String parameterName) {
-        
+
         String tenantDatstoreCacheName = getCacheNameForTenantDatastore();
         ConcurrentHashMap<String,Integer> currentDsMap;
         Integer parameterNameId = null;
-        
+
         if (enabled) {
             currentDsMap = parameterNameIdMaps.putIfAbsent(tenantDatstoreCacheName, new ConcurrentHashMap<String,Integer>());
             if (currentDsMap == null) {
@@ -53,14 +54,14 @@ public class ParameterNamesCache {
             currentDsMap = parameterNameIdMaps.get(tenantDatstoreCacheName);
             parameterNameId = currentDsMap.get(parameterName);
         }
-                        
+
         return parameterNameId;
-         
+
     }
-    
+
     /**
      * Adds the passed parameter name and id to the current tenant-datastore cache.
-     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to. 
+     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to.
      * @param parameterName A valid search parameter name.
      * @param parameterId The id associated with the passed parameter name.
      */
@@ -68,7 +69,7 @@ public class ParameterNamesCache {
 
         ConcurrentHashMap<String,Integer> currentDsMap;
         Integer tempValue;
-        
+
         if (enabled) {
             currentDsMap = parameterNameIdMaps.putIfAbsent(tenantDatastoreCacheName, new ConcurrentHashMap<String,Integer>());
             if (currentDsMap == null) {
@@ -81,78 +82,78 @@ public class ParameterNamesCache {
             }
         }
     }
-    
+
     /**
      * Adds the passed search parameter name/id pairs to the the current tenant-datastore cache.
-     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to. 
+     * @param tenantDatastoreCacheName The name of the datastore-specific cache the entry should be added to.
      * @param newParameters A Map containing parameter name/id pairs.
      */
     public static void putParameterNameIds(String tenantDatastoreCacheName, Map<String, Integer> newParameters) {
-        
+
         if (enabled) {
             for (Map.Entry<String, Integer> entry : newParameters.entrySet()) {
                  putParameterNameId(tenantDatastoreCacheName, entry.getKey(), entry.getValue());
             }
         }
     }
-    
-    
-    
+
+
+
     /**
      * Returns a String containing a combination of the current tenantId and datastoreId.
      * @return
      */
     public static String getCacheNameForTenantDatastore() {
-        
+
         StringBuilder cacheName = new StringBuilder();
         cacheName.append(FHIRRequestContext.get().getTenantId())
                  .append("~")
                  .append(FHIRRequestContext.get().getDataStoreId());
         return cacheName.toString();
     }
-    
+
     /**
-     * 
+     *
      * @return String - A formatted representation of the entire cache managed by this class.
      */
     public static String dumpCacheContents() {
-        
+
         return CacheUtil.dumpCacheContents("ParameterNamesCache", parameterNameIdMaps);
     }
-    
-    
+
+
     /**
      * Determines and reports any discrepancies between the current thread's Parameter Names cache and the contents of the database PARAMETER_NAMES table.
      * @param dao A Parameter DAO instance
      * @return String - A report detailing cache/db discrepancies.
      */
     public static String reportCacheDiscrepancies(ParameterDAO dao) {
-        
+
         String tenantDatstoreCacheName = getCacheNameForTenantDatastore();
         ConcurrentHashMap<String,Integer> cachedMap = parameterNameIdMaps.get(tenantDatstoreCacheName);
         Map<String, Integer> dbMap;
         String discrepancies = "";
-        
+
         if (enabled) {
             try {
                 dbMap = dao.readAllSearchParameterNames();
                 discrepancies = CacheUtil.reportCacheDiscrepancies("ParameterNamesCache", cachedMap, dbMap);
-            } 
+            }
             catch (FHIRPersistenceDBConnectException | FHIRPersistenceDataAccessException e) {
                 log.log(Level.SEVERE, "Failure obtaining  all search parameter names." , e);
                 discrepancies = CacheUtil.NEWLINE + "Could not report on ParameterNames cache discrepancies." + CacheUtil.NEWLINE;
             }
         }
-        
+
         return discrepancies;
     }
-    
+
     public static boolean isEnabled() {
         return enabled;
     }
 
     public static void setEnabled(boolean newEnabled) {
-        
+
         if (newEnabled != enabled) {
             synchronized(CodeSystemsCache.class) {
                 enabled = newEnabled;

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterNamesCacheUpdater.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterNamesCacheUpdater.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 /**
  * This cache updater writes its Parameter Names cache candidates to the ParameterNamesCache upon a transaction commit.
  */
+@Deprecated
 public class ParameterNamesCacheUpdater extends CacheUpdater {
     private static final String CLASSNAME = ParameterNamesCacheUpdater.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
@@ -20,14 +21,14 @@ public class ParameterNamesCacheUpdater extends CacheUpdater {
         super(tenantDatastoreCacheName, newCacheCandidates);
     }
 
-    
+
     @Override
     public void commitCacheCandidates() {
         final String METHODNAME = "commitCacheCandidates";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         ParameterNamesCache.putParameterNameIds(this.getTenantDatastoreCacheName(), this.getCacheCandidates());
-        
+
         log.exiting(CLASSNAME, METHODNAME);
 
     }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ResourceTypesCache.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ResourceTypesCache.java
@@ -19,6 +19,7 @@ import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessExceptio
 /**
  * This class provides a static cache for FHIR Resource type names.
  */
+@Deprecated
 public class ResourceTypesCache {
     private static final String CLASSNAME = ResourceTypesCache.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ResourceTypesCacheUpdater.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ResourceTypesCacheUpdater.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 /**
  * This cache updater writes its Resource Types cache candidates to the ResourceTypesCache upon a transaction commit.
  */
+@Deprecated
 public class ResourceTypesCacheUpdater extends CacheUpdater {
     private static final String CLASSNAME = ResourceTypesCacheUpdater.class.getName();
     private static final Logger log = Logger.getLogger(CLASSNAME);
@@ -24,12 +25,12 @@ public class ResourceTypesCacheUpdater extends CacheUpdater {
     public void commitCacheCandidates() {
         final String METHODNAME = "commitCacheCandidates";
         log.entering(CLASSNAME, METHODNAME);
-        
+
         ResourceTypesCache.putResourceTypeIds(this.getTenantDatastoreCacheName(), this.getCacheCandidates());
-        
+
         log.exiting(CLASSNAME, METHODNAME);
 
     }
 }
 
- 
+


### PR DESCRIPTION
These were largely replaced by JDBCIdentityCache and the JDBCIdentityCacheImpl.

A couple of the older caches are still used by live code, so we should only
deprecate them if we know that they aren't really needed.

For example, the ParameterNamesCache is used (transitively) from
JDBCIdentityCacheImpl.getParameterNameId.


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>