### PR TITLE
Remove undocumented feature for overriding the http method via header and related cleanup

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -32,8 +32,6 @@ import com.ibm.fhir.server.util.FHIRRestHelper;
 import com.ibm.fhir.server.util.RestAuditLogger;
 
 @Path("/")
-@Consumes({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
-        FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @Produces({ FHIRMediaType.APPLICATION_FHIR_JSON, MediaType.APPLICATION_JSON,
         FHIRMediaType.APPLICATION_FHIR_XML, MediaType.APPLICATION_XML })
 @RolesAllowed("FHIRUsers")
@@ -142,7 +140,6 @@ public class Search extends FHIRResource {
     }
 
     @GET
-    @Path("/")
     public Response searchAllGet() {
         return doSearchAll();
     }


### PR DESCRIPTION
1. We had an undocumented / untested feature where you can override the
HTTP method via a header. This changeset removes that. CXF has a
slightly different header for doing exactly the same thing. Not sure
about RESTEasy.

2. We had a whole lot of unnecessary override methods in
FHIRHttpServletRequestWrapper. Since the parent class defaults to
calling the delegate already, its cleaner to leave those out of this
subclass.

3. Committing minor edits to the JAX-RS Search resource...it doesn't
actually consume APPLICATION_FHIR media types in any of the methods and
there's no need to override the class-level path with the same value

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>