### PR TITLE
introduce disabled configDropin for a derby-backed job repository

### DIFF
--- a/fhir-server/liberty-config/configDropins/disabled/db2-cloud/bulkdata.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/db2-cloud/bulkdata.xml
@@ -51,5 +51,5 @@
     </dataSource>
 
     <batchPersistence jobStoreRef="BatchDatabaseStore"/>
-    <databaseStore dataSourceRef="fhirbatchDS" id="BatchDatabaseStore" schema="${BATCH_DB_SCHEMA}" tablePrefix="" createTables="false"/>
+    <databaseStore id="BatchDatabaseStore" dataSourceRef="fhirbatchDS" schema="${BATCH_DB_SCHEMA}" tablePrefix="" createTables="false"/>
 </server>

--- a/fhir-server/liberty-config/configDropins/disabled/derby/bulkdata.xml
+++ b/fhir-server/liberty-config/configDropins/disabled/derby/bulkdata.xml
@@ -1,6 +1,6 @@
 <server description="fhir-server">
     <!-- 
-        This configDropin work with Db2 and user-password
+        This configDropin work with Derby
     -->
     <featureManager>
         <feature>batch-1.0</feature>
@@ -32,25 +32,10 @@
         </application-bnd>
     </webApplication>
 
-    <variable name="BATCH_DB_HOSTNAME" defaultValue="localhost"/>
-    <variable name="BATCH_DB_PORT" defaultValue="50000"/>
-    <variable name="BATCH_DB_NAME" defaultValue="FHIRDB"/>
-    <variable name="BATCH_DB_SCHEMA" defaultValue="FHIR_JBATCH"/>
-    <variable name="BATCH_DB_USER" defaultValue="db2inst1"/>
-    <variable name="BATCH_DB_PASS" defaultValue=""/>
-    <variable name="BATCH_DB_SSL" defaultValue="true"/>
-
-    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true">
-        <jdbcDriver javax.sql.XADataSource="com.ibm.db2.jcc.DB2XADataSource" libraryRef="sharedLibDb2"/>
-        <properties.db2.jcc
-            serverName="${BATCH_DB_HOSTNAME}"
-            currentSchema="${BATCH_DB_SCHEMA}"
-            databaseName="${BATCH_DB_NAME}"
-            driverType="4"
-            portNumber="${BATCH_DB_PORT}"
-            sslConnection="${BATCH_DB_SSL}"
-            user="${BATCH_DB_USER}"
-            password="${BATCH_DB_PASS}"/>
+    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
+        <jdbcDriver javax.sql.XADataSource="org.apache.derby.jdbc.EmbeddedXADataSource" libraryRef="sharedLibDerby"/>
+        <properties.derby.embedded databaseName="derby/fhirDB"/>
+        <connectionManager maxPoolSize="50" minPoolSize="10"/>
     </dataSource>
 
    <batchPersistence jobStoreRef="BatchDatabaseStore"/>


### PR DESCRIPTION
In the future, we may want to use this as the default instead of the default in-memory store because its better aligned with our default db config.
The biggest advantage is that the derby-backed store supports delete (purge) whereas the in-memory store does not.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>