### PR TITLE
Erroneous reporting of Pending Outcome in Audit #3204

### DIFF
--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/AuditEventMapper.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/AuditEventMapper.java
@@ -442,16 +442,12 @@ public class AuditEventMapper implements Mapper {
         // @formatter:on
     }
 
-    /*
-     * in the future, we could
-     * enhance this part to log the alternative outcomes.
-     * This applies to the next two methods: outcomeDesc, outcome
+    /**
+     * @implNote This applies to the next two methods: outcomeDesc, outcome
+     * Previously, it had pending as an option, however it should not it in all cases.
      */
     private com.ibm.fhir.model.type.String outcomeDesc(AuditLogEntry entry) {
-        if (entry.getContext().getEndTime() == null ||
-                entry.getContext().getStartTime().equalsIgnoreCase(entry.getContext().getEndTime())) {
-            return string("pending");
-        } else if (entry.getContext().getApiParameters().getStatus() < 400) {
+        if (entry.getContext().getApiParameters().getStatus() < 400) {
             return string("success");
         } else if (entry.getContext().getApiParameters().getStatus() < 500) {
             return string("minor failure");

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/AuditEventMapper.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/AuditEventMapper.java
@@ -444,7 +444,7 @@ public class AuditEventMapper implements Mapper {
 
     /**
      * @implNote This applies to the next two methods: outcomeDesc, outcome
-     * Previously, it had pending as an option, however it should not it in all cases.
+     * Previously, it had pending as an option, however it should now be success/failure in all cases.
      */
     private com.ibm.fhir.model.type.String outcomeDesc(AuditLogEntry entry) {
         if (entry.getContext().getApiParameters().getStatus() < 400) {

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/CADFMapper.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/CADFMapper.java
@@ -133,10 +133,11 @@ public class CADFMapper implements Mapper {
             fhirContext.setLocation(logEntry.getLocation());
             fhirContext.setDescription(logEntry.getDescription());
 
-            if (logEntry.getContext().getEndTime() == null ||
-                    logEntry.getContext().getStartTime().equalsIgnoreCase(logEntry.getContext().getEndTime())) {
-                cadfEventOutCome = Outcome.pending;
-            } else if (logEntry.getContext().getApiParameters().getStatus() < 400) {
+            /*
+             * @implNote This applies to the next two methods: outcomeDesc, outcome
+             * Previously, it had pending as an option, however it should not it in all cases.
+             */
+            if (logEntry.getContext().getApiParameters().getStatus() < 400) {
                 cadfEventOutCome = Outcome.success;
             } else {
                 cadfEventOutCome = Outcome.failure;

--- a/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/CADFMapper.java
+++ b/fhir-audit/src/main/java/com/ibm/fhir/audit/mapper/impl/CADFMapper.java
@@ -135,7 +135,7 @@ public class CADFMapper implements Mapper {
 
             /*
              * @implNote This applies to the next two methods: outcomeDesc, outcome
-             * Previously, it had pending as an option, however it should not it in all cases.
+             * Previously, it had pending as an option, however it should now be success/failure in all cases.
              */
             if (logEntry.getContext().getApiParameters().getStatus() < 400) {
                 cadfEventOutCome = Outcome.success;


### PR DESCRIPTION
- Timing of start/end leads to Outcome.pending to be reported
- It should be success/failure rather then pending
- I traced through the code and think it might have been a method to filter out fast running operations and snuck into the code. We set endTime/startTime on every request.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>