### PR TITLE
Replace the fhir-search test dependency on US Core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Build tools
-      run: mvn -B install --file fhir-tools -Dmaven.wagon.http.retryHandler.count=3 -X
+      run: mvn -B install --file fhir-tools -Dmaven.wagon.http.retryHandler.count=3
     - name: Build samples with condensed json
-      run: mvn -B install --file fhir-examples -P condense-json -Dmaven.wagon.http.retryHandler.count=3 -X
+      run: mvn -B install --file fhir-examples -P condense-json -Dmaven.wagon.http.retryHandler.count=3
     - name: Build parent with condensed json
-      run: mvn -B install --file fhir-parent -P integration,condense-json -Dmaven.wagon.http.retryHandler.count=3 -X
+      run: mvn -B install --file fhir-parent -P integration,condense-json -Dmaven.wagon.http.retryHandler.count=3
     - name: Build sample generator
       run: mvn -B package --file fhir-examples-generator -Dmaven.wagon.http.retryHandler.count=3
     - name: Build benchmark
@@ -54,8 +54,8 @@ jobs:
       run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${BASE}:refs/remotes/origin/${BASE}
     - name: Build tools and samples
       run: |
-        mvn -B install --file fhir-tools --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -X
-        mvn -B install --file fhir-examples --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -X
+        mvn -B install --file fhir-tools --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3
+        mvn -B install --file fhir-examples --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3
     - name: Build parent with tests
       env:
         BASE: origin/${{ github['base_ref'] }}
@@ -116,7 +116,7 @@ jobs:
         echo "Using profiles ${PROFILES}"
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline -f fhir-parent --no-transfer-progress -DexcludeReactor=true -Dmaven.wagon.http.retryHandler.count=3
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:resolve-plugins -f fhir-parent --no-transfer-progress -DexcludeReactor=true -Dmaven.wagon.http.retryHandler.count=3
-        mvn -B -T2C package --file fhir-parent -P "${PROFILES}" --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240 -Dmaven.wagon.http.retryHandler.count=3 -X
+        mvn -B -T2C package --file fhir-parent -P "${PROFILES}" --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240 -Dmaven.wagon.http.retryHandler.count=3
   e2e-tests:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'ci-skip')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,11 +24,11 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: 'maven'
     - name: Build tools
-      run: mvn -B install --file fhir-tools -Dmaven.wagon.http.retryHandler.count=3
+      run: mvn -B install --file fhir-tools -Dmaven.wagon.http.retryHandler.count=3 -X
     - name: Build samples with condensed json
-      run: mvn -B install --file fhir-examples -P condense-json -Dmaven.wagon.http.retryHandler.count=3
+      run: mvn -B install --file fhir-examples -P condense-json -Dmaven.wagon.http.retryHandler.count=3 -X
     - name: Build parent with condensed json
-      run: mvn -B install --file fhir-parent -P integration,condense-json -Dmaven.wagon.http.retryHandler.count=3
+      run: mvn -B install --file fhir-parent -P integration,condense-json -Dmaven.wagon.http.retryHandler.count=3 -X
     - name: Build sample generator
       run: mvn -B package --file fhir-examples-generator -Dmaven.wagon.http.retryHandler.count=3
     - name: Build benchmark
@@ -54,8 +54,8 @@ jobs:
       run: git fetch --no-tags --prune --depth=1 origin +refs/heads/${BASE}:refs/remotes/origin/${BASE}
     - name: Build tools and samples
       run: |
-        mvn -B install --file fhir-tools --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3
-        mvn -B install --file fhir-examples --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3
+        mvn -B install --file fhir-tools --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -X
+        mvn -B install --file fhir-examples --no-transfer-progress -Dmaven.wagon.http.retryHandler.count=3 -X
     - name: Build parent with tests
       env:
         BASE: origin/${{ github['base_ref'] }}
@@ -116,7 +116,7 @@ jobs:
         echo "Using profiles ${PROFILES}"
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:go-offline -f fhir-parent --no-transfer-progress -DexcludeReactor=true -Dmaven.wagon.http.retryHandler.count=3
         mvn -B org.apache.maven.plugins:maven-dependency-plugin:3.1.2:resolve-plugins -f fhir-parent --no-transfer-progress -DexcludeReactor=true -Dmaven.wagon.http.retryHandler.count=3
