### PR TITLE
Perf improvement - guard FHIRPath evaluation during search interaction

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -78,6 +78,7 @@ import com.ibm.fhir.model.type.code.HTTPVerb;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.SearchEntryMode;
+import com.ibm.fhir.model.util.CollectingVisitor;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.SaltHash;
@@ -85,6 +86,7 @@ import com.ibm.fhir.model.visitor.ResourceFingerprintVisitor;
 import com.ibm.fhir.path.FHIRPathNode;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator;
 import com.ibm.fhir.path.evaluator.FHIRPathEvaluator.EvaluationContext;
+import com.ibm.fhir.path.exception.FHIRPathException;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
 import com.ibm.fhir.persistence.InteractionStatus;
@@ -110,6 +112,7 @@ import com.ibm.fhir.profile.ProfileSupport;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.SummaryValueSet;
 import com.ibm.fhir.search.context.FHIRSearchContext;
+import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.parameters.QueryParameter;
 import com.ibm.fhir.search.parameters.QueryParameterValue;
 import com.ibm.fhir.search.util.ReferenceUtil;
@@ -1337,7 +1340,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             List<Resource> resources =
                     persistence.search(persistenceContext, resourceType).getResource();
 
-            bundle = createSearchBundle(resources, searchContext, type);
+            bundle = createSearchResponseBundle(resources, searchContext, type);
             if (requestUri != null) {
                 bundle = addLinks(searchContext, bundle, requestUri);
             }
@@ -2056,7 +2059,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @return the bundle
      * @throws Exception
      */
