### PR TITLE
Can't start the docker container when Docker Resource/Memory is less than 3.25 GB #3111

### DIFF
--- a/build/pre-integration-test.ps1
+++ b/build/pre-integration-test.ps1
@@ -104,7 +104,7 @@ Copy-Item $OVR_ITEM -Destination $OVR_ITEM_DST
 $OVR_ITEM2=[string]$DIR_WORKSPACE + '\fhir-server-webapp\src\main\liberty\config\configDropins\disabled\datasource-derby.xml'
 $OVR_ITEM_DST2=[string]$DIR_WORKSPACE + '\SIT\wlp\usr\servers\fhir-server\configDropins\overrides\datasource-derby.xml'
 Copy-Item $OVR_ITEM2 -Destination $OVR_ITEM_DST2
-$OVR_ITEM3=[string]$DIR_WORKSPACE + '\fhir-server-webapp\src\main\liberty\config\configDropins\disabled\jvm.options'
+$OVR_ITEM3=[string]$DIR_WORKSPACE + '\fhir-server-webapp\src\main\liberty\config\configDropins\disabled\windows-jvm.options'
 $OVR_ITEM_DST3=[string]$DIR_WORKSPACE + '\SIT\wlp\usr\servers\fhir-server\configDropins\overrides\jvm.options'
 Copy-Item $OVR_ITEM3 -Destination $OVR_ITEM_DST3
 

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -46,6 +46,7 @@ ENV FHIR_CONFIG_HOME=/opt/ol/wlp/usr/servers/defaultServer \
 COPY target/LICENSE /licenses/
 
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/server.xml /opt/ol/wlp/usr/servers/defaultServer/
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/jvm.options
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins /opt/ol/wlp/usr/servers/defaultServer/configDropins
 
 RUN features.sh

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -47,7 +47,9 @@ COPY target/LICENSE /licenses/
 
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/server.xml /opt/ol/wlp/usr/servers/defaultServer/
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins /opt/ol/wlp/usr/servers/defaultServer/configDropins
-COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/jvm.options
+
+# Movies the Container Specific Settings inplace
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/configDropins/defaults/jvm.options
 
 RUN features.sh
 

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -48,7 +48,7 @@ COPY target/LICENSE /licenses/
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/server.xml /opt/ol/wlp/usr/servers/defaultServer/
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins /opt/ol/wlp/usr/servers/defaultServer/configDropins
 
-# Movies the Container Specific Settings inplace
+# Moves the Container Specific Settings in place
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/configDropins/defaults/jvm.options
 
 RUN features.sh

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -46,8 +46,8 @@ ENV FHIR_CONFIG_HOME=/opt/ol/wlp/usr/servers/defaultServer \
 COPY target/LICENSE /licenses/
 
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/server.xml /opt/ol/wlp/usr/servers/defaultServer/
-COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/jvm.options
 COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins /opt/ol/wlp/usr/servers/defaultServer/configDropins
+COPY --chown=1001:0 --from=base /opt/ol/wlp/usr/servers/defaultServer/configDropins/disabled/jvm.options /opt/ol/wlp/usr/servers/defaultServer/jvm.options
 
 RUN features.sh
 

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
@@ -1,3 +1,21 @@
+# ----------------------------------------------------------------------------
+# (C) Copyright IBM Corp. 2016, 2021
+# 
+# SPDX-License-Identifier: Apache-2.0
+# ----------------------------------------------------------------------------
+
+# This file contains options that are passed directly to the JVM on startup
+# See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
+
+# Use only TLSv1.2
+-Dhttps.protocols=TLSv1.2
+-Djdk.tls.client.protocols=TLSv1.2
+-Dcom.ibm.jsse2.overrideDefaultProtocol=TLSv1.2
+-Dcom.ibm.jsse2.renegotiate=DISABLED
+
+# Prevents Apache Xerces from overactively using the service loader to find a class
+-Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
+
 # Container Configuration - https://www.eclipse.org/openj9/docs/xxinitialrampercentage/
 # We need to leave room to operate on the VM - curl.
 -XX:InitialRAMPercentage=0.25

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
@@ -1,28 +1,9 @@
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2016, 2021
+# (C) Copyright IBM Corp. 2021
 # 
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-# This file contains options that are passed directly to the JVM on startup
-# See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
-
-# Use only TLSv1.2
--Dhttps.protocols=TLSv1.2
--Djdk.tls.client.protocols=TLSv1.2
--Dcom.ibm.jsse2.overrideDefaultProtocol=TLSv1.2
--Dcom.ibm.jsse2.renegotiate=DISABLED
-
-# Prevents Apache Xerces from overactively using the service loader to find a class
--Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
-
-# Container Configuration - https://www.eclipse.org/openj9/docs/xxinitialrampercentage/
-# We need to leave room to operate on the VM - curl.
--XX:InitialRAMPercentage=0.25
--XX:MaxRAMPercentage=0.90
-
-# Turn on verbose classloading
-#-verbose:class
-
-# Turn on verbose garbage collection
-#-verbose:gc
+# https://www.eclipse.org/openj9/docs/xxinitialrampercentage/
+-XX:InitialRAMPercentage=50.00
+-XX:MaxRAMPercentage=90.00

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
@@ -6,4 +6,3 @@
 
 # https://www.eclipse.org/openj9/docs/xxinitialrampercentage/
 -XX:InitialRAMPercentage=50.00
