### PR TITLE
issue #2803 - checkout to base dir instead of subdir

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -22,15 +22,12 @@ jobs:
       - name: Checkout source code for main
         uses: actions/checkout@v2.3.4
         with:
-          path: fhir/
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Fetch the right branch
         env:
           BASE: ${{ github['base_ref'] }}
         run: |
-          cd fhir/
           git fetch --no-tags --prune --depth=1 origin +refs/heads/${BASE}:refs/remotes/origin/${BASE}
 
       - name: Setup java
@@ -41,12 +38,12 @@ jobs:
       - name: Gather the environment details
         if: always()
         run: |
-          bash fhir/build/common/gather-environment-details.sh
+          bash build/common/gather-environment-details.sh
 
       - name: Determine parameters for environment variables
         env:
           WORKSPACE: ${{ github.workspace }}
-        run: bash fhir/build/migration/bin/0_determine.sh ${{matrix.release}}
+        run: bash build/migration/bin/0_determine.sh ${{matrix.release}}
 
       - name: Restore the cache for the previous version
         if: "!contains(env.migration_skip, 'true')"
@@ -54,7 +51,7 @@ jobs:
         env:
           cache-name: migration-db-${{ matrix.datastore }}-${{ env.migration_branch }}
         with:
-            path: fhir/build/migration/.cache
+            path: build/migration/.cache
             key: ${{ env.cache-name }}-${{ hashFiles('db.tgz') }}
             restore-keys: |
               ${{ env.cache-name }}-${{ hashFiles('db.tgz') }}
@@ -64,7 +61,7 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/1_check-cache.sh ${{matrix.datastore}}
+          bash build/migration/bin/1_check-cache.sh ${{matrix.datastore}}
 
       - name: Checkout source code for previous
         if: "contains(env.migration_cache, 'false')"
@@ -80,52 +77,52 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/1_previous-setup.sh ${{matrix.datastore}}
+          bash build/migration/bin/1_previous-setup.sh ${{matrix.datastore}}
 
       - name: Setup docker-compose and database
         if: "contains(env.migration_cache, 'false')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/2_compose.sh ${{matrix.datastore}} ${{ env.migration_branch }}
+          bash build/migration/bin/2_compose.sh ${{matrix.datastore}} ${{ env.migration_branch }}
 
       - name: Run previous release's Integration Tests
         if: "contains(env.migration_cache, 'false')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/2_previous-integration-test.sh ${{matrix.datastore}}
-          bash fhir/build/migration/bin/3_previous-teardown.sh ${{matrix.datastore}}
+          bash build/migration/bin/2_previous-integration-test.sh ${{matrix.datastore}}
+          bash build/migration/bin/3_previous-teardown.sh ${{matrix.datastore}}
       
       - name: Setup previous release's cached database
         if: "contains(env.migration_cache, 'true')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/3_previous-cache-startup.sh ${{matrix.datastore}}
+          bash build/migration/bin/3_previous-cache-startup.sh ${{matrix.datastore}}
 
       - name: Migrate to the current release 
         if: "!contains(env.migration_skip, 'true')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/4_current-migrate.sh ${{matrix.datastore}}
+          bash build/migration/bin/4_current-migrate.sh ${{matrix.datastore}}
 
       - name: Run LATEST Integration Tests
         if: "!contains(env.migration_skip, 'true')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/5_current-pre-integration-test.sh ${{matrix.datastore}} ${{ env.migration_branch }}
-          bash fhir/build/migration/bin/6_current-reindex.sh ${{matrix.datastore}}
-          bash fhir/build/migration/bin/7_current-integration-test.sh ${{matrix.datastore}}
+          bash build/migration/bin/5_current-pre-integration-test.sh ${{matrix.datastore}} ${{ env.migration_branch }}
+          bash build/migration/bin/6_current-reindex.sh ${{matrix.datastore}}
+          bash build/migration/bin/7_current-integration-test.sh ${{matrix.datastore}}
 
       - name: Teardown and cleanup
         if: "!contains(env.migration_skip, 'true')"
         env:
           WORKSPACE: ${{ github.workspace }}
         run: |
-          bash fhir/build/migration/bin/8_teardown.sh ${{matrix.datastore}}
+          bash build/migration/bin/8_teardown.sh ${{matrix.datastore}}
 
       - name: Cache the Database
         if: "contains(env.migration_cache, 'false') && contains(env.migration_skip, 'false')"
