### PR TITLE
issue #3032 only update when current schema is behind code version

### DIFF
--- a/fhir-bucket/src/main/java/com/ibm/fhir/bucket/app/Main.java
+++ b/fhir-bucket/src/main/java/com/ibm/fhir/bucket/app/Main.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -753,13 +753,13 @@ public class Main {
             // If our schema is already at the latest version, we can skip a lot of processing
             SchemaVersionsManager svm = new SchemaVersionsManager(translator, connectionPool, transactionProvider, schemaName,
                 FhirBucketSchemaVersion.getLatestSchemaVersion().vid());
-            if (svm.isLatestSchema()) {
-                logger.info("Already at latest version; skipping update for: '" + schemaName + "'");
-            } else {
+            if (svm.isSchemaOld()) {
                 buildSchema();
                 
                 // Update the whole schema version
                 svm.updateSchemaVersion();
+            } else {
+                logger.info("Already at latest version; skipping update for: '" + schemaName + "'");
             }
         } finally {
             leaseManager.cancelLease();

--- a/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/schema/SchemaVersionsManager.java
+++ b/fhir-database-utils/src/main/java/com/ibm/fhir/database/utils/schema/SchemaVersionsManager.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,8 +8,6 @@ package com.ibm.fhir.database.utils.schema;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 import com.ibm.fhir.database.utils.api.IConnectionProvider;
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
@@ -90,15 +88,28 @@ public class SchemaVersionsManager {
      * table
      */
     public void updateSchemaVersion() {
-        updateSchemaVersionId(this.latestCodeVersion);
+        // The schema version should never regress, so make sure we don't change
+        // anything if this code is older than what's currently in the database
+        if (latestCodeVersion > getVersionForSchema()) {
+            updateSchemaVersionId(this.latestCodeVersion);
+        }
     }
 
     /**
-     * Returns true if the current schema version recorded in WHOLE_SCHEMA_VERSION is the
-     * latest FhirSchemaVersion
+     * Returns true if the current schema version recorded in WHOLE_SCHEMA_VERSION is older
+     * the last version in FhirSchemaVersion and therefore needs to be updated
      * @return
      */
-    public boolean isLatestSchema() {
+    public boolean isSchemaOld() {
+        return getVersionForSchema() < latestCodeVersion;
+    }
+
+    /**
+     * Returns true if the current schema version recorded in WHOLE_SCHEMA_VERSION 
+     * exactly matches the last version in FhirSchemaVersion
+     * @return
+     */
+    public boolean isSchemaVersionMatch() {
         return getVersionForSchema() == latestCodeVersion;
     }
 }

--- a/fhir-persistence-schema/README.md
+++ b/fhir-persistence-schema/README.md
@@ -808,6 +808,7 @@ and grants permission to the username|
 |--vacuum-cost-limit|costLimit|The Vacuum cost limit to set|
 |--skip-allocate-if-tenant-exists||Skips allocating a tenant if it already exists|
 |--force-unused-table-removal||Forces the removal of unused tables - DomainResource, Resource|
+|--force||Do not skip schema update process when the whole-schema-version matches.|
 |--prop|name=value|name=value that is passed in on the commandline|
 |--pool-size|poolSize|poolsize used with the database actions|
 |--drop-schema-oauth||drop the db schema used by liberty's oauth/openid connect features|

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
@@ -545,6 +545,7 @@ public class Main {
                 }
             } else if (this.force) {
                 logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+                this.exitStatus = EXIT_BAD_ARGS;
             } else {
                 logger.info("Schema is up-to-date; skipping update for: '" + targetSchemaName + "'");
             }
@@ -590,6 +591,7 @@ public class Main {
                 }
             } else if (this.force) {
                 logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+                this.exitStatus = EXIT_BAD_ARGS;
             } else {
                 logger.info("Schema is current; skipping update for: '" + targetSchemaName + "'");
             }
@@ -635,6 +637,7 @@ public class Main {
                 }
             } else if (this.force) {
                 logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+                this.exitStatus = EXIT_BAD_ARGS;
             } else {
                 logger.info("Schema is current; skipping update for: '" + targetSchemaName + "'");
             }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/Main.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -23,6 +23,7 @@ import static com.ibm.fhir.schema.app.menu.Menu.DROP_SCHEMA_BATCH;
 import static com.ibm.fhir.schema.app.menu.Menu.DROP_SCHEMA_FHIR;
 import static com.ibm.fhir.schema.app.menu.Menu.DROP_SCHEMA_OAUTH;
 import static com.ibm.fhir.schema.app.menu.Menu.DROP_TENANT;
+import static com.ibm.fhir.schema.app.menu.Menu.FORCE;
 import static com.ibm.fhir.schema.app.menu.Menu.FORCE_UNUSED_TABLE_REMOVAL;
 import static com.ibm.fhir.schema.app.menu.Menu.FREEZE_TENANT;
 import static com.ibm.fhir.schema.app.menu.Menu.GRANT_TO;
