### PR TITLE
Bundle Change impacted the member-match behavior. #3212

### DIFF
--- a/build/pre-integration-test.sh
+++ b/build/pre-integration-test.sh
@@ -78,6 +78,9 @@ cp -pr ${WORKSPACE}/operation/fhir-operation-test/target/fhir-operation-*-tests.
 cp -pr ${WORKSPACE}/term/operation/fhir-operation-term-cache/target/fhir-operation-*.jar ${USERLIB}/
 find ${WORKSPACE}/conformance -iname 'fhir-ig*.jar' -not -iname 'fhir*-tests.jar' -not -iname 'fhir*-test-*.jar' -exec cp -f {} ${USERLIB} \;
 
+# Add the member-match to the build
+find ${WORKSPACE}/operation/fhir-operation-member-match/target -iname 'fhir-operation*.jar' -not -iname 'fhir*-tests.jar' -exec cp -f {} ${USERLIB} \;
+
 # Start up the fhir server
 echo "
 >>> Current time: " $(date)

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciHealthRecordExchangeTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/profiles/DavinciHealthRecordExchangeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -191,11 +191,15 @@ public class DavinciHealthRecordExchangeTest extends ProfilesTestBaseV2 {
             }
 
             @Override
+            public String datastore() {
+                return "profile";
+            }
+
+            @Override
             public Parameters getInputParameters() {
                 try {
                     return HREXExamplesUtil.readLocalJSONResource("020", "Parameters-member-match-in.json");
                 } catch (Exception e) {
-                    e.printStackTrace();
                     throw new AssertionError("Unexpected");
                 }
             }

--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
@@ -164,7 +164,7 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
                         .build();
             }
 
-            String patientReference = "Patient/" + patientBundle.getEntry().get(0).getId();
+            String patientReference = "Patient/" + patientBundle.getEntry().get(0).getResource().getId();
             type = "Coverage";
 
             // Compiles the Coverage Search Parameters


### PR DESCRIPTION
- During the Bundle behavior refactoring, the Bundle.Entry.id is no longer populated. The member-match needs this id (which was a proxy for the Resource.id). 
- The code change redirects to Resource.id. 
- The shell script change makes sure we test Member-Match

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>