### PR TITLE
Fix issues with Patient $everything #2963

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -435,7 +435,7 @@ Type operations are invoked at `[base]/[resourceType]/$[operation]`
 | [$export](https://hl7.org/fhir/uv/bulkdata/OperationDefinition-patient-export.html) | Patient | Obtain a set of resources pertaining to all patients | exports to an S3-compatible data store; see the [user guide](https://ibm.github.io/FHIR/guides/FHIRServerUsersGuide/#410-bulk-data-operations) for config info |
 | [$document](https://hl7.org/fhir/R4/operation-composition-document.html) | Composition | Generate a document | Prototype-level implementation |
 | [$apply](https://hl7.org/fhir/R4/operation-plandefinition-apply.html) | PlanDefinition | Applies a PlanDefinition to a given context | A prototype implementation that performs naive conversion |
-| [$everything](https://www.hl7.org/fhir/operation-patient-everything.html) | Patient | Obtain all resources pertaining to a patient | Current implementation supports obtaining all resources for a patient up to an aggregate total of 10,000 resources (at which point it is recommended to use the `$export` operation). This implementation does not currently support using the `_since` and `_count` query parameters. Pagination is not currently supported. |
+| [$everything](https://www.hl7.org/fhir/operation-patient-everything.html) | Patient | Obtain all resources pertaining to a patient | Current implementation supports obtaining all resources for a patient up to an aggregate total of 10,000 resources (at which point it is recommended to use the `$export` operation). This implementation does not currently support using the `_since` and `_count` query parameters. Pagination is not currently supported. The resource types returned can be configured. If a server has restricted down the list of supported resource types, only those resource types will be returned. |
 
 ### Instance operations
 Instance operations are invoked at `[base]/[resourceType]/[id]/$[operation]`
@@ -446,6 +446,7 @@ Instance operations are invoked at `[base]/[resourceType]/[id]/$[operation]`
 | [$export](https://hl7.org/fhir/uv/bulkdata/OperationDefinition-group-export.html) | Group | Obtain a set resources pertaining to patients in a specific Group | Only supports static membership; does not resolve inclusion/exclusion criteria |
 | [$document](https://hl7.org/fhir/R4/operation-composition-document.html) | Composition | Generate a document | Prototype-level implementation |
 | [$apply](https://hl7.org/fhir/R4/operation-plandefinition-apply.html) | PlanDefinition | Applies a PlanDefinition to a given context | A prototype implementation that performs naive conversion |
+| [$everything](https://www.hl7.org/fhir/operation-patient-everything.html) | Patient | Obtain all resources pertaining to a patient | Current implementation supports obtaining all resources for a patient up to an aggregate total of 10,000 resources (at which point it is recommended to use the `$export` operation). This implementation does not currently support using the `_since` and `_count` query parameters. Pagination is not currently supported. The resource types returned can be configured. If a server has restricted down the list of supported resource types, only those resource types will be returned. |
 
 ## HL7 FHIR R4 (v4.0.1) errata
 We add information here as we find issues with the artifacts provided with this version of the specification.

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
@@ -6,9 +6,13 @@
 
 package com.ibm.fhir.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
+import com.ibm.fhir.exception.FHIRException;
 
 import jakarta.json.JsonValue;
 
@@ -151,5 +155,40 @@ public class FHIRConfigHelper {
         }
 
         return (result != null ? result : defaultValue);
+    }    
+    
+    /**
+     * This method returns the list of supported resource types
+     * @return a list of resource types that isn't null
+     */
+    public static List<String> getSupportedResourceTypes() throws FHIRException {
+        List<String> result = new ArrayList<>();
+
+        PropertyGroup rsrcsGroup = FHIRConfigHelper.getPropertyGroup(FHIRConfiguration.PROPERTY_RESOURCES);
+        List<PropertyEntry> rsrcsEntries;
+        try {
+            rsrcsEntries = rsrcsGroup.getProperties();
+
+            if (rsrcsEntries != null && !rsrcsEntries.isEmpty()) {
+                for (PropertyEntry rsrcsEntry : rsrcsEntries) {
+                    String name = rsrcsEntry.getName();
+                    
+                    // Ensure we skip over the special property "open" and process only the others
+                    if (!FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN.equals(name)) {
+                        
+                        // Skip the abstract types Resource and DomainResource
+                        if (!"Resource".equals(name) &&
+                                !"DomainResource".equals(name)) {
+                            result.add(name);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.throwing("FHIRConfigHelper", "getSupportedResourceTypes", e);
+            throw new FHIRException("Unexpected error retrieving supported resource types", e);
+        }
+        
+        return result;
     }
 }

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2021
+ * (C) Copyright IBM Corp. 2017, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -174,19 +174,19 @@ public class FHIRConfigHelper {
                     String name = rsrcsEntry.getName();
                     
                     // Ensure we skip over the special property "open" and process only the others
-                    if (!FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN.equals(name)) {
-                        
-                        // Skip the abstract types Resource and DomainResource
-                        if (!"Resource".equals(name) &&
-                                !"DomainResource".equals(name)) {
+                    // and skip the abstract types Resource and DomainResource
+                    // It would be nice to be able to verify if the resource names were valid, but
+                    // not possible at this layer of the code.  
+                    if (!FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN.equals(name) &&
+                        !"Resource".equals(name) &&
+                        !"DomainResource".equals(name)) {
                             result.add(name);
-                        }
                     }
                 }
             }
         } catch (Exception e) {
-            log.throwing("FHIRConfigHelper", "getSupportedResourceTypes", e);
-            throw new FHIRException("Unexpected error retrieving supported resource types", e);
+            log.fine("FHIRConfigHelper.getSupportedResourceTypes is configured with no "
+                    + "resources in the server config file or is not configured properly");
         }
         
         return result;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -336,18 +336,39 @@ public class EverythingOperation extends AbstractOperation {
         
         try {
             List<String> supportedResourceTypes = FHIRConfigHelper.getSupportedResourceTypes();
+            if (LOG.isLoggable(Level.FINE)) {
+                StringBuilder resourceTypeBuilder = new StringBuilder(supportedResourceTypes.size());
+                resourceTypeBuilder.append("supportedResourceTypes are: ");
+                for (String resourceType: supportedResourceTypes) {
+                   resourceTypeBuilder.append(resourceType);
+                   resourceTypeBuilder.append(" ");
+                }
+                LOG.fine(resourceTypeBuilder.toString());
+            }
             // TODO: Practitioner and Organization are not included in the getCompartmentReourceTypes() by default but it seems
             // like a couple of good additional resources to include and they are even mentioned as examples of resources
             // to include in the docs: https://www.hl7.org/fhir/operation-patient-everything.html
             // resourceTypes.add(Practitioner.class.getSimpleName());
             // resourceTypes.add(Organization.class.getSimpleName());
-            resourceTypes.retainAll(supportedResourceTypes);
+            // Need to have this if check to support server config files that do not specify resources
+            if (!supportedResourceTypes.isEmpty()) {
+                resourceTypes.retainAll(supportedResourceTypes);
+            }
         } catch (Exception e) {
             FHIRSearchException exceptionWithIssue = new FHIRSearchException("There has been an error retrieving the list of supported resource types of the $everything operation.", e);
             LOG.throwing(this.getClass().getName(), "doInvoke", exceptionWithIssue);
             throw exceptionWithIssue;
         }
-            
+        
+        if (LOG.isLoggable(Level.FINE)) {
+            StringBuilder resourceTypeBuilder = new StringBuilder(resourceTypes.size());
+            resourceTypeBuilder.append("resourceTypes are: ");
+            for (String resourceType: resourceTypes) {
+                resourceTypeBuilder.append(resourceType);
+                resourceTypeBuilder.append(" ");
+            }
+            LOG.fine(resourceTypeBuilder.toString());
+        }
         return resourceTypes;
     }
 

--- a/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
+++ b/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
@@ -12,6 +12,7 @@ import static org.testng.AssertJUnit.assertTrue;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -60,7 +61,9 @@ public class EverythingOperationTest {
     @Test
     public void testConvertParametersType() throws FHIRParserException, IOException, FHIRSearchException {
         Parameters parameters = loadParametersFile("parameters-type.json");
-        List<String> overrideTypes = everythingOperation.getOverridenIncludedResourceTypes(parameters, new ArrayList<String>(0));
+        String types[] = new String[] {"CarePlan", "CareTeam"};
+        List<String> supportedResourceTypes = new ArrayList<String>(Arrays.asList(types));
+        List<String> overrideTypes = everythingOperation.getOverridenIncludedResourceTypes(parameters, supportedResourceTypes);
         assertEquals(2, overrideTypes.size());
         assertTrue(overrideTypes.contains("CarePlan"));
         assertTrue(overrideTypes.contains("CareTeam"));

--- a/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
+++ b/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
@@ -11,6 +11,7 @@ import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.ws.rs.core.MultivaluedMap;
@@ -59,7 +60,7 @@ public class EverythingOperationTest {
     @Test
     public void testConvertParametersType() throws FHIRParserException, IOException, FHIRSearchException {
         Parameters parameters = loadParametersFile("parameters-type.json");
-        List<String> overrideTypes = everythingOperation.getOverridenIncludedResourceTypes(parameters);
+        List<String> overrideTypes = everythingOperation.getOverridenIncludedResourceTypes(parameters, new ArrayList<String>(0));
         assertEquals(2, overrideTypes.size());
         assertTrue(overrideTypes.contains("CarePlan"));
         assertTrue(overrideTypes.contains("CareTeam"));


### PR DESCRIPTION
- Fixed issue where Patient $everything returned "Error retrieving $everything resources of type 'Appointment' for patient" when config has the list of resource types restricted
- Fixed issue where Patient $everything wasn't reading tenant-specific config 
- Tested on our tenant-specific config server that a test patient resource was returned along with the related EOB and Coverage resources

Signed-off-by: Susan Crowell sfc@us.ibm.com