### PR TITLE
Update to the latest janusgraph and gremlin

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -43,6 +43,7 @@
         <derby.version>10.14.2.0</derby.version>
         <db2.version>11.5.5.0</db2.version>
         <postgresql.version>42.2.18</postgresql.version>
+        <janusgraph.version>0.6.0</janusgraph.version>
         <!-- Updated per [CVE-2021-22696] CXF supports (via JwtRequestCodeFilter) -->
         <cxf.version>3.4.3</cxf.version>
         <surefire.plugin.version>3.0.0-M5</surefire.plugin.version>
@@ -524,32 +525,32 @@
             <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-core</artifactId>
-                <version>0.5.3</version>
+                <version>${janusgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-berkeleyje</artifactId>
-                <version>0.5.3</version>
+                <version>${janusgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-cql</artifactId>
-                <version>0.5.3</version>
+                <version>${janusgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-lucene</artifactId>
-                <version>0.5.3</version>
+                <version>${janusgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.janusgraph</groupId>
                 <artifactId>janusgraph-es</artifactId>
-                <version>0.5.3</version>
+                <version>${janusgraph.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-driver</artifactId>
-                <version>3.4.6</version>
+                <version>3.5.1</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml.bind</groupId>

--- a/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/listener/FHIRServletContextListener.java
@@ -38,7 +38,7 @@ import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
 import javax.websocket.server.ServerContainer;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.owasp.encoder.Encode;
 
 import com.ibm.fhir.cache.CachingProxy;

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/FHIRTermGraph.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/FHIRTermGraph.java
@@ -8,7 +8,7 @@ package com.ibm.fhir.term.graph;
 
 import java.util.stream.Stream;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphIndexQuery.Result;

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/factory/FHIRTermGraphFactory.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/factory/FHIRTermGraphFactory.java
@@ -6,8 +6,10 @@
 
 package com.ibm.fhir.term.graph.factory;
 
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 
 import com.ibm.fhir.term.graph.FHIRTermGraph;
 import com.ibm.fhir.term.graph.impl.FHIRTermGraphImpl;
@@ -28,7 +30,10 @@ public final class FHIRTermGraphFactory {
      */
     public static FHIRTermGraph open(String propFileName) {
         try {
-            return open(new PropertiesConfiguration(propFileName));
+            FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
+                    new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                    .configure(new Parameters().properties().setFileName("myconfig.properties"));
+            return open(builder.getConfiguration());
         } catch (Exception e) {
             throw new Error(e);
         }

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/impl/FHIRTermGraphImpl.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/impl/FHIRTermGraphImpl.java
@@ -12,7 +12,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.janusgraph.core.JanusGraph;

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/loader/impl/AbstractTermGraphLoader.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/loader/impl/AbstractTermGraphLoader.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.janusgraph.core.JanusGraph;
 

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/loader/impl/CodeSystemTermGraphLoader.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/loader/impl/CodeSystemTermGraphLoader.java
@@ -27,7 +27,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.MissingOptionException;
 import org.apache.commons.cli.Options;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import com.ibm.fhir.model.format.Format;

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
@@ -104,7 +104,7 @@ public class GraphTermServiceProvider extends AbstractTermServiceProvider {
         boolean caseSensitive = isCaseSensitive(codeSystem);
 
         GraphTraversal<Vertex, Vertex> g = whereCodeSystem(hasCode(vertices(), code.getValue(), caseSensitive), codeSystem)
-            .union(__.identity(), whereCodeSystem(hasCode(vertices(), code.getValue(), caseSensitive), codeSystem)
+            .union(__.identity(), whereCodeSystem(hasCode(code.getValue(), caseSensitive), codeSystem)
                 .repeat(__.in(FHIRTermGraph.IS_A)
                     .simplePath()
                     .dedup())
@@ -363,7 +363,7 @@ public class GraphTermServiceProvider extends AbstractTermServiceProvider {
                 (CodeSystemHierarchyMeaning.IS_A.equals(codeSystem.getHierarchyMeaning()) ||
                         codeSystem.getHierarchyMeaning() == null)) {
             return whereCodeSystem(hasCode(g, value.getValue(), caseSensitive), codeSystem)
-                .union(__.identity(), whereCodeSystem(hasCode(vertices(), value.getValue(), caseSensitive), codeSystem)
+                .union(__.identity(), whereCodeSystem(hasCode(value.getValue(), caseSensitive), codeSystem)
                     .repeat(__.out(FHIRTermGraph.IS_A)
                         .simplePath()
                         .dedup())
@@ -391,7 +391,7 @@ public class GraphTermServiceProvider extends AbstractTermServiceProvider {
                 (CodeSystemHierarchyMeaning.IS_A.equals(codeSystem.getHierarchyMeaning()) ||
                         codeSystem.getHierarchyMeaning() == null)) {
             return whereCodeSystem(hasCode(g, value.getValue(), caseSensitive), codeSystem)
-                .union(__.identity(), whereCodeSystem(hasCode(vertices(), value.getValue(), caseSensitive), codeSystem)
+                .union(__.identity(), whereCodeSystem(hasCode(value.getValue(), caseSensitive), codeSystem)
                     .repeat(__.in(FHIRTermGraph.IS_A)
                         .simplePath()
                         .dedup())

--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/provider/GraphTermServiceProvider.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;

--- a/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/CodeSystemTermGraphLoaderTest.java
+++ b/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/CodeSystemTermGraphLoaderTest.java
@@ -10,7 +10,9 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,7 +29,9 @@ import com.ibm.fhir.term.util.CodeSystemSupport;
 public class CodeSystemTermGraphLoaderTest {
     @Test
     public void testCodeSystemTermGraphLoader() throws Exception {
-        FHIRTermGraph graph = FHIRTermGraphFactory.open(new PropertiesConfiguration("conf/janusgraph-berkeleyje-lucene.properties"));
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder = new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                .configure(new Parameters().properties().setFileName("conf/janusgraph-berkeleyje-lucene.properties"));
+        FHIRTermGraph graph = FHIRTermGraphFactory.open(builder.getConfiguration());
         graph.dropAllVertices();
 
         CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/test");

--- a/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/GraphTermServiceProviderTest.java
+++ b/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/GraphTermServiceProviderTest.java
@@ -6,7 +6,9 @@
 
 package com.ibm.fhir.term.graph.test;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.testng.annotations.AfterClass;
 
 import com.ibm.fhir.term.graph.FHIRTermGraph;
@@ -22,7 +24,9 @@ public class GraphTermServiceProviderTest extends FHIRTermServiceProviderTest {
 
     @Override
     public FHIRTermServiceProvider createProvider() throws Exception {
-        graph = FHIRTermGraphFactory.open(new PropertiesConfiguration("conf/janusgraph-berkeleyje-lucene.properties"));
+        FileBasedConfigurationBuilder<PropertiesConfiguration> builder = new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                .configure(new Parameters().properties().setFileName("conf/janusgraph-berkeleyje-lucene.properties"));
+        graph = FHIRTermGraphFactory.open(builder.getConfiguration());
         graph.dropAllVertices();
 
         FHIRTermGraphLoader loader = new CodeSystemTermGraphLoader(graph, codeSystem);

--- a/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/GraphTermServiceProviderTimeLimitTest.java
+++ b/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/GraphTermServiceProviderTimeLimitTest.java
@@ -8,7 +8,9 @@ package com.ibm.fhir.term.graph.test;
 
 import static org.testng.Assert.fail;
 
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,7 +29,9 @@ public class GraphTermServiceProviderTimeLimitTest {
     public void testGraphTermServiceProviderTimeLimit() throws Exception {
         FHIRTermGraph graph = null;
         try {
-            graph = FHIRTermGraphFactory.open(new PropertiesConfiguration("conf/janusgraph-berkeleyje-lucene.properties"));
+            FileBasedConfigurationBuilder<PropertiesConfiguration> builder = new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
+                    .configure(new Parameters().properties().setFileName("conf/janusgraph-berkeleyje-lucene.properties"));
+            graph = FHIRTermGraphFactory.open(builder.getConfiguration());
             graph.dropAllVertices();
 
             CodeSystem codeSystem = CodeSystemSupport.getCodeSystem("http://ibm.com/fhir/CodeSystem/test");

--- a/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/SnomedGraphTermServiceProviderTest.java
+++ b/fhir-term-graph/src/test/java/com/ibm/fhir/term/graph/test/SnomedGraphTermServiceProviderTest.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 
 import com.ibm.fhir.model.resource.CodeSystem;
 import com.ibm.fhir.model.resource.CodeSystem.Concept;


### PR DESCRIPTION
The previous version included versions of jackson-databind and netty that had known vulnerabilities.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>