-        mvn -B -T2C package --file fhir-parent -P "${PROFILES}" --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240 -Dmaven.wagon.http.retryHandler.count=3
+        mvn -B -T2C package --file fhir-parent -P "${PROFILES}" --no-transfer-progress -Dmaven.wagon.httpconnectionManager.ttlSeconds=240 -Dmaven.wagon.http.retryHandler.count=3 -X
   e2e-tests:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'ci-skip')"

--- a/fhir-model/src/test/java/com/ibm/fhir/model/spec/test/R4ExamplesDriver.java
+++ b/fhir-model/src/test/java/com/ibm/fhir/model/spec/test/R4ExamplesDriver.java
@@ -348,8 +348,7 @@ public class R4ExamplesDriver {
                 } else {
                     // oops, hit an unexpected validation error
                     System.out.println();
-                    logger.severe("validateResource(" + file + ") unexpected failure: "
-                            + x.getMessage());
+                    logger.log(Level.SEVERE, "validateResource(" + file + ") unexpected failure.", x);
 
                     // continue processing the other files
                     ExampleProcessorException error =

--- a/fhir-search/pom.xml
+++ b/fhir-search/pom.xml
@@ -33,13 +33,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <!-- Strictly for testing with search parameters loaded from new providers -->
-            <groupId>${project.groupId}</groupId>
-            <artifactId>fhir-ig-us-core</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fhir-validation</artifactId>
             <version>${project.version}</version>

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -15,11 +15,13 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.resource.Basic;
 import com.ibm.fhir.model.resource.Device;
 import com.ibm.fhir.model.resource.Observation;
@@ -39,12 +41,18 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         FHIRConfiguration.setConfigHome("target/test-classes");
     }
 
