### PR TITLE
Handle null values in fhir-server-config and throw for exceptional case

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -237,12 +237,16 @@ public class PropertyGroup {
     /**
      * Returns the properties contained in the PropertyGroup in the form of a list of
      * PropertyEntry instances. If no properties exist, then an empty list will be returned.
+     * Properties with a value of null will be omitted from the list.
      * @throws Exception
      */
     public List<PropertyEntry> getProperties() throws Exception {
         List<PropertyEntry> results = new ArrayList<>();
         for (Map.Entry<String, JsonValue> entry : jsonObj.entrySet()) {
-            results.add(new PropertyEntry(entry.getKey(), convertJsonValue(entry.getValue())));
+            Object jsonValue = convertJsonValue(entry.getValue());
+            if (jsonValue != null) {
+                results.add(new PropertyEntry(entry.getKey(), convertJsonValue(entry.getValue())));
+            }
         }
         return results;
     }

--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -11,13 +11,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.ibm.fhir.core.FHIRUtilities;
+
 import jakarta.json.JsonArray;
 import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
-
-import com.ibm.fhir.core.FHIRUtilities;
 
 /**
  * This class represents a collection of properties - a property group. This could be the entire set of properties
@@ -107,7 +107,7 @@ public class PropertyGroup {
     /**
      * This is a convenience function that will retrieve an array property, then convert it
      * to a list of Strings by calling toString() on each array element.
-     * 
+     *
      * @param propertyName the name of the property to retrieve
      * @return a List<String> containing the elements from the JSON array property; possibly null
      * @throws Exception
@@ -262,7 +262,7 @@ public class PropertyGroup {
     /**
      * Converts the specified JsonValue into the appropriate java.lang.* type.
      * @param jsonValue the JsonValue instance to be converted
-     * @return an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
+     * @return either null or an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
      * @throws Exception
      */
     public static Object convertJsonValue(JsonValue jsonValue) throws Exception {
@@ -291,6 +291,8 @@ public class PropertyGroup {
             break;
         case FALSE:
             result = Boolean.FALSE;
+            break;
+        case NULL:
             break;
         default:
             throw new IllegalStateException("Unexpected JSON value type: " + jsonValue.getValueType().name());

--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -323,6 +323,7 @@ public class PropertyGroup {
      *
      * @param propertyName
      *            the possibly hierarchical property name.
+     * @return the property value as a JsonValue or null if the property is either missing or has a null value
      */
     public JsonValue getJsonValue(String propertyName) {
         String[] pathElements = getPathElements(propertyName);
@@ -331,7 +332,7 @@ public class PropertyGroup {
         if (subGroup != null) {
             result = subGroup.get(pathElements[pathElements.length - 1]);
         }
-        return result;
+        return result == JsonValue.NULL ? null : result;
     }
 
     /**

--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -245,7 +245,7 @@ public class PropertyGroup {
         for (Map.Entry<String, JsonValue> entry : jsonObj.entrySet()) {
             Object jsonValue = convertJsonValue(entry.getValue());
             if (jsonValue != null) {
-                results.add(new PropertyEntry(entry.getKey(), convertJsonValue(entry.getValue())));
+                results.add(new PropertyEntry(entry.getKey(), jsonValue));
             }
         }
         return results;

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
@@ -1,16 +1,16 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2020
+ * (C) Copyright IBM Corp. 2017, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.config.test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertNotNull;
-import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import java.io.PrintWriter;
 import java.util.Arrays;
@@ -33,6 +33,9 @@ public class FHIRConfigHelperTest {
 
     String[] array2 = { "token3", "token4" };
     List<String> expectedList2 = Arrays.asList(array2);
+
+    String[] arrayWithNull = { "token1", null, "token2" };
+    List<String> expectedListWithNull = Arrays.asList(arrayWithNull);
 
     // String used to write out json config file on the fly.
     String tenant3ConfigTemplate =
@@ -62,39 +65,72 @@ public class FHIRConfigHelperTest {
         Double d;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
-        assertEquals("defaultValue1", s);
+        assertEquals(s, "defaultValue1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
-        assertEquals("defaultValue2", s);
+        assertEquals(s, "defaultValue2");
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
-        assertEquals(expectedList1, l);
+        assertEquals(l, expectedList1);
 
         s = FHIRConfigHelper.getStringProperty("collection/groupB/boolProp1", null);
         assertNotNull(s);
-        assertEquals("false", s);
+        assertEquals(s, "false");
 
         i = FHIRConfigHelper.getIntProperty("collection/groupC/intProp1", null);
         assertNotNull(i);
-        assertEquals(12345, i.intValue());
+        assertEquals(i.intValue(), 12345);
 
         i = FHIRConfigHelper.getIntProperty("collection/groupC/intProp2", null);
         assertNotNull(i);
-        assertEquals(12345, i.intValue());
+        assertEquals(i.intValue(), 12345);
 
         d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp2", null);
         assertNotNull(d);
-        assertEquals(12345.001, d.doubleValue());
+        assertEquals(d.doubleValue(), 12345.001);
+    }
+
+    @Test
+    public void testNullValues() throws Exception {
+        String tenant = FHIRConfigHelper.getStringProperty("collection/tenant", null);
+        assertNotNull(tenant);
+        assertEquals("default", tenant);
+
+        String s;
+        Boolean b;
+        Integer i;
+        Double d;
+        List<String> l;
+
+        s = FHIRConfigHelper.getStringProperty("collection/groupD/nullProp", "defaultValue1");
+        assertNotNull(s);
+        assertEquals(s, "defaultValue1");
+
+        b = FHIRConfigHelper.getBooleanProperty("collection/groupD/nullProp", false);
+        assertNotNull(b);
+        assertEquals(b, Boolean.FALSE);
+
+        i = FHIRConfigHelper.getIntProperty("collection/groupD/nullProp", 12345);
+        assertNotNull(i);
+        assertEquals(i.intValue(), 12345);
+
+        d = FHIRConfigHelper.getDoubleProperty("collection/groupD/nullProp", 12345.001);
+        assertNotNull(d);
+        assertEquals(d.doubleValue(), 12345.001);
+
+        l = FHIRConfigHelper.getStringListProperty("collection/groupD/stringListWithNullProp");
+        assertNotNull(l);
+        assertEquals(l, expectedListWithNull);
     }
 
     @Test
@@ -110,23 +146,23 @@ public class FHIRConfigHelperTest {
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
-        assertEquals("tenant1Value1", s);
+        assertEquals(s, "tenant1Value1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
-        assertEquals("defaultValue2", s);
+        assertEquals(s, "defaultValue2");
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.TRUE, b);
+        assertEquals(b, Boolean.TRUE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
-        assertEquals(expectedList2, l);
+        assertEquals(l, expectedList2);
     }
 
     @Test
@@ -140,25 +176,26 @@ public class FHIRConfigHelperTest {
         List<String> l;
         String s;
         Boolean b;
+
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
-        assertEquals("defaultValue1", s);
+        assertEquals(s, "defaultValue1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
-        assertEquals("tenant2Value2", s);
+        assertEquals(s, "tenant2Value2");
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
-        assertEquals(Boolean.TRUE, b);
+        assertEquals(b, Boolean.TRUE);
 
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
-        assertEquals(0, l.size());
+        assertEquals(l.size(), 0);
     }
 
     @Test
@@ -178,11 +215,11 @@ public class FHIRConfigHelperTest {
         // Load tenant3's config and check the initial property values.
         String s = FHIRConfigHelper.getStringProperty("fhirServer/property1", null);
         assertNotNull(s);
-        assertEquals("property1Value1", s);
+        assertEquals(s, "property1Value1");
 
         s = FHIRConfigHelper.getStringProperty("fhirServer/property2", null);
         assertNotNull(s);
-        assertEquals("property2Value1", s);
+        assertEquals(s, "property2Value1");
 
         // Sleep for just a bit to make sure the updated config file has a newer timestamp.
         Thread.sleep(1000);
@@ -196,11 +233,11 @@ public class FHIRConfigHelperTest {
 
         s = FHIRConfigHelper.getStringProperty("fhirServer/property1", null);
         assertNotNull(s);
-        assertEquals("property1Value2", s);
+        assertEquals(s, "property1Value2");
 
         s = FHIRConfigHelper.getStringProperty("fhirServer/property2", null);
         assertNotNull(s);
-        assertEquals("property2Value2", s);
+        assertEquals(s, "property2Value2");
     }
 
     @Test
@@ -218,36 +255,36 @@ public class FHIRConfigHelperTest {
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
-        assertEquals("defaultValue1", s);
+        assertEquals(s, "defaultValue1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
-        assertEquals("defaultValue2", s);
+        assertEquals(s, "defaultValue2");
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
-        assertEquals(expectedList1, l);
+        assertEquals(l, expectedList1);
 
         Double d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp1", 1.0);
         assertNotNull(d);
-        assertEquals(12345.001, d);
+        assertEquals(d.doubleValue(), 12345.001);
 
         d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp2", 1.0);
         assertNotNull(d);
-        assertEquals(12345.001, d);
+        assertEquals(d.doubleValue(), 12345.001);
 
         d = FHIRConfigHelper.getDoubleProperty("collection/groupC/doubleProp3", 1.0);
         assertNotNull(d);
-        assertEquals(1.0, d);
-        
+        assertEquals(d.doubleValue(), 1.0);
+
         assertNotNull(FHIRConfiguration.getInstance().loadConfiguration().toString());
         assertFalse(FHIRConfiguration.getInstance().loadConfiguration().toString().isEmpty());
     }
@@ -268,31 +305,31 @@ public class FHIRConfigHelperTest {
         Boolean b;
         s = FHIRConfigHelper.getStringProperty("collection/groupA/newProp1", null);
         assertNotNull(s);
-        assertEquals("newValue1", s);
+        assertEquals(s, "newValue1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp1", null);
         assertNotNull(s);
-        assertEquals("defaultValue1", s);
+        assertEquals(s, "defaultValue1");
 
         s = FHIRConfigHelper.getStringProperty("collection/groupA/stringProp2", null);
         assertNotNull(s);
-        assertEquals("defaultValue2", s);
+        assertEquals(s, "defaultValue2");
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/boolProp2", null);
         assertNotNull(b);
-        assertEquals(Boolean.FALSE, b);
+        assertEquals(b, Boolean.FALSE);
 
         b = FHIRConfigHelper.getBooleanProperty("collection/groupB/newBoolProp1", null);
         assertNotNull(b);
-        assertEquals(Boolean.TRUE, b);
+        assertEquals(b, Boolean.TRUE);
 
         l = FHIRConfigHelper.getStringListProperty("collection/groupB/stringList1");
         assertNotNull(l);
-        assertEquals(expectedList1, l);
+        assertEquals(l, expectedList1);
     }
 
     @Test

--- a/fhir-config/src/test/resources/config/default/fhir-server-config.json
+++ b/fhir-config/src/test/resources/config/default/fhir-server-config.json
@@ -16,6 +16,10 @@
             "intProp2": "12345",
             "doubleProp1": 12345.001,
             "doubleProp2": "12345.001"
+        },
+        "groupD": {
+            "nullProp": null,
+            "stringListWithNullProp": ["token1", null, "token2"]
         }
     },
     "fhirServer": {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/registry/ServerRegistryResourceProvider.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/registry/ServerRegistryResourceProvider.java
@@ -136,13 +136,13 @@ public class ServerRegistryResourceProvider extends AbstractRegistryResourceProv
                         .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
             }
         } catch (Exception e) {
-            log.log(Level.WARNING, "An error occurred during a search interaction", e);
+            log.log(Level.WARNING, "An error occurred during the underlying search interaction; returning empty", e);
         } finally {
             if (transactionHelper != null) {
                 try {
                     transactionHelper.rollback();
                 } catch (FHIRPersistenceException e) {
-                    log.log(Level.WARNING, "An error occurred ending the current transaction", e);
+                    log.log(Level.WARNING, "An error occurred while rolling back the current transaction", e);
                 }
             }
         }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -3279,8 +3279,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 }
             }
         } catch (Exception e) {
-            return Collections.singletonList(buildOperationOutcomeIssue(IssueSeverity.ERROR, IssueType.UNKNOWN,
-                "Error retrieving profile configuration."));
+            throw new FHIRValidationException("Error retrieving profile configuration.", e);
         }
 
         // If required profiles were configured, perform validation of asserted profiles against required profiles


### PR DESCRIPTION
Previously, we'd throw an IllegalStateException if we encountered a
null value. This came up because the helm `toJson` function produces all
possible fields for an object, even when some are null.

Additionally, if we have an invalid config (such as described above), in
FHIRRestHelper.validateResource we were swallowing the underlying
exception and instread constructing a generic OperationOutcomeIssue with
message "Error retrieving profile configuration". This meant we were missing
the root cause in our logs and also meant that this exception was being handled
just like any other validation error and so, even though it was a server
config issue, this was not clear to the client.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>