@@ -257,6 +258,9 @@ public class Main {
 
     // Forces the removal of tables if data exists
     private boolean forceUnusedTableRemoval = false;
+
+    // Force schema update even if whole-schema-version is current
+    private boolean force = false;
 
     // Tenant Key Output or Input File
     private String tenantKeyFileName;
@@ -501,9 +505,7 @@ public class Main {
             // If our schema is already at the latest version, we can skip a lot of processing
             SchemaVersionsManager svm = new SchemaVersionsManager(translator, connectionPool, transactionProvider, targetSchemaName,
                 FhirSchemaVersion.getLatestFhirSchemaVersion().vid());
-            if (svm.isLatestSchema()) {
-                logger.info("Already at latest version; skipping update for: '" + targetSchemaName + "'");
-            } else {
+            if (svm.isSchemaOld() || this.force && svm.isSchemaVersionMatch()) {
                 // Build/update the FHIR-related tables as well as the stored procedures
                 PhysicalDataModel pdm = new PhysicalDataModel();
                 buildFhirDataSchemaModel(pdm);
@@ -541,6 +543,10 @@ public class Main {
                     // Finally, update the whole schema version
                     svm.updateSchemaVersion();
                 }
+            } else if (this.force) {
+                logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+            } else {
+                logger.info("Schema is up-to-date; skipping update for: '" + targetSchemaName + "'");
             }
         } finally {
             leaseManager.cancelLease();
@@ -568,9 +574,7 @@ public class Main {
             // If our schema is already at the latest version, we can skip a lot of processing
             SchemaVersionsManager svm = new SchemaVersionsManager(translator, connectionPool, transactionProvider, targetSchemaName,
                 FhirSchemaVersion.getLatestFhirSchemaVersion().vid());
-            if (svm.isLatestSchema()) {
-                logger.info("Already at latest version; skipping update for: '" + targetSchemaName + "'");
-            } else {
+            if (svm.isSchemaOld() || this.force && svm.isSchemaVersionMatch()) {
                 PhysicalDataModel pdm = new PhysicalDataModel();
                 buildOAuthSchemaModel(pdm);
                 updateSchema(pdm);
@@ -584,6 +588,10 @@ public class Main {
                     // Mark the schema as up-to-date
                     svm.updateSchemaVersion();
                 }
+            } else if (this.force) {
+                logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+            } else {
+                logger.info("Schema is current; skipping update for: '" + targetSchemaName + "'");
             }
         } finally {
             leaseManager.cancelLease();
@@ -611,9 +619,7 @@ public class Main {
             // If our schema is already at the latest version, we can skip a lot of processing
             SchemaVersionsManager svm = new SchemaVersionsManager(translator, connectionPool, transactionProvider, targetSchemaName,
                 FhirSchemaVersion.getLatestFhirSchemaVersion().vid());
-            if (svm.isLatestSchema()) {
-                logger.info("Already at latest version; skipping update for: '" + targetSchemaName + "'");
-            } else {
+            if (svm.isSchemaOld() || this.force && svm.isSchemaVersionMatch()) {
                 PhysicalDataModel pdm = new PhysicalDataModel();
                 buildJavaBatchSchemaModel(pdm);
                 updateSchema(pdm);
@@ -627,6 +633,10 @@ public class Main {
                     // Mark the schema as up-to-date
                     svm.updateSchemaVersion();
                 }
+            } else if (this.force) {
+                logger.info("Cannot force when schema is ahead of this version; skipping update for: '" + targetSchemaName + "'");
+            } else {
+                logger.info("Schema is current; skipping update for: '" + targetSchemaName + "'");
             }
         } finally {
             leaseManager.cancelLease();
@@ -2060,6 +2070,9 @@ public class Main {
                 break;
             case FORCE_UNUSED_TABLE_REMOVAL:
                 forceUnusedTableRemoval = true;
+                break;
+            case FORCE:
+                force = true;
                 break;
             default:
                 throw new IllegalArgumentException("Invalid argument: '" + arg + "'");

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/menu/Menu.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/menu/Menu.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -55,6 +55,7 @@ public class Menu {
     public static final String CREATE_SCHEMA_FHIR = "--create-schema-fhir";
     public static final String CREATE_SCHEMA_BATCH = "--create-schema-batch";
     public static final String CREATE_SCHEMA_OAUTH = "--create-schema-oauth";
+    public static final String FORCE = "--force";
     public static final String HELP = "--help";
 
     public Menu() {

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/menu/Menu.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/app/menu/Menu.java
@@ -92,6 +92,7 @@ public class Menu {
         MI_VACUUM_TRESHOLD(VACUUM_TRESHOLD, "threshold", "The threshold value to alter to 'threshold'"),
         MI_VACUUM_COST_LIMIT(VACUUM_COST_LIMIT, "costLimit", "The Vacuum cost limit to set"),
         MI_SKIP_ALLOCATE_IF_TENANT_EXISTS(SKIP_ALLOCATE_IF_TENANT_EXISTS, "", "Skips allocating a tenant if it already exists"),
+        MI_FORCE(FORCE, "", "Do not skip schema update process when the whole-schema-version matches."),
         MI_FORCE_UNUSED_TABLE_REMOVAL(FORCE_UNUSED_TABLE_REMOVAL, "", "Forces the removal of unused tables - DomainResource, Resource"),
         MI_PROP(PROP, "name=value", "name=value that is passed in on the commandline"),
         MI_POOL_SIZE(POOL_SIZE, "poolSize", "poolsize used with the database actions"),

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbySchemaVersionsTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbySchemaVersionsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,7 +7,7 @@
 package com.ibm.fhir.schema.derby;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
 
 import org.testng.annotations.Test;
 
@@ -54,7 +54,7 @@ public class DerbySchemaVersionsTest {
             svm.updateSchemaVersion();
             assertEquals(svm.getVersionForSchema(), FhirSchemaVersion.V0024.vid());
 
-            assertTrue(svm.isLatestSchema());
+            assertFalse(svm.isSchemaOld());
        }
     }
 }


### PR DESCRIPTION
Signed-off-by: Robin Arnold <robin.arnold@ibm.com>

Also added `--force` option which will cause the schema upgrade steps to be performed (partially bypassing the whole-schema-version check) but only if the code schema version is equal to the database schema version. Note that if the database schema version is behind the code schema version, you don't need `--force` because the changes will be applied anyway.