+    @AfterMethod
+    public void cleanup() throws FHIRException {
+        // Restore the threadLocal FHIRRequestContext to the default tenant
+        FHIRRequestContext.get().setTenantId("default");
+    }
+
     @Test
     public void testGetApplicableSearchParameters2() throws Exception {
         // Looking only for built-in search parameters for "Patient".
 
         // Use tenant1 since it doesn't have any tenant-specific search parameters for resourceType Medication.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         // Using Medication because tenant1 has filters in place for Patient and Observation
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Medication");
@@ -68,7 +76,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         // Looking for built-in and tenant-specific search parameters for "Patient" and "Observation".
 
         // Use the default tenant since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("default"));
+        FHIRRequestContext.get().setTenantId("default");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -86,7 +94,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         // Looking for built-in and tenant-specific search parameters for "Observation".
 
         // Use tenant1 since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         // tenant1's filtering includes only 1 search parameter for Observation.
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
@@ -101,7 +109,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetApplicableSearchParameters5() throws Exception {
         // Test filtering of search parameters for Device (tenant1).
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
@@ -115,7 +123,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetApplicableSearchParameters6() throws Exception {
         // Test filtering of search parameters for Patient (tenant1).
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -138,7 +146,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetApplicableSearchParameters7() throws Exception {
         // Test filtering of search parameters for Patient (default tenant).
-        FHIRRequestContext.set(new FHIRRequestContext("default"));
+        FHIRRequestContext.get().setTenantId("default");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -156,7 +164,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         // Looking only for built-in search parameters for "Patient".
 
         // Use tenant3 since it doesn't have any tenant-specific search parameters.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant3"));
+        FHIRRequestContext.get().setTenantId("tenant3");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -167,7 +175,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameter1() throws Exception {
         // Use tenant1 since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         SearchParameter result = SearchUtil.getSearchParameter(Basic.class, "measurement-type");
         assertNotNull(result);
@@ -176,7 +184,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameter2() throws Exception {
         // Use tenant1 since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         SearchParameter result = SearchUtil.getSearchParameter(Observation.class, "value-range");
         assertNotNull(result);
@@ -197,7 +205,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
 
     @Test
     public void testGetSearchParameter3() throws Exception {
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
         SearchParameter result = SearchUtil.getSearchParameter("Observation", "value-range-value");
         assertNull(result);
     }
@@ -205,7 +213,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameter4() throws Exception {
         // Use tenant1 since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         SearchParameter result = SearchUtil.getSearchParameter("Device", "patient");
         assertNotNull(result);
@@ -241,14 +249,14 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
 
     @Test
     public void testGetSearchParameter7() throws Exception {
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
         SearchParameter result = SearchUtil.getSearchParameter("Observation", "_lastUpdated");
         assertNotNull(result);
     }
 
     @Test
     public void testGetSearchParameter8() throws Exception {
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
         SearchParameter result = SearchUtil.getSearchParameter(Observation.class, "_lastUpdated");
         assertNotNull(result);
     }
@@ -261,14 +269,14 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
 
     @Test
     public void testGetSearchParameter10() throws Exception {
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
         SearchParameter result = SearchUtil.getSearchParameter("Observation", "device");
         assertNull(result);
     }
 
     @Test
     public void testGetSearchParameter11() throws Exception {
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
         SearchParameter result = SearchUtil.getSearchParameter("Observation", "code");
         assertNotNull(result);
     }
@@ -282,7 +290,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     void testDynamicSearchParameters1() throws Exception {
         // Test behavior of dynamic updates to search parameters.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant2"));
+        FHIRRequestContext.get().setTenantId("tenant2");
 
         String mainFile = "target/test-classes/config/tenant2/extension-search-parameters.json";
         String hiddenFile1 = mainFile + ".hide1";
@@ -336,7 +344,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     void testDynamicSearchParameters2() throws Exception {
         // Test behavior related to falling back to default tenant.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant2"));
+        FHIRRequestContext.get().setTenantId("tenant2");
 
         String mainFile = "target/test-classes/config/tenant2/extension-search-parameters.json";
         String hiddenFile1 = mainFile + ".hide1";
@@ -394,7 +402,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
     @Test
     public void testGetSearchParametersWithAllResource() throws Exception {
         // Looking only for built-in search parameters for "Patient" versus "Resource"
-        FHIRRequestContext.set(new FHIRRequestContext("tenant6"));
+        FHIRRequestContext.get().setTenantId("tenant6");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/MultiTenantSearchParameterTest.java
@@ -148,7 +148,7 @@ public class MultiTenantSearchParameterTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetApplicableSearchParameters7/Device", result);
-        assertEquals(18, result.size());
+        assertEquals(20, result.size());
     }
 
     @Test

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
@@ -153,7 +153,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
         printSearchParameters("testGetSearchParameters6/Device", result);
-        assertEquals(18, result.size());
+        assertEquals(20, result.size());
     }
 
     @Test
@@ -167,8 +167,8 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         boolean found = false;
         for (SearchParameter sp : result) {
             System.out.println(sp.getUrl().getValue() + "|" + sp.getVersion().getValue());
-            if ("http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type".equals(sp.getUrl().getValue())) {
-                assertNotEquals("4.0.0", sp.getVersion());
+            if ("http://example.com/SearchParameter/sp_a".equals(sp.getUrl().getValue())) {
+                assertNotEquals("1.0.1", sp.getVersion());
                 found = true;
             }
         }
@@ -181,8 +181,8 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         printSearchParameters("testVersionedSearchParameterFilter/Device", result);
         found = false;
         for (SearchParameter sp : result) {
-            if ("http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type".equals(sp.getUrl().getValue())) {
-                assertNotEquals("3.1.1", sp.getVersion());
+            if ("http://example.com/SearchParameter/sp_a".equals(sp.getUrl().getValue())) {
+                assertNotEquals("1.0.0", sp.getVersion());
                 found = true;
             }
         }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersSearchUtilTest.java
@@ -16,11 +16,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.SearchParameter;
 import com.ibm.fhir.search.test.BaseSearchTest;
@@ -36,6 +38,12 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
     @BeforeClass
     public void setup() {
         FHIRConfiguration.setConfigHome("src/test/resources");
+    }
+
+    @AfterMethod
+    public void cleanup() throws FHIRException {
+        // Restore the threadLocal FHIRRequestContext to the default tenant
+        FHIRRequestContext.get().setTenantId("default");
     }
 
     @Test
@@ -60,7 +68,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         // Looking for built-in and tenant-specific search parameters for "Patient"
         // and "Observation". Use the default tenant since it has some Patient search
         // parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("default"));
+        FHIRRequestContext.get().setTenantId("default");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -78,7 +86,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         // Looking for built-in and tenant-specific search parameters for "Observation".
 
         // Use tenant1 since it has some Patient search parameters defined.
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         // tenant1's filtering includes only 1 search parameter for Observation.
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Observation");
@@ -106,7 +114,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameters4Tenant() throws Exception {
         // Test filtering of search parameters for Device (tenant1).
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
@@ -120,7 +128,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameters5Tenant() throws Exception {
         // Test filtering of search parameters for Patient (tenant1).
-        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        FHIRRequestContext.get().setTenantId("tenant1");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -143,7 +151,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
     @Test
     public void testGetSearchParameters6Default() throws Exception {
         // Test filtering of search parameters for Patient (default tenant).
-        FHIRRequestContext.set(new FHIRRequestContext("default"));
+        FHIRRequestContext.get().setTenantId("default");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Patient");
         assertNotNull(result);
@@ -159,7 +167,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
     @Test
     public void testVersionedSearchParameterFilter() throws Exception {
         // Test filtering of search parameters for Patient (default tenant).
-        FHIRRequestContext.set(new FHIRRequestContext("tenant4"));
+        FHIRRequestContext.get().setTenantId("tenant4");
 
         List<SearchParameter> result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);
@@ -174,7 +182,7 @@ public class ParametersSearchUtilTest extends BaseSearchTest {
         }
         assertTrue(found);
 
-        FHIRRequestContext.set(new FHIRRequestContext("tenant5"));
+        FHIRRequestContext.get().setTenantId("tenant5");
 
         result = SearchUtil.getApplicableSearchParameters("Device");
         assertNotNull(result);

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ExamplesDriverTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ExamplesDriverTest.java
@@ -7,18 +7,27 @@
 package com.ibm.fhir.search.test;
 
 import org.testng.annotations.Test;
+import org.testng.annotations.BeforeClass;
 
+import com.ibm.fhir.config.FHIRConfiguration;
+import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.examples.Index;
 import com.ibm.fhir.model.spec.test.R4ExamplesDriver;
 import com.ibm.fhir.validation.test.ValidationProcessor;
 
 public class ExamplesDriverTest {
 
+    @BeforeClass
+    public void setup() {
+        FHIRConfiguration.setConfigHome("target/test-classes");
+    }
+
     /**
      * Process all the examples in the fhir-r4-spec example library
      */
     @Test(groups = { "server-examples" })
     public void processExamples() throws Exception {
+        FHIRRequestContext.get().setTenantId("default");
         // Process each of the examples using the provided ExampleRequestProcessor. We want to
         // validate first before we try and send to FHIR
         final R4ExamplesDriver driver = new R4ExamplesDriver();
@@ -27,6 +36,7 @@ public class ExamplesDriverTest {
         String index = System.getProperty(this.getClass().getName()
             + ".index", Index.MINIMAL_JSON.name());
         driver.processIndex(Index.valueOf(index));
+        FHIRRequestContext.remove();
      }
     
 }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/SampleRegistryResourceProvider.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/SampleRegistryResourceProvider.java
@@ -1,0 +1,110 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.search.test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ibm.fhir.cache.annotation.Cacheable;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Markdown;
+import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.PublicationStatus;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.model.type.code.SearchParamType;
+import com.ibm.fhir.registry.resource.FHIRRegistryResource;
+import com.ibm.fhir.registry.util.FHIRRegistryResourceProviderAdapter;
+
+/**
+ * FHIRRegistryResourceProvider for providing versioned SearchParameter definitions to the registry for search tests
+ */
+public class SampleRegistryResourceProvider extends FHIRRegistryResourceProviderAdapter {
+    SearchParameter sp_a1 = SearchParameter.builder()
+            .url(Uri.of("http://example.com/SearchParameter/sp_a"))
+            .version("1.0.0")
+            .status(PublicationStatus.DRAFT)
+            .description(Markdown.of("sample search param for ParametersSearchUtilTest.testVersionedSearchParameterFilter"))
+            .name("a")
+            .code(Code.of("a"))
+            .base(ResourceType.DEVICE, ResourceType.PATIENT)
+            .type(SearchParamType.STRING)
+            .expression("Device.id")
+            .build();
+
+    SearchParameter sp_a2 = sp_a1.toBuilder()
+            .version("1.0.1")
+            .build();
+
+    SearchParameter sp_b1 = SearchParameter.builder()
+            .url(Uri.of("http://example.com/SearchParameter/sp_b"))
+            .version("1.0.0")
+            .status(PublicationStatus.DRAFT)
+            .description(Markdown.of("sample search param for ParametersSearchUtilTest.testVersionedSearchParameterFilter"))
+            .name("b")
+            .code(Code.of("b"))
+            .base(ResourceType.PATIENT, ResourceType.DEVICE)
+            .type(SearchParamType.STRING)
+            .expression("Device.id")
+            .build();
+
+    SearchParameter sp_b2 = sp_a1.toBuilder()
+            .version("2.0.0")
+            .build();
+
+    private List<FHIRRegistryResource> registryResources = Arrays.asList(
+        // Add them in descending version order so that getRegistryResource with no version returns the highest version
+        FHIRRegistryResource.from(sp_a2),
+        FHIRRegistryResource.from(sp_a1),
+
+        FHIRRegistryResource.from(sp_b2),
+        FHIRRegistryResource.from(sp_b1)
+    );
+
+    @Cacheable
+    @Override
+    public FHIRRegistryResource getRegistryResource(Class<? extends Resource> resourceType, String url, String version) {
+        return registryResources.stream()
+                .filter(rr -> rr.getResourceType() == resourceType)
+                .filter(rr -> rr.getUrl().equals(url))
+                .filter(rr -> rr.getVersion() == null || rr.getVersion().equals(version))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Cacheable
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources(Class<? extends Resource> resourceType) {
+        return registryResources.stream()
+                .filter(rr -> rr.getResourceType() == resourceType)
+                .collect(Collectors.toSet());
+    }
+
+    @Cacheable
+    @Override
+    public Collection<FHIRRegistryResource> getRegistryResources() {
+        return registryResources;
+    }
+
+    @Cacheable
+    @Override
+    public Collection<FHIRRegistryResource> getProfileResources(String type) {
+        return Collections.emptySet();
+    }
+
+    @Cacheable
+    @Override
+    public Collection<FHIRRegistryResource> getSearchParameterResources(String type) {
+        return registryResources.stream()
+                .filter(rr -> rr.getResourceType() == SearchParameter.class)
+                .filter(rr -> ((SearchParameter) rr.getResource()).getType().getValue().equals(type))
+                .collect(Collectors.toSet());
+    }
+}

--- a/fhir-search/src/test/resources/META-INF/services/com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider
+++ b/fhir-search/src/test/resources/META-INF/services/com.ibm.fhir.registry.spi.FHIRRegistryResourceProvider
@@ -1,0 +1,1 @@
+com.ibm.fhir.search.test.SampleRegistryResourceProvider

--- a/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant4/fhir-server-config.json
@@ -5,8 +5,8 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient|3.1.1",
-                    "type": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type|3.1.1"
+                    "a": "http://example.com/SearchParameter/sp_a|1.0.0",
+                    "b": "http://example.com/SearchParameter/sp_b|1.0.0"
                 }
             },
             "Observation": {

--- a/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
+++ b/fhir-search/src/test/resources/config/tenant5/fhir-server-config.json
@@ -5,8 +5,8 @@
             "open": true,
             "Device": {
                 "searchParameters": {
-                    "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-                    "type": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type|4.0.0"
+                    "a": "http://example.com/SearchParameter/sp_a",
+                    "b": "http://example.com/SearchParameter/sp_b|2.0.0"
                 }
             },
             "Observation": {

--- a/term/fhir-term/src/main/java/com/ibm/fhir/term/util/ValueSetSupport.java
+++ b/term/fhir-term/src/main/java/com/ibm/fhir/term/util/ValueSetSupport.java
@@ -93,7 +93,8 @@ public final class ValueSetSupport {
             return computeCodeSetMap(valueSet);
         }
         java.lang.String url = cacheKey(valueSet);
-        Map<java.lang.String, Map<java.lang.String, Set<java.lang.String>>> cacheAsMap = CacheManager.getCacheAsMap(CODE_SET_MAP_CACHE_NAME, CODE_SET_MAP_CACHE_CONFIG);
+        Map<java.lang.String, Map<java.lang.String, Set<java.lang.String>>> cacheAsMap =
+                CacheManager.getCacheAsMap(CODE_SET_MAP_CACHE_NAME, CODE_SET_MAP_CACHE_CONFIG);
         try {
             return cacheAsMap.computeIfAbsent(url, k -> computeCodeSetMap(valueSet));
         } finally {


### PR DESCRIPTION
With a SampleRegistryResourceProvider that contains multiple versions of
a dummy search parameter.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>