### PR TITLE
Update to clean up the dependency trees

### DIFF
--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -641,6 +641,7 @@
                 <artifactId>azure-core</artifactId>
                 <version>1.24.0</version>
             </dependency>
+            <!-- Used in OKHTTP as part of azure-core -->
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -642,6 +642,16 @@
                 <version>1.24.0</version>
             </dependency>
             <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>1.6.10</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-common</artifactId>
+                <version>1.6.10</version>
+            </dependency>
+            <dependency>
                 <groupId>org.fhir</groupId>
                 <artifactId>ucum</artifactId>
                 <version>1.0.3</version>

--- a/fhir-server-test/pom.xml
+++ b/fhir-server-test/pom.xml
@@ -30,6 +30,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-jdk14</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.ibm.fhir</groupId>
+                    <artifactId>fhir-term-graph</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -89,6 +89,10 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-classic</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.sleepycat</groupId>
+                    <artifactId>je</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/term/fhir-term-graph/pom.xml
+++ b/term/fhir-term-graph/pom.xml
@@ -57,6 +57,84 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mindrot</groupId>
+                    <artifactId>jbcrypt</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-jvm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.thinkaurelius.thrift</groupId>
+                    <artifactId>thrift-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.ning</groupId>
+                    <artifactId>compress-lzf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>tinkergraph-gremlin</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-ffi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.jnr</groupId>
+                    <artifactId>jnr-posix</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.dropwizard.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
@@ -65,6 +143,18 @@
                 <exclusion>
                     <groupId>org.apache.lucene</groupId>
                     <artifactId>lucene-spatial</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-sandbox</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-backward-codecs</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.lucene</groupId>
+                    <artifactId>lucene-spatial-extras</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
- Remove unused surface area. 

- Address 
fhir-persistence-blob:
kotlin-stdlib-1.3.72.jar (pkg:maven/org.jetbrains.kotlin/kotlin-stdlib@1.3.72, cpe:2.3:a:jetbrains:kotlin:1.3.72:*:*:*:*:*:*:*) : CVE-2020-29582
kotlin-stdlib-common-1.3.70.jar (pkg:maven/org.jetbrains.kotlin/kotlin-stdlib-common@1.3.70, cpe:2.3:a:jetbrains:kotlin:1.3.70:*:*:*:*:*:*:*) : CVE-2020-29582
- also an issue in bulkdata.


Signed-off-by: Paul Bastide <pbastide@us.ibm.com>