### PR TITLE
cleanup after https://github.com/IBM/FHIR/pull/2755

### DIFF
--- a/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/factory/FHIRTermGraphFactory.java
+++ b/fhir-term-graph/src/main/java/com/ibm/fhir/term/graph/factory/FHIRTermGraphFactory.java
@@ -32,7 +32,7 @@ public final class FHIRTermGraphFactory {
         try {
             FileBasedConfigurationBuilder<PropertiesConfiguration> builder =
                     new FileBasedConfigurationBuilder<>(PropertiesConfiguration.class)
-                    .configure(new Parameters().properties().setFileName("myconfig.properties"));
+                    .configure(new Parameters().properties().setFileName(propFileName));
             return open(builder.getConfiguration());
         } catch (Exception e) {
             throw new Error(e);


### PR DESCRIPTION
I accidentally used a placeholder "myconfig.properties" instead of the
propFileName argument when I switched over to apache commons config 2.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>