### PR TITLE
turn off DEBUG in ParametersUtilTest

### DIFF
--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/ParametersUtilTest.java
@@ -37,7 +37,7 @@ import com.ibm.fhir.search.test.BaseSearchTest;
  * Tests ParametersUtil
  */
 public class ParametersUtilTest extends BaseSearchTest {
-    public static final boolean DEBUG = true;
+    public static final boolean DEBUG = false;
 
     @Test
     public void testGetAllSearchParameters() throws IOException {


### PR DESCRIPTION
this setting gates a lot of output and I had accidentally set it to true in the build, producing lots of noise

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>