### PR TITLE
Rev kafka-client version to stay on latest working release

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -326,7 +326,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.7.0</version>
+                <version>2.8.1</version>
             </dependency>
             <dependency>
                 <groupId>io.nats</groupId>


### PR DESCRIPTION
Re https://kafka.apache.org/cve-list https://nvd.nist.gov/vuln/detail/CVE-2021-38153
- We are not impacted as we are using kafka-clients

Re 3.0.0 we cannot upgrade as it requires us to drop Java8 support. 
- per https://kafka.apache.org/downloads

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>