### PR TITLE
ArrayIndexOutOfBoundsException during startup (while running in dev mode) #3092

### DIFF
--- a/fhir-server-webapp/src/main/webapp/META-INF/microprofile-config.properties
+++ b/fhir-server-webapp/src/main/webapp/META-INF/microprofile-config.properties
@@ -1,1 +1,2 @@
 mp.openapi.scan.disable=true
+mp.openapi.extensions.scan-dependencies.disable=true


### PR DESCRIPTION
it was scanning the dependencies, using the trace I found:

`org.jboss.*=FINE:io.openliberty.microprofile.*=FINE`

```
[12/8/21, 0:53:23:733 UTC] 00000032 ApplicationRe 1   Application Processor: Adding application started: appInfo=com.ibm.ws.container.service.app.deploy.internal.ApplicationInfoImpl@63b34b5c[fhir-server]
[12/8/21, 0:53:23:733 UTC] 00000032 ApplicationPr 1   Application Processor: Processing application started: appInfo=com.ibm.ws.container.service.app.deploy.internal.ApplicationInfoImpl@63b34b5c[fhir-server]
[12/8/21, 0:53:23:733 UTC] 00000032 ApplicationPr 1   WebModule: Processing started : deploymentName=fhir-server-webapp : contextRoot=/fhir-server/api/v4
[12/8/21, 0:53:23:746 UTC] 00000032 OLSmallRyeCon 1   Config created with profile: null 
                                 io.smallrye.config.SmallRyeConfig@6df70fc2
[12/8/21, 0:53:23:756 UTC] 00000032 ApplicationPr 1   Retrieved configuration values : ConfigProcessor : {
mp.openapi.model.reader=null
mp.openapi.filter=null
mp.openapi.scan.disable=true
mp.openapi.scan.packages=
mp.openapi.scan.classes=
mp.openapi.scan.exclude.packages=(\Qjava.lang\E)
mp.openapi.scan.exclude.classes=
mp.openapi.servers=[]
mp.openapi.extensions.scan-dependencies.disable=false
mp.openapi.extensions.scan-dependencies.jars=[]
mp.openapi.extensions.custom-schema-registry.class=null
mp.openapi.extensions.application-path.disable=false
mp.openapi.extensions.liberty.validation=true
mp.openapi.extensions.liberty.file.polling.interval=2
}
```

Turned to disable.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>