### PR TITLE
Small Utility to Live Convert Capability Statements to fhir-server-config.json

### DIFF
--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/tool/CapabilitiesToConfigGeneratorMain.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/tool/CapabilitiesToConfigGeneratorMain.java
@@ -1,0 +1,150 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.ig.carin.bb.test.tool;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.type.BackboneElement;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.visitor.DefaultVisitor;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/**
+ * This class processes the CapabilityStatements in the ImplementationGuide to fhir-server-config.json.
+ * The output is to the sysout, and the user is expected to select between the versions processed.
+ */
+public class CapabilitiesToConfigGeneratorMain {
+
+    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(null);
+
+    public static void main(String[] args) throws Exception {
+        CapabilitiesToConfigGeneratorMain main = new CapabilitiesToConfigGeneratorMain();
+
+        for (String version : main.versions()) {
+            File file = new File("src/main/resources/hl7/fhir/us/carin-bb/" + version + "/package/CapabilityStatement-c4bb.json");
+
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                CapabilityStatement statement = FHIRParser.parser(Format.JSON).parse(reader).as(com.ibm.fhir.model.resource.CapabilityStatement.class);
+                JsonObject object = main.adaptCapabilityStatement(statement, version);
+                System.out.println(object);
+            }
+
+        }
+    }
+
+    /**
+     * List of the Versions
+     *
+     * @return
+     */
+    public String[] versions() {
+        return new String[] { "100", "110" };
+    }
+
+    public JsonObject adaptCapabilityStatement(CapabilityStatement statement, String version) {
+        CalculateConfigurationElements cce = new CalculateConfigurationElements(true, version);
+        statement.accept(cce);
+
+        JsonObjectBuilder typesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        for (Entry<String, List<ConfigurationResource>> entry : cce.cces.entrySet()) {
+            JsonObjectBuilder defaultsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            String resource = null;
+
+            for (ConfigurationResource cr : entry.getValue()) {
+                String uri = cr.url.split("\\|")[0];
+                if ("100".equals(cr.version)) {
+                    defaultsBuilder.add(uri, "1.0.0");
+                } else {
+                    defaultsBuilder.add(uri, "1.1.0");
+                }
+                resource = entry.getKey();
+            }
+
+            JsonObjectBuilder profilesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            profilesBuilder.add("defaultVersions", defaultsBuilder);
+
+            JsonObjectBuilder typeBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            typeBuilder.add("profiles", profilesBuilder);
+
+            typesBuilder.add(resource, typeBuilder);
+
+        }
+
+        JsonObjectBuilder rBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        rBuilder.add("resources", typesBuilder);
+
+        JsonObjectBuilder fsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        fsBuilder.add("fhirServer", rBuilder);
+
+        return fsBuilder.build();
+    }
+
+    /**
+     * Simple data transfer object
+     */
+    private static class ConfigurationResource {
+
+        String resource;
+        String version;
+        String url;
+
+        @Override
+        public String toString() {
+            return "ConfigurationResource [resource=" + resource + ", version=" + version + ", url=" + url + "]";
+        }
+    }
+
+    /**
+     * Visitor processes through the Capability Statement
+     */
+    private static class CalculateConfigurationElements extends DefaultVisitor {
+
+        private String version;
+        Map<String, List<ConfigurationResource>> cces = new HashMap<>();
+
+        public CalculateConfigurationElements(boolean visitChildren, String version) {
+            super(visitChildren);
+            this.version = version;
+        }
+
+        @Override
+        public boolean visit(String elementName, int elementIndex, BackboneElement backboneElement) {
+            if ("resource".equals(elementName) && backboneElement.is(CapabilityStatement.Rest.Resource.class)) {
+                CapabilityStatement.Rest.Resource ccr = backboneElement.as(CapabilityStatement.Rest.Resource.class);
+
+                for (Canonical c : ccr.getSupportedProfile()) {
+                    ConfigurationResource cce = new ConfigurationResource();
+                    cce.resource = ccr.getType().getValue();
+                    cce.url = c.getValue();
+                    cce.version = version;
+                    if (!cces.containsKey(cce.resource)) {
+                        cces.put(cce.resource, new ArrayList<>(Arrays.asList(cce)));
+                    } else {
+                        cces.get(cce.resource).add(cce);
+                    }
+                }
+                return false;
+            }
+            return super.visit(elementName, elementIndex, backboneElement);
+        }
+    }
+}