@@ -133,17 +130,17 @@ jobs:
         with:
           key: migration-db-${{ matrix.datastore }}-${{ env.migration_branch }}
           path: | 
-            fhir/build/migration/.cache/db.tgz
+            build/migration/.cache/db.tgz
 
       - name: Gather error logs
-        if: failure()
+        if: always()
         env:
           WORKSPACE: ${{ github.workspace }}
-        run: bash fhir/build/common/gather-logs.sh migration ${{matrix.datastore}}
+        run: bash build/common/gather-logs.sh migration ${{matrix.datastore}}
 
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v2.2.0
         with:
           name: integration-test-results-${{ matrix.datastore }}-${{ matrix.release }}
-          path: fhir/build/migration/integration-test-results
+          path: build/migration/integration-test-results

--- a/build/common/gather-logs.sh
+++ b/build/common/gather-logs.sh
@@ -50,7 +50,7 @@ package_logs(){
     if [ -f ${WORKSPACE}/build/${workflow}/${job}/workarea/${job}-test1.log ]
     then
         echo "Move the '${job}' Elements to the output area'"
-        cp -pr build/${workflow}/${job}/workarea/${job}-test*.log ${it_results}
+        cp -pr ${WORKSPACE}/build/${workflow}/${job}/workarea/${job}-test*.log ${it_results}
     fi
 }
 

