### PR TITLE
Reduce severity of failed membership checks

### DIFF
--- a/conformance/fhir-ig-davinci-pdex/src/test/java/com/ibm/fhir/ig/davinci/pdex/test/ProvenanceValidationTest.java
+++ b/conformance/fhir-ig-davinci-pdex/src/test/java/com/ibm/fhir/ig/davinci/pdex/test/ProvenanceValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2020
+ * (C) Copyright IBM Corp. 2019, 2021
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,6 +7,7 @@
 package com.ibm.fhir.ig.davinci.pdex.test;
 
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countErrors;
+import static com.ibm.fhir.validation.util.FHIRValidationUtil.countInformation;
 import static com.ibm.fhir.validation.util.FHIRValidationUtil.countWarnings;
 
 import java.io.InputStream;
@@ -24,13 +25,14 @@ import com.ibm.fhir.validation.FHIRValidator;
 public class ProvenanceValidationTest {
     @Test
     public void testProvenanceValidation1() throws Exception {
-        
+
         try (InputStream in = ProvenanceValidationTest.class.getClassLoader().getResourceAsStream("JSON/Provenance-Practitioner.json")) {
             Provenance provenance = FHIRParser.parser(Format.JSON).parse(in);
             List<Issue> issues = FHIRValidator.validator().validate(provenance);
             issues.forEach(System.out::println);
             Assert.assertEquals(countErrors(issues), 0);
-            Assert.assertEquals(countWarnings(issues), 1);
+            Assert.assertEquals(countWarnings(issues), 0);
+            Assert.assertEquals(countInformation(issues), 2);
         }
     }
 }

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
@@ -268,15 +268,15 @@ public class MemberOfFunction extends FHIRPathAbstractFunction {
      * @param strength the binding strength
      */
     private void generateIssue(String message, EvaluationContext evaluationContext, FHIRPathElementNode elementNode, String strength) {
-        IssueSeverity severity = ("extensible".equals(strength) || "preferred".equals(strength)) ? IssueSeverity.WARNING : IssueSeverity.ERROR;
+        IssueSeverity severity = ("required".equals(strength)) ? IssueSeverity.ERROR : IssueSeverity.INFORMATION;
         generateIssue(evaluationContext, severity, IssueType.CODE_INVALID, message, elementNode.path());
     }
 
     private Collection<FHIRPathNode> membershipCheckFailed(EvaluationContext evaluationContext, FHIRPathElementNode elementNode, String url, String strength) {
         if ("extensible".equals(strength) || "preferred".equals(strength)) {
             String prefix = evaluationContext.hasConstraint() ? evaluationContext.getConstraint().id() + ": " : "";
-            String description = prefix + "The concept in this element " + ("extensible".equals(strength) ? "must" : "should") + " be from the specified value set '" + url + "' if possible";
-            generateIssue(evaluationContext, IssueSeverity.WARNING, IssueType.CODE_INVALID, description, elementNode.path());
+            String description = prefix + "A code in this element " + ("extensible".equals(strength) ? "must" : "should") + " be from the specified value set '" + url + "' if possible";
+            generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.CODE_INVALID, description, elementNode.path());
             return SINGLETON_TRUE;
         }
         return SINGLETON_FALSE;

--- a/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
+++ b/fhir-path/src/test/java/com/ibm/fhir/path/test/MemberOfFunctionTest.java
@@ -136,7 +136,7 @@ public class MemberOfFunctionTest {
 
         Assert.assertEquals(evaluationContext.getIssues().size(), 2);
         Issue issue = evaluationContext.getIssues().get(0);
-        Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
+        Assert.assertEquals(issue.getSeverity(), IssueSeverity.INFORMATION);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);
         Assert.assertEquals(result, SINGLETON_TRUE);
     }
@@ -150,7 +150,7 @@ public class MemberOfFunctionTest {
 
         Assert.assertEquals(evaluationContext.getIssues().size(), 2);
         Issue issue = evaluationContext.getIssues().get(0);
-        Assert.assertEquals(issue.getSeverity(), IssueSeverity.WARNING);
+        Assert.assertEquals(issue.getSeverity(), IssueSeverity.INFORMATION);
         Assert.assertEquals(issue.getCode(), IssueType.CODE_INVALID);
         Assert.assertEquals(result, SINGLETON_TRUE);
     }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/MaxValueSetTest.java
@@ -155,21 +155,24 @@ public class MaxValueSetTest {
                 )).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Warning for type
         device = buildDevice().toBuilder()
                 .type(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("tlh")).build()).build()).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
 
         // Error for type
         device = buildDevice().toBuilder()
                 .type(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build()).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
 
         // Warning and error for specialization.systemType
         device = buildDevice().toBuilder().specialization(Arrays.asList(
@@ -177,7 +180,8 @@ public class MaxValueSetTest {
                 Specialization.builder().systemType(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidSystem")).build()).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Warning and error for safety
         device = buildDevice().toBuilder().safety(Arrays.asList(
@@ -186,16 +190,17 @@ public class MaxValueSetTest {
                 )).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Warning for test-language-primary-extension
         device = buildDevice().toBuilder()
                 .extension(Collections.singletonList(Extension.builder().url("http://ibm.com/fhir/StructureDefinition/test-language-primary-extension")
                 .value(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("tlh")).build()).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
-        issues.forEach(System.out::println);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
 
         // Error for test-language-primary-extension
         device = buildDevice().toBuilder()
@@ -203,8 +208,8 @@ public class MaxValueSetTest {
                 .value(CodeableConcept.builder().coding(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 1);
-        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Warning for test-language-secondary-extension
         device = buildDevice().toBuilder()
@@ -212,7 +217,8 @@ public class MaxValueSetTest {
                 .value(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("tlh")).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Error for test-language-secondary-extension
         device = buildDevice().toBuilder()
@@ -220,8 +226,8 @@ public class MaxValueSetTest {
                 .value(Coding.builder().system(Uri.of(ValidationSupport.BCP_47_URN)).code(Code.of("invalidLanguage")).build()).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
-        assertEquals(FHIRValidationUtil.countInformation(issues), 1);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 3);
 
         // Warning for test-language-tertiary-extension
         device = buildDevice().toBuilder()
@@ -229,7 +235,8 @@ public class MaxValueSetTest {
                 .value(Code.of("tlh")).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 0);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 2);
 
         // Error for test-language-tertiary-extension
         device = buildDevice().toBuilder()
@@ -237,7 +244,8 @@ public class MaxValueSetTest {
                 .value(Code.of("invalidLanguage")).build())).build();
         issues = FHIRValidator.validator().validate(device);
         assertEquals(FHIRValidationUtil.countErrors(issues), 2);
-        assertEquals(FHIRValidationUtil.countWarnings(issues), 2);
+        assertEquals(FHIRValidationUtil.countWarnings(issues), 0);
+        assertEquals(FHIRValidationUtil.countInformation(issues), 3);
     }
 
     /**


### PR DESCRIPTION
For extensible and preferred binding we now emit failed membership check issues with a
severity of INFORMATION instead of WARNING.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>