-    Bundle createSearchBundle(List<Resource> resources, FHIRSearchContext searchContext, String type) throws Exception {
+    Bundle createSearchResponseBundle(List<Resource> resources, FHIRSearchContext searchContext, String type) throws Exception {
 
         // throws if we have a count of more than 2,147,483,647 resources
         UnsignedInt totalCount = searchContext.getTotalCount() != null ? UnsignedInt.of(searchContext.getTotalCount()) : null;
@@ -2202,44 +2205,78 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             queryParameters.addAll(logicalIdReferenceQueryParameters);
             Map<String, String> logicalIdToTypeMap = new HashMap<>();
 
+            FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
+
+
             // Loop through the resources, looking for versioned references and references to multiple resource types for the same logical ID
             for (Resource resource : matchResources) {
-                FHIRPathEvaluator evaluator = FHIRPathEvaluator.evaluator();
-                EvaluationContext evaluationContext = new EvaluationContext(resource);
-                for (QueryParameter queryParameter : queryParameters) {
-                    SearchParameter searchParameter = searchParameterMap.get(queryParameter);
-                    if (searchParameter == null) {
-                        searchParameter = SearchUtil.getSearchParameter(resource.getClass(), queryParameter.getCode());
-                    }
+                // A flag that indicates whether we need to take a closer look at the reference values or not
+                boolean needsEval = false;
 
-                    // For logical ID check, only need to look at search parameters with more than one target resource type
-                    if (logicalIdReferenceQueryParameters.contains(queryParameter) && searchParameter.getTarget().size() == 1) {
-                        continue;
+                // If any of the reference values are "versioned"
+                // then we'll need to check that they aren't used for chaining
+                // TODO Should we pass the previously-gathered set of references into the method instead?
+                CollectingVisitor<Reference> refCollector = new CollectingVisitor<>(Reference.class);
+                resource.accept(refCollector);
+                List<Reference> references = refCollector.getResult();
+                for (Reference ref : references) {
+                    if (ref.getReference() != null && ref.getReference().getValue() != null
+                            && ref.getReference().getValue().contains("/_history/")) {
+                        needsEval = true;
                     }
+                }
 
-                    Collection<FHIRPathNode> nodes = evaluator.evaluate(evaluationContext, searchParameter.getExpression().getValue());
-                    for (FHIRPathNode node : nodes) {
-                        Reference reference = node.asElementNode().element().as(Reference.class);
-                        ReferenceValue rv = ReferenceUtil.createReferenceValueFrom(reference, ReferenceUtil.getBaseUrl(null));
-                        if (chainQueryParameters.contains(queryParameter) && rv.getVersion() != null &&
-                                (rv.getTargetResourceType() == null || rv.getTargetResourceType().equals(queryParameter.getModifierResourceTypeName()))) {
-                            // Found versioned reference value
-                            String msg = "Resource with id '" + resource.getId() +
-                                    "' contains a versioned reference in an element used for chained search, but chained search does not act on versioned references.";
-                            issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, msg, node.path()));
-                        } else if (logicalIdReferenceQueryParameters.contains(queryParameter) && rv.getTargetResourceType() != null &&
-                                !rv.getTargetResourceType().equals(logicalIdToTypeMap.computeIfAbsent(queryParameter.getCode() + "|" + rv.getValue(), v -> rv.getTargetResourceType()))) {
-                            // Found multiple resource types this logical ID
-                            String msg = "Multiple resource type matches found for logical ID '" + rv.getValue() +
-                                    "' for search parameter '" + queryParameter.getCode() + "'.";
-                            throw buildRestException(msg, IssueType.INVALID, IssueSeverity.ERROR);
-                        }
-                    }
+                // If any of the ids are "logical id only" (i.e. have no target resource type info),
+                // then we'll need to check that they aren't ambiguous
+                if (!logicalIdReferenceQueryParameters.isEmpty()) {
+                    needsEval = true;
+                }
+
+                if (needsEval) {
+                    validateReferenceParams(chainQueryParameters, logicalIdReferenceQueryParameters, issues,
+                            searchParameterMap, queryParameters, logicalIdToTypeMap, evaluator, resource);
                 }
             }
         }
 
         return issues;
+    }
+
+    private void validateReferenceParams(List<QueryParameter> chainQueryParameters, List<QueryParameter> logicalIdReferenceQueryParameters,
+            List<Issue> issues, Map<QueryParameter, SearchParameter> searchParameterMap, List<QueryParameter> queryParameters,
+            Map<String, String> logicalIdToTypeMap, FHIRPathEvaluator evaluator, Resource resource)
+            throws Exception, FHIRPathException, FHIRSearchException, FHIROperationException {
+        EvaluationContext evaluationContext = new EvaluationContext(resource);
+        for (QueryParameter queryParameter : queryParameters) {
+            SearchParameter searchParameter = searchParameterMap.get(queryParameter);
+            if (searchParameter == null) {
+                searchParameter = SearchUtil.getSearchParameter(resource.getClass(), queryParameter.getCode());
+            }
+
+            // For logical ID check, only need to look at search parameters with more than one target resource type
+            if (logicalIdReferenceQueryParameters.contains(queryParameter) && searchParameter.getTarget().size() == 1) {
+                continue;
+            }
+
+            Collection<FHIRPathNode> nodes = evaluator.evaluate(evaluationContext, searchParameter.getExpression().getValue());
+            for (FHIRPathNode node : nodes) {
+                Reference reference = node.asElementNode().element().as(Reference.class);
+                ReferenceValue rv = ReferenceUtil.createReferenceValueFrom(reference, ReferenceUtil.getBaseUrl(null));
+                if (chainQueryParameters.contains(queryParameter) && rv.getVersion() != null &&
+                        (rv.getTargetResourceType() == null || rv.getTargetResourceType().equals(queryParameter.getModifierResourceTypeName()))) {
+                    // Found versioned reference value
+                    String msg = "Resource with id '" + resource.getId() +
+                            "' contains a versioned reference in an element used for chained search, but chained search does not act on versioned references.";
+                    issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, msg, node.path()));
+                } else if (logicalIdReferenceQueryParameters.contains(queryParameter) && rv.getTargetResourceType() != null &&
+                        !rv.getTargetResourceType().equals(logicalIdToTypeMap.computeIfAbsent(queryParameter.getCode() + "|" + rv.getValue(), v -> rv.getTargetResourceType()))) {
+                    // Found multiple resource types this logical ID
+                    String msg = "Multiple resource type matches found for logical ID '" + rv.getValue() +
+                            "' for search parameter '" + queryParameter.getCode() + "'.";
+                    throw buildRestException(msg, IssueType.INVALID, IssueSeverity.ERROR);
+                }
+            }
+        }
     }
 
     /**

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -2223,6 +2223,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     if (ref.getReference() != null && ref.getReference().getValue() != null
                             && ref.getReference().getValue().contains("/_history/")) {
                         needsEval = true;
+                        break;
                     }
                 }
 

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -1983,7 +1983,7 @@ public class FHIRRestHelperTest {
                 .build();
 
         // Process bundle
-        Bundle responseBundle = helper.createSearchBundle(Arrays.asList(null, patientNoId), context, "Patient");
+        Bundle responseBundle = helper.createSearchResponseBundle(Arrays.asList(null, patientNoId), context, "Patient");
 
         // Validate results
         assertNotNull(responseBundle);


### PR DESCRIPTION
FHIRRestHelper.performSearchReferenceChecks showed up as a hot spot on a
recent profiling exercise.  I think we can add some simple checks to
avoid most of the work in this method for most cases, so I prototyped
that here.  Needs evaluation.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>