### PR TITLE
MemberMatchFactory should throw custom exception when Strategy is not found

### DIFF
--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/MemberMatchFactory.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/MemberMatchFactory.java
@@ -10,9 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.operation.davinci.hrex.configuration.ConfigurationAdapter;
 import com.ibm.fhir.operation.davinci.hrex.provider.strategy.DefaultMemberMatchStrategy;
 import com.ibm.fhir.operation.davinci.hrex.provider.strategy.MemberMatchStrategy;
+import com.ibm.fhir.server.spi.operation.FHIROperationUtil;
 
 /**
  * Controls the creation of the MemberMatchProviderStrategy objects using the ServiceLoader.
@@ -48,12 +51,13 @@ public class MemberMatchFactory {
      * Gets the strategy for this specific configuration.
      * @param config
      * @return the MemberMatchStrategy or the DefaultMemberMatchStrategy
+     * @throws FHIROperationException
      */
-    public MemberMatchStrategy getStrategy(ConfigurationAdapter config) {
+    public MemberMatchStrategy getStrategy(ConfigurationAdapter config) throws FHIROperationException {
         String key = config.getStrategyKey();
         MemberMatchStrategy strategy = keyToMemberMatchStrategy.get(key);
         if (strategy == null) {
-            strategy = keyToMemberMatchStrategy.get(DEFAULT_STRATEGY);
+            throw FHIROperationUtil.buildExceptionWithIssue("The MemberMatchStrategy is not found [" + key + "]", IssueType.EXCEPTION);
         }
         return strategy;
     }

--- a/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
+++ b/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
@@ -209,7 +209,7 @@ public class MemberMatchTest {
     }
 
     @Test
-    public void testMemberMatchFactory() {
+    public void testMemberMatchFactory() throws FHIROperationException {
         MemberMatchFactory factory = MemberMatchFactory.factory();
         assertNotNull(factory);
         MemberMatchStrategy strategy = factory.getStrategy(new ConfigurationAdapter() {
@@ -233,11 +233,11 @@ public class MemberMatchTest {
 
     }
 
-    @Test
-    public void testMemberMatchFactory_BadKey() {
+    @Test(expectedExceptions= {FHIROperationException.class})
+    public void testMemberMatchFactory_BadKey() throws FHIROperationException {
         MemberMatchFactory factory = MemberMatchFactory.factory();
         assertNotNull(factory);
-        MemberMatchStrategy strategy = factory.getStrategy(new ConfigurationAdapter() {
+        factory.getStrategy(new ConfigurationAdapter() {
 
             @Override
             public boolean enabled() {
@@ -254,8 +254,6 @@ public class MemberMatchTest {
                 return null;
             }
         });
-        assertNotNull(strategy);
-        assertEquals("default", strategy.getMemberMatchIdentifier());
     }
 
     @Test


### PR DESCRIPTION
- MemberMatchFactory should throw custom exception when Strategy is not found

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>