### PR TITLE
beef up error messages in the FHIRTermService

### DIFF
--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
@@ -200,10 +200,15 @@ public class FHIRValidatorTest {
             .system(Uri.of("http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS"))
             .display("HL7 FHIR Operation")
             .build());
-        System.out.println(builder.build());
         Endpoint endpoint = builder.build();
 
         List<Issue> issues = FHIRValidator.validator().validate(endpoint);
-        issues.forEach(System.out::println);
+        // 1. Profile 'http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint' is not supported
+        // 2. dom-6: A resource should have narrative for robust management
+        // 3. Code 'hl7-fhir-opn' in system 'http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS' 
+        //    is not a valid member of ValueSet with URL=http://hl7.org/fhir/ValueSet/endpoint-connection-type and version=4.0.1
+        // 4. endpoint-0: The concept in this element must be from the specified value set 
+        //    'http://hl7.org/fhir/ValueSet/endpoint-connection-type' if possible
+        assertEquals(issues.size(), 4, "number of issues");
     }
 }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/FHIRValidatorTest.java
@@ -17,17 +17,17 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.Endpoint;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.type.Boolean;
 import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.Coding;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.HumanName;
@@ -36,9 +36,14 @@ import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.String;
+import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.validation.FHIRValidator;
+import com.ibm.fhir.validation.exception.FHIRValidationException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class FHIRValidatorTest {
     @Test
@@ -179,5 +184,26 @@ public class FHIRValidatorTest {
             issues.forEach(System.out::println);
             Assert.assertEquals(countErrors(issues), 0);
         }
+    }
+
+    @Test
+    public void testCodingValidation() throws FHIRValidationException {
+        Endpoint.Builder builder = Endpoint.builder();
+        builder.setValidating(false);
+        builder.meta(Meta.builder()
+                            .profile(
+                                Canonical.of("http://hl7.org/fhir/us/davinci-pdex-plan-net/StructureDefinition/plannet-Endpoint"))
+                            .lastUpdated(Instant.now())
+                            .build());
+        builder.connectionType(Coding.builder()
+            .code(Code.of("hl7-fhir-opn"))
+            .system(Uri.of("http://hl7.org/fhir/us/davinci-pdex-plan-net/CodeSystem/EndpointConnectionTypeCS"))
+            .display("HL7 FHIR Operation")
+            .build());
+        System.out.println(builder.build());
+        Endpoint endpoint = builder.build();
+
+        List<Issue> issues = FHIRValidator.validator().validate(endpoint);
+        issues.forEach(System.out::println);
     }
 }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
@@ -140,8 +140,18 @@ public class MaxValueSetTest {
 
         // Warning for statusReason
         device = buildDevice().toBuilder().statusReason(Arrays.asList(
-                CodeableConcept.builder().coding(Coding.builder().system(Uri.of("http://terminology.hl7.org/CodeSystem/device-status-reason")).code(Code.of("invalidCode")).build()).build(),
-                CodeableConcept.builder().coding(Coding.builder().system(Uri.of("invalidSystem")).code(Code.of("online")).build()).build()
+                CodeableConcept.builder()
+                        .coding(Coding.builder()
+                                .system(Uri.of("http://terminology.hl7.org/CodeSystem/device-status-reason"))
+                                .code(Code.of("invalidCode"))
+                                .build())
+                        .build(),
+                CodeableConcept.builder()
+                        .coding(Coding.builder()
+                                .system(Uri.of("invalidSystem"))
+                                .code(Code.of("online"))
+                                .build())
+                        .build()
                 )).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);

--- a/term/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationOutcome.java
+++ b/term/fhir-term/src/main/java/com/ibm/fhir/term/service/ValidationOutcome.java
@@ -131,4 +131,9 @@ public class ValidationOutcome {
             return this;
         }
     }
+
+    @Override
+    public java.lang.String toString() {
+        return "ValidationOutcome [display=" + display + ", message=" + message + ", result=" + result + "]";
+    }
 }

--- a/term/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
+++ b/term/fhir-term/src/test/java/com/ibm/fhir/term/service/test/FHIRTermServiceTest.java
@@ -264,7 +264,7 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
-                .message(string("Code 'x' is invalid"))
+                .message(string("Code 'x' was not found in system 'http://ibm.com/fhir/CodeSystem/cs5'"))
                 .build();
 
         CodeSystem codeSystem = getCodeSystem("http://ibm.com/fhir/CodeSystem/cs5");
@@ -306,7 +306,8 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
-                .message(string("Code 'x' is invalid"))
+                .message(string("Code 'x' in system 'http://ibm.com/fhir/CodeSystem/cs5' is not a valid member of ValueSet" +
+                        " with URL=http://ibm.com/fhir/ValueSet/vs5 and version=1.0.0"))
                 .build();
 
         ValidationOutcome actual = FHIRTermService.getInstance().validateCode(valueSet, coding);
@@ -455,7 +456,8 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
-                .message(string("Code 'a' is invalid"))
+                .message(string("Code 'a' in system 'null' is not a valid member of ValueSet " +
+                        "with URL=http://ibm.com/fhir/ValueSet/vs1 and version=1.0.0"))
                 .build();
 
         ValidationOutcome actual = FHIRTermService.getInstance().validateCode(valueSet, coding);
@@ -474,6 +476,8 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
+                .message(string("Code 'null' in system 'http://ibm.com/fhir/CodeSystem/cs1' is not a valid member of ValueSet" +
+                        " with URL=http://ibm.com/fhir/ValueSet/vs1 and version=1.0.0"))
                 .build();
 
         ValidationOutcome actual = FHIRTermService.getInstance().validateCode(valueSet, coding);
@@ -504,7 +508,8 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
-                .message(string("Code 'x' is invalid"))
+                .message(string("Code 'x' is not a valid member of ValueSet" +
+                        " with URL=http://ibm.com/fhir/ValueSet/vs1 and version=1.0.0"))
                 .build();
 
         ValidationOutcome actual = FHIRTermService.getInstance().validateCode(valueSet, code);
@@ -520,7 +525,8 @@ public class FHIRTermServiceTest {
 
         ValidationOutcome expected = ValidationOutcome.builder()
                 .result(Boolean.FALSE)
-                .message(string("Code 'null' is invalid"))
+                .message(string("Code 'null' is not a valid member of ValueSet" +
+                        " with URL=http://ibm.com/fhir/ValueSet/vs1 and version=1.0.0"))
                 .build();
 
         ValidationOutcome actual = FHIRTermService.getInstance().validateCode(valueSet, code);


### PR DESCRIPTION
Two main changes:
* split Coding display validation logic into its own separate private method `FHIRTermService.validateDisplay`
* build the ValidationOutcome with an appropriate message when we first know the response instead of passing it around

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>