### PR TITLE
patch the release script to avoid bad test

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -26,6 +26,10 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
         cache: 'maven'
+    - name: Patch release script
+      run: |
+        # only needed until we get past FHIR 4.10.2
+        sed -i '/^mvn -T2C test .* -f fhir-parent -P "${BUILD_PROFILES}"$/ s/$/ -Dtest=!com.ibm.fhir.ig.us.spl.ExamplesValidationTest/' build/release/bin/20_test/1_code_coverage.sh
     - name: Build and Release
       env:
         BASE: origin/${{ github['base_ref'] }}


### PR DESCRIPTION
attempt number 2 to fix the rebuild workflow

because i'm checking out the tagged version, it doesn't have our updated release script.
so we need to either copy/move the logic of those scripts into the action or patch them in place...I chose the latter.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>