### PR TITLE
issue #3232 - add resourceType IN where clause to whole-system search subquery

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/domain/SearchQuery.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/domain/SearchQuery.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -71,13 +71,18 @@ public abstract class SearchQuery {
      */
     public <T> T visit(SearchQueryVisitor<T> visitor) throws FHIRPersistenceException {
         logger.entering(CLASSNAME, "visit");
-        T query = getRoot(visitor);
 
-        // Pre-process any extensions before we process the parameters
+        // Get the root query and process extensions for it
+        T query = getRoot(visitor);
         visitExtensions(query, visitor);
 
+        // Add the parameters subquery and add the extensions there too
         T parameterBase = visitor.getParameterBaseQuery(query);
+        for (SearchExtension ext: this.extensions) {
+            ext.visit(parameterBase, visitor);
+        }
         visitSearchParams(parameterBase, visitor);
+
         logger.exiting(CLASSNAME, "visit");
         return query;
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractWholeSystemSearchTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -469,8 +469,14 @@ public abstract class AbstractWholeSystemSearchTest extends AbstractPLSearchTest
     public void testSearchAllUsingType() throws Exception {
         List<Resource> resources = runQueryTest(Resource.class, "_type", "Basic,EvidenceVariable,ServiceRequest");
         assertNotNull(resources);
-        assertEquals(resources.size(), 1, "Number of resources returned");
-        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource not found in the response");
+        assertTrue(resources.size() > 0, "At least one resource returned");
+        assertTrue(resources.size() == resources.stream().distinct().count(), "No repeats");
+        assertTrue(isResourceInResponse(savedResource, resources), "Expected resource is in the response");
+        for (Resource resource : resources) {
+            if (!(resource instanceof Basic) && !(resource instanceof Basic) && !(resource instanceof Basic)) {
+                fail("query retrieved unexpected resource of type " + resource.getClass());
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
example from test:
```
runQueryTest(Resource.class, "_type", "Basic,EvidenceVariable,ServiceRequest")`
```

before:
```
      SELECT LR0.RESOURCE_TYPE_ID, LR0.LOGICAL_RESOURCE_ID 
        FROM LOGICAL_RESOURCES AS LR0
       WHERE LR0.IS_DELETED = 'N'
         AND LR0.RESOURCE_TYPE_ID IN (8,52,126)
         AND EXISTS (
      SELECT 1 
        FROM LOGICAL_RESOURCES AS LR1
       WHERE LR1.LOGICAL_RESOURCE_ID = LR0.LOGICAL_RESOURCE_ID)
    ORDER BY LR0.LOGICAL_RESOURCE_ID
 FETCH FIRST 10 ROWS ONLY
```

after:
```
      SELECT LR0.RESOURCE_TYPE_ID, LR0.LOGICAL_RESOURCE_ID 
        FROM LOGICAL_RESOURCES AS LR0
       WHERE LR0.IS_DELETED = 'N'
         AND LR0.RESOURCE_TYPE_ID IN (8,52,126)
         AND EXISTS (
      SELECT 1 
        FROM LOGICAL_RESOURCES AS LR1
       WHERE LR1.LOGICAL_RESOURCE_ID = LR0.LOGICAL_RESOURCE_ID
         AND LR0.RESOURCE_TYPE_ID IN (8,52,126))
    ORDER BY LR0.LOGICAL_RESOURCE_ID
 FETCH FIRST 10 ROWS ONLY
```

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>