### PR TITLE
Potential race condition when create overlaps with erase (hard-delete) #2454

### DIFF
--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConcurrentEraseUpdateTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/ConcurrentEraseUpdateTest.java
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.client.FHIRResponse;
+import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.test.TestUtil;
+import com.ibm.fhir.server.test.concurrent.InteractionFactory.InteractionCallable;
+import com.ibm.fhir.server.test.concurrent.InteractionFactory.InteractionType;
+
+/**
+ * Tests the concurrent creation and updating of a single patient, with the updateCreate feature enabled.
+ * The idea is to ensure that:
+ * 1. No updates are "lost".
+ * 2. No deadlocks occur.
+ * 3. No duplicate logical ids are created.
+ * 4. The resource is searchable in the end.
+ */
+public class ConcurrentEraseUpdateTest extends FHIRServerTestBase {
+
+    private static final int MAX_THREADS = 10;
+
+    @BeforeClass
+    public void shouldRun() throws Exception {
+        if (!this.isUpdateCreateSupported()) {
+            throw new SkipException("Update Create Support is not enabled");
+        }
+    }
+
+    @Test
+    public void testConcurrentUpdateCreate() throws Exception {
+        List<Callable<Resource>> concurrentUpdates = new ArrayList<>();
+        List<Future<Resource>> futureResults = new ArrayList<>();
+
+        // Read a JSON Patient and set the id.
+        String logicalId = UUID.randomUUID().toString();
+        Patient patient = TestUtil.readLocalResource("Patient_SalMonella.json");
+        patient = patient.toBuilder().id(logicalId).build();
+
+        // Initialize multi-thread Executor Service.
+        ExecutorService executor = Executors.newFixedThreadPool(MAX_THREADS);
+
+        // Prepare PatientUpdater instances for running each on its own thread.
+        for (int i = 0; i < MAX_THREADS; i++) {
+            concurrentUpdates.add(new InteractionCallable(InteractionType.UPDATE, client, patient, "Patient", logicalId, MAX_THREADS));
+            concurrentUpdates.add(new InteractionCallable(InteractionType.ERASE, client, patient, "Patient", logicalId, MAX_THREADS));
+            concurrentUpdates.add(new InteractionCallable(InteractionType.DELETE, client, patient, "Patient", logicalId, MAX_THREADS));
+            concurrentUpdates.add(new InteractionCallable(InteractionType.READ, client, patient, "Patient", logicalId, MAX_THREADS));
+        }
+
+        // Run each PatientUpdater on its own thread.
+        futureResults = executor.invokeAll(concurrentUpdates);
+        assertNotNull(futureResults);
+
+        // The final call to Erase
+        InteractionCallable call = new InteractionCallable(InteractionType.ERASE, client, patient, "Patient", logicalId, MAX_THREADS);
+        call.call();
+
+        try {
+            FHIRResponse response = client.read("Patient", logicalId);
+            assertEquals(response.getStatus(), 404);
+        } catch (Exception e) {
+            fail("Unexpected", e);
+        }
+    }
+
+
+}

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/concurrent/InteractionFactory.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/concurrent/InteractionFactory.java
@@ -198,7 +198,7 @@ public final class InteractionFactory {
     }
 
     /**
-     * This inner class invokes the FHIRClient update API for the Patient instance it encapsulates,
+     * This inner class invokes the InteractionType FHIRClient API for the resource instance it encapsulates,
      * retrying in a tight loop in the case of a 409 Conflict.
      */
     public static class InteractionCallable implements Callable<Resource> {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/concurrent/InteractionFactory.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/concurrent/InteractionFactory.java
@@ -1,0 +1,226 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.server.test.concurrent;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.Callable;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import com.ibm.fhir.client.FHIRClient;
+import com.ibm.fhir.client.FHIRResponse;
+import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.server.test.operation.EraseOperationTest;
+
+/**
+ * There is a lot packed into this one class for testing purposes only.
+ */
+public final class InteractionFactory {
+
+    /**
+     * The type of concurrent interaction
+     */
+    public static enum InteractionType {
+        CREATE,
+        READ,
+        UPDATE,
+        DELETE,
+        ERASE
+    }
+
+    private InteractionFactory() {
+        // No Operation
+    }
+
+    public static InteractionStrategy getInteraction(InteractionType type) {
+        InteractionStrategy strategy;
+        switch (type) {
+        case ERASE:
+            strategy = new EraseInteraction();
+            break;
+        case CREATE:
+            strategy = new CreateInteraction();
+        case UPDATE:
+            strategy = new UpdateInteraction();
+            break;
+        case READ:
+            strategy = new ReadInteraction();
+            break;
+        case DELETE:
+            strategy = new DeleteInteraction();
+            break;
+        default:
+            throw new AssertionError("There are no other interaction types");
+        }
+        return strategy;
+    }
+
+    public static interface InteractionStrategy {
+
+        /**
+         * executes the Interaction Strategy and Returns the Resource
+         *
+         * @param client
+         * @param resource
+         * @param resourceType
+         * @param logicalId
+         * @param maxExecutions
+         * @return
+         */
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions);
+    }
+
+    /**
+     * EraseInteraction encapsulates the Interaction with the REST API.
+     */
+    public static class EraseInteraction implements InteractionStrategy {
+
+        @Override
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            Entity<Parameters> entity = Entity.entity(EraseOperationTest.generateParameters(true, true, "Test", null), FHIRMediaType.APPLICATION_FHIR_JSON);
+
+            for (int i = 0; i < maxExecutions; i++) {
+                try {
+                    Response r = client.getWebTarget().path("/" + resourceType + "/" + logicalId
+                            + "/$erase").request(FHIRMediaType.APPLICATION_FHIR_JSON).header("X-FHIR-TENANT-ID", "default").header("X-FHIR-DSID", "default").post(entity, Response.class);
+                    assertTrue(r.getStatus() == Response.Status.OK.getStatusCode() || r.getStatus() == Response.Status.NOT_FOUND.getStatusCode());
+                    Thread.sleep(1000);
+                } catch (Exception e) {
+                    fail("Unexpected", e);
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Update Interaction
+     */
+    public static class UpdateInteraction implements InteractionStrategy {
+
+        @Override
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            int status = 500;
+            do {
+                FHIRResponse response;
+                try {
+                    response = client.update(resource);
+                    status = response.getStatus();
+                } catch (Exception e) {
+                    status = 500;
+                    fail("Unexpected", e);
+                }
+            } while (status == Response.Status.CONFLICT.getStatusCode());
+
+            assertTrue(status == Response.Status.OK.getStatusCode() || status == Response.Status.CREATED.getStatusCode(), "Status=" + status);
+            return null;
+        }
+    }
+
+    /**
+     * Create Interaction
+     */
+    public static class CreateInteraction implements InteractionStrategy {
+
+        @Override
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            int status = 500;
+            do {
+                FHIRResponse response;
+                try {
+                    response = client.create(resource);
+                    status = response.getStatus();
+                } catch (Exception e) {
+                    status = 500;
+                    fail("Unexpected", e);
+                }
+            } while (status == Response.Status.CONFLICT.getStatusCode());
+
+            assertTrue(status == Response.Status.OK.getStatusCode() || status == Response.Status.CREATED.getStatusCode(), "Status=" + status);
+            return null;
+        }
+    }
+
+    /**
+     * Read Interaction
+     */
+    public static class ReadInteraction implements InteractionStrategy {
+
+        @Override
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            int status = 500;
+            do {
+                FHIRResponse response;
+                try {
+                    response = client.read(resourceType, logicalId);
+                    status = response.getStatus();
+                } catch (Exception e) {
+                    status = 500;
+                    fail("Unexpected", e);
+                }
+            } while (status == Response.Status.CONFLICT.getStatusCode());
+
+            assertTrue(status == Response.Status.OK.getStatusCode(), "Status=" + status);
+            return null;
+        }
+    }
+
+    /**
+     * Delete Interaction
+     */
+    public static class DeleteInteraction implements InteractionStrategy {
+        @Override
+        public Resource execute(FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            int status = 500;
+            do {
+                FHIRResponse response;
+                try {
+                    response = client.delete(resourceType, logicalId);
+                    status = response.getStatus();
+                } catch (Exception e) {
+                    status = 500;
+                    fail("Unexpected", e);
+                }
+            } while (status == Response.Status.CONFLICT.getStatusCode());
+
+            assertTrue(status == Response.Status.OK.getStatusCode() || status == Response.Status.NOT_FOUND.getStatusCode(), "Status=" + status);
+            return null;
+        }
+    }
+
+    /**
+     * This inner class invokes the FHIRClient update API for the Patient instance it encapsulates,
+     * retrying in a tight loop in the case of a 409 Conflict.
+     */
+    public static class InteractionCallable implements Callable<Resource> {
+        private InteractionStrategy strategy = null;
+        private FHIRClient client = null;
+        private Resource resource = null;
+        private String resourceType = null;
+        private String logicalId = null;
+        private int maxExecutions = -1;
+
+        public InteractionCallable(InteractionType type, FHIRClient client, Resource resource, String resourceType, String logicalId, int maxExecutions) {
+            this.strategy = getInteraction(type);
+            this.client = client;
+            this.resource = resource;
+            this.resourceType = resourceType;
+            this.logicalId = logicalId;
+            this.maxExecutions = maxExecutions;
+        }
+
+        @Override
+        public Resource call() throws Exception {
+            return strategy.execute(client, resource, resourceType, logicalId, maxExecutions);
+        }
+    }
+}

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
@@ -272,7 +272,7 @@ public class EraseOperationTest extends FHIRServerTestBase {
      * @param version the version that is to be erased
      * @return
      */
-    public Parameters generateParameters(boolean patient, boolean reason, String reasonMsg, Optional<Integer> version) {
+    public static Parameters generateParameters(boolean patient, boolean reason, String reasonMsg, Optional<Integer> version) {
         List<Parameter> parameters = new ArrayList<>();
         if (patient) {
             parameters.add(Parameter.builder().name(string("patient")).value(string("Patient/1-2-3-4")).build());


### PR DESCRIPTION
Introduced an Interaction Factory with a public final class to support Concurrent Tests which mix a number of various test cases so we can test the locking.  Good news is that it worked properly and the concurrency didn't show any deadlock situations with the test (it's a very aggressive test and can be tuned up or down appropriately).

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>