### PR TITLE
#3061 - Fix NPE when Measure refers to non-existent library

### DIFF
--- a/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/helpers/LibraryHelper.java
+++ b/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/helpers/LibraryHelper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/helpers/LibraryHelper.java
+++ b/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/helpers/LibraryHelper.java
@@ -75,6 +75,11 @@ public class LibraryHelper {
                     String canonicalURL = canonical.getValue();
                     if (!visited.contains(canonicalURL)) {
                         if (isLibraryReference(canonicalURL)) {
+                            // This won't resolve canonical URLs that happen to be ResourceType/ID references as
+                            // we've done for some of the values passed into the CQL-related operations. R4B 
+                            // updates the examples to all contain valid canonical URLs and the spec
+                            // is somewhat ambiguous on what you would do if they aren't found in the registry, so
+                            // we are accepting this as ok.
                             Library dependency = FHIRRegistry.getInstance().getResource(canonicalURL, Library.class);
                             if (dependency != null) {
                                 if (isLogicLibrary(dependency)) {

--- a/cql/fhir-quality-measure/src/main/java/com/ibm/fhir/ecqm/r4/MeasureHelper.java
+++ b/cql/fhir-quality-measure/src/main/java/com/ibm/fhir/ecqm/r4/MeasureHelper.java
@@ -12,15 +12,29 @@ import com.ibm.fhir.model.resource.Measure;
  * Utility methods for working with Measure resources
  */
 public class MeasureHelper {
+
+    /**
+     * Retrieve the primary library ID from a FHIR measure resource. The baseline
+     * validation will not catch cases when no reference is provided and we
+     * enforce here the rule from the CQF measures IG where exactly one library
+     * reference is expected.
+     * 
+     * @param measure
+     *            Measure resource
+     * @return primary library ID
+     * @throws FHIROperationException
+     *             when there are more or less than one
+     *             library references in the resource
+     */
     public static String getPrimaryLibraryId(Measure measure) throws FHIROperationException {
         String primaryLibraryId = null;
-        if( measure.getLibrary() != null && measure.getLibrary().size() == 1 ) {
+        if (measure.getLibrary() != null && measure.getLibrary().size() == 1) {
             primaryLibraryId = measure.getLibrary().get(0).getValue();
         } else {
             // See https://hl7.org/fhir/us/cqfmeasures/2021May/StructureDefinition-computable-measure-cqfm.html
             throw new FHIROperationException("Measures utilizing CQL SHALL reference one and only one CQL library (and that referenced library MUST be the primary library for the measure)");
         }
-        
+
         return primaryLibraryId;
     }
 }

--- a/cql/fhir-quality-measure/src/main/java/com/ibm/fhir/ecqm/r4/MeasureHelper.java
+++ b/cql/fhir-quality-measure/src/main/java/com/ibm/fhir/ecqm/r4/MeasureHelper.java
@@ -1,0 +1,26 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.ecqm.r4;
+
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Measure;
+
+/**
+ * Utility methods for working with Measure resources
+ */
+public class MeasureHelper {
+    public static String getPrimaryLibraryId(Measure measure) throws FHIROperationException {
+        String primaryLibraryId = null;
+        if( measure.getLibrary() != null && measure.getLibrary().size() == 1 ) {
+            primaryLibraryId = measure.getLibrary().get(0).getValue();
+        } else {
+            // See https://hl7.org/fhir/us/cqfmeasures/2021May/StructureDefinition-computable-measure-cqfm.html
+            throw new FHIROperationException("Measures utilizing CQL SHALL reference one and only one CQL library (and that referenced library MUST be the primary library for the measure)");
+        }
+        
+        return primaryLibraryId;
+    }
+}

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
@@ -74,7 +74,14 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
     public static final String PARAM_IN_CONTENT_ENDPOINT = "contentEndpoint";
     public static final String PARAM_IN_TERMINOLOGY_ENDPOINT = "terminologyEndpoint";
     
-    
+    /**
+     * Check if the user provided any currently unsupported operation parameters.
+     * 
+     * @param paramMap
+     *            Operation input parameters
+     * @throws FHIROperationException
+     *             when one or more unsupported parameters are found
+     */
     protected void checkUnsupportedParameters(ParameterMap paramMap) throws FHIROperationException {
         List<Issue> issues = new ArrayList<>();
         
@@ -92,7 +99,16 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         }
     }
     
-    protected Issue checkUnsupportedParameter(ParameterMap paramMap, String paramName) throws FHIROperationException {
+    /**
+     * Check for a single unsupported parameter by name
+     * 
+     * @param paramMap
+     *            Operation input parameters
+     * @param paramName
+     *            Name of unsupported parameter
+     * @return FHIR Issue data describing the error or null if no such parameter is found.
+     */
+    protected Issue checkUnsupportedParameter(ParameterMap paramMap, String paramName) {
         Issue issue = null;
         if( paramMap.containsKey(paramName) ) {
             String msg = "Parameter '" + paramName + "' is not currently supported";
@@ -109,12 +125,36 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         }
         return issue;
     }
-    
+
+    /**
+     * Evaluate the requested CQL from the provided Library resource.
+     * 
+     * @param resourceHelper
+     *            Resource operation provider for loading related Library resources
+     * @param paramMap
+     *            Parameters object that describes the operation to perform
+     * @param primaryLibrary
+     *            Library resource that is the entry point for the evaluation
+     * @return Parameters describing the evaluation result
+     */
     protected Parameters doEvaluation(FHIRResourceHelpers resourceHelper, ParameterMap paramMap, Library primaryLibrary) {
         List<Library> libraries = LibraryHelper.loadLibraries(primaryLibrary);
         return doEvaluation(resourceHelper, paramMap, libraries);
     }
     
+    /**
+     * Evaluate the requested CQL from the provided Library resource.
+     * 
+     * @param resourceHelper
+     *            Resource operation provider for loading related Library resources
+     * @param paramMap
+     *            Parameters object that describes the operation to perform
+     * @param primaryLibrary
+     *            Library resource that is the entry point for the evaluation
+     * @param libraries
+     *            List of all necessary library resources. The first entry in the list is the primary library.
+     * @return Parameters describing the evaluation result
+     */
     protected Parameters doEvaluation(FHIRResourceHelpers resourceHelper, ParameterMap paramMap, List<Library> libraries) {
         Library primaryLibrary = libraries.get(0);
         LibraryLoader ll = createLibraryLoader(libraries);
@@ -165,7 +205,6 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         return output.build();
     }
 
-    @SuppressWarnings("unused")
     private Parameter convertDebugResultToParameter(EvaluationResult evaluationResult) {
         Parameter.Builder debugResultBuilder = Parameter.builder().name(fhirstring(PARAM_OUT_DEBUG_RESULT));
         
@@ -189,18 +228,32 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         return debugResultParameter;
     }
 
-
-
+    /**
+     * Retrieve subject parameter from the operation input
+     * 
+     * @param paramMap
+     *            operation input
+     * @return Pair of context name and value
+     */
     protected Pair<String, Object> getCqlContext(ParameterMap paramMap) {
         Pair<String, Object> context = null;
         Parameter subjectParam = paramMap.getSingletonParameter(PARAM_IN_SUBJECT);
         if (subjectParam != null) {
-            context = getCqlContext(context, subjectParam);
+            context = getCqlContext(subjectParam);
         }
         return context;
     }
 
-    protected Pair<String, Object> getCqlContext(Pair<String, Object> context, Parameter subjectParam) {
+    /**
+     * Retrieve subject parameter from the operation input
+     * 
+     * @param paramMap
+     *            operation input
+     * @return Pair of context name and value
+     */
+    protected Pair<String, Object> getCqlContext(Parameter subjectParam) {
+        Pair<String, Object> context = null;
+        
         String ref = javastring(((com.ibm.fhir.model.type.String) subjectParam.getValue()));
         String[] parts = ref.split("/");
         if (parts.length >= 2) {
@@ -211,6 +264,18 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         return context;
     }
 
+    /**
+     * Retrieve CQL parameters data from the operation input. FHIR data types are
+     * automatically converted to CQL System data types.
+     * 
+     * @param converter
+     *            Converter logic for transforming FHIR data types to CQL
+     *            input parameters.
+     * @param paramMap
+     *            operation input
+     * @return Map of parameter name to parameter value where value objects are
+     *         types in the CQL typesystem.
+     */
     protected Map<String, Object> getCqlParameters(ParameterConverter converter, ParameterMap paramMap) {
         Map<String, Object> engineParameters = null;
         Parameter parametersParam = paramMap.getOptionalSingletonParameter(PARAM_IN_PARAMETERS);
@@ -220,6 +285,18 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         return engineParameters;
     }
 
+    /**
+     * Retrieve CQL parameters data from the operation input. FHIR data types are
+     * automatically converted to CQL System data types.
+     * 
+     * @param converter
+     *            Converter logic for transforming FHIR data types to CQL
+     *            input parameters.
+     * @param parametersParam
+     *            operation input
+     * @return Map of parameter name to parameter value where value objects are
+     *         types in the CQL typesystem.
+     */
     protected Map<String, Object> getCqlEngineParameters(ParameterConverter converter, Parameter parametersParam) {
         Map<String, Object> engineParameters;
         engineParameters = new HashMap<>();
@@ -232,8 +309,22 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         return engineParameters;
     }
 
+    /**
+     * Get the expression names to evaluate in the primary library
+     * 
+     * @param paramMap
+     *            operation input
+     * @return expression names to evaluate
+     */
     protected abstract Set<String> getCqlExpressionsToEvaluate(ParameterMap paramMap);
 
+    /**
+     * Create a CQL Library loader for the content of the provided FHIR Library resources
+     * 
+     * @param libraries
+     *            FHIR Library resources containing CQL and/or ELM content
+     * @return CQL Engine LibraryLoader
+     */
     protected LibraryLoader createLibraryLoader(List<Library> libraries) {  
         FHIRLibraryLibrarySourceProvider sourceProvider = new FHIRLibraryLibrarySourceProvider(libraries);
         CqlTranslationProvider translator = new InJVMCqlTranslationProvider(sourceProvider);
@@ -245,7 +336,14 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
                     () -> new TreeSet<>( CqlLibraryComparator.INSTANCE ) ));
         return new InMemoryLibraryLoader(result);
     }
-    
+
+    /**
+     * Create a CQL DebugMap object based on the configuation in the operation input
+     * 
+     * @param paramMap
+     *            operation input
+     * @return DebugMap
+     */
     protected DebugMap getDebugMap(ParameterMap paramMap) {
         DebugMap debugMap = null;
         Parameter pDebug = paramMap.getOptionalSingletonParameter(PARAM_IN_DEBUG);

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/CqlOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/CqlOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -58,6 +58,12 @@ public class CqlOperation extends AbstractCqlOperation {
 
     private static final Logger LOG = Logger.getLogger(CqlOperation.class.getName());
 
+    /**
+     * Data container for grouped input parameters library.url, library.name. The 
+     * version is parsed from the library.url if present. Alias is part of the
+     * FHIR RelatedArtifact DataType, so it is included as an attribute, but is
+     * not currently used.
+     */
     public static class IncludeLibraryDetail {
         public IncludeLibraryDetail() {
             // No Operation
@@ -125,6 +131,18 @@ public class CqlOperation extends AbstractCqlOperation {
         return result;
     }
 
+    /**
+     * Create a Library resource matching the provided input parameters.
+     * 
+     * @param context
+     *            CQL execution context (e.g. Patient)
+     * @param expression
+     *            FHIR Parameter resource containg the CQL code to evaluate
+     * @param includes
+     *            List of FHIR parameter resources describing any helper libraries
+     *            that need to be included in order to evaluate the provided expression.
+     * @return generated Library resource
+     */
     protected Library createLibraryResource(String context, Parameter expression, List<Parameter> includes) {
         String libraryName = DEFAULT_LIBRARY_NAME;
         String libraryVersion = DEFAULT_LIBRARY_VERSION;
@@ -185,6 +203,12 @@ public class CqlOperation extends AbstractCqlOperation {
         return builder.build();
     }
 
+    /**
+     * Convert FHIR Parameter resource into corresponding IncludeLibraryDetail DTO
+     * 
+     * @param includeParameter FHIR Parameter resource
+     * @return IncludeLibraryDetail
+     */
     protected IncludeLibraryDetail getIncludeDetail(Parameter includeParameter) {
         IncludeLibraryDetail includeDetail = new IncludeLibraryDetail();
         

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractDataRequirementsOperation.java
@@ -32,10 +32,30 @@ import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
 public abstract class AbstractDataRequirementsOperation extends AbstractOperation {
     public static final String PARAM_OUT_RETURN = "return";
 
+    /**
+     * Perform the data requirements operation for the provided list of Library
+     * resources.
+     * 
+     * @param fhirLibraries
+     *            List of library resources.
+     * @return Library data requirements
+     */
     protected Parameters doDataRequirements(List<Library> fhirLibraries) {
         return doDataRequirements(fhirLibraries, null);
     }
     
+    /**
+     * Perform the data requirements operation for the provided list of Library
+     * resources.
+     * 
+     * @param fhirLibraries
+     *            List of library resources.
+     * @param additionalRelated
+     *            Supplier of additional RelatedArtifacts that should be 
+     *            addeded to the generated data requirements.
+     *            
+     * @return Library data requirements
+     */
     protected Parameters doDataRequirements(List<Library> fhirLibraries, Supplier<List<RelatedArtifact>> additionalRelated) {
         Library.Builder result = Library.builder()
                 .status(PublicationStatus.UNKNOWN)

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractMeasureOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractMeasureOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractMeasureOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/AbstractMeasureOperation.java
@@ -79,6 +79,33 @@ public abstract class AbstractMeasureOperation extends AbstractOperation {
         return retrieveProvider;
     }
 
+    /**
+     * Given a FHIR Measure resource, evaluate the measure and return
+     * a report of the results. 
+     * 
+     * @param resourceHelpers
+     *            Resource helpers for data access operations
+     * @param measure
+     *            Measure resource to be evaluated
+     * @param zoneOffset
+     *            Zone offset of the timezone that will be used for Now
+     *            or when partial dates are specified in the CQL.
+     * @param measurementPeriod
+     *            Measurement period that will be provided as input
+     *            to the Measure calculation.
+     * @param subjectOrPractitionerId
+     *            Subject or Practitioner ID for which the measure will be calculated.
+     * @param reportType
+     *            The type of measure report: subject, subject-list, or population. If not specified, a default value of
+     *            subject will be used if the subject parameter is supplied, otherwise, population will be used
+     * @param termProvider
+     *            terminology provider
+     * @param dataProviders
+     *            data provider
+     * @return MeasureReport.Builder that contains the calculated report data
+     * @throws FHIROperationException
+     *             Measure evaluation fails
+     */
     public MeasureReport.Builder doMeasureEvaluation(FHIRResourceHelpers resourceHelpers, Measure measure, ZoneOffset zoneOffset, Interval measurementPeriod, String subjectOrPractitionerId,
         MeasureReportType reportType,
         TerminologyProvider termProvider, Map<String, DataProvider> dataProviders) throws FHIROperationException {

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
@@ -98,11 +98,25 @@ public class CareGapsOperation extends AbstractMeasureOperation {
         }
     }
 
+    /**
+     * Evaluate all of the measures matching the specified care gap topic.
+     * The measure reports are bundled together and returned as a result.
+     * 
+     * @param cursor Provides an iterator over the Measure resources that match the topic
+     * @param subject Subject for which the measures will be evaluated (e.g. Patient ID)
+     * @param zoneOffset Timezone offset to be used by the CQL engine for date operations
+     * @param measurementPeriod Measurement Period provided as input to all measures
+     * @param resourceHelper Provides data access operations
+     * @param termProvider Terminology Provider
+     * @param dataProviders Data Providers
+     * @return Bundle containing a MeasureReport resource for each evaluated measure.
+     * @throws FHIROperationException
+     */
     protected Bundle processAllMeasures(FHIRBundleCursor cursor, String subject, ZoneOffset zoneOffset, Interval measurementPeriod, FHIRResourceHelpers resourceHelper, TerminologyProvider termProvider, Map<String,DataProvider> dataProviders) throws FHIROperationException {
         Bundle.Builder reports = Bundle.builder().type(BundleType.COLLECTION); 
         
         AtomicInteger count = new AtomicInteger(0);
-        for(Object resource : cursor) {
+        for (Object resource : cursor) {
             Measure measure = (Measure) resource;
             MeasureReport report = doMeasureEvaluation(resourceHelper, measure, zoneOffset, measurementPeriod, subject, MeasureReportType.INDIVIDUAL, termProvider, dataProviders).build();
             reports.entry( Bundle.Entry.builder().resource(report).build() );

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
@@ -98,16 +98,16 @@ public class CareGapsOperation extends AbstractMeasureOperation {
         }
     }
 
-    protected Bundle processAllMeasures(FHIRBundleCursor cursor, String subject, ZoneOffset zoneOffset, Interval measurementPeriod, FHIRResourceHelpers resourceHelper, TerminologyProvider termProvider, Map<String,DataProvider> dataProviders) {
+    protected Bundle processAllMeasures(FHIRBundleCursor cursor, String subject, ZoneOffset zoneOffset, Interval measurementPeriod, FHIRResourceHelpers resourceHelper, TerminologyProvider termProvider, Map<String,DataProvider> dataProviders) throws FHIROperationException {
         Bundle.Builder reports = Bundle.builder().type(BundleType.COLLECTION); 
         
         AtomicInteger count = new AtomicInteger(0);
-        cursor.forEach(resource -> {
+        for(Object resource : cursor) {
             Measure measure = (Measure) resource;
-            MeasureReport report = doMeasureEvaluation(measure, zoneOffset, measurementPeriod, subject, MeasureReportType.INDIVIDUAL, termProvider, dataProviders).build();
+            MeasureReport report = doMeasureEvaluation(resourceHelper, measure, zoneOffset, measurementPeriod, subject, MeasureReportType.INDIVIDUAL, termProvider, dataProviders).build();
             reports.entry( Bundle.Entry.builder().resource(report).build() );
             count.incrementAndGet();
-        });
+        }
         
         reports.total(UnsignedInt.of(count.get()));
         return reports.build();

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
@@ -86,8 +86,18 @@ public class EvaluateMeasureOperation extends AbstractMeasureOperation {
         return FHIROperationUtil.getOutputParameters(PARAM_OUT_RETURN, report.build());
     }
 
-
-
+    /**
+     * Retrieve the MeasureReportType to use based on operation inputs. The
+     * logic is defined as first use the provided code value, second use
+     * INDIVIDUAL if a subject is provided, and, last, use SUMMARY if
+     * neither a code or subject is available.
+     * 
+     * @param paramMap
+     *            operation input
+     * @param subject
+     *            subject value
+     * @return MeasureReportType
+     */
     public MeasureReportType getReportType(ParameterMap paramMap, String subject) {
         MeasureReportType reportType = null;
         
@@ -105,6 +115,13 @@ public class EvaluateMeasureOperation extends AbstractMeasureOperation {
         return reportType;
     }
 
+    /**
+     * Retrieve the subject parameter from operation input
+     * 
+     * @param paramMap
+     *            operation input
+     * @return subject parameter or null if not found.
+     */
     public String getSubject(ParameterMap paramMap) {
         String subject = null;
         Parameter pSubject = paramMap.getOptionalSingletonParameter(PARAM_IN_SUBJECT);
@@ -114,6 +131,13 @@ public class EvaluateMeasureOperation extends AbstractMeasureOperation {
         return subject;
     }
 
+    /**
+     * Retrieve the practitioner parameter from operation input
+     * 
+     * @param paramMap
+     *            operation input
+     * @return practitioner parameter or null if not found.
+     */
     public String getPractitioner(ParameterMap paramMap) {
         String practitioner = null;
         Parameter pPractitioner = paramMap.getOptionalSingletonParameter(PARAM_IN_PRACTITIONER);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperation.java
@@ -50,11 +50,11 @@ public class EvaluateMeasureOperation extends AbstractMeasureOperation {
 
         Measure measure = null;
         if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
-            measure = loadMeasureById(resourceHelper, logicalId);
+            measure = OperationHelper.loadMeasureById(resourceHelper, logicalId);
         } else if (operationContext.getType().equals(FHIROperationContext.Type.RESOURCE_TYPE)) {
             Parameter param = paramMap.getSingletonParameter(PARAM_IN_MEASURE);
             String reference = ((com.ibm.fhir.model.type.String) param.getValue()).getValue();
-            measure = loadMeasureByReference(resourceHelper, reference);
+            measure = OperationHelper.loadMeasureByReference(resourceHelper, reference);
         } else {
             assert false;
         }
@@ -81,7 +81,7 @@ public class EvaluateMeasureOperation extends AbstractMeasureOperation {
 
         Map<String, DataProvider> dataProviders = DataProviderFactory.createDataProviders(retrieveProvider);
 
-        MeasureReport.Builder report = doMeasureEvaluation(measure, zoneOffset, measurementPeriod, subjectOrPractitionerId, reportType, termProvider, dataProviders);
+        MeasureReport.Builder report = doMeasureEvaluation(resourceHelper, measure, zoneOffset, measurementPeriod, subjectOrPractitionerId, reportType, termProvider, dataProviders);
 
         return FHIROperationUtil.getOutputParameters(PARAM_OUT_RETURN, report.build());
     }

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.ibm.fhir.cql.helpers.LibraryHelper;
+import com.ibm.fhir.ecqm.r4.MeasureHelper;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Library;
 import com.ibm.fhir.model.resource.Measure;
@@ -47,7 +48,8 @@ public class MeasureDataRequirementsOperation extends AbstractDataRequirementsOp
             throw new IllegalArgumentException(String.format("Unexpected number of libraries '%d' referenced by measure '%s'", numLibraries, measure.getId()));
         }
 
-        Library primaryLibrary = FHIRRegistry.getInstance().getResource(measure.getLibrary().get(0).getValue(), Library.class);
+        String primaryLibraryId = MeasureHelper.getPrimaryLibraryId(measure);
+        Library primaryLibrary = OperationHelper.loadLibraryByReference(resourceHelper, primaryLibraryId);
         List<Library> fhirLibraries = LibraryHelper.loadLibraries(primaryLibrary);
 
         RelatedArtifact related = RelatedArtifact.builder().type(RelatedArtifactType.DEPENDS_ON).resource(measure.getLibrary().get(0)).build();

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureSubmitDataOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureSubmitDataOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -72,6 +72,13 @@ public class MeasureSubmitDataOperation extends AbstractOperation {
         }
     }
     
+    /**
+     * Create a bundle entry for the provided resource
+     * 
+     * @param resource
+     *            FHIR resource
+     * @return Bundle entry
+     */
     protected Bundle.Entry createEntry( Resource resource ) {
         // the cqf-ruler implementation uses POST, but the operation definition says that 
         // this operation needs to be idempotent. In order to be idempotent, I believe this

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -57,24 +57,66 @@ public class OperationHelper {
         return result;
     }
     
+    /**
+     * Load a Measure resource by reference. 
+     * @see loadResourceByReference
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param reference Resource reference either in ResourceType/ID or canonical URL format
+     * @return loaded resource
+     * @throws FHIROperationException when resource is not found
+     */
     public static Measure loadMeasureByReference(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
         return loadResourceByReference(resourceHelper, ResourceType.MEASURE, Measure.class, reference);
     }
-    
 
-    public static Measure loadMeasureById(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
-        return loadResourceById(resourceHelper, ResourceType.MEASURE, reference);
+    /**
+     * Load a Measure resource by ID.
+     * 
+     * @see loadResourceById
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param resourceId Resource ID
+     * @return loaded resource
+     * @throws FHIROperationException when resource is not found
+     */
+    public static Measure loadMeasureById(FHIRResourceHelpers resourceHelper, String resourceId) throws FHIROperationException {
+        return loadResourceById(resourceHelper, ResourceType.MEASURE, resourceId);
     }
     
+    /**
+     * Load a Library resource by reference. 
+     * @see loadResourceByReference
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param reference Resource reference either in ResourceType/ID or canonical URL format
+     * @return loaded resource
+     * @throws FHIROperationException when resource is not found
+     */
     public static Library loadLibraryByReference(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
         return loadResourceByReference(resourceHelper, ResourceType.LIBRARY, Library.class, reference);
     }
     
-
-    public static Library loadLibraryById(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
-        return loadResourceById(resourceHelper, ResourceType.LIBRARY, reference);
+    /**
+     * Load a Library resource by ID.
+     * 
+     * @see loadResourceById
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param resourceId Resource ID
+     * @return loaded resource
+     * @throws FHIROperationException when resource is not found
+     */
+    public static Library loadLibraryById(FHIRResourceHelpers resourceHelper, String resourceId) throws FHIROperationException {
+        return loadResourceById(resourceHelper, ResourceType.LIBRARY, resourceId);
     }
     
+    /**
+     * Load a resource by reference. If the reference is of the format, ResourceType/ID or
+     * does not contain any forward slash characters, it will be loaded directly. Otherwise,
+     * the reference will be treated as a canonical URL and resolved from the FHIR registry. 
+     *
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param reference Resource reference either in ResourceType/ID or canonical URL format
+     * @return loaded resource
+     * @throws FHIROperationException when resource is not found
+     */
     @SuppressWarnings("unchecked")
     public static <T extends Resource> T loadResourceByReference(FHIRResourceHelpers resourceHelper, ResourceType resourceType, Class<T> resourceClass, String reference) throws FHIROperationException {
         T resource;
@@ -95,14 +137,25 @@ public class OperationHelper {
         return resource;
     }
 
+    /**
+     * Load a resource by ID. ID values are expected to already be separated
+     * from the ResourceType in a reference.
+     * 
+     * @param <T> Resource class to load
+     * @param resourceHelper FHIRResourceHelpers for resource reads
+     * @param resourceType ResourceType of the resource to load
+     * @param resourceId ID
+     * @return
+     * @throws FHIROperationException
+     */
     @SuppressWarnings("unchecked")
-    public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String reference) throws FHIROperationException {
+    public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String resourceId) throws FHIROperationException {
         T resource;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), reference, true, false, null);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true, false, null);
             resource = (T) readResult.getResource();
         } catch (Exception ex) {
-            throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), reference), ex);
+            throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId), ex);
         }
         return resource;
     }

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -1,0 +1,109 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.operation.cqf;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.opencds.cqf.cql.engine.execution.InMemoryLibraryLoader;
+import org.opencds.cqf.cql.engine.execution.LibraryLoader;
+
+import com.ibm.fhir.cql.helpers.LibraryHelper;
+import com.ibm.fhir.cql.translator.CqlTranslationProvider;
+import com.ibm.fhir.cql.translator.FHIRLibraryLibrarySourceProvider;
+import com.ibm.fhir.cql.translator.impl.InJVMCqlTranslationProvider;
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.Library;
+import com.ibm.fhir.model.resource.Measure;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.code.ResourceType;
+import com.ibm.fhir.persistence.SingleResourceResult;
+import com.ibm.fhir.registry.FHIRRegistry;
+import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
+
+public class OperationHelper {
+    /**
+     * Create a library loader that will server up the CQL library content of the
+     * provided list of FHIR Library resources.
+     * 
+     * @param libraries
+     *            FHIR library resources
+     * @return LibraryLoader that will serve the CQL Libraries for the provided FHIR resources
+     */
+    public static LibraryLoader createLibraryLoader(List<Library> libraries) {
+        List<org.cqframework.cql.elm.execution.Library> result = loadCqlLibraries(libraries);
+        return new InMemoryLibraryLoader(result);
+    }
+
+    /**
+     * Load the CQL Library content for each of the provided FHIR Library resources with
+     * translation as needed for Libraries with CQL attachments and no corresponding
+     * ELM attachment.
+     * 
+     * @param libraries
+     *            FHIR Libraries
+     * @return CQL Libraries
+     */
+    public static List<org.cqframework.cql.elm.execution.Library> loadCqlLibraries(List<Library> libraries) {
+        FHIRLibraryLibrarySourceProvider sourceProvider = new FHIRLibraryLibrarySourceProvider(libraries);
+        CqlTranslationProvider translator = new InJVMCqlTranslationProvider(sourceProvider);
+
+        List<org.cqframework.cql.elm.execution.Library> result =
+                libraries.stream().flatMap(fl -> LibraryHelper.loadLibrary(translator, fl).stream()).filter(Objects::nonNull).collect(Collectors.toList());
+        return result;
+    }
+    
+    public static Measure loadMeasureByReference(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
+        return loadResourceByReference(resourceHelper, ResourceType.MEASURE, Measure.class, reference);
+    }
+    
+
+    public static Measure loadMeasureById(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
+        return loadResourceById(resourceHelper, ResourceType.MEASURE, reference);
+    }
+    
+    public static Library loadLibraryByReference(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
+        return loadResourceByReference(resourceHelper, ResourceType.LIBRARY, Library.class, reference);
+    }
+    
+
+    public static Library loadLibraryById(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
+        return loadResourceById(resourceHelper, ResourceType.LIBRARY, reference);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public static <T extends Resource> T loadResourceByReference(FHIRResourceHelpers resourceHelper, ResourceType resourceType, Class<T> resourceClass, String reference) throws FHIROperationException {
+        T resource;
+        int pos = reference.indexOf('/');
+        if( pos == -1 || reference.startsWith(resourceType.getValue() + "/") ) {
+            String resourceId = reference;
+            if( pos > -1 ) {
+                resourceId = reference.substring(pos + 1);
+            } 
+            resource = (T) loadResourceById(resourceHelper, resourceType, resourceId);
+        } else {
+            resource = FHIRRegistry.getInstance().getResource(reference, resourceClass);
+            if( resource == null ) {
+                throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), reference));
+            }
+        }
+        
+        return resource;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String reference) throws FHIROperationException {
+        T resource;
+        try {
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), reference, true, false, null);
+            resource = (T) readResult.getResource();
+        } catch (Exception ex) {
+            throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), reference), ex);
+        }
+        return resource;
+    }
+}

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -79,8 +79,12 @@ public abstract class BaseDataRequirementsOperationTest {
             return outParameters;
         }
     }
-
+    
     protected Library initializeLibraries(FHIRRegistry mockRegistry, FHIRResourceHelpers resourceHelper) throws Exception {
+        return initializeLibraries(mockRegistry, resourceHelper, true);
+    }
+
+    protected Library initializeLibraries(FHIRRegistry mockRegistry, FHIRResourceHelpers resourceHelper, boolean exists) throws Exception {
         String cql = CqlBuilder.builder()
                 .library("Test", "1.0.0")
                 .using("FHIR", Constants.FHIR_VERSION)
@@ -96,9 +100,11 @@ public abstract class BaseDataRequirementsOperationTest {
         Library primaryLibrary = getPrimaryLibrary(cql, modelInfo, fhirHelpers, sde);
         List<Library> fhirLibraries = Arrays.asList(primaryLibrary, getSupplementalDataElementsLibrary(), getFHIRHelpers(), getFHIRModelInfo());
     
-        when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
-        
-        fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
+        if( exists ) {
+            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
+            
+            fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
+        }
         return primaryLibrary;
     }
 

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -100,7 +100,7 @@ public abstract class BaseDataRequirementsOperationTest {
         Library primaryLibrary = getPrimaryLibrary(cql, modelInfo, fhirHelpers, sde);
         List<Library> fhirLibraries = Arrays.asList(primaryLibrary, getSupplementalDataElementsLibrary(), getFHIRHelpers(), getFHIRModelInfo());
     
-        if( exists ) {
+        if (exists) {
             when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
             
             fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -146,23 +148,8 @@ public class EvaluateMeasureOperationTest {
     }
     
     @Test
-    public void testDoEvaluationInvalidReference() throws Exception {
+    public void testDoEvaluationInvalidIDReferenceNoPrefix() throws Exception {
         Patient patient = (Patient) TestHelper.getTestResource("Patient.json");
-
-        String codesystem = "http://snomed.ct/info";
-        String encounterCode = "office-visit";
-        Coding reason = coding(codesystem, encounterCode);
-        Encounter encounter = Encounter.builder()
-                .reasonCode(concept(reason))
-                .status(EncounterStatus.FINISHED)
-                .clazz(reason)
-                .period(Period.builder().start(DateTime.now()).end(DateTime.now()).build())
-                .build();
-
-        String procedureCode = "fluoride-application";
-        Coding type = coding(codesystem, procedureCode);
-        Procedure procedure = Procedure.builder().subject(Reference.builder().reference(fhirstring("Patient/"
-                + patient.getId())).build()).code(concept(type)).status(ProcedureStatus.COMPLETED).performed(DateTime.of("2019-03-14")).build();
 
         List<Measure> measures = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Measure.class);
         assertEquals( measures.size(), 1 );
@@ -188,8 +175,48 @@ public class EvaluateMeasureOperationTest {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(encounter) );
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(procedure) );
+        try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
+            FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
+            staticRegistry.when(FHIRRegistry::getInstance).thenReturn(mockRegistry);
+
+            when(mockRegistry.getResource(measureURL, Measure.class)).thenReturn( measure );
+            fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
+
+            operation.doInvoke(FHIROperationContext.createResourceTypeOperationContext("evaluate-measure"),
+                Measure.class, null, null, parameters, resourceHelper);
+            fail("Operation was expected to fail");
+        } catch( FHIROperationException fex ) {
+            assertEquals(fex.getMessage(), "Failed to resolve Measure resource \"NOT VALID\"");
+        }
+    }
+    
+    @Test
+    public void testDoEvaluationInvalidIDReferenceWithPrefix() throws Exception {
+        Patient patient = (Patient) TestHelper.getTestResource("Patient.json");
+
+        List<Measure> measures = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Measure.class);
+        assertEquals( measures.size(), 1 );
+        Measure measure = measures.get(0);
+        String measureURL = canonical(measure.getUrl(), measure.getVersion()).getValue();
+
+        List<Library> fhirLibraries = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Library.class);
+
+        List<String> names = fhirLibraries.stream().map( l -> l.getName().getValue()).collect(Collectors.toList());
+        System.out.println(names);
+
+        LocalDate periodStart = LocalDate.of(2000, 1, 1);
+        LocalDate periodEnd = periodStart.plus(1, ChronoUnit.YEARS);
+
+        Parameters.Parameter pPeriodStart = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_START)).value(Date.of(periodStart)).build();
+        Parameters.Parameter pPeriodEnd = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_END)).value(Date.of(periodEnd)).build();
+        Parameters.Parameter pReportType = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_REPORT_TYPE)).value(MeasureReportType.INDIVIDUAL).build();
+        Parameters.Parameter pMeasure = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_MEASURE)).value(fhirstring("Measure/NOT_VALID")).build();
+        Parameters.Parameter pSubject = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_SUBJECT)).value(fhirstring("Patient/" + patient.getId())).build();
+
+        Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -202,7 +229,91 @@ public class EvaluateMeasureOperationTest {
                 Measure.class, null, null, parameters, resourceHelper);
             fail("Operation was expected to fail");
         } catch( FHIROperationException fex ) {
-            assertEquals(fex.getMessage(), "Failed to resolve resource NOT VALID");
+            assertEquals(fex.getMessage(), "Failed to resolve Measure resource \"NOT_VALID\"");
+        }
+    }
+    
+    @Test
+    public void testDoEvaluationInvalidURLReference() throws Exception {
+        Patient patient = (Patient) TestHelper.getTestResource("Patient.json");
+
+        List<Measure> measures = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Measure.class);
+        assertEquals( measures.size(), 1 );
+        Measure measure = measures.get(0);
+        String measureURL = canonical(measure.getUrl(), measure.getVersion()).getValue();
+
+        List<Library> fhirLibraries = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Library.class);
+
+        List<String> names = fhirLibraries.stream().map( l -> l.getName().getValue()).collect(Collectors.toList());
+        System.out.println(names);
+
+        LocalDate periodStart = LocalDate.of(2000, 1, 1);
+        LocalDate periodEnd = periodStart.plus(1, ChronoUnit.YEARS);
+
+        Parameters.Parameter pPeriodStart = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_START)).value(Date.of(periodStart)).build();
+        Parameters.Parameter pPeriodEnd = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_END)).value(Date.of(periodEnd)).build();
+        Parameters.Parameter pReportType = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_REPORT_TYPE)).value(MeasureReportType.INDIVIDUAL).build();
+        Parameters.Parameter pMeasure = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_MEASURE)).value(fhirstring("https://iamnothere.com/Measure/NOT_VALID|1.0")).build();
+        Parameters.Parameter pSubject = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_SUBJECT)).value(fhirstring("Patient/" + patient.getId())).build();
+
+        Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+
+        try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
+            FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
+            staticRegistry.when(FHIRRegistry::getInstance).thenReturn(mockRegistry);
+
+            when(mockRegistry.getResource(measureURL, Measure.class)).thenReturn( measure );
+            fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
+
+            operation.doInvoke(FHIROperationContext.createResourceTypeOperationContext("evaluate-measure"),
+                Measure.class, null, null, parameters, resourceHelper);
+            fail("Operation was expected to fail");
+        } catch( FHIROperationException fex ) {
+            assertEquals(fex.getMessage(), "Failed to resolve Measure resource \"https://iamnothere.com/Measure/NOT_VALID|1.0\"");
+        }
+    }
+    
+    /**
+     * Evaluate a Measure that does not define a library reference
+     */
+    @Test
+    public void testDoEvaluationMeasureNoLibraries() throws Exception {
+        Patient patient = (Patient) TestHelper.getTestResource("Patient.json");
+
+        List<Measure> measures = TestHelper.getBundleResources("EXM74-10.2.000-request.json", Measure.class);
+        assertEquals( measures.size(), 1 );
+        Measure measure = measures.get(0);
+        measure = measure.toBuilder().library(Collections.emptyList()).build();
+        String measureURL = canonical(measure.getUrl(), measure.getVersion()).getValue();
+
+        LocalDate periodStart = LocalDate.of(2000, 1, 1);
+        LocalDate periodEnd = periodStart.plus(1, ChronoUnit.YEARS);
+
+        Parameters.Parameter pPeriodStart = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_START)).value(Date.of(periodStart)).build();
+        Parameters.Parameter pPeriodEnd = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_PERIOD_END)).value(Date.of(periodEnd)).build();
+        Parameters.Parameter pReportType = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_REPORT_TYPE)).value(MeasureReportType.INDIVIDUAL).build();
+        Parameters.Parameter pMeasure = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_MEASURE)).value(measureURL).build();
+        Parameters.Parameter pSubject = Parameters.Parameter.builder().name(fhirstring(EvaluateMeasureOperation.PARAM_IN_SUBJECT)).value(fhirstring("Patient/" + patient.getId())).build();
+
+        Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
+
+        FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+
+        try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
+            FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
+            staticRegistry.when(FHIRRegistry::getInstance).thenReturn(mockRegistry);
+
+            when(mockRegistry.getResource(measureURL, Measure.class)).thenReturn( measure );
+
+            operation.doInvoke(FHIROperationContext.createResourceTypeOperationContext("evaluate-measure"),
+                Measure.class, null, null, parameters, resourceHelper);
+            fail("Operation was expected to fail");
+        } catch( FHIROperationException fex ) {
+            assertTrue(fex.getMessage().startsWith("Measures utilizing CQL SHALL reference one and only one CQL library"), fex.getMessage());
         }
     }
 }

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/BaseMeasureOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/BaseMeasureOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/BaseMeasureOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/BaseMeasureOperationTest.java
@@ -67,6 +67,16 @@ public class BaseMeasureOperationTest extends FHIRServerTestBase {
         entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
         response = getWebTarget().request().post( entity );
         assertResponse( response, Response.Status.Family.SUCCESSFUL );
+        
+        jsonObject = TestUtil.readJsonObject("testdata/Measure-MissingLibrary.json");
+        entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
+        response = getWebTarget().path("/Measure/MissingLibrary").request().put( entity );
+        assertResponse( response, Response.Status.Family.SUCCESSFUL );
+        
+        jsonObject = TestUtil.readJsonObject("testdata/Measure-NoLibrary.json");
+        entity = Entity.entity(jsonObject, FHIRMediaType.APPLICATION_FHIR_JSON);
+        response = getWebTarget().path("/Measure/NoLibrary").request().put( entity );
+        assertResponse( response, Response.Status.Family.SUCCESSFUL );
     }
     
     public Period getPeriod(String start, String end) {

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerEvaluateMeasureOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerEvaluateMeasureOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureCollectDataOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureCollectDataOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureCollectDataOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureCollectDataOperationTest.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.server.test.cqf;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.StringReader;
 
@@ -16,6 +17,7 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.resource.MeasureReport;
+import com.ibm.fhir.model.resource.OperationOutcome;
 
 public class ServerMeasureCollectDataOperationTest extends BaseMeasureOperationTest {
 
@@ -51,5 +53,25 @@ public class ServerMeasureCollectDataOperationTest extends BaseMeasureOperationT
         //System.out.println(responseBody);
         MeasureReport report = (MeasureReport) FHIRParser.parser(Format.JSON).parse(new StringReader(responseBody));        
         assertEquals(report.getSubject().getReference().getValue(), TEST_PATIENT_ID);
+    }
+    
+    @Test
+    public void testCollectDataPatientMeasureInstanceLibraryNotFound() throws Exception {
+        Response response =
+                getWebTarget().path("/Measure/{measureId}/$collect-data")
+                    .resolveTemplate("measureId", "MissingLibrary")
+                    .queryParam("periodStart", TEST_PERIOD_START)
+                    .queryParam("periodEnd", TEST_PERIOD_END)
+                    .queryParam("subject", TEST_PATIENT_ID)
+                    .request().get();
+
+        String responseBody = response.readEntity(String.class);
+        //System.out.println(responseBody);
+        assertResponse(response, 500);
+
+        OperationOutcome outcome = (OperationOutcome) FHIRParser.parser(Format.JSON).parse(new StringReader(responseBody));
+        String details = outcome.getIssue().get(0).getDetails().getText().getValue();
+        assertTrue(details.contains("Failed to resolve"));
+        assertTrue(details.contains("NotExists"), details);        
     }
 }

