### PR TITLE
issue #2050 - perform extra read in case of IfNoneMatch conflict

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
@@ -166,7 +166,8 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
 
         doInteraction(entryIndex, requestDescription, initialTime, () -> {
 
-            FHIRRestOperationResponse ior = helpers.doPatchOrUpdatePersist(event, type, id, false, newResource, prevResource, warnings, isDeleted, ifNoneMatch);
+            FHIRRestOperationResponse ior = helpers.doPatchOrUpdatePersist(event, type, id, false, newResource,
+                    prevResource, warnings, isDeleted, ifNoneMatch);
             OperationOutcome validationOutcome = null;
             if (validationResponseEntry != null && validationResponseEntry.getResponse() != null) {
                 validationOutcome = validationResponseEntry.getResponse().getOutcome().as(OperationOutcome.class);


### PR DESCRIPTION
Question: should undeleting a deleted resource be handled like an
updateCreate?

Without this, we could run into cases where the locationURI could list
the deleted version of a resource.
Basically, handling the undelete like create-on-update means that we can
avoid doing the extra read in the normal IfNoneMatch case.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>