--XX:MaxRAMPercentage=90.00

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/jvm.options
@@ -1,5 +1,7 @@
-# Set a fixed max heap size
--Xmx3072M
+# Container Configuration - https://www.eclipse.org/openj9/docs/xxinitialrampercentage/
+# We need to leave room to operate on the VM - curl.
+-XX:InitialRAMPercentage=0.25
+-XX:MaxRAMPercentage=0.90
 
 # Turn on verbose classloading
 #-verbose:class

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
@@ -1,4 +1,21 @@
+# ----------------------------------------------------------------------------
+# (C) Copyright IBM Corp. 2016, 2020
+# 
+# SPDX-License-Identifier: Apache-2.0
+# ----------------------------------------------------------------------------
 # This jvm.options file is used in Windows CICD
+
+# This file contains options that are passed directly to the JVM on startup
+# See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
+
+# Use only TLSv1.2
+-Dhttps.protocols=TLSv1.2
+-Djdk.tls.client.protocols=TLSv1.2
+-Dcom.ibm.jsse2.overrideDefaultProtocol=TLSv1.2
+-Dcom.ibm.jsse2.renegotiate=DISABLED
+
+# Prevents Apache Xerces from overactively using the service loader to find a class
+-Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
 
 # Set a fixed max heap size
 -Xmx3072M

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
@@ -5,23 +5,6 @@
 # ----------------------------------------------------------------------------
 # This jvm.options file is used in Windows CICD
 
-# This file contains options that are passed directly to the JVM on startup
-# See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
-
-# Use only TLSv1.2
--Dhttps.protocols=TLSv1.2
--Djdk.tls.client.protocols=TLSv1.2
--Dcom.ibm.jsse2.overrideDefaultProtocol=TLSv1.2
--Dcom.ibm.jsse2.renegotiate=DISABLED
-
-# Prevents Apache Xerces from overactively using the service loader to find a class
--Dorg.apache.xml.dtm.DTMManager=org.apache.xml.dtm.ref.DTMManagerDefault
 
 # Set a fixed max heap size
 -Xmx3072M
-
-# Turn on verbose classloading
-#-verbose:class
-
-# Turn on verbose garbage collection
-#-verbose:gc

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/windows-jvm.options
@@ -1,0 +1,10 @@
+# This jvm.options file is used in Windows CICD
+
+# Set a fixed max heap size
+-Xmx3072M
+
+# Turn on verbose classloading
+#-verbose:class
+
+# Turn on verbose garbage collection
+#-verbose:gc

--- a/fhir-server-webapp/src/main/liberty/config/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/jvm.options
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2016, 2021
+# (C) Copyright IBM Corp. 2016, 2020
 # 
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
@@ -7,7 +7,6 @@
 # This file contains options that are passed directly to the JVM on startup
 # See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
 
-# Be sure to update the jvm.options in the disabled folder.
 
 # Use only TLSv1.2
 -Dhttps.protocols=TLSv1.2

--- a/fhir-server-webapp/src/main/liberty/config/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/jvm.options
@@ -1,11 +1,13 @@
 # ----------------------------------------------------------------------------
-# (C) Copyright IBM Corp. 2016, 2020
+# (C) Copyright IBM Corp. 2016, 2021
 # 
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
 # This file contains options that are passed directly to the JVM on startup
 # See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
+
+# Be sure to update the jvm.options in the disabled folder.
 
 # Use only TLSv1.2
 -Dhttps.protocols=TLSv1.2

--- a/fhir-server-webapp/src/main/liberty/config/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/jvm.options
@@ -6,8 +6,6 @@
 
 # This file contains options that are passed directly to the JVM on startup
 # See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
-
-
 # Use only TLSv1.2
 -Dhttps.protocols=TLSv1.2
 -Djdk.tls.client.protocols=TLSv1.2

--- a/fhir-server-webapp/src/main/liberty/config/jvm.options
+++ b/fhir-server-webapp/src/main/liberty/config/jvm.options
@@ -6,6 +6,7 @@
 
 # This file contains options that are passed directly to the JVM on startup
 # See https://openliberty.io/docs/ref/config/serverConfiguration.html for more info
+
 # Use only TLSv1.2
 -Dhttps.protocols=TLSv1.2
 -Djdk.tls.client.protocols=TLSv1.2


### PR DESCRIPTION
- Updated the fhir-install/Dockerfile to point to a Docker container specific jvm.options file
- Update the jvm.otpions in disabled to use XX MaxMemory Resources
- Tested with 2G max assigned to container (we could document this as tested, I only assigned 2G max to Docker / Racher Desktop)

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>