### PR TITLE
Harden Bulk Data Audit Logging with Skippable Updates

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/audit/BulkAuditLogger.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/audit/BulkAuditLogger.java
@@ -250,9 +250,39 @@ public class BulkAuditLogger {
         final String METHODNAME = "logUpdateOnImport";
         log.entering(CLASSNAME, METHODNAME);
         if (shouldLog()) {
-            // Right now, we don't log or treat the oldResource. The signature is left for the commonality with the REST
-            // Audit Logger.
-            log(AuditLogEventType.FHIR_UPDATE, "U", "FHIR BulkData Update request", null, updatedResource, startTime, endTime, responseStatus, null, null, location, users);
+            if (Response.Status.CREATED.equals(responseStatus)) {
+                logCreateOnImport(updatedResource, startTime, endTime, responseStatus, location, users);
+            } else {
+                // Right now, we don't log or treat the oldResource. The signature is left for the commonality with the REST
+                // Audit Logger.
+                log(AuditLogEventType.FHIR_UPDATE, "U", "FHIR BulkData Update request", null, updatedResource, startTime, endTime, responseStatus, null, null, location, users);
+            }
+        }
+        log.exiting(CLASSNAME, METHODNAME);
+    }
+
+    /**
+     * Builds an audit log entry for an 'update' skipped in a bulkdata service invocation.
+     *
+     * @param resource
+     *            The updated version of the Resource.
+     * @param startTime
+     *            The start time of the update request execution.
+     * @param endTime
+     *            The end time of the update request execution.
+     * @param responseStatus
+     *            The response status.
+     * @param location
+     *            the destination or source for the export or import
+     * @param users
+     *            the principals that initiated the request
+     */
+    public void logUpdateOnImportSkipped(Resource resource, Date startTime, Date endTime, Response.Status responseStatus, String location,
+        String users) throws Exception {
+        final String METHODNAME = "logUpdateOnImport";
+        log.entering(CLASSNAME, METHODNAME);
+        if (shouldLog()) {
+            log(AuditLogEventType.FHIR_UPDATE, "U", "FHIR BulkData Update Resource Skipped request", null, resource, startTime, endTime, responseStatus, null, null, location, users);
         }
         log.exiting(CLASSNAME, METHODNAME);
     }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -54,11 +54,11 @@ import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 import com.ibm.fhir.operation.bulkdata.model.type.OperationFields;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.InteractionStatus;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
 import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceHelper;
