### PR TITLE
Issue 2843 - store both versioned and unversioned canonicals in ParametersMap

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -48,10 +48,11 @@
         <fhir-persistence-jdbc.index>MINIMAL_JSON</fhir-persistence-jdbc.index>
         <fhir-server-test.index>MINIMAL_JSON</fhir-server-test.index>
         <java.version>1.8</java.version>
+        <fhir-examples.version>4.10.0-SNAPSHOT</fhir-examples.version>
         <fhir-tools.version>4.10.0-SNAPSHOT</fhir-tools.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-        <!-- We use github depend-a-bot to keep dependencies up-to-date and that doesn't
-             yet support dependencies with versions from variables, so prefer inlining over version vars -->
+        <!-- We use github depend-a-bot to keep dependencies up-to-date and that doesn't seem to work as well
+             for dependencies with versions from variables, so prefer inlining over version vars -->
     </properties>
 
     <modules>
@@ -110,7 +111,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>fhir-examples</artifactId>
-                <version>4.9.2</version>
+                <version>${fhir-examples.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/fhir-search/pom.xml
+++ b/fhir-search/pom.xml
@@ -33,6 +33,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <!-- Strictly for testing with search parameters loaded from new providers -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-ig-us-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-validation</artifactId>
             <version>${project.version}</version>

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
@@ -15,17 +15,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.ibm.fhir.model.resource.SearchParameter;
 
 /**
- * A multi-key map that indexes a set of search parameters by SearchParameter.code and SearchParameter.url
+ * A multi-key map that indexes a set of search parameters by SearchParameter.code and
+ * SearchParameter.url / canonical (url + "|" + version)
  */
 public class ParametersMap {
     private static final Logger log = Logger.getLogger(ParametersMap.class.getName());
 
     private final Map<String, Set<SearchParameter>> codeMap;
-    private final Map<String, SearchParameter> urlMap;
+    private final Map<String, SearchParameter> canonicalMap;
 
     /**
      * Construct a ParametersMap from a Bundle of SearchParameter
@@ -33,7 +35,7 @@ public class ParametersMap {
     public ParametersMap() {
         // LinkedHashMaps to preserve insertion order
         codeMap = new LinkedHashMap<>();
-        urlMap = new LinkedHashMap<>();
+        canonicalMap = new LinkedHashMap<>();
     }
 
     public void insert(String code, SearchParameter parameter) {
@@ -41,28 +43,50 @@ public class ParametersMap {
         Objects.requireNonNull(parameter, "cannot insert a null parameter");
 
         String url = parameter.getUrl().getValue();
+        String version = parameter.getVersion() == null ? null : parameter.getVersion().getValue();
+
         Set<SearchParameter> previousParams = codeMap.get(code);
         if (previousParams != null && previousParams.size() > 0) {
             if (log.isLoggable(Level.FINE)) {
-                log.fine("SearchParameter with code '" + code + "' already exists; adding additional parameter with url '" + url + "'");
+                log.fine("SearchParameter with code '" + code + "' already exists; adding additional parameter '" + url + "'");
             }
         }
         codeMap.computeIfAbsent(code, k -> new HashSet<>()).add(parameter);
 
-        if (urlMap.containsKey(url)) {
-            SearchParameter previous = urlMap.get(url);
+        // for versioned search params, we store them in the canonicalMap twice:
+        // once with their version and once without it
+        if (canonicalMap.containsKey(url)) {
+            SearchParameter previous = canonicalMap.get(url);
             if (previous.getExpression() == null || previous.getExpression().equals(parameter.getExpression())) {
                 if (!code.equals(previous.getCode().getValue())) {
-                    log.info("SearchParameter with url '" + url + "' already exists with the same expression; "
+                    log.info("SearchParameter '" + url + "' already exists with the same expression; "
                             + "adding additional code '" + code + "'");
                 }
             } else {
-                log.warning("SearchParameter with url '" + url + "' already exists with a different expression;\n"
-                        + "replacing [id=" + previous.getId() + ", expression=" + previous.getExpression().getValue()
-                        + "] with [id=" + parameter.getId() + ", expression=" + parameter.getExpression().getValue() + "]");
+                log.info("SearchParameter '" + url + "' already exists with a different expression;\n"
+                        + "replacing [id=" + previous.getId() + ", version=" + previous.getVersion().getValue() + ", expression=" + previous.getExpression().getValue()
+                        + "] with [id=" + parameter.getId() + ", version=" + parameter.getVersion().getValue() + ", expression=" + parameter.getExpression().getValue() + "]");
             }
         }
-        urlMap.put(url, parameter);
+        canonicalMap.put(url, parameter);
+
+        if (version != null) {
+            String canonical = url + (version == null ? "" : "|" + version);
+            if (canonicalMap.containsKey(canonical)) {
+                SearchParameter previous = canonicalMap.get(canonical);
+                if (previous.getExpression() == null || previous.getExpression().equals(parameter.getExpression())) {
+                    if (!code.equals(previous.getCode().getValue())) {
+                        log.info("SearchParameter '" + canonical + "' already exists with the same expression; "
+                                + "adding additional code '" + code + "'");
+                    }
+                } else {
+                    log.warning("SearchParameter '" + canonical + "' already exists with a different expression;\n"
+                            + "replacing [id=" + previous.getId() + ", expression=" + previous.getExpression().getValue()
+                            + "] with [id=" + parameter.getId() + ", expression=" + parameter.getExpression().getValue() + "]");
+                }
+            }
+            canonicalMap.put(canonical, parameter);
+        }
     }
 
     public void insertAll(ParametersMap map) {
@@ -77,12 +101,24 @@ public class ParametersMap {
         return codeMap.get(searchParameterCode);
     }
 
+    /**
+     * @deprecated use {@link #lookupByCanonical(String)}, which takes an optional version, instead
+     */
+    @Deprecated
     public SearchParameter lookupByUrl(String searchParameterUrl) {
-        return urlMap.get(searchParameterUrl);
+        return canonicalMap.get(searchParameterUrl);
+    }
+
+    public SearchParameter lookupByCanonical(String searchParameterCanonical) {
+        return canonicalMap.get(searchParameterCanonical);
     }
 
     public Collection<SearchParameter> values() {
-        return urlMap.values();
+        // use List to preserve order
+        return Collections.unmodifiableList(canonicalMap.entrySet().stream()
+                .filter(e -> !e.getKey().contains("|"))
+                .map(e -> e.getValue())
+                .collect(Collectors.toList()));
     }
 
     public boolean isEmpty() {
@@ -97,7 +133,21 @@ public class ParametersMap {
         return Collections.unmodifiableSet(codeMap.entrySet());
     }
 
+    /**
+     * @deprecated use {@link #canonicalEntries()} instead
+     */
+    @Deprecated
     public Set<Entry<String, SearchParameter>> urlEntries() {
-        return Collections.unmodifiableSet(urlMap.entrySet());
+        return Collections.unmodifiableSet(canonicalMap.entrySet().stream()
+                .filter(e -> !e.getKey().contains("|"))
+                .collect(Collectors.toSet()));
+    }
+
+    /**
+     * @implSpec Note that versioned search parameters will be listed twice;
+     *      once with their version and once without
+     */
+    public Set<Entry<String, SearchParameter>> canonicalEntries() {
+        return Collections.unmodifiableSet(canonicalMap.entrySet());
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
@@ -101,14 +101,6 @@ public class ParametersMap {
         return codeMap.get(searchParameterCode);
     }
 
-    /**
-     * @deprecated use {@link #lookupByCanonical(String)}, which takes an optional version, instead
-     */
-    @Deprecated
-    public SearchParameter lookupByUrl(String searchParameterUrl) {
-        return canonicalMap.get(searchParameterUrl);
-    }
-
     public SearchParameter lookupByCanonical(String searchParameterCanonical) {
         return canonicalMap.get(searchParameterCanonical);
     }
@@ -131,16 +123,6 @@ public class ParametersMap {
 
     public Set<Entry<String, Set<SearchParameter>>> codeEntries() {
         return Collections.unmodifiableSet(codeMap.entrySet());
-    }
-
-    /**
-     * @deprecated use {@link #canonicalEntries()} instead
-     */
-    @Deprecated
-    public Set<Entry<String, SearchParameter>> urlEntries() {
-        return Collections.unmodifiableSet(canonicalMap.entrySet().stream()
-                .filter(e -> !e.getKey().contains("|"))
-                .collect(Collectors.toSet()));
     }
 
     /**

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersMap.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -71,7 +71,7 @@ public class ParametersMap {
         canonicalMap.put(url, parameter);
 
         if (version != null) {
-            String canonical = url + (version == null ? "" : "|" + version);
+            String canonical = url + "|" + version;
             if (canonicalMap.containsKey(canonical)) {
                 SearchParameter previous = canonicalMap.get(canonical);
                 if (previous.getExpression() == null || previous.getExpression().equals(parameter.getExpression())) {

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,6 @@
 package com.ibm.fhir.search.parameters;
 
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
@@ -74,7 +73,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters3/Patient", result);
-        assertEquals(35, result.size());
+        assertEquals(37, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Observation");
         assertNotNull(result);
@@ -144,7 +143,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Patient", result);
-        assertEquals(35, result.size());
+        assertEquals(37, result.size());
 
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
@@ -162,7 +161,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters2", result);
-        assertEquals(29, result.size());
+        assertEquals(31, result.size());
     }
 
     @Test
@@ -356,10 +355,10 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertEquals(35, result.size());
+        assertEquals(37, result.size());
 
         // Sleep a bit to allow file mod times to register.
-        Thread.sleep(1000);
+        Thread.sleep(100);
 
         // Copy our first hidden file into place.
         // This should add two tenant-specific search parameters.
@@ -374,7 +373,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertNotEquals(33, result.size());
+        assertEquals(33, result.size());
 
         // Sleep a bit to allow file mod times to register.
         Thread.sleep(1000);
@@ -389,7 +388,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testDynamicSearchParameters2/Patient", result);
-        assertEquals(35, result.size());
+        assertEquals(37, result.size());
     }
 
     @Test
@@ -400,7 +399,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
         printSearchParameters("testGetSearchParametersWithAllResource", result);
-        assertEquals(31, result.size());
+        assertEquals(33, result.size());
 
         // confirm that favorite-number exists as well as the RESOURCE level favorite-color
         List<String> codes = result.stream().map(r -> r.getCode().getValue()).collect(Collectors.toList());

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersMapTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersMapTest.java
@@ -86,10 +86,6 @@ public class ParametersMapTest {
       assertTrue(pm.lookupByCode("a").contains(sp_a2));
       assertTrue(pm.lookupByCode("b").contains(sp_b2));
 
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_a1"), sp_a1);
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_a2"), sp_a2);
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b2);
-
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_a1"), sp_a1);
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_a2"), sp_a2);
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b2);
@@ -97,7 +93,6 @@ public class ParametersMapTest {
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b|2"), sp_b2);
 
       assertTrue(pm.codeEntries().size() == 2);
-      assertTrue(pm.urlEntries().size() == 3);
       assertTrue(pm.canonicalEntries().size() == 5); // versionless ones for a1, a2, and b2; versioned ones for b1 and b2
   }
 
@@ -113,11 +108,9 @@ public class ParametersMapTest {
       assertTrue(pm.lookupByCode("b").contains(sp_b));
       assertTrue(pm.lookupByCode("b2").contains(sp_b));
 
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b);
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b);
 
       assertTrue(pm.codeEntries().size() == 2);
-      assertTrue(pm.urlEntries().size() == 1);
       assertTrue(pm.canonicalEntries().size() == 1);
   }
 
@@ -132,11 +125,9 @@ public class ParametersMapTest {
 
       assertTrue(pm.lookupByCode("b").contains(sp_b));
 
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b);
       assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b);
 
       assertTrue(pm.codeEntries().size() == 1);
-      assertTrue(pm.urlEntries().size() == 1);
       assertTrue(pm.canonicalEntries().size() == 1);
   }
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersMapTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersMapTest.java
@@ -50,6 +50,28 @@ public class ParametersMapTest {
           .code(Code.of("b"))
           .expression(string("extension.value as String"))
           .build();
+  SearchParameter sp_b1 = SearchParameter.builder()
+          .url(Uri.of("http://ibm.com/fhir/test/sp_b"))
+          .version("1")
+          .status(PublicationStatus.ACTIVE)
+          .name(string("b"))
+          .base(ResourceType.RESOURCE)
+          .type(SearchParamType.STRING)
+          .description(Markdown.of("Param with code 'b'"))
+          .code(Code.of("b"))
+          .expression(string("extension.value as String"))
+          .build();
+  SearchParameter sp_b2 = SearchParameter.builder()
+          .url(Uri.of("http://ibm.com/fhir/test/sp_b"))
+          .version("2")
+          .status(PublicationStatus.ACTIVE)
+          .name(string("b"))
+          .base(ResourceType.RESOURCE)
+          .type(SearchParamType.STRING)
+          .description(Markdown.of("Param with code 'b'"))
+          .code(Code.of("b"))
+          .expression(string("extension.value as String"))
+          .build();
 
   @Test
   public void testParametersMap() {
@@ -57,17 +79,26 @@ public class ParametersMapTest {
       pm.insert("a", sp_a1);
       pm.insert("a", sp_a2);
       pm.insert("b", sp_b);
+      pm.insert("b", sp_b1);
+      pm.insert("b", sp_b2);
 
       assertTrue(pm.lookupByCode("a").contains(sp_a1));
       assertTrue(pm.lookupByCode("a").contains(sp_a2));
-      assertTrue(pm.lookupByCode("b").contains(sp_b));
+      assertTrue(pm.lookupByCode("b").contains(sp_b2));
 
       assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_a1"), sp_a1);
       assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_a2"), sp_a2);
-      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b);
+      assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b2);
+
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_a1"), sp_a1);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_a2"), sp_a2);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b2);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b|1"), sp_b1);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b|2"), sp_b2);
 
       assertTrue(pm.codeEntries().size() == 2);
       assertTrue(pm.urlEntries().size() == 3);
+      assertTrue(pm.canonicalEntries().size() == 5); // versionless ones for a1, a2, and b2; versioned ones for b1 and b2
   }
 
   /**
@@ -83,9 +114,11 @@ public class ParametersMapTest {
       assertTrue(pm.lookupByCode("b2").contains(sp_b));
 
       assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b);
 
       assertTrue(pm.codeEntries().size() == 2);
       assertTrue(pm.urlEntries().size() == 1);
+      assertTrue(pm.canonicalEntries().size() == 1);
   }
 
   /**
@@ -100,8 +133,10 @@ public class ParametersMapTest {
       assertTrue(pm.lookupByCode("b").contains(sp_b));
 
       assertEquals(pm.lookupByUrl("http://ibm.com/fhir/test/sp_b"), sp_b);
+      assertEquals(pm.lookupByCanonical("http://ibm.com/fhir/test/sp_b"), sp_b);
 
       assertTrue(pm.codeEntries().size() == 1);
       assertTrue(pm.urlEntries().size() == 1);
+      assertTrue(pm.canonicalEntries().size() == 1);
   }
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -40,10 +40,10 @@ import com.ibm.fhir.model.type.code.SearchParamType;
 import com.ibm.fhir.search.test.BaseSearchTest;
 
 /**
- *
  * Tests ParametersUtil
  */
 public class ParametersUtilTest extends BaseSearchTest {
+    public static final boolean DEBUG = true;
 
     @Test
     public void testGetBuiltInSearchParameterMap() throws IOException {

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -43,7 +43,7 @@ import com.ibm.fhir.search.test.BaseSearchTest;
  * Tests ParametersUtil
  */
 public class ParametersUtilTest extends BaseSearchTest {
-    public static final boolean DEBUG = true;
+    public static final boolean DEBUG = false;
 
     @Test
     public void testGetBuiltInSearchParameterMap() throws IOException {

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ExtractParameterValuesTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ExtractParameterValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -131,9 +131,6 @@ public class ExtractParameterValuesTest extends BaseSearchTest {
 
     @Test
     public void testWithEmptyExpressionAndTenant() throws Exception {
-        // Looking only for built-in search parameters for "Patient".
-
-        // Use tenant1 since it doesn't have any tenant-specific search parameters for resourceType Medication.
         FHIRRequestContext.set(new FHIRRequestContext("tenant5"));
 
         String testFile = "extract/observation-some.json";
@@ -204,8 +201,4 @@ public class ExtractParameterValuesTest extends BaseSearchTest {
 
         runTest(testFile, Patient.class, false, builder.build(), false);
     }
-
-
-
-
 }

--- a/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
@@ -5,8 +5,8 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": "http://hl7.org/fhir/SearchParameter/Device-patient",
-                    "organization": "http://hl7.org/fhir/SearchParameter/Device-organization"
+                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient|3.1.1",
+                    "type": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type|3.1.1"
                 }
             },
             "Observation": {

--- a/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
@@ -5,8 +5,8 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": "http://hl7.org/fhir/SearchParameter/Device-patient",
-                    "organization": "http://hl7.org/fhir/SearchParameter/Device-organization"
+                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+                    "type": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type|4.0.0"
                 }
             },
             "Observation": {


### PR DESCRIPTION
To make this simpler, I also updated the way we apply the filter rules.

Note: this changeset introduces the fhir-ig-us-core as a test dependency for
fhir-search. This was strictly out of convenience...the alternative
would be to create a new test-only PackagedRegistryResourceProvider that
provides multiple versions of the same search parameter(s).