### PR TITLE
Issue #2981 - Update testcases to handle date with 0 milliseconds field

### DIFF
--- a/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/date/DateTimeHandlerTest.java
@@ -698,6 +698,17 @@ public class DateTimeHandlerTest {
     }
 
     @Test
+    public void testGenerateLowerUpperBoundWithNullPrefixYearMonthDayHoursMinutesSecondsZeroNanos()
+            throws FHIRSearchException {
+        String v = "2019-10-11T11:00:00.000000000";
+        TemporalAccessor value = DateTimeHandler.parse(v);
+        Instant lowerBound = DateTimeHandler.generateLowerBound(null, value, v);
+        Instant upperBound = DateTimeHandler.generateUpperBound(null, value, v);
+        assertEquals(lowerBound.toString(), "2019-10-11T11:00:00Z");
+        assertEquals(upperBound.toString(), "2019-10-11T11:00:00Z");
+    }
+
+    @Test
     public void testGenerateLowerUpperBoundWithNonNullPrefix() throws FHIRSearchException {
         String v = "2019";
         TemporalAccessor value = DateTimeHandler.parse(v);

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ChainParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ChainParameterParseTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -308,6 +309,9 @@ public class ChainParameterParseTest extends BaseSearchTest {
         FHIRSearchContext searchContext;
         Class<ClinicalImpression> resourceType = ClinicalImpression.class;
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        if (now.get(ChronoField.MILLI_OF_SECOND) == 0) {
+            now = now.plusMillis(1);
+        }
         String queryString = "&investigation:RiskAssessment.date=" + now.toString();
 
         queryParameters.put("investigation:RiskAssessment.date", Collections.singletonList(now.toString()));

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/ChainParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/ChainParameterParseTest.java
@@ -309,6 +309,10 @@ public class ChainParameterParseTest extends BaseSearchTest {
         FHIRSearchContext searchContext;
         Class<ClinicalImpression> resourceType = ClinicalImpression.class;
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        // If the Instant has a millseconds value of exactly 0, then the toString() will not include milliseconds in the search query,
+        // which will cause the lower/upper bound to include all milliseconds within the second, instead of just the exact millisecond.
+        // For the purpose of this testcase, just ensure that there is a non-0 value for milliseconds, so the toString() includes
+        // milliseconds in the search query.
         if (now.get(ChronoField.MILLI_OF_SECOND) == 0) {
             now = now.plusMillis(1);
         }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/RevChainParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/RevChainParameterParseTest.java
@@ -588,6 +588,10 @@ public class RevChainParameterParseTest extends BaseSearchTest {
       FHIRSearchContext searchContext;
       Class<Patient> resourceType = Patient.class;
       Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+      // If the Instant has a millseconds value of exactly 0, then the toString() will not include milliseconds in the search query,
+      // which will cause the lower/upper bound to include all milliseconds within the second, instead of just the exact millisecond.
+      // For the purpose of this testcase, just ensure that there is a non-0 value for milliseconds, so the toString() includes
+      // milliseconds in the search query.
       if (now.get(ChronoField.MILLI_OF_SECOND) == 0) {
           now = now.plusMillis(1);
       }

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/RevChainParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/RevChainParameterParseTest.java
@@ -14,6 +14,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -587,6 +588,9 @@ public class RevChainParameterParseTest extends BaseSearchTest {
       FHIRSearchContext searchContext;
       Class<Patient> resourceType = Patient.class;
       Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+      if (now.get(ChronoField.MILLI_OF_SECOND) == 0) {
+          now = now.plusMillis(1);
+      }
       String queryString = "&_has:RiskAssessment:subject:date=" + now.toString();
 
       queryParameters.put("_has:RiskAssessment:subject:date", Collections.singletonList(now.toString()));


### PR DESCRIPTION
Issue #2981 - Update testcases to handle date with 0 milliseconds field

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>