### PR TITLE
bump spark-sql version to 3.2.0

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.30</version>
+                <version>1.7.32</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -495,7 +495,7 @@
             <dependency>
                 <groupId>com.ibm.stocator</groupId>
                 <artifactId>stocator</artifactId>
-                <version>1.1.3</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -490,7 +490,7 @@
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_2.12</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
             </dependency>
             <dependency>
                 <groupId>com.ibm.stocator</groupId>


### PR DESCRIPTION
its only a provided dependency, but there's a few vulnerabilities in the transitive dependencies for 3.1.0.

dependabot opened this for it in the past https://github.com/IBM/FHIR/pull/2985 ...we closed but I forget why

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>