### PR TITLE
Two Fixes - MemberMatch and BulkData Regression

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -220,7 +220,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
                                 FHIRPersistenceEvent event = new FHIRPersistenceEvent(fhirResource, props);
 
-                                // Set up the persistence context to include NOT include the deleted resources when we read
+                                // Set up the persistence context to include the deleted resources when we read
                                 FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event, true);
                                 long startTime = System.currentTimeMillis();
                                 operationOutcome = conditionalFingerprintUpdate(chunkData, skip, localCache, fhirPersistence, persistenceContext, id, fhirResource);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -54,6 +54,7 @@ import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 import com.ibm.fhir.operation.bulkdata.model.type.OperationFields;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
@@ -219,7 +220,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
                                 FHIRPersistenceEvent event = new FHIRPersistenceEvent(fhirResource, props);
 
-                                // Set up the persistence context to include deleted resources when we read
+                                // Set up the persistence context to include NOT include the deleted resources when we read
                                 FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event, true);
                                 long startTime = System.currentTimeMillis();
                                 operationOutcome = conditionalFingerprintUpdate(chunkData, skip, localCache, fhirPersistence, persistenceContext, id, fhirResource);
@@ -306,15 +307,18 @@ public class ChunkWriter extends AbstractItemWriter {
         // latest version id. The persistence layer no longer makes any changes to the
         // resource so the resource needs to be fully prepared before the persistence
         // create/update call is made
-        final Resource oldResource = persistence.read(context, resource.getClass(), logicalId).getResource();
+        SingleResourceResult<? extends Resource> oldResourceResult = persistence.read(context, resource.getClass(), logicalId);
+        Resource oldResource = oldResourceResult.getResource();
 
         final com.ibm.fhir.model.type.Instant lastUpdated = PayloadPersistenceHelper.getCurrentInstant();
         final int newVersionNumber = oldResource != null && oldResource.getMeta() != null && oldResource.getMeta().getVersionId() != null
                 ? Integer.parseInt(oldResource.getMeta().getVersionId().getValue()) + 1 : 1;
         resource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionNumber, lastUpdated);
 
+        // If the resource was previously deleted, we need to treat this as a not to skip, otherwise we end up with really inconsistent data
+        // when there is a DELETED resource.
         OperationOutcome oo;
-        if (skip) {
+        if (skip && !oldResourceResult.isDeleted()) {
             // Key is scoped to the ResourceType.
             String key = resourceType + "/" + logicalId;
             SaltHash oldBaseLine = localCache.get(key);

--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
@@ -188,7 +188,7 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
             patient.accept(getPatientIdentifier);
 
             /*
-             * QA: Since there is filtering ton the codesystem and value, the MB has to exist.
+             * QA: Since there is filtering on the codesystem and value, the MB has to exist.
              * if it doesn't there is no MATCH.
              */
             if (getPatientIdentifier.getSystem() == null || getPatientIdentifier.getValue() == null) {

--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
@@ -186,6 +186,17 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
 
             Patient patient = patientBundle.getEntry().get(0).getResource().as(Patient.class);
             patient.accept(getPatientIdentifier);
+
+            /*
+             * QA: Since there is filtering ton the codesystem and value, the MB has to exist.
+             * if it doesn't there is no MATCH.
+             */
+            if (getPatientIdentifier.getSystem() == null || getPatientIdentifier.getValue() == null) {
+                returnNoMatchException();
+                return MemberMatchResult.builder()
+                        .responseType(ResponseType.NO_MATCH)
+                        .build();
+            }
         } catch (Exception e) {
             LOG.throwing(getClass().getSimpleName(), "executeMemberMatch", e);
             throw FHIROperationUtil.buildExceptionWithIssue("Error executing the MemberMatch", IssueType.EXCEPTION);


### PR DESCRIPTION
1 - Regression on $import - Bulk Data Import skipping a resource marked
deleted #2958 (https://github.com/IBM/FHIR/commit/3d877c59542#diff-ad9adffb91185e4b3058adfc485a5a90f173fbd23b223afd39dbaba9fb7911f4R222 introduced the regression as `delete status` is not checked)
2 - Fix for edge case when no identifier exists in MemberMatch

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>