@@ -186,7 +186,6 @@ public class ChunkWriter extends AbstractItemWriter {
 
             // Get the Skippable Update status
             boolean skip = adapter.enableSkippableUpdates();
-            Map<String,SaltHash> localCache = new HashMap<>();
             try {
                 for (Object objResJsonList : arg0) {
                     @SuppressWarnings("unchecked")
@@ -222,13 +221,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
                                 // Set up the persistence context to include the deleted resources when we read
                                 FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event, true);
-                                long startTime = System.currentTimeMillis();
-                                operationOutcome = conditionalFingerprintUpdate(chunkData, skip, localCache, fhirPersistence, persistenceContext, id, fhirResource);
-                                if (auditLogger.shouldLog()) {
-                                    long endTime = System.currentTimeMillis();
-                                    String location = "@source:" + ctx.getSource() + "/" + ctx.getImportPartitionWorkitem();
-                                    auditLogger.logUpdateOnImport(null, fhirResource, new Date(startTime), new Date(endTime), Response.Status.OK, location, "BulkDataOperator");
-                                }
+                                operationOutcome = conditionalFingerprintUpdate(chunkData, skip, fhirPersistence, persistenceContext, id, fhirResource, ctx);
                             }
 
                             succeededNum++;
@@ -293,15 +286,17 @@ public class ChunkWriter extends AbstractItemWriter {
      *
      * @param chunkData the transient user data used increment the number of skips
      * @param skip should skip the resource if it matches
-     * @param localCache map containing the key-saltHash
      * @param persistence used to facilitate the calls to the underlying db
      * @param context used in db calls
      * @param logicalId the logical id of the FHIR resource (e.g. 1-2-3-4)
      * @param resource the FHIR Resource
+     * @param ctx the bulk data context
      * @return outcomes including information or warnings
-     * @throws FHIRPersistenceException
+     * @throws Exception
      */
-    public OperationOutcome conditionalFingerprintUpdate(ImportTransientUserData chunkData, boolean skip, Map<String, SaltHash> localCache, FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, Resource resource) throws FHIRPersistenceException {
+    public OperationOutcome conditionalFingerprintUpdate(ImportTransientUserData chunkData, boolean skip, FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, Resource resource, BulkDataContext ctx) throws Exception {
+        long startTime = System.currentTimeMillis();
+        Response.Status status = Response.Status.OK;
 
         // Since issue 1869, we must perform the read at this point in order to obtain the
         // latest version id. The persistence layer no longer makes any changes to the
@@ -317,27 +312,29 @@ public class ChunkWriter extends AbstractItemWriter {
 
         // If the resource was previously deleted, we need to treat this as a not to skip, otherwise we end up with really inconsistent data
         // when there is a DELETED resource.
+        boolean skipped = false;
         OperationOutcome oo;
-        if (skip && !oldResourceResult.isDeleted()) {
-            // Key is scoped to the ResourceType.
-            String key = resourceType + "/" + logicalId;
-            SaltHash oldBaseLine = localCache.get(key);
+        if (!skip || oldResourceResult.isDeleted() || oldResource == null) {
+            SingleResourceResult<? extends Resource> result = persistence.updateWithMeta(context, resource);
 
-            ResourceFingerprintVisitor fp = new ResourceFingerprintVisitor();
-            if (oldBaseLine == null) {
-                // If the resource exists, then we need to fingerprint.
-                if (oldResource != null) {
-                    ResourceFingerprintVisitor fpOld = new ResourceFingerprintVisitor();
-                    oldResource.accept(fpOld);
-                    oldBaseLine = fpOld.getSaltAndHash();
-                    fp = new ResourceFingerprintVisitor(oldBaseLine);
-                }
+            if (result.getStatus() == InteractionStatus.MODIFIED) {
+                status = Response.Status.CREATED;
             }
+            oo = result.getOutcome();
+        } else {
+            // Fingerprint old base line
+            ResourceFingerprintVisitor fpOld = new ResourceFingerprintVisitor();
+            oldResource.accept(fpOld);
+            SaltHash oldBaseLine = fpOld.getSaltAndHash();
 
+            // Fingerprint new base line
+            ResourceFingerprintVisitor fp = new ResourceFingerprintVisitor(oldBaseLine);
             resource.accept(fp);
             SaltHash newBaseLine = fp.getSaltAndHash();
 
             if (oldBaseLine != null && oldBaseLine.equals(newBaseLine)) {
+                // Outcome is an informational message (no change to datastore)
+                String key = resource.getClass().getSimpleName() + "/" + logicalId;
                 if (logger.isLoggable(Level.FINE)) {
                     logger.fine("Skipping $import - update for '" + key + "'");
                 }
@@ -347,21 +344,30 @@ public class ChunkWriter extends AbstractItemWriter {
                         .severity(IssueSeverity.INFORMATION)
                         .code(IssueType.INFORMATIONAL)
                         .details(CodeableConcept.builder()
-                            .text(string("Update resource matches the existing resource; skipping the update for '" + key + "'"))
+                            .text(string("Update to an existing resource matches the stored resource's hash; skipping the update for '" + key + "'"))
                             .build())
                         .build())
                     .build();
+                skipped = true;
             } else {
+                // Outcome is an Update
                 // We need to update the db and update the local cache
-                if (oldResource != null) {
-                    // Old Resource is set so we avoid an extra read
-                    context.getPersistenceEvent().setPrevFhirResource(oldResource);
-                }
-                oo = persistence.updateWithMeta(context, resource).getOutcome();
-                localCache.put(key, newBaseLine);
+                // Old Resource is set so we avoid an extra read
+                context.getPersistenceEvent().setPrevFhirResource(oldResource);
+                SingleResourceResult<? extends Resource> result = persistence.updateWithMeta(context, resource);
+                oo = result.getOutcome();
             }
-        } else {
-            oo = persistence.updateWithMeta(context, resource).getOutcome();
+        }
+
+        // Audit Logging
+        if (auditLogger.shouldLog()) {
+            long endTime = System.currentTimeMillis();
+            String location = "@source:" + ctx.getSource() + "/" + ctx.getImportPartitionWorkitem();
+            if (!skipped) {
+                auditLogger.logUpdateOnImport(oldResource, resource, new Date(startTime), new Date(endTime), status, location, "BulkDataOperator");
+            } else {
+                auditLogger.logUpdateOnImportSkipped(resource, new Date(startTime), new Date(endTime), status, location, "BulkDataOperator");
+            }
         }
         return oo;
     }


### PR DESCRIPTION
- Improve logging out of the right http status
- Harden the use of Resource Fingerprinting with changes to persistence
layer


## Message with an Create to a Resource that doesn't yet exist

```
offset = 412, key = null�� ti{
    "request_unique_id": "67ef69d4-ae25-4d36-a3eb-dcba8b99ad46",
    "action": "C",
    "start_time": "2021-11-11 17:34:11.818",
    "end_time": "2021-11-11 17:34:11.846",
    "api_parameters": {
        "request": "https://localhost:9443/fhir-server/api/v4/$import",
        "request_status": 201
    },
    "data": {
        "resource_type": "Patient",
        "id": "9972b0d93c-93d0-10d9-94a8-d2154c1100001",
        "version_id": "1"
    },
    "event_type": "fhir-create",
    "description": "FHIR BulkData Create request",
    "location": "@source:default/test-import.ndjson",
    "resource_name": "Patient"
}
```

## Message with an Update to an existing exact match resource (note the message change)

```
offset = 413, key = null�� tz{
    "request_unique_id": "67ef69d4-ae25-4d36-a3eb-dcba8b99ad46",
    "action": "U",
    "start_time": "2021-11-11 17:34:11.856",
    "end_time": "2021-11-11 17:34:11.864",
    "api_parameters": {
        "request": "https://localhost:9443/fhir-server/api/v4/$import",
        "request_status": 200
    },
    "data": {
        "resource_type": "Patient",
        "id": "9972b0d93c-93d0-10d9-94a8-d2154c1100001",
        "version_id": "2"
    },
    "event_type": "fhir-update",
    "description": "FHIR BulkData Update Resource Skipped request",
    "location": "@source:default/test-import.ndjson",
    "resource_name": "Patient"
}
```

## Message with a Create (no id passed in bulkdata)

```
offset = 414, key = null�� t{
    "request_unique_id": "67ef69d4-ae25-4d36-a3eb-dcba8b99ad46",
    "action": "C",
    "start_time": "2021-11-11 17:34:11.873",
    "end_time": "2021-11-11 17:34:11.901",
    "api_parameters": {
        "request": "https://localhost:9443/fhir-server/api/v4/$import",
        "request_status": 201
    },
    "data": {
        "resource_type": "Patient"
    },
    "event_type": "fhir-create",
    "description": "FHIR BulkData Create request",
    "location": "@source:default/test-import.ndjson",
    "resource_name": "Patient"
}
```



Signed-off-by: Paul Bastide <pbastide@us.ibm.com>