--- a/fhir-server-test/src/test/resources/testdata/Measure-MissingLibrary.json
+++ b/fhir-server-test/src/test/resources/testdata/Measure-MissingLibrary.json
@@ -1,0 +1,27 @@
+{
+	"resourceType": "Measure",
+	"id": "MissingLibrary",
+	"name": "MissingLibrary",
+	"version": "1.0.0",
+	"url": "http://localhost/fhir-server/api/v4/Measure/MissingLibrary",
+	"status": "active",
+	"library": ["Library/NotExists"],
+	"scoring": {
+		"coding": [{
+			"code": "cohort"
+		}]
+	},
+	"group": [{
+		"population": [{
+			"code": {
+				"coding": [{
+					"code": "initial-population"
+				}]
+			},
+			"criteria": {
+				"language": "text/cql",
+				"expression": "cohort"
+			}
+		}]
+	}]
+}

--- a/fhir-server-test/src/test/resources/testdata/Measure-NoLibrary.json
+++ b/fhir-server-test/src/test/resources/testdata/Measure-NoLibrary.json
@@ -1,0 +1,26 @@
+{
+	"resourceType": "Measure",
+	"id": "NoLibrary",
+	"name": "NoLibrary",
+	"version": "1.0.0",
+	"url": "http://localhost/fhir-server/api/v4/Measure/NoLibrary",
+	"status": "active",
+	"scoring": {
+		"coding": [{
+			"code": "cohort"
+		}]
+	},
+	"group": [{
+		"population": [{
+			"code": {
+				"coding": [{
+					"code": "initial-population"
+				}]
+			},
+			"criteria": {
+				"language": "text/cql",
+				"expression": "cohort"
+			}
+		}]
+	}]
+}


### PR DESCRIPTION
I applied a fix before the holiday that corrected a category of NPE
errors related to execution against measure or library resources that
don't exist. It turns out that wasn't the core of the issue 3061. This
goes back and addresses when a valid measure reference is used, but that
Measure refers to a Library resource that does not exist. I also added
some handling that allows resolution of Library resources by reference
in addition to by canonical URL in the registry and also updated the
error handling around retrieving the primary library reference from the
Measure resource.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>