### PR TITLE
issue #2742 - aggregate exit status of all executions in bulkdata-status

### DIFF
--- a/build/docker/copy-server-config.sh
+++ b/build/docker/copy-server-config.sh
@@ -43,8 +43,9 @@ mkdir -p ${OVERRIDES}
 # Just in case it already exists, let's wipe the datsource*.xml files
 rm -f ${OVERRIDES}/datasource*.xml
 
-# Copy over both the db2 (default_default) and derby (tenant1_*) datasource definitions
+# Copy over the db2 (default_default and fhirbatchDS) and derby (tenant1_*) datasource definitions
 cp -p ${WORKSPACE}/fhir-server/liberty-config/configDropins/disabled/datasource-db2.xml ${OVERRIDES}/
+cp -p ${WORKSPACE}/fhir-server/liberty-config/configDropins/disabled/db2/bulkdata.xml ${OVERRIDES}/
 cp -p ${WORKSPACE}/fhir-server/liberty-config/configDropins/disabled/datasource-derby.xml ${OVERRIDES}/
 
 echo "Finished copying the server config."

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -4,6 +4,14 @@ services:
   fhir-server:
     image: ibmcom/ibm-fhir-server
     hostname: fhir
+    environment:
+      BATCH_DB_HOSTNAME: db2
+      BATCH_DB_SCHEMA: FHIR_JBATCH
+      BATCH_DB_NAME: FHIRDB
+      BATCH_DB_PORT: "50000"
+      BATCH_DB_SSL: "false"
+      BATCH_DB_USER: fhirserver
+      BATCH_DB_PASS: change-password
     volumes:
       - type: bind
         source: ./fhir-server/volumes/config

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
@@ -37,7 +37,7 @@ public class BatchContextAdapter {
         this.props = props;
     }
 
