### PR TITLE
Investigate cache stats / cache management #2733

### DIFF
--- a/fhir-cache/src/test/java/com/ibm/fhir/cache/test/FHIRCacheManagerTest.java
+++ b/fhir-cache/src/test/java/com/ibm/fhir/cache/test/FHIRCacheManagerTest.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.cache.test;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.logging.Logger;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -18,6 +19,7 @@ import com.ibm.fhir.cache.CacheManager;
 import com.ibm.fhir.cache.CacheManager.Configuration;
 
 public class FHIRCacheManagerTest {
+    private static final Logger LOG = Logger.getLogger(FHIRCacheManagerTest.class.getName());
     @Test
     public void testTimeBasedEvictionCache() throws InterruptedException {
         Cache<String, Integer> cache = CacheManager.getCache("testCache", Configuration.of(Duration.of(1000, ChronoUnit.MILLIS)));
@@ -66,6 +68,8 @@ public class FHIRCacheManagerTest {
         cacheStats = cache.stats();
         Assert.assertEquals(cacheStats.hitCount(), 1);
         Assert.assertEquals(cacheStats.missCount(), 1);
+
+        CacheManager.reportCacheStats(LOG, "testCache");
 
         CacheManager.removeCache("testCache");
         Assert.assertNull(CacheManager.getCache("testCache"));

--- a/fhir-server/src/main/java/com/ibm/fhir/server/registry/ServerRegistryResourceProvider.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/registry/ServerRegistryResourceProvider.java
@@ -62,8 +62,12 @@ public class ServerRegistryResourceProvider extends AbstractRegistryResourceProv
     protected List<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType, String url) {
         String dataStoreId = FHIRRequestContext.get().getDataStoreId();
         CacheKey key = key(dataStoreId, url);
-        Map<CacheKey, List<FHIRRegistryResource>> cacheAsMap = CacheManager.getCacheAsMap(REGISTRY_RESOURCE_CACHE_NAME, REGISTRY_RESOURCE_CACHE_CONFIGURATION);
-        return cacheAsMap.computeIfAbsent(key, k -> computeRegistryResources(resourceType, url));
+        try {
+            Map<CacheKey, List<FHIRRegistryResource>> cacheAsMap = CacheManager.getCacheAsMap(REGISTRY_RESOURCE_CACHE_NAME, REGISTRY_RESOURCE_CACHE_CONFIGURATION);
+            return cacheAsMap.computeIfAbsent(key, k -> computeRegistryResources(resourceType, url));
+        } finally {
+            CacheManager.reportCacheStats(log, REGISTRY_RESOURCE_CACHE_NAME);
+        }
     }
 
     @Override

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resolve/ServerResolveFunction.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resolve/ServerResolveFunction.java
@@ -52,6 +52,7 @@ public class ServerResolveFunction extends ResolveFunction {
     @Override
     protected Resource resolveRelativeReference(EvaluationContext evaluationContext, FHIRPathNode node, String resourceType, String logicalId, String versionId) {
         Map<CacheKey, Object> cacheAsMap = CacheManager.getCacheAsMap(RESOURCE_CACHE_NAME, RESOURCE_CACHE_CONFIGURATION);
+        CacheManager.reportCacheStats(log, RESOURCE_CACHE_NAME);
         CacheKey key = key(resourceType, logicalId, versionId);
         Object result = cacheAsMap.computeIfAbsent(key, k -> computeResource(evaluationContext, node, resourceType, logicalId, versionId));
         return (result != NULL) ? (Resource) result : null;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Capabilities.java
@@ -146,6 +146,7 @@ public class Capabilities extends FHIRResource {
             Configuration configuration = Configuration.of(Duration.of(cacheTimeout, ChronoUnit.MINUTES));
 
             Map<String, Resource> cacheAsMap = CacheManager.getCacheAsMap(CAPABILITY_STATEMENT_CACHE_NAME, configuration);
+            CacheManager.reportCacheStats(log, CAPABILITY_STATEMENT_CACHE_NAME);
             Resource capabilityStatement = cacheAsMap.computeIfAbsent(mode, k -> computeCapabilityStatement(mode));
 
             RestAuditLogger.logMetadata(httpServletRequest, startTime, new Date(), Response.Status.OK);

--- a/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
+++ b/fhir-term/src/main/java/com/ibm/fhir/term/util/CodeSystemSupport.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -61,6 +62,7 @@ import com.ibm.fhir.term.service.FHIRTermService;
  * A utility class for working with FHIR code systems
  */
 public final class CodeSystemSupport {
+    private static final Logger LOG = Logger.getLogger(CodeSystemSupport.class.getName());
     public static final java.lang.String ANCESTORS_AND_SELF_CACHE_NAME = "com.ibm.fhir.term.util.CodeSystemSupport.ancestorsAndSelfCache";
     public static final java.lang.String DESCENDANTS_AND_SELF_CACHE_NAME = "com.ibm.fhir.term.util.CodeSystemSupport.descendantsAndSelfCache";
     public static final Configuration ANCESTORS_AND_SELF_CACHE_CONFIG = Configuration.of(128);
@@ -210,6 +212,7 @@ public final class CodeSystemSupport {
         }
         CacheKey key = key(codeSystem, code);
         Map<CacheKey, Set<java.lang.String>> cacheAsMap = CacheManager.getCacheAsMap(ANCESTORS_AND_SELF_CACHE_NAME, ANCESTORS_AND_SELF_CACHE_CONFIG);
+        CacheManager.reportCacheStats(LOG, ANCESTORS_AND_SELF_CACHE_NAME);
         return cacheAsMap.computeIfAbsent(key, k -> computeAncestorsAndSelf(codeSystem, code));
     }
 
@@ -458,6 +461,7 @@ public final class CodeSystemSupport {
         }
         CacheKey key = key(codeSystem, code);
         Map<CacheKey, Set<java.lang.String>> cacheAsMap = CacheManager.getCacheAsMap(DESCENDANTS_AND_SELF_CACHE_NAME, DESCENDANTS_AND_SELF_CACHE_CONFIG);
+        CacheManager.reportCacheStats(LOG, DESCENDANTS_AND_SELF_CACHE_NAME);
         return cacheAsMap.computeIfAbsent(key, k -> computeDescendantsAndSelf(codeSystem, code));
     }
 


### PR DESCRIPTION
- Added CacheStats hooks to the CacheManager.getCache callers
- Adding logging trace string to activate:
	- Cache on the Capabilities class
com.ibm.fhir.server.resources.Capabilities=finest
	- Server Registry provider
:com.ibm.fhir.server.registry.ServerRegistryResourceProvider=finest
	- paired with the CacheManager stats guard
com.ibm.fhir.cache.CacheManager=fine
- The intent of the pairing means that meaningless CacheManager stats
are not dumped into the sysout syserror (the output is at the FINE
level)

Examples of the output:
- initial load
```
[9/23/21, 15:50:02:900 UTC] 00000038 Capabilities  1   CacheStats for
'com.ibm.fhir.server.resources.Capabilities.statementCache'
averageLoadPenalty=[0.0],evictionCount=[0],hitCount=[0],hitRate=[1.0],loadCount=[0],missCount=[0],requestCount=[0],missRate=[0.0],loadFailureRate=[0.0]
```
- After multiple calls

```
CacheStats for
'com.ibm.fhir.server.resources.Capabilities.statementCache'
averageLoadPenalty=[7.453065269E9],evictionCount=[0],hitCount=[1],hitRate=[0.5],loadCount=[1],missCount=[1],requestCount=[2],missRate=[0.5],loadFailureRate=[0.0]
```

TRACE_SPEC
*=info:com.ibm.fhir.server.resources.Capabilities=finest:com.ibm.fhir.cache.CacheManager=fine:com.ibm.fhir.server.registry.ServerRegistryResourceProvider=finest

Note, the use of the dual logger enables a dynamic non-configuration bound way of turning on or off the logging.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>