### PR TITLE
bulkdata: Add known limitation for fhir-persistence interceptor

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1590,6 +1590,10 @@ In the `ibmcom/ibm-fhir-server` docker image, these logs will be at `/logs/joblo
 
 Note, if you are using the default derby, the logs are overwritten upon restart of the server. You should use Db2 or Postgres for production purposes.
 
+### 4.10.6 Known Limitations
+
+The IBM FHIR Server's fhir-bulkdata-webapp does not support [persistence interceptors](https://github.com/IBM/FHIR/blob/main/docs/src/pages/guides/FHIRServerUsersGuide.md#43-persistence-interceptors). As the IBM FHIR Server's notifications feature is implemented as a persistence interceptor, the afterCreate and afterUpdate operation are not executed. 
+
 ## 4.11 Audit logging service
 The Audit logging service pushes FHIR server audit events for FHIR operations in [Cloud Auditing Data Federation (CADF)](https://www.dmtf.org/standards/cadf) standard format to a Kafka backend, such as *IBM Cloud Event Streams service*.
 

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1592,7 +1592,8 @@ Note, if you are using the default derby, the logs are overwritten upon restart 
 
 ### 4.10.6 Known Limitations
 
-The IBM FHIR Server's fhir-bulkdata-webapp does not support [persistence interceptors](https://github.com/IBM/FHIR/blob/main/docs/src/pages/guides/FHIRServerUsersGuide.md#43-persistence-interceptors). As the IBM FHIR Server's notifications feature is implemented as a persistence interceptor, the afterCreate and afterUpdate operation are not executed. 
+The IBM FHIR Server's fhir-bulkdata-webapp does not support [persistence interceptors](https://github.com/IBM/FHIR/blob/main/docs/src/pages/guides/FHIRServerUsersGuide.md#43-persistence-interceptors). Therefor, $import requests will not lead to `beforeCreate`/`beforeUpdate` or `afterCreate`/`afterUpdate` method calls and $export requests will not lead to `beforeRead`/`beforeSearch` or `afterRead`/`afterSearch` method calls.
+Because the IBM FHIR Server's notifications feature is implemented as a persistence interceptor, bulk operations will not result in any notification events.
 
 ## 4.11 Audit logging service
 The Audit logging service pushes FHIR server audit events for FHIR operations in [Cloud Auditing Data Federation (CADF)](https://www.dmtf.org/standards/cadf) standard format to a Kafka backend, such as *IBM Cloud Event Streams service*.


### PR DESCRIPTION
Add known limitation for fhir-persistence interceptor to the BulkData section. 

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>