-    public BulkDataContext getStepContextForPatientExportPartitionMapper() {
+    public BulkDataContext getStepContextForExportPartitionMapper() {
         BulkDataContext ctx = new BulkDataContext();
         context(ctx);
         source(ctx);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
@@ -46,7 +46,7 @@ public class PatientExportPartitionMapper implements PartitionMapper {
 
         BatchContextAdapter ctxAdapter = new BatchContextAdapter(jobExecution.getJobParameters());
 
-        BulkDataContext ctx = ctxAdapter.getStepContextForPatientExportPartitionMapper();
+        BulkDataContext ctx = ctxAdapter.getStepContextForExportPartitionMapper();
 
         // By default we're in the Patient Compartment, if we have a valid context
         // which has a resourceType specified, it's valid as the operation has already checked.

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
@@ -49,7 +49,7 @@ public class SystemExportPartitionMapper implements PartitionMapper {
 
         BatchContextAdapter ctxAdapter = new BatchContextAdapter(jobExecution.getJobParameters());
 
-        BulkDataContext ctx = ctxAdapter.getStepContextForPatientExportPartitionMapper();
+        BulkDataContext ctx = ctxAdapter.getStepContextForExportPartitionMapper();
 
         // We know these are real resource types.
         List<String> resourceTypes = Arrays.asList(ctx.getFhirResourceTypes().split("\\s*,\\s*"));

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionMapper.java
@@ -76,7 +76,7 @@ public class ImportPartitionMapper implements PartitionMapper {
             return pp;
         } catch (FHIRLoadException e) {
             jobCtx.setExitStatus("FAILED_BAD_SOURCE");
-            logger.log(Level.SEVERE, "Import PartitionMapper source[" + executionId + "] - " + e.getMessage(), e);
+            logger.log(Level.WARNING, "Import PartitionMapper source[" + executionId + "] - " + e.getMessage(), e);
             throw e;
         } catch (FHIRException e) {
             logger.log(Level.SEVERE, "Import PartitionMapper.mapPartitions during job[" + executionId + "] - " + e.getMessage(), e);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/load/partition/transformer/impl/S3Transformer.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/load/partition/transformer/impl/S3Transformer.java
@@ -37,7 +37,7 @@ public class S3Transformer implements PartitionSourceTransformer {
         }
 
         String loc = location.trim();
-        LOG.fine(() -> "Location being verified is'" + loc + "'");
+        LOG.fine(() -> "Location being verified is '" + loc + "'");
 
         String continuationToken = null;
         ListObjectsV2Result result = null;

--- a/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportFastJob.xml
+++ b/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkExportFastJob.xml
@@ -11,7 +11,7 @@
             </properties>
         </listener>
     </listeners>
-    <step id="step1">
+    <step id="step1" start-limit="3">
         <listeners>
             <listener ref="com.ibm.fhir.bulkdata.jbatch.listener.StepChunkListener"></listener>
         </listeners>

--- a/fhir-server/liberty-config/configDropins/defaults/bulkdata.xml
+++ b/fhir-server/liberty-config/configDropins/defaults/bulkdata.xml
@@ -1,6 +1,6 @@
 <server description="fhir-server">
     <!-- 
-        By default, in-memory derby is used for job repository, no configuration is needed.
+        By default, an in-memory store is used for the job repository; no configuration is needed.
         If you need an alternative, check the disabled folder for your persistence datastore/provider.
     -->
     <featureManager>

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/OperationConstants.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/OperationConstants.java
@@ -51,6 +51,7 @@ public class OperationConstants {
 
     // Status
     public static final List<String> SUCCESS_STATUS = Collections.unmodifiableList(Arrays.asList("COMPLETED"));
+    public static final List<String> RUNNING_STATUS = Collections.unmodifiableList(Arrays.asList("STARTING", "STARTED"));
     public static final List<String> FAILED_STATUS = Collections.unmodifiableList(Arrays.asList("FAILED", "ABANDONED"));
     public static final List<String> STOPPED_STATUS = Collections.unmodifiableList(Arrays.asList("STOPPED"));
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/action/batch/BatchCancelRequestAction.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/action/batch/BatchCancelRequestAction.java
@@ -115,11 +115,9 @@ public class BatchCancelRequestAction implements BulkDataClientAction {
         stopJobExecutions(jobExecutions);
 
         if (supportsDeleteJob()) {
-            // Delete The Job
             deleteJob(job);
         } else {
-            // The following is marked as not-found
-            throw export.buildOperationException("The Job is stopped intentionally with an in memory database.", IssueType.NOT_FOUND);
+            throw export.buildOperationException("Job deletion is not supported with the configured (in-memory) database.", IssueType.NOT_SUPPORTED);
         }
 
         // Check for a server-side error

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/JobInstanceResponse.java
@@ -65,15 +65,15 @@ public class JobInstanceResponse {
     private String instanceName;
     private String lastUpdatedTime;
     private String instanceState;
-    private Integer executionId;
+    private List<Integer> executionId;
 
     private List<Link> _links = new ArrayList<>();
 
-    public Integer getExecutionId() {
+    public List<Integer> getExecutionId() {
         return executionId;
     }
 
-    public void setExecutionId(Integer executionId) {
+    public void setExecutionId(List<Integer> executionId) {
         this.executionId = executionId;
     }
 
@@ -193,7 +193,7 @@ public class JobInstanceResponse {
             // Intentionally hiding from external callers.
         }
 
-        public Builder executionId(Integer executionId) {
+        public Builder executionId(List<Integer> executionId) {
             response.setExecutionId(executionId);
             return this;
         }
@@ -360,7 +360,7 @@ public class JobInstanceResponse {
                 builder.lastUpdatedTime(lastUpdatedTime);
             }
 
-            int jobExecutionId = 0;
+            List<Integer> jobExecutionId = new ArrayList<>();
             if (jsonObject.containsKey("_links")) {
                 JsonArray arr = jsonObject.getJsonArray("_links");
                 ListIterator<JsonValue> iter = arr.listIterator();
@@ -381,11 +381,13 @@ public class JobInstanceResponse {
                             // as the current job execution id.
                             int tmpJobExecutionId =
                                     Integer.parseInt(href.substring(href.indexOf("jobexecutions") + 14));
-                            jobExecutionId =
-                                    jobExecutionId < tmpJobExecutionId ? tmpJobExecutionId : jobExecutionId;
+                            jobExecutionId.add(tmpJobExecutionId);
                         }
                     }
                 }
+            }
+            if (jobExecutionId.isEmpty()) {
+                jobExecutionId = Collections.singletonList(0);
             }
             builder.executionId(jobExecutionId);
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/PollingLocationResponse.java
@@ -10,6 +10,8 @@ import static com.ibm.fhir.model.type.String.string;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +83,13 @@ public class PollingLocationResponse {
 
     public void setOutput(List<Output> output) {
         this.output = output;
+    }
+
+    public void addOutput(Collection<Output> output) {
+        if (this.output == null) {
+            this.output = new ArrayList<>();
+        }
+        this.output.addAll(output);
     }
 
     public List<Output> getError() {


### PR DESCRIPTION
I found that the liberty implementation of java batch has a "feature"
where it only restarts partitions that have *not* completed
successfully.
Unfortunately, I couldn't find a simple way to get the ExitStatus of
successful partitions from previous executions and stuff those into the
ExitStatus of the latest execution.
Therefore, to get a complete list of partition results, it is necessary
for the status endpoint to aggregate the Exit Status of *all* of the
jobs executions for a particular job instance.
Previously we were only checking the last execution and that was leading
to confusing behavior where the status shows partial results from the
export (even though the entire job was completed).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>