### PR TITLE
#3195 - Bubble up exception message from CQL engine

### DIFF
--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/AbstractCqlOperation.java
@@ -354,4 +354,21 @@ public abstract class AbstractCqlOperation extends AbstractOperation {
         }
         return debugMap;
     }
+    
+    /**
+     * Construct a FHIROperationExcepiton from the provided exception. This allows commonality
+     * of error handling between related operations.
+     * 
+     * @throws FHIROperationException 
+     */
+    protected void throwOperationException(Exception ex) throws FHIROperationException {
+        throw new FHIROperationException("Evaluation failed", ex)
+            .withIssue(Issue.builder()
+                .code(IssueType.EXCEPTION)
+                .severity(IssueSeverity.FATAL)
+                .details(CodeableConcept.builder()
+                    .text(ex.getMessage())
+                    .build())
+                .build());
+    }
 }

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/CqlOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/CqlOperation.java
@@ -123,9 +123,16 @@ public class CqlOperation extends AbstractCqlOperation {
             result = doEvaluation(resourceHelper, paramMap, primaryLibrary);
             
         } catch (IllegalArgumentException | CqlTranslationException iex) {
-            throw new FHIROperationException(iex.getMessage(), iex).withIssue(Issue.builder().severity(IssueSeverity.ERROR).code(IssueType.INVALID).details(CodeableConcept.builder().text(fhirstring(iex.getMessage())).build()).build());
+            throw new FHIROperationException(iex.getMessage(), iex)
+                .withIssue(Issue.builder()
+                    .severity(IssueSeverity.ERROR)
+                    .code(IssueType.INVALID)
+                    .details(CodeableConcept.builder()
+                        .text(fhirstring(iex.getMessage()))
+                        .build())
+                    .build());
         } catch (Exception ex) {
-            throw new FHIROperationException("Evaluation failed", ex);
+            throwOperationException(ex);
         }
 
         return result;

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
@@ -84,7 +84,7 @@ public class LibraryEvaluateOperation extends AbstractCqlOperation {
             throw new FHIROperationException(iex.getMessage(), iex).withIssue(Issue.builder().severity(IssueSeverity.ERROR).code(IssueType.INVALID).details(CodeableConcept.builder().text(fhirstring(iex.getMessage())).build()).build());
         } catch (Exception ex) {
             logger.log(Level.SEVERE, "Evaluation failed", ex);
-            throw new FHIROperationException("Evaluation failed", ex);
+            throwOperationException(ex);
         }
 
         return result;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
@@ -7,6 +7,7 @@ package com.ibm.fhir.server.test.cpg;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Properties;
 
@@ -85,5 +86,20 @@ public class ServerCqlOperationTest extends BaseCPGOperationTest {
         Parameters parameters = response.readEntity(Parameters.class);
         assertNotNull(parameters.getParameter(), "Null parameters list");
         assertEquals(parameters.getParameter().size(), 2);
+    }
+    
+    @Test
+    public void testUsefulDetailIncludedInMissingPatientResponse() {
+        Response response = getWebTarget()
+                .path("$cql")
+                .queryParam("expression", "Patient.gender")
+                .queryParam("subject", "Patient/does-not-exist")
+                .request()
+                .get();
+        assertResponse(response, 500);
+
+        String responseBody = response.readEntity(String.class);
+        //System.out.println(responseBody);
+        assertTrue(responseBody.contains("Resource 'Patient/does-not-exist' not found."), responseBody);
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -99,7 +99,6 @@ public class ServerCqlOperationTest extends BaseCPGOperationTest {
         assertResponse(response, 500);
 
         String responseBody = response.readEntity(String.class);
-        //System.out.println(responseBody);
         assertTrue(responseBody.contains("Resource 'Patient/does-not-exist' not found."), responseBody);
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerEvaluateMeasureOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerEvaluateMeasureOperationTest.java
@@ -60,6 +60,22 @@ public class ServerEvaluateMeasureOperationTest extends BaseMeasureOperationTest
     }
     
     @Test
+    public void testEvaluatePatientMeasureMissingPatient() throws Exception {
+        Response response =
+                getWebTarget().path("/Measure/{measureId}/$evaluate-measure")
+                    .resolveTemplate("measureId", TEST_MEASURE_ID)
+                    .queryParam("periodStart", TEST_PERIOD_START)
+                    .queryParam("periodEnd", TEST_PERIOD_END)
+                    .queryParam("subject", "Patient/not-exists")
+                    .request().get();
+        assertResponse(response, 500);
+
+        String responseBody = response.readEntity(String.class);
+        System.out.println(responseBody);
+        assertTrue(responseBody.contains("Resource 'Patient/not-exists' not found."), responseBody);
+    }
+    
+    @Test
     public void testEvaluatePatientMeasureInstanceLibraryNotFound() throws Exception {
         Response response =
                 getWebTarget().path("/Measure/{measureId}/$evaluate-measure")


### PR DESCRIPTION
The CQL operations were wrapping the exception from the CQL engine in a
FHIROperationException and assuming that the nested exception would
automatically be included in the issues list which isn't the case at
all. I added logic to manually add the details from the CQLException to
the issues list so that it shows up in the OperationOutcome.

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>