### PR TITLE
remove outdated property

### DIFF
--- a/fhir-examples/pom.xml
+++ b/fhir-examples/pom.xml
@@ -188,8 +188,6 @@
                             <maxmemory>2g</maxmemory>
                             <!-- doclint is none, otherwise build breaks -->
                             <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none
-                                -Djava.awt.headless=true</additionalparam>
                             <detectLinks>true</detectLinks>
                             <!-- control display -->
                             <author>false</author>
@@ -416,7 +414,6 @@
                             <maxmemory>2g</maxmemory>
                             <!-- doclint is none, otherwise build breaks -->
                             <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none -Djava.awt.headless=true</additionalparam>
                             <detectLinks>true</detectLinks>
                             <!-- control display -->
                             <author>false</author>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -1116,8 +1116,6 @@
                             <source>8</source>
                             <verbose>true</verbose>
                             <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none
-                                -Djava.awt.headless=true</additionalparam>
                             <minmemory>2g</minmemory>
                             <maxmemory>2g</maxmemory>
                             <nohelp>true</nohelp>
@@ -1167,8 +1165,6 @@
                             <maxmemory>2g</maxmemory>
                             <!-- doclint is none, otherwise build breaks -->
                             <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none
-                                -Djava.awt.headless=true</additionalparam>
                             <detectLinks>true</detectLinks>
                             <!-- control display -->
                             <author>false</author>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -867,8 +867,6 @@
                         <maxmemory>2g</maxmemory>
                         <!-- doclint is none, otherwise build breaks -->
                         <doclint>none</doclint>
-                        <additionalparam>-Xdoclint:none
-                            -Djava.awt.headless=true</additionalparam>
                         <detectLinks>true</detectLinks>
                         <!-- control display -->
                         <author>false</author>


### PR DESCRIPTION
I guess `additionalparam` went away with javadoc plugin 3.0.0.
In Eclipse its just a warning, but in IDEA its an error (by default).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>