### PR TITLE
Sonatype lift reports three vulnerabilities on fhir-term-graph-loader #3067

### DIFF
--- a/term/fhir-term-graph-loader/pom.xml
+++ b/term/fhir-term-graph-loader/pom.xml
@@ -61,6 +61,23 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- libthrift is not used by default and not in Cassandra 4.0.0 (a dependency) -->
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>libthrift</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not required to include it - has vulnerabilities -->
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- not required to include it - has vulnerabilities -->
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>


### PR DESCRIPTION
Excluded Three Dependencies which are not used

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>