### PR TITLE
Move kafka-clients from 2.8.1 to 3.0.0 #2923

### DIFF
--- a/fhir-audit/pom.xml
+++ b/fhir-audit/pom.xml
@@ -29,6 +29,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/impl/KafkaService.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/impl/KafkaService.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,8 @@ package com.ibm.fhir.audit.impl;
 
 import static com.ibm.fhir.audit.AuditLogServiceConstants.IGNORED_AUDIT_EVENT_TYPE;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -101,7 +102,7 @@ public class KafkaService implements AuditLogService {
     @Override
     public void stop(PropertyGroup auditLogProperties) throws Exception {
         try{
-            this.producer.close(30, TimeUnit.SECONDS);
+            this.producer.close(Duration.of(30, ChronoUnit.SECONDS));
         } catch(InterruptException ie) {
             logger.warning("During shutdown... stopping the producer");
         }

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.8.1</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>io.nats</groupId>


### PR DESCRIPTION
- Need to make a slight code change and dependency change. 
- Added slf4j-api to fhir-audit
- KafkaService - Change timeout to use Duration.of 

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>