### PR TITLE
Update Test to use the specific version

### DIFF
--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v100/ProviderTest.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v100/ProviderTest.java
@@ -75,7 +75,8 @@ public class ProviderTest {
         FHIRRegistryResourceProvider provider = new C4BB100ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
-                String url = registryResource.getUrl();
+                String url = registryResource.getUrl() + "|1.0.0";
+                System.out.println(registryResource.getVersion());
                 System.out.println(url);
                 Class<?> type =
                         ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;

--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v100/ProviderTest.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v100/ProviderTest.java
@@ -76,7 +76,6 @@ public class ProviderTest {
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
                 String url = registryResource.getUrl() + "|1.0.0";
-                System.out.println(registryResource.getVersion());
                 System.out.println(url);
                 Class<?> type =
                         ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;

--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v110/ProviderTest.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v110/ProviderTest.java
@@ -52,7 +52,7 @@ public class ProviderTest {
         FHIRRegistryResourceProvider provider = new C4BB110ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
-                String url = registryResource.getUrl();
+                String url = registryResource.getUrl() + "|1.1.0";
                 System.out.println(url);
                 Class<?> type =
                         ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/v311/ProviderTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/v311/ProviderTest.java
@@ -36,7 +36,7 @@ public class ProviderTest {
         FHIRRegistryResourceProvider provider = new USCore311ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
-                String url = registryResource.getUrl();
+                String url = registryResource.getUrl() + "|3.1.1";
                 System.out.println(url);
                 Class<?> type = ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
                 for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/v400/ProviderTest.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/test/v400/ProviderTest.java
@@ -76,7 +76,7 @@ public class ProviderTest {
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {
                 assertEquals(registryResource.getVersion().toString(), "4.0.0");
-                String url = registryResource.getUrl();
+                String url = registryResource.getUrl() + "|4.0.0";
                 System.out.println(url);
                 Class<?> type = ModelSupport.isResourceType(registryResource.getType()) ? ModelSupport.getResourceType(registryResource.getType()) : Extension.class;
                 for (Constraint constraint : ProfileSupport.getConstraints(url, type)) {


### PR DESCRIPTION
Karen is opening the issue for this one.  testConstraintGenerator not targetting intended version #3095 
She discovered this during testing, and we did a screenshare to diagnose.


Signed-off-by: Paul Bastide <pbastide@us.ibm.com>