### PR TITLE
Mark janusgraph-cql and janusgraph-es as provided

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:resolve-plugins -f fhir-parent --no-transfer-progress -DexcludeReactor=true -Dmaven.wagon.http.retryHandler.count=3
         mvn -B -T2C package --file fhir-parent -P "${PROFILES}" --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240 -Dmaven.wagon.http.retryHandler.count=3
   e2e-tests:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'ci-skip')"
     strategy:
       matrix:

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -118,6 +118,10 @@
             <artifactId>encoder</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.tyrus.bundles</groupId>
             <artifactId>tyrus-standalone-client-jdk</artifactId>
             <scope>test</scope>

--- a/fhir-term-graph/pom.xml
+++ b/fhir-term-graph/pom.xml
@@ -52,9 +52,11 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-berkeleyje</artifactId>
         </dependency>
+        <!-- change to compile scope or manually package in userlib separately to enable cassandra as a backend graph store option -->
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
@@ -66,9 +68,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- change to compile scope or manually package in userlib to enable elasticsearch as a search index option for graphs -->
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-es</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>


### PR DESCRIPTION
When we bumped to JanusGraph 0.6.0, our webapp went from 82MB to 126MB.
Most of this is from the `janusgraph-cql` module pulling in all of
Cassandra.
Since this is an experimental feature, I think it makes sense to require
user action to enable cassandra and elasticsearch options for graphs.
In our experience, the berkeleyje + lucene option performs better and is
easier to manage anyway.

Note: we don't actually have any compile-time dependencies on these
modules at this time, but I opted to mark the as provided (instead of
omitting them entirely) to make it as easy as possible to bring them back in.
This is similar to what we did with our optional Spark dependencies in
fhir-bulkdata-webapp.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>