### PR TITLE
tell maven its ok if some modules have no tests

### DIFF
--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Patch release script
       run: |
         # only needed until we get past FHIR 4.10.2
-        sed -i '/^mvn -T2C test .* -f fhir-parent -P "${BUILD_PROFILES}"$/ s/$/ -Dtest=!com.ibm.fhir.ig.us.spl.ExamplesValidationTest/' build/release/bin/20_test/1_code_coverage.sh
+        sed -i '/^mvn -T2C test .* -f fhir-parent -P "${BUILD_PROFILES}"$/ s/$/ -DfailIfNoTests=false -Dtest=!com.ibm.fhir.ig.us.spl.ExamplesValidationTest/' build/release/bin/20_test/1_code_coverage.sh
     - name: Build and Release
       env:
         BASE: origin/${{ github['base_ref'] }}

--- a/build/release/bin/20_test/1_code_coverage.sh
+++ b/build/release/bin/20_test/1_code_coverage.sh
@@ -36,6 +36,6 @@ mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-exam
 
 # fhir-parent
 export BUILD_PROFILES=" $(jq -r '.build[] | select(.type == "fhir-parent").profiles | map(.) | join(",")' build/release/config/release.json)"
-mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-parent -P "${BUILD_PROFILES}" -Dtest=$(tests)
+mvn -T2C test org.jacoco:jacoco-maven-plugin:0.8.7:report-aggregate -f fhir-parent -P "${BUILD_PROFILES}" -DfailIfNoTests=false -Dtest=$(tests)
 
 # EOF


### PR DESCRIPTION
attempt number 3 to fix the rebuild workflow

the previous run is failing with an error like this:
> 2022-01-20T07:21:43.0000022Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test (default-test) on project fhir-openapi: No tests were executed!  (Set -DfailIfNoTests=false to ignore this error.) -> [Help 1]

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>