### PR TITLE
ByteInputStream does not implement mark/reset #2940

### DIFF
--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/InputOutputByteStream.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/InputOutputByteStream.java
@@ -95,6 +95,9 @@ public class InputOutputByteStream {
         // each read stream gets its own read offset in the buffer
         private int posn = 0;
 
+        // maintains the position of the last call to mark
+        private int mark = 0;
+
         @Override
         public int read() throws IOException {
             return posn < offset ? (buffer[posn++] & 0xff) : -1;
@@ -138,6 +141,21 @@ public class InputOutputByteStream {
 
             posn += n;
             return n;
+        }
+
+        @Override
+        public void reset() throws IOException {
+            posn = mark;
+        }
+
+        @Override
+        public void mark(int readlimit) {
+            mark = posn;
+        }
+
+        @Override
+        public boolean markSupported() {
+            return true;
         }
     }
 
@@ -221,7 +239,7 @@ public class InputOutputByteStream {
     public ByteBuffer wrap() {
         return ByteBuffer.wrap(this.buffer, 0, size()).asReadOnlyBuffer();
     }
-    
+
     /**
      * Reset the offset to make the buffer appear empty. Does not change the current
      * length (capacity). Note that any streams currently being used to read the data

--- a/fhir-persistence/src/test/java/com/ibm/fhir/test/InputOutputByteStreamTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/test/InputOutputByteStreamTest.java
@@ -49,9 +49,42 @@ public class InputOutputByteStreamTest {
         assertEquals(compare(source, 0, source.length-1, readBack2, 0, len2-1), 0);
     }
 
+    @Test
+    public void testBasicOperationWithMarkAndReset() throws IOException {
+        InputOutputByteStream iobs = new InputOutputByteStream(10);
+        byte[] source = {0x01, 0x02, 0x03, 0x04};
+        OutputStream os = iobs.outputStream();
+        os.write(source);
+
+        // read back and check
+        InputStream is = iobs.inputStream();
+        byte[] readBack = new byte[8];
+        int len = is.read(readBack);
+        assertEquals(len, source.length);
+        assertEquals(compare(source, 0, source.length-1, readBack, 0, len-1), 0);
+
+        // If it's not supported then it'll throw an exception.
+        is.reset();
+
+        // Read 3 of 4 bytes, and then iterate.
+        byte[] readReset = new byte[3];
+        int lenReset = is.read(readReset);
+        assertEquals(lenReset, 3);
+
+        // Fixing the mark to the current posn
+        is.mark(100);
+        lenReset = is.read(readReset);
+        assertEquals(lenReset, 1);
+
+        // Reset to marked point
+        is.reset();
+        lenReset = is.read(readReset);
+        assertEquals(lenReset, 1);
+    }
+
     /**
      * Check that the two arrays are equal. Can't use {@link Arrays#compare(byte[], int, int, byte[], int, int)}
-     * because that's since J9 and we still supprt J8.
+     * because that's since Java9 and we still support Java8.
      * @param left
      * @param leftFrom
      * @param leftTo


### PR DESCRIPTION
- Add mark/reset to the InputStream
- Add Test for mark/reset

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>