--- a/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/tool/LiveCapabilitiesToConfigGeneratorMain.java
+++ b/conformance/fhir-ig-carin-bb/src/test/java/com/ibm/fhir/ig/carin/bb/test/tool/LiveCapabilitiesToConfigGeneratorMain.java
@@ -1,0 +1,216 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.ig.carin.bb.test.tool;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.type.BackboneElement;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.visitor.DefaultVisitor;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/**
+ * This class processes the Live CapabilityStatements to fhir-server-config.json.
+ * The output is to the sysout, and the user is expected to specify default versions.
+ *
+ * java LiveCapabilitiesToConfigGeneratorMain http://hl7.org/fhir/us/core/|3.1.1,http://hl7.org/fhir/us/carin-bb/|1.0.0
+ */
+public class LiveCapabilitiesToConfigGeneratorMain {
+
+    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(null);
+    private List<String> include = new ArrayList<>();
+
+    public static void main(String[] args) throws Exception {
+        LiveCapabilitiesToConfigGeneratorMain main = new LiveCapabilitiesToConfigGeneratorMain();
+        main.generateFilters(args);
+
+        CapabilityStatement statement = FHIRParser.parser(Format.JSON).parse(main.readMetadata()).as(com.ibm.fhir.model.resource.CapabilityStatement.class);
+        JsonObject object = main.adaptCapabilityStatement(statement);
+        System.out.println(object);
+    }
+
+    public void generateFilters(String[] args) {
+        if (args.length != 1) {
+           throw new IllegalArgumentException("Args not included to filter the right versions of the profiles");
+        }
+        for (String pattern : args[0].split(",")) {
+            include.add(pattern);
+        }
+    }
+
+    /**
+     * Trusts the access to the given URL
+     */
+    private class AllTrustManager implements X509TrustManager {
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+            // NOP
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+         // NOP
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[] {};
+        }
+
+    }
+
+    /**
+     * Creates a local factory to Trust All
+     * @return
+     * @throws Exception
+     */
+    private SSLSocketFactory createFactory() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(null, new TrustManager[]{new AllTrustManager()} , null);
+        return sslContext.getSocketFactory();
+    }
+
+    /**
+     * Read metadata (CapabilityStatement)
+     * @return
+     * @throws Exception
+     */
+    public BufferedReader readMetadata() throws Exception {
+        URL url = new URL("https://localhost:9443/fhir-server/api/v4/metadata");
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+        conn.setHostnameVerifier(new HostnameVerifier() {
+            // Ignore Hostname checks
+            @Override
+            public boolean verify(String arg0, SSLSession arg1) {
+                return true;
+            }
+        });
+        conn.setSSLSocketFactory(createFactory());
+        return new BufferedReader(new InputStreamReader(conn.getInputStream()));
+    }
+
+    /**
+     * Runs through the CapabilityStatement
+     * @param statement
+     * @return
+     */
+    public JsonObject adaptCapabilityStatement(CapabilityStatement statement) {
+        CalculateConfigurationElements cce = new CalculateConfigurationElements(true);
+        statement.accept(cce);
+
+        JsonObjectBuilder typesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        for (Entry<String, List<ConfigurationResource>> entry : cce.cces.entrySet()) {
+            JsonObjectBuilder defaultsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+
+            boolean f = false;
+            String resource = entry.getKey();
+            for (ConfigurationResource cr : entry.getValue()) {
+                for (String in: include) {
+                    System.out.println(in);
+                    String pre = in.split("\\|")[0];
+                    String ver = in.split("\\|")[1];
+                    if (cr.version.equals(ver) && cr.url.startsWith(pre)) {
+                        defaultsBuilder.add(cr.url, cr.version);
+                        f = true;
+                    }
+                }
+            }
+
+            if (f) {
+                JsonObjectBuilder profilesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+                profilesBuilder.add("defaultVersions", defaultsBuilder);
+
+                JsonObjectBuilder typeBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+                typeBuilder.add("profiles", profilesBuilder);
+
+                typesBuilder.add(resource, typeBuilder);
+            }
+        }
+
+        JsonObjectBuilder rBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        rBuilder.add("resources", typesBuilder);
+
+        JsonObjectBuilder fsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        fsBuilder.add("fhirServer", rBuilder);
+
+        return fsBuilder.build();
+    }
+
+    /**
+     * Simple data transfer object
+     */
+    private static class ConfigurationResource {
+
+        String resource;
+        String version;
+        String url;
+
+        @Override
+        public String toString() {
+            return "ConfigurationResource [resource=" + resource + ", version=" + version + ", url=" + url + "]";
+        }
+    }
+
+    /**
+     * Visitor processes through the Capability Statement
+     */
+    private static class CalculateConfigurationElements extends DefaultVisitor {
+
+        Map<String, List<ConfigurationResource>> cces = new HashMap<>();
+
+        public CalculateConfigurationElements(boolean visitChildren) {
+            super(visitChildren);
+        }
+
+        @Override
+        public boolean visit(String elementName, int elementIndex, BackboneElement backboneElement) {
+            if ("resource".equals(elementName) && backboneElement.is(CapabilityStatement.Rest.Resource.class)) {
+                CapabilityStatement.Rest.Resource ccr = backboneElement.as(CapabilityStatement.Rest.Resource.class);
+
+                for (Canonical c : ccr.getSupportedProfile()) {
+                    ConfigurationResource cce = new ConfigurationResource();
+                    cce.resource = ccr.getType().getValue();
+                    cce.url = c.getValue().split("\\|")[0];
+                    cce.version = c.getValue().split("\\|")[1];
+                    if (!cces.containsKey(cce.resource)) {
+                        cces.put(cce.resource, new ArrayList<>(Arrays.asList(cce)));
+                    } else {
+                        cces.get(cce.resource).add(cce);
+                    }
+                }
+                return false;
+            }
+            return super.visit(elementName, elementIndex, backboneElement);
+        }
+    }
+}

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/CapabilitiesToConfigGeneratorMain.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/CapabilitiesToConfigGeneratorMain.java
@@ -1,0 +1,149 @@
+/*
+ * (C) Copyright IBM Corp. 2021
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.ig.us.core.tool;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.ibm.fhir.model.format.Format;
+import com.ibm.fhir.model.parser.FHIRParser;
+import com.ibm.fhir.model.resource.CapabilityStatement;
+import com.ibm.fhir.model.type.BackboneElement;
+import com.ibm.fhir.model.type.Canonical;
+import com.ibm.fhir.model.visitor.DefaultVisitor;
+
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+
+/**
+ *This class processes the CapabilityStatements in the ImplementationGuide to fhir-server-config.json.
+ * The output is to the sysout, and the user is expected to select between the versions processed.
+ */
+public class CapabilitiesToConfigGeneratorMain {
+    private static final JsonBuilderFactory JSON_BUILDER_FACTORY = Json.createBuilderFactory(null);
+
+    /**
+     * List of the Versions
+     * @return
+     */
+    public String[] versions() {
+        return new String[] { "311", "400" };
+    }
+
+    public JsonObject adaptCapabilityStatement(CapabilityStatement statement, String version) {
+        CalculateConfigurationElements cce = new CalculateConfigurationElements(true, version);
+        statement.accept(cce);
+
+        JsonObjectBuilder typesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        for (Entry<String, List<ConfigurationResource>> entry : cce.cces.entrySet()) {
+            JsonObjectBuilder defaultsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            String resource = null;
+
+            for (ConfigurationResource cr : entry.getValue()) {
+                String uri = cr.url.split("\\|")[0];
+                if ("311".equals(cr.version)) {
+                    defaultsBuilder.add(uri, "3.1.1");
+                } else {
+                    defaultsBuilder.add(uri, "4.0.0");
+                }
+                resource = entry.getKey();
+            }
+
+            JsonObjectBuilder profilesBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            profilesBuilder.add("defaultVersions", defaultsBuilder);
+
+            JsonObjectBuilder typeBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+            typeBuilder.add("profiles", profilesBuilder);
+
+
+            typesBuilder.add(resource, typeBuilder);
+
+
+        }
+
+        JsonObjectBuilder rBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        rBuilder.add("resources", typesBuilder);
+
+        JsonObjectBuilder fsBuilder = JSON_BUILDER_FACTORY.createObjectBuilder();
+        fsBuilder.add("fhirServer", rBuilder);
+
+        return fsBuilder.build();
+    }
+
+    public static void main(String[] args) throws Exception {
+        CapabilitiesToConfigGeneratorMain main = new CapabilitiesToConfigGeneratorMain();
+
+        for (String version : main.versions()) {
+            File file = new File("src/main/resources/hl7/fhir/us/core/" + version + "/package/CapabilityStatement-us-core-server.json");
+
+            try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                CapabilityStatement statement = FHIRParser.parser(Format.JSON).parse(reader).as(com.ibm.fhir.model.resource.CapabilityStatement.class);
+                JsonObject object = main.adaptCapabilityStatement(statement, version);
+                System.out.println(object);
+            }
+
+        }
+    }
+
+    /**
+     * Simple data transfer object
+     */
+    private static class ConfigurationResource {
+        String resource;
+        String version;
+        String url;
+
+        @Override
+        public String toString() {
+            return "ConfigurationResource [resource=" + resource + ", version=" + version + ", url=" + url + "]";
+        }
+    }
+
+    /**
+     * Visitor processes through the Capability Statement
+     */
+    private static class CalculateConfigurationElements extends DefaultVisitor {
+
+        private String version;
+        Map<String, List<ConfigurationResource>> cces = new HashMap<>();
+
+        public CalculateConfigurationElements(boolean visitChildren, String version) {
+            super(visitChildren);
+            this.version = version;
+        }
+
+        @Override
+        public boolean visit(String elementName, int elementIndex, BackboneElement backboneElement) {
+            if ("resource".equals(elementName) && backboneElement.is(CapabilityStatement.Rest.Resource.class)) {
+                CapabilityStatement.Rest.Resource ccr = backboneElement.as(CapabilityStatement.Rest.Resource.class);
+
+                for (Canonical c : ccr.getSupportedProfile()) {
+                    ConfigurationResource cce = new ConfigurationResource();
+                    cce.resource = ccr.getType().getValue();
+                    cce.url = c.getValue();
+                    cce.version = version;
+                    if (!cces.containsKey(cce.resource)) {
+                        cces.put(cce.resource, new ArrayList<>(Arrays.asList(cce)));
+                    } else {
+                        cces.get(cce.resource).add(cce);
+                    }
+                }
+                return false;
+            }
+            return super.visit(elementName, elementIndex, backboneElement);
+        }
+    }
+}

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/ParametersUtil.java
@@ -234,7 +234,7 @@ public final class ParametersUtil {
                         if (log.isLoggable(Level.FINE)) {
                             String canonical = getCanonicalUrl(sp);
                             log.fine("Skipping search parameter '" + canonical + "' because code '" +
-                                    sp.getCode() + "' is already configured.");
+                                    sp.getCode().getValue() + "' is already configured.");
                         }
                     } else {
                         paramMap.insert(sp.getCode().getValue(), sp);


### PR DESCRIPTION
- This class processes the Live CapabilityStatements to fhir-server-config.json.
- The output is to the sysout, and the user is expected to specify default versions.
- java LiveCapabilitiesToConfigGeneratorMain
http://hl7.org/fhir/us/core/|3.1.1,http://hl7.org/fhir/us/carin-bb/|1.0.0
- Fix this error message in ParametersUti 1   Skipping search
parameter 'http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient|4.0.0' because code '{  "code": "patient" }' is already configured. so it's not split

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>