### PR TITLE
update convention template to avoid string that looks like xml element

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,11 +94,11 @@ Leave the code better than you found it.
 
 ### Branch naming convention
 
-issue-#<number>
+issue-#[number]
 
 ### Commit message convention
 
-issue #<number> - short description
+issue #[number] - short description
 
 long description
 


### PR DESCRIPTION
the template was like `issue #<number> - short description` but the `<number>` bit wasn't visible on the page (stripped due to looking like an xml tag)

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>