### PR TITLE
C4BB-ExplanationOfBenefit warning received - constraint not generated #3096

### DIFF
--- a/conformance/fhir-ig-carin-bb/CHANGELOG
+++ b/conformance/fhir-ig-carin-bb/CHANGELOG
@@ -35,3 +35,7 @@ Changed the constraint location from: `ExplanationOfBenefit.item` and `Explanati
 
 - Clean up the CapabilityStatement-c4bb.json to provide a parsable narrative text.
 - Remove invalid parameters from ig-r4.json
+
+08 DEC 2021 
+- v1.1.0 - Locked in the patternCanonical to avoid a needless discriminator warning. "patternCanonical": "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit|1.1.0",
+The same change is not reflected in 1.0.0.

--- a/conformance/fhir-ig-carin-bb/CHANGELOG
+++ b/conformance/fhir-ig-carin-bb/CHANGELOG
@@ -38,4 +38,5 @@ Changed the constraint location from: `ExplanationOfBenefit.item` and `Explanati
 
 08 DEC 2021 
 - v1.1.0 - Locked in the patternCanonical to avoid a needless discriminator warning. "patternCanonical": "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit|1.1.0",
-The same change is not reflected in 1.0.0.
+- The same change is not reflected in 1.0.0.
+- [JIRA FHIR-34504](https://jira.hl7.org/browse/FHIR-34504) ExplanationOfBenefit.meta.profile specifies a slicing discriminator pattern on $this and is missing in supportedProfile

--- a/conformance/fhir-ig-carin-bb/src/main/resources/hl7/fhir/us/carin-bb/110/package/StructureDefinition-C4BB-ExplanationOfBenefit.json
+++ b/conformance/fhir-ig-carin-bb/src/main/resources/hl7/fhir/us/carin-bb/110/package/StructureDefinition-C4BB-ExplanationOfBenefit.json
@@ -471,6 +471,7 @@
                         ]
                     }
                 ],
+                "patternCanonical": "http://hl7.org/fhir/us/carin-bb/StructureDefinition/C4BB-ExplanationOfBenefit|1.1.0",
                 "constraint": [
                     {
                         "key": "ele-1",

--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v110/ProviderTest.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/v110/ProviderTest.java
@@ -48,7 +48,7 @@ public class ProviderTest {
     }
 
     @Test
-    public static void testConstraintGenerator() throws Exception {
+    public void testConstraintGenerator() throws Exception {
         FHIRRegistryResourceProvider provider = new C4BB110ResourceProvider();
         for (FHIRRegistryResource registryResource : provider.getRegistryResources()) {
             if (StructureDefinition.class.equals(registryResource.getResourceType())) {


### PR DESCRIPTION
C4BB-ExplanationOfBenefit warning received - constraint not generated #3096

- small limit on the C4BB warning... as the discriminator isn't different when there is no pattern to match

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>