--- a/build/migration/bin/0_determine.sh
+++ b/build/migration/bin/0_determine.sh
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 
-set +x
+set -ex
 
 # generate_between_tag_changelog - generates the details of the changes between tags
 generate_between_tag_changelog() {
@@ -114,7 +114,6 @@ pick_version() {
 }
 
 ###############################################################################
-cd fhir/
 
 generate_between_tag_changelog
 should_run

--- a/build/migration/bin/1_check-cache.sh
+++ b/build/migration/bin/1_check-cache.sh
@@ -8,10 +8,10 @@
 
 set -x
 
-if [ -d ~/fhir/build/migration/.cache ]
+if [ -d ~/build/migration/.cache ]
 then
     echo "Listing the files in the cache: "
-    find ~/fhir/build/migration/.cache
+    find ~/build/migration/.cache
 fi
 
 if [ -f "$GITHUB_ENV" ]
@@ -20,21 +20,21 @@ then
     cat "$GITHUB_ENV"
 fi
 
-if [ ! -f ~/fhir/build/migration/.cache/db.tgz ]
+if [ ! -f ~/build/migration/.cache/db.tgz ]
 then
     echo "Skipping as the cached file does not exist"
     echo "migration_skip=false" >> $GITHUB_ENV
     exit 0
 fi
 
-if [ -z ~/fhir/build/migration/.cache/db.tgz ]
+if [ -z ~/build/migration/.cache/db.tgz ]
 then
     echo "The cached file is empty"
     echo "migration_skip=false" >> $GITHUB_ENV
     exit 0
 fi
 
-if [ "$(file ~/fhir/build/migration/.cache/db.tgz | grep -q 'gzip compressed data' && echo yes || echo no)" == "no" ]
+if [ "$(file ~/build/migration/.cache/db.tgz | grep -q 'gzip compressed data' && echo yes || echo no)" == "no" ]
 then
     echo "Invalid tgz format"
     echo "migration_skip=false" >> $GITHUB_ENV
@@ -49,7 +49,7 @@ then
     cat "$GITHUB_ENV"
 fi
 
-mkdir -p ${WORSKPACE}/fhir/build/migration/integration-test-results
+mkdir -p ${WORSKPACE}/build/migration/integration-test-results
 
 # EOF
 ###############################################################################

--- a/build/migration/bin/2_compose.sh
+++ b/build/migration/bin/2_compose.sh
@@ -13,10 +13,10 @@ set -x
 startup_database(){
     migration="${1}"
     version="${2}"
-    if [ -f "${WORKSPACE}/fhir/build/migration/${migration}/2_compose.sh" ]
+    if [ -f "${WORKSPACE}/build/migration/${migration}/2_compose.sh" ]
     then
         echo "Running [${migration}] setting up prerequisites"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/2_compose.sh "${version}"
+        bash ${WORKSPACE}/build/migration/${migration}/2_compose.sh "${version}"
     else
         echo "Docker Compose is not up and running"
         exit 1
@@ -28,7 +28,7 @@ startup_database(){
 pushd $(pwd) > /dev/null
 
 # Change to the release directory
-cd "${WORKSPACE}/fhir"
+cd "${WORKSPACE}"
 
 startup_database "${1}" "${2}"
 

--- a/build/migration/bin/2_previous-integration-test.sh
+++ b/build/migration/bin/2_previous-integration-test.sh
@@ -15,7 +15,7 @@ run_tests(){
     if [ ! -z "${migration}" ] && [ -f "build/migration/${migration}/2_previous-integration-test.sh" ]
     then 
         echo "Running [${migration}] previouos specific integration tests"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/2_previous-integration-test.sh
+        bash ${WORKSPACE}/build/migration/${migration}/2_previous-integration-test.sh
     else
         # Runs the migration tests
         echo "Running containers are:"
@@ -26,10 +26,10 @@ run_tests(){
         docker container inspect $(docker container ls | grep fhir_1 | awk '{print $NF}' ) | jq -r '.[]'
         echo ""
     
-        mkdir -p ${WORKSPACE}/fhir/build/migration/integration-test-results
+        mkdir -p ${WORKSPACE}/build/migration/integration-test-results
         echo "Running Integration tests: "
         mvn -B test -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress \
-            -DskipTests=false | tee ${WORKSPACE}/fhir/build/migration/integration-test-results/prev-integration-tests.log
+            -DskipTests=false | tee ${WORKSPACE}/build/migration/integration-test-results/prev-integration-tests.log
         # Add || docker container logs "$(docker container ls | grep fhir_1 | awk '{print $NF}' )"
         echo "Done Running Tests"
         echo ""
@@ -46,7 +46,7 @@ pushd $(pwd) > /dev/null
 # Change to the migration/bin directory
 cd "prev/"
 
-bash ${WORKSPACE}/fhir/build/common/wait_for_it.sh
+bash ${WORKSPACE}/build/common/wait_for_it.sh
 run_tests "${1}"
 
 # Reset to Original Directory

--- a/build/migration/bin/3_previous-cache-startup.sh
+++ b/build/migration/bin/3_previous-cache-startup.sh
@@ -14,7 +14,7 @@ set -o pipefail
 pushd $(pwd) > /dev/null
 
 # Change to the migration directory
-cd "${WORKSPACE}/fhir/build/migration/${1}/"
+cd "${WORKSPACE}/build/migration/${1}/"
 
 echo "Details for the db.tgz"
 ls -al ../workarea/db.tgz

--- a/build/migration/bin/3_previous-teardown.sh
+++ b/build/migration/bin/3_previous-teardown.sh
@@ -12,10 +12,10 @@ set -o pipefail
 # previous_teardown
 previous_teardown(){
     migration="${1}"
-    if [ -f "${WORKSPACE}/fhir/build/migration/${migration}/3_previous-teardown.sh" ]
+    if [ -f "${WORKSPACE}/build/migration/${migration}/3_previous-teardown.sh" ]
     then
         echo "Running [${migration}] setting setup prerequisites"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/3_previous-teardown.sh "${1}"
+        bash ${WORKSPACE}/build/migration/${migration}/3_previous-teardown.sh "${1}"
     fi
 }
 
@@ -24,7 +24,7 @@ previous_teardown(){
 pushd $(pwd) > /dev/null
 
 # Change to the migration/bin directory
-cd "${WORKSPACE}/fhir/build/migration/${1}/"
+cd "${WORKSPACE}/build/migration/${1}/"
 
 previous_teardown "${1}"
 

--- a/build/migration/bin/4_current-migrate.sh
+++ b/build/migration/bin/4_current-migrate.sh
@@ -14,7 +14,7 @@ run_migrate(){
 
     echo "Building the current docker image and the current java artifacts"
     pushd $(pwd) > /dev/null
-    cd "${WORKSPACE}/fhir"
+    cd "${WORKSPACE}"
     mvn -T2C -B install --file fhir-examples --no-transfer-progress
     mvn -T2C -B install --file fhir-parent -DskipTests -P include-fhir-igs,integration --no-transfer-progress
 
@@ -23,10 +23,10 @@ run_migrate(){
     cd ..
     popd > /dev/null
 
-    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/fhir/build/migration/${migration}/4_current-migrate.sh" ]
+    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/build/migration/${migration}/4_current-migrate.sh" ]
     then 
         echo "Running [${migration}] migration"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/4_current-migrate.sh
+        bash ${WORKSPACE}/build/migration/${migration}/4_current-migrate.sh
     fi
 }
 
@@ -34,9 +34,6 @@ run_migrate(){
 
 # Store the current directory to reset to
 pushd $(pwd) > /dev/null
-
-# Change to the migration/bin directory
-cd "fhir/"
 
 run_migrate "${1}"
 

--- a/build/migration/bin/5_current-pre-integration-test.sh
+++ b/build/migration/bin/5_current-pre-integration-test.sh
@@ -11,10 +11,10 @@ set -ex
 # current_migration_pre - executes for each migration pre integration steps
 current_migration_pre(){
     migration="${1}"
-    if [ ! -z "${migration}" ] && [ -f ${WORKSPACE}/fhir/build/migration/${migration}/5_current-pre-integration-test.sh ]
+    if [ ! -z "${migration}" ] && [ -f ${WORKSPACE}/build/migration/${migration}/5_current-pre-integration-test.sh ]
     then 
         echo "Running [${migration}] current pre-integration-test"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/5_current-pre-integration-test.sh
+        bash ${WORKSPACE}/build/migration/${migration}/5_current-pre-integration-test.sh
     fi
 }
 

--- a/build/migration/bin/6_current-reindex.sh
+++ b/build/migration/bin/6_current-reindex.sh
@@ -11,14 +11,14 @@ set -x
 run_reindex(){
     migration="${1}"
 
-    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/fhir/build/migration/${migration}/6_current-reindex.sh" ]
+    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/build/migration/${migration}/6_current-reindex.sh" ]
     then 
         echo "Running [${migration}] specific integration tests"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/6_current-reindex.sh
+        bash ${WORKSPACE}/build/migration/${migration}/6_current-reindex.sh
     else
         # Run the $reindex
         i=1
-        bash ${WORKSPACE}/fhir/build/common/wait_for_it.sh
+        bash ${WORKSPACE}/build/common/wait_for_it.sh
         # Date YYYY-MM-DDTHH:MM:SSZ
         DATE_ISO=$(date +%Y-%m-%dT%H:%M:%SZ)
         status=$(curl -k -X POST -o reindex.json -i -w '%{http_code}' -u 'fhiruser:change-password' 'https://localhost:9443/fhir-server/api/v4/$reindex' \
@@ -67,9 +67,6 @@ run_reindex(){
 
 # Store the current directory to reset to
 pushd $(pwd) > /dev/null
-
-# Change to the migration/bin directory
-cd "fhir/"
 
 run_reindex "${1}"
 

--- a/build/migration/bin/7_current-integration-test.sh
+++ b/build/migration/bin/7_current-integration-test.sh
@@ -13,17 +13,17 @@ run_tests(){
     # The integration tests may be overriden completely, or fall through to the default. 
     migration="${1}"
 
-    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/fhir/build/migration/${migration}/7_current-integration-test.sh" ]
+    if [ ! -z "${migration}" ] && [ -f "${WORKSPACE}/build/migration/${migration}/7_current-integration-test.sh" ]
     then 
         echo "Running [${migration}] specific integration tests"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/7_current-integration-test.sh
+        bash ${WORKSPACE}/build/migration/${migration}/7_current-integration-test.sh
     else
         # Runs the migration tests
-        cd ${WORKSPACE}/fhir
-        mkdir -p ${WORKSPACE}/fhir/build/migration/integration-test-results
+        cd ${WORKSPACE}
+        mkdir -p ${WORKSPACE}/build/migration/integration-test-results
         echo "Running Integration tests: "
         mvn -B test -f fhir-server-test -DskipWebSocketTest=true --no-transfer-progress \
-            -DskipTests=false | tee ${WORKSPACE}/fhir/build/migration/integration-test-results/current-integration-tests.log
+            -DskipTests=false | tee ${WORKSPACE}/build/migration/integration-test-results/current-integration-tests.log
 
         # Add || docker container logs "$(docker container ls --format {{.Names}} | grep -i ${migration} | grep -i fhir)"
         echo "Done Running Tests"
@@ -37,10 +37,7 @@ pushd $(pwd) > /dev/null
 
 export BASE="$(pwd)"
 
-# Change to the migration/bin directory
-cd "fhir/"
-
-bash ${WORKSPACE}/fhir/build/common/wait_for_it.sh
+bash ${WORKSPACE}/build/common/wait_for_it.sh
 run_tests "${1}"
 
 # Reset to Original Directory

--- a/build/migration/bin/8_teardown.sh
+++ b/build/migration/bin/8_teardown.sh
@@ -11,15 +11,13 @@ set -ex
 # migration_post - executes for each migration post integration steps
 migration_post(){
     migration="${1}"
-    if [ ! -z "${migration}" ] && [ -f ${WORKSPACE}/fhir/build/migration/${migration}/8_teardown.sh ]
+    if [ ! -z "${migration}" ] && [ -f ${WORKSPACE}/build/migration/${migration}/8_teardown.sh ]
     then 
         echo "Running [${migration}] teardown"
-        bash ${WORKSPACE}/fhir/build/migration/${migration}/8_teardown.sh
+        bash ${WORKSPACE}/build/migration/${migration}/8_teardown.sh
     else
-        cd ${WORKSPACE}/fhir/build/migration/${migration}/
-        docker-compose down --remove-orphans --rmi local -v --timeout 30
-        docker system df
-        docker system prune -f
+        cd ${WORKSPACE}/build/migration/${migration}/
+        docker-compose stop -v --timeout 30
     fi
 }
 

--- a/build/migration/db2/3_previous-teardown.sh
+++ b/build/migration/db2/3_previous-teardown.sh
@@ -15,7 +15,7 @@ set -o pipefail
 pushd $(pwd) > /dev/null
 
 # Change to the migration directory
-cd "${WORKSPACE}/fhir/build/migration/${1}/"
+cd "${WORKSPACE}/build/migration/${1}/"
 
 docker-compose down
 
@@ -33,11 +33,11 @@ do
 done
 
 echo "Creating the database cache"
-sudo chmod -R 755 ${WORKSPACE}/fhir/build/migration/${1}/workarea/volumes/dist/db
-tar czf ${WORKSPACE}/fhir/build/migration/${1}/workarea/db.tgz ${WORKSPACE}/fhir/build/migration/${1}/workarea/volumes/dist/db
+sudo chmod -R 755 ${WORKSPACE}/build/migration/${1}/workarea/volumes/dist/db
+tar czf ${WORKSPACE}/build/migration/${1}/workarea/db.tgz ${WORKSPACE}/build/migration/${1}/workarea/volumes/dist/db
 
 echo "Details for the db.tgz"
-ls -al ${WORKSPACE}/fhir/build/migration/${1}/workarea/db.tgz
+ls -al ${WORKSPACE}/build/migration/${1}/workarea/db.tgz
 
 # Reset to Original Directory
 popd > /dev/null

--- a/build/migration/db2/4_current-migrate.sh
+++ b/build/migration/db2/4_current-migrate.sh
@@ -16,7 +16,7 @@ set -o pipefail
 pushd $(pwd) > /dev/null
 
 # Change to the migration/bin directory
-cd "${WORKSPACE}/fhir/build/migration/db2"
+cd "${WORKSPACE}/build/migration/db2"
 
 # Startup db
 docker-compose up --remove-orphans -d db
@@ -42,27 +42,27 @@ done
 
 echo ">>> Persistence >>> current is being run"
 echo 'change-password' > tenant.key
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type db2 --prop db.host=localhost --prop db.port=50000 --prop db.database=fhirdb \
     --prop user=db2inst1 --prop password=change-password \
     --update-schema --grant-to fhirserver
 
 echo ">>> Set up the derby databases for multidatastore scenarios"
-DB_LOC="${WORKSPACE}/fhir/build/migration/db2/workarea/volumes/dist/derby"
-rm -rf ${WORKSPACE}/fhir/build/migration/db2/workarea/volumes/dist/derby
+DB_LOC="${WORKSPACE}/build/migration/db2/workarea/volumes/dist/derby"
+rm -rf ${WORKSPACE}/build/migration/db2/workarea/volumes/dist/derby
 mkdir -p ${DB_LOC}
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/fhirDB --prop db.create=Y \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Device,Organization,Location,Medication,Observation,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/study1 --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Device,Organization,Location,Encounter,AllergyIntolerance,Observation,Condition,CarePlan,Provenance,Medication,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema

--- a/build/migration/db2/5_current-pre-integration-test.sh
+++ b/build/migration/db2/5_current-pre-integration-test.sh
@@ -16,7 +16,7 @@ pre_integration(){
 
 # config - update configuration
 config(){
-    DIST="${WORKSPACE}/fhir/build/migration/db2/workarea/volumes/dist"
+    DIST="${WORKSPACE}/build/migration/db2/workarea/volumes/dist"
 
     echo "Create the db volume..."
     mkdir -p ${DIST}/db
@@ -25,25 +25,25 @@ config(){
     echo "Copying fhir configuration files..."
     rm -rf ${DIST}/config
     mkdir -p ${DIST}/config
-    cp -pr ${WORKSPACE}/fhir/fhir-server-webapp/src/main/liberty/config/config $DIST
-    cp -pr ${WORKSPACE}/fhir/fhir-server/liberty-config-tenants/config/* $DIST/config
+    cp -pr ${WORKSPACE}/fhir-server-webapp/src/main/liberty/config/config $DIST
+    cp -pr ${WORKSPACE}/fhir-server/liberty-config-tenants/config/* $DIST/config
 
     echo "Copying test artifacts to install location..."
     USERLIB="${DIST}/userlib"
     rm -rf ${DIST}/userlib
     mkdir -p "${USERLIB}"
-    find ${WORKSPACE}/fhir/conformance -iname 'fhir-ig*.jar' -not -iname 'fhir*-tests.jar' -not -iname 'fhir*-test-*.jar' -exec cp -f {} ${USERLIB} \;
-    find ${WORKSPACE}/fhir/operation/fhir-operation-test/target -iname '*.jar' -exec cp -f {} ${USERLIB} \;
-    if [ -d ${WORKSPACE}/fhir/operation/fhir-operation-term-cache/target ]
+    find ${WORKSPACE}/conformance -iname 'fhir-ig*.jar' -not -iname 'fhir*-tests.jar' -not -iname 'fhir*-test-*.jar' -exec cp -f {} ${USERLIB} \;
+    find ${WORKSPACE}/operation/fhir-operation-test/target -iname '*.jar' -exec cp -f {} ${USERLIB} \;
+    if [ -d ${WORKSPACE}/operation/fhir-operation-term-cache/target ]
     then
-        find ${WORKSPACE}/fhir/operation/fhir-operation-term-cache/target -iname '*.jar' -exec cp -f {} ${USERLIB} \;
+        find ${WORKSPACE}/operation/fhir-operation-term-cache/target -iname '*.jar' -exec cp -f {} ${USERLIB} \;
     fi
 
     echo "Remove the old overrides, and copy the current overrides for the datasource"
     rm -rf ${DIST}/overrides
     mkdir -p ${DIST}/overrides
-    cp -p ${WORKSPACE}/fhir/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/datasource-db2.xml ${DIST}/overrides
-    cp -p ${WORKSPACE}/fhir/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/datasource-derby.xml ${DIST}/overrides
+    cp -p ${WORKSPACE}/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/datasource-db2.xml ${DIST}/overrides
+    cp -p ${WORKSPACE}/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/datasource-derby.xml ${DIST}/overrides
 
     # Move over the test configurations
     echo "Copying over the fhir-server-config.json and updating publishing"
@@ -59,7 +59,7 @@ config(){
 
 # bringup
 bringup(){
-    cd ${WORKSPACE}/fhir/build/migration/db2
+    cd ${WORKSPACE}/build/migration/db2
     echo "Bringing up containers >>> Current time: " $(date)
     # Startup db
     export IMAGE_VERSION="snapshot"
@@ -105,7 +105,7 @@ bringup(){
 
 ###############################################################################
 
-cd ${WORKSPACE}/fhir/build/migration/db2
+cd ${WORKSPACE}/build/migration/db2
 pre_integration
 
 # EOF

--- a/build/migration/postgres/3_previous-teardown.sh
+++ b/build/migration/postgres/3_previous-teardown.sh
@@ -15,7 +15,7 @@ set -o pipefail
 pushd $(pwd) > /dev/null
 
 # Change to the migration directory
-cd "${WORKSPACE}/fhir/build/migration/${1}/"
+cd "${WORKSPACE}/build/migration/${1}/"
 
 docker-compose down
 
@@ -33,11 +33,11 @@ do
 done
 
 echo "Creating the database cache"
-sudo chmod -R 755 ${WORKSPACE}/fhir/build/migration/${1}/workarea/volumes/dist/db
-tar czf ${WORKSPACE}/fhir/build/migration/${1}/workarea/db.tgz ${WORKSPACE}/fhir/build/migration/${1}/workarea/volumes/dist/db
+sudo chmod -R 755 ${WORKSPACE}/build/migration/${1}/workarea/volumes/dist/db
+tar czf ${WORKSPACE}/build/migration/${1}/workarea/db.tgz ${WORKSPACE}/build/migration/${1}/workarea/volumes/dist/db
 
 echo "Details for the db.tgz"
-ls -al ${WORKSPACE}/fhir/build/migration/${1}/workarea/db.tgz
+ls -al ${WORKSPACE}/build/migration/${1}/workarea/db.tgz
 
 # Reset to Original Directory
 popd > /dev/null

--- a/build/migration/postgres/4_current-migrate.sh
+++ b/build/migration/postgres/4_current-migrate.sh
@@ -16,13 +16,13 @@ set -o pipefail
 pushd $(pwd) > /dev/null
 
 # Change to the migration/bin directory
-cd "${WORKSPACE}/fhir/build/migration/postgres"
+cd "${WORKSPACE}/build/migration/postgres"
 
 # In order not to hit this after packaging everything up,w e want to run this before we start up the db.
 # waiting for server to start....2021-07-16 20:42:03.136 UTC [9] FATAL:  data directory "/db/data" has invalid permissions
 # 2021-07-16 20:42:03.136 UTC [9] DETAIL:  Permissions should be u=rwx (0700) or u=rwx,g=rx (0750).
-sudo chown -R 70:70 ${WORKSPACE}/fhir/build/migration/postgres/workarea/volumes/dist/db
-sudo chmod -R 0750 ${WORKSPACE}/fhir/build/migration/postgres/workarea/volumes/dist/db
+sudo chown -R 70:70 ${WORKSPACE}/build/migration/postgres/workarea/volumes/dist/db
+sudo chmod -R 0750 ${WORKSPACE}/build/migration/postgres/workarea/volumes/dist/db
 
 # Startup db
 docker-compose up --remove-orphans -d db
@@ -50,33 +50,33 @@ done
 echo ">>> Persistence >>> current is being run"
 
 echo "- Update Schema"
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type postgresql --prop db.host=localhost --prop db.port=5432 --prop db.database=fhirdb \
     --prop user=fhiradmin --prop password=change-password \
     --schema-name FHIRDATA --update-schema --pool-size 1
 
 echo "- Grants to FHIRSERVER"
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type postgresql --prop db.host=localhost --prop db.port=5432 --prop db.database=fhirdb \
     --prop user=fhiradmin --prop password=change-password \
     --schema-name FHIRDATA --grant-to FHIRSERVER --pool-size 1
 
 echo ">>> Set up the derby databases for multidatastore scenarios"
-DB_LOC="${WORKSPACE}/fhir/build/migration/postgres/workarea/volumes/dist/derby"
-rm -rf ${WORKSPACE}/fhir/build/migration/postgres/workarea/volumes/dist/derby
+DB_LOC="${WORKSPACE}/build/migration/postgres/workarea/volumes/dist/derby"
+rm -rf ${WORKSPACE}/build/migration/postgres/workarea/volumes/dist/derby
 mkdir -p ${DB_LOC}
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/fhirDB --prop db.create=Y \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Device,Organization,Location,Medication,Observation,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema
-java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
+java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/study1 --prop db.create=Y \
     --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Device,Organization,Location,Encounter,AllergyIntolerance,Observation,Condition,CarePlan,Provenance,Medication,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource \
     --update-schema

--- a/build/pre-integration-test.ps1
+++ b/build/pre-integration-test.ps1
@@ -69,7 +69,7 @@ java -jar $SCHEMATOOL `
   --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Device,Organization,Location,Encounter,AllergyIntolerance,Observation,Condition,CarePlan,Provenance,Medication,MedicationAdministration,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Resource `
   --update-schema
 
-# If the Config Exists, let's wipe it outfind
+# If the Config Exists, let's wipe it out
 Write-Host 'Copying configuration to install location'
 $RM_ITEM=[string]$SIT + '\wlp\usr\servers\fhir-server\config'
 If ( Test-Path $RM_ITEM ) {


### PR DESCRIPTION
Accidentally did this on top of liberty-dev-mode, but pushed anyway because I want to see if it works or not.
The original design was to checkout the "current" code in the fhir subdir so that it doesn't conflict with the "prev" code in the "prev" subdir.  But that causes some trouble with "common" utilities.  This PR checks out "current" code in the default (base) dir and hopefully that still works (and fixes 2803).

My backup idea was to set WORKSPACE to the fhir subdir in this particular case.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>