### PR TITLE
issue #3158 remove deprecated methods from FHIRPersistence

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/FHIRDAOConstants.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/api/FHIRDAOConstants.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,4 +24,8 @@ public class FHIRDAOConstants {
     // Thrown if the stored procedure finds an existing record
     // when If-None-Match is specified
     public static final String SQLSTATE_MATCHES = "99003";
+
+    // Thrown if the procedure sees that the current record
+    // is deleted and the request deletion flag is set
+    public static final String SQLSTATE_CURRENTLY_DELETED = "99004";
 }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -560,7 +560,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
     @Override
     public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, T resource)
             throws FHIRPersistenceException {
-        final String METHODNAME = "updateWithMeta";
+        final String METHODNAME = "update";
         log.entering(CLASSNAME, METHODNAME);
 
         try (Connection connection = openConnection()) {
@@ -1020,7 +1020,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
     @Override
     public <T extends Resource> void delete(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
-        final String METHODNAME = "deleteWithMeta";
+        final String METHODNAME = "delete";
         log.entering(CLASSNAME, METHODNAME);
 
         try (Connection connection = openConnection()) {

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/search/test/JDBCSearchNearTest.java
@@ -110,7 +110,7 @@ public class JDBCSearchNearTest {
         persistence   = new FHIRPersistenceJDBCImpl(this.testProps, connectionPool, cache);
 
         SingleResourceResult<Location> result =
-                persistence.createWithMeta(FHIRPersistenceContextFactory.createPersistenceContext(null), savedResource);
+                persistence.create(FHIRPersistenceContextFactory.createPersistenceContext(null), savedResource);
         assertTrue(result.isSuccess());
         assertNotNull(result.getResource());
         savedResource = result.getResource();
@@ -127,7 +127,7 @@ public class JDBCSearchNearTest {
             FHIRSearchContext ctx = SearchUtil.parseQueryParameters(Location.class, Collections.emptyMap(), true, true);
             FHIRPersistenceContext persistenceContext =
                     FHIRPersistenceContextFactory.createPersistenceContext(null, ctx);
-            persistence.delete(persistenceContext, Location.class, savedResource.getId());
+            persistence.delete(persistenceContext, savedResource);
             if (persistence.isTransactional()) {
                 persistence.getTransaction().end();
             }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/CreateOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/CreateOperation.java
@@ -1,15 +1,19 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.persistence.jdbc.test.spec;
 
+import java.time.ZoneOffset;
+
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.spec.test.DriverMetrics;
+import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 
 /**
  * Create the resource using the persistence
@@ -44,8 +48,11 @@ public class CreateOperation extends BaseOperation {
         final Resource resource = tc.getResource();
 
         // This needs to be a new resource. If it's not, then the
-        // create will fail with a version id mismatch error
-        Resource newResource = tc.getPersistence().create(context, resource).getResource();
+        // create will fail with a version id mismatch error.
+        final String logicalId = tc.getPersistence().generateResourceId();
+        final Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+        Resource newResource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, 1, lastUpdated);
+        newResource = tc.getPersistence().create(context, newResource).getResource();
         check(tc, resource, newResource, this.getClass().getSimpleName());
         
         // Update the context with the modified resource

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/DeleteOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/DeleteOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,7 @@ package com.ibm.fhir.persistence.jdbc.test.spec;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 public class DeleteOperation extends BaseOperation {
 
@@ -17,13 +18,9 @@ public class DeleteOperation extends BaseOperation {
         final Resource resource = tc.getResource();
         final FHIRPersistenceContext context = tc.createPersistenceContext();
 
-        final String logicalId = resource.getId();
-        
-        Resource newResource = tc.getPersistence().delete(context, resource.getClass(), logicalId).getResource();
-        
-        // Update the context with the modified resource. This is the deletion marker
-        // and so should be substantially different when compared with the actual resource
-        tc.setResource(newResource);
-    }
+        Resource deletedResource = FHIRPersistenceTestSupport.delete(tc.getPersistence(), context, resource);
 
+        // Update the context with the modified resource
+        tc.setResource(deletedResource);
+    }
 }

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/R4JDBCExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -70,8 +70,7 @@ public class R4JDBCExamplesTest extends AbstractPersistenceTest {
         operations.add(new ReadOperation());
         operations.add(new VReadOperation());
         operations.add(new HistoryOperation(3));
-        operations.add(new DeleteOperation());
-        operations.add(new DeleteOperation());
+        operations.add(new DeleteOperation()); // only one delete operation because a second would now generate an exception
         operations.add(new HistoryOperation(4));
         R4JDBCExamplesProcessor processor = new R4JDBCExamplesProcessor(
                 operations,

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/UpdateOperation.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/spec/UpdateOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,7 @@ public class UpdateOperation extends BaseOperation {
         final int newVersionNumber = Integer.parseInt(resource.getMeta().getVersionId().getValue()) + 1;
         resource = copyAndSetResourceMetaFields(resource, resource.getId(), newVersionNumber, lastUpdated);
 
-        Resource newResource = tc.getPersistence().updateWithMeta(context, resource).getResource();
+        Resource newResource = tc.getPersistence().update(context, resource).getResource();
         check(tc, tc.getResource(), newResource, this.getClass().getSimpleName());
         
         // Update the context with the modified resource

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/FhirSchemaVersion.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,6 +44,7 @@ public enum FhirSchemaVersion {
     ,V0022(22, "issue-2979 stored procedure update for 2050 ifNoneMatch", false)
     ,V0023(23, "issue-2900 erased_resources to support $erase when offloading payloads", false)
     ,V0024(24, "issue-2900 for offloading add resource_payload_key to xx_resources", false)
+    ,V0025(25, "issue-3158 stored proc updates to prevent deleting currently deleted resources", false)
     ;
 
     // The version number recorded in the VERSION_HISTORY

--- a/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbySchemaVersionsTest.java
+++ b/fhir-persistence-schema/src/test/java/com/ibm/fhir/schema/derby/DerbySchemaVersionsTest.java
@@ -52,7 +52,7 @@ public class DerbySchemaVersionsTest {
 
             // Make sure we can correctly determine the latest schema version value
             svm.updateSchemaVersion();
-            assertEquals(svm.getVersionForSchema(), FhirSchemaVersion.V0024.vid());
+            assertEquals(svm.getVersionForSchema(), FhirSchemaVersion.V0025.vid());
 
             assertFalse(svm.isSchemaOld());
        }

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/FHIRPersistence.java
@@ -26,22 +26,8 @@ import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 public interface FHIRPersistence {
 
     /**
-     * Stores a new FHIR Resource in the datastore. Id assignment handled by the implementation.
-     * This method has been deprecated. Instead, generate the logical id first and use the
-     * createWithMeta(context, resource) call instead.
-     * @param context the FHIRPersistenceContext instance associated with the current request
-     * @param resource the FHIR Resource instance to be created in the datastore
-     * @return a SingleResourceResult with a copy of resource with Meta fields updated by the persistence layer and/or
-     *         an OperationOutcome with hints, warnings, or errors related to the interaction
-     * @throws FHIRPersistenceException
-     */
-    @Deprecated
-    <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
-
-    /**
      * Stores a new FHIR Resource in the datastore. The resource is not modified before it is stored. It
-     * must therefore already include correct Meta fields. Should be used instead of
-     * method {@link #create(FHIRPersistenceContext, Resource)}.
+     * must therefore already include correct Meta fields.
      *
      * @param context the FHIRPersistenceContext instance associated with the current request
      * @param resource the FHIR Resource instance to be created in the datastore
@@ -49,7 +35,7 @@ public interface FHIRPersistence {
      *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    <T extends Resource> SingleResourceResult<T> createWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
+    <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
 
     /**
      * Retrieves the most recent version of a FHIR Resource from the datastore.
@@ -80,20 +66,6 @@ public interface FHIRPersistence {
 
     /**
      * Updates an existing FHIR Resource by storing a new version in the datastore.
-     *
-     * @param context the FHIRPersistenceContext instance associated with the current request
-     * @param logicalId the logical id of the FHIR Resource to be updated
-     * @param resource the new contents of the FHIR Resource to be stored
-     * @return a SingleResourceResult with a copy of resource with fields updated by the persistence layer and/or
-     *         an OperationOutcome with hints, warnings, or errors related to the interaction
-     * @throws FHIRPersistenceException
-     */
-    @Deprecated
-    <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException;
-
-    /**
-     * Updates an existing FHIR Resource by storing a new version in the datastore. This implementation
-     * is added to replace the deprecated {@link #update(FHIRPersistenceContext, String, Resource)} method
      * This new method expects the resource being passed in to already be modified with correct
      * meta and id information. It no longer updates the meta itself.
      *
@@ -103,28 +75,7 @@ public interface FHIRPersistence {
      *         an OperationOutcome with hints, warnings, or errors related to the interaction
      * @throws FHIRPersistenceException
      */
-    <T extends Resource> SingleResourceResult<T> updateWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
-
-    /**
-     * Deletes the specified FHIR Resource from the datastore.
-     * 
-     * This implementation of delete is open to a race condition if an update and delete
-     * are issues at the same time. This API has been deprecated and replaced with 
-     *     {@link #deleteWithMeta(FHIRPersistenceContext, Resource)}
-     * following the new pattern where the resource is never modified by the persistence
-     * layer.
-     * 
-     * @param context the FHIRPersistenceContext instance associated with the current request
-     * @param resourceType The type of FHIR Resource to be deleted.
-     * @param logicalId the logical id of the FHIR Resource to be deleted
-     * @return a SingleResourceResult with the FHIR Resource that was deleted or null if the specified resource doesn't exist and/or
-     *         an OperationOutcome with hints, warnings, or errors related to the interaction
-     * @throws FHIRPersistenceException
-     */
-    @Deprecated
-    default <T extends Resource> SingleResourceResult<T> delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
-        throw new FHIRPersistenceNotSupportedException("The 'delete' operation is not supported by this persistence implementation");
-    }
+    <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException;
 
     /**
      * Deletes the FHIR resource from the datastore. The resource must be configured with the correct
@@ -134,7 +85,7 @@ public interface FHIRPersistence {
      * @param resource
      * @throws FHIRPersistenceException
      */
-    default <T extends Resource> void deleteWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+    default <T extends Resource> void delete(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
         throw new FHIRPersistenceNotSupportedException("The 'delete' operation is not supported by this persistence implementation");
     }
 
@@ -269,17 +220,6 @@ public interface FHIRPersistence {
         return false;
     }
 
-    /**
-     * Fetch up to resourceCount records from the RESOURCE_CHANGE_LOG table
-     * @param resourceCount the max number of resource change records to fetch
-     * @param fromLastModified filter records with record.lastUpdate >= fromLastModified. Optional.
-     * @param afterResourceId filter records with record.resourceId > afterResourceId. Optional.
-     * @param resourceTypeName filter records with record.resourceType = resourceTypeName. Optional.
-     * @return a list containing up to resourceCount elements describing resources which have changed
-     */
-    @Deprecated
-    List<ResourceChangeLogRecord> changes(int resourceCount, java.time.Instant fromLastModified, Long afterResourceId, String resourceTypeName) throws FHIRPersistenceException;
-    
     /**
      * Fetch up to resourceCount records from the RESOURCE_CHANGE_LOG table
      * @param resourceCount the max number of resource change records to fetch

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/InteractionStatus.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/InteractionStatus.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractPLSearchTest.java
@@ -33,6 +33,7 @@ import com.ibm.fhir.persistence.ResourceResult;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.test.common.AbstractPersistenceTest;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.util.SearchUtil;
 
@@ -85,7 +86,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
             if (persistence.isTransactional()) {
                 persistence.getTransaction().begin();
             }
-            persistence.delete(getDefaultPersistenceContext(), Basic.class, savedResource.getId());
+            FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), savedResource);
             if (persistence.isTransactional()) {
                 persistence.getTransaction().end();
             }
@@ -98,7 +99,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
      * Modifies the resource in-place and saves it to {@code savedResource}.
      */
     protected void saveBasicResource(Basic resource) throws FHIRPersistenceException, Exception {
-        SingleResourceResult<Basic> result = persistence.create(getDefaultPersistenceContext(), resource);
+        SingleResourceResult<Basic> result = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource);
         assertTrue(result.isSuccess());
         resource = result.getResource();
         assertNotNull(resource);
@@ -108,7 +109,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
         assertEquals("1", resource.getMeta().getVersionId().getValue());
 
         // update the resource to verify that historical versions won't be returned in search results
-        result = persistence.update(getDefaultPersistenceContext(), resource.getId(), resource);
+        result = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource.getId(), resource);
         assertTrue(result.isSuccess());
         resource = result.getResource();
         assertNotNull(resource);
@@ -230,7 +231,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
                 .title(string("TEST"))
                 .build();
 
-        SingleResourceResult<Composition> result = persistence.create(getDefaultPersistenceContext(), composition);
+        SingleResourceResult<Composition> result = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), composition);
         assertTrue(result.isSuccess());
         composition = result.getResource();
         assertNotNull(composition);
@@ -240,7 +241,7 @@ public abstract class AbstractPLSearchTest extends AbstractPersistenceTest {
         assertEquals("1", composition.getMeta().getVersionId().getValue());
 
         // update the resource to verify that historical versions won't be returned in search results
-        result = persistence.update(getDefaultPersistenceContext(), composition.getId(), composition);
+        result = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), composition.getId(), composition);
         assertTrue(result.isSuccess());
         composition = result.getResource();
         assertNotNull(composition);

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/search/test/AbstractSearchIdAndLastUpdatedTest.java
@@ -39,6 +39,7 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.persistence.MultiResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.util.SearchUtil;
 
@@ -217,27 +218,27 @@ public abstract class AbstractSearchIdAndLastUpdatedTest extends AbstractPLSearc
                 ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
 
         Patient patient = TestUtil.getMinimalResource(Patient.class);
-        savedPatient = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
         observationBuilder.subject(buildReference(savedPatient));
         observationBuilder.performer(buildReference(savedPatient));
 
         Device device = TestUtil.getMinimalResource(Device.class);
-        savedDevice = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        savedDevice = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), device).getResource();
         observationBuilder.device(buildReference(savedDevice));
 
         Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
-        savedEncounter = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
+        savedEncounter = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), encounter).getResource();
         observationBuilder.encounter(buildReference(savedEncounter));
 
         Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
-        savedPractitioner = persistence.create(getDefaultPersistenceContext(), practitioner).getResource();
+        savedPractitioner = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), practitioner).getResource();
         observationBuilder.performer(buildReference(savedPractitioner));
 
         RelatedPerson relatedPerson = TestUtil.getMinimalResource(RelatedPerson.class);
-        savedRelatedPerson = persistence.create(getDefaultPersistenceContext(), relatedPerson).getResource();
+        savedRelatedPerson = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), relatedPerson).getResource();
         observationBuilder.performer(buildReference(savedRelatedPerson));
 
-        savedObservation = persistence.create(getDefaultPersistenceContext(), observationBuilder.build()).getResource();
+        savedObservation = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), observationBuilder.build()).getResource();
         assertNotNull(savedObservation);
         assertNotNull(savedObservation.getId());
         assertNotNull(savedObservation.getMeta());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceHelperTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017,2019
+ * (C) Copyright IBM Corp. 2017, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -66,7 +66,7 @@ public class FHIRPersistenceHelperTest {
         assertNotNull(persistence);
         
         assertFalse(persistence.isDeleteSupported());
-        persistence.delete(null, null, null);
+        persistence.delete(null, null);
     }
     
     @Test(expectedExceptions = {FHIRPersistenceException.class})

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2021
+ * (C) Copyright IBM Corp. 2017, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,12 +34,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @Override
     public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) 
             throws FHIRPersistenceException {
-    	return null;
-    }
-
-    @Override
-    public <T extends Resource> SingleResourceResult<T> createWithMeta(FHIRPersistenceContext context, T resource) 
-            throws FHIRPersistenceException {
         return null;
     }
 
@@ -53,11 +47,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
             throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
         return null;
-    }
-
-    @Override
-    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException {
-    	return null;
     }
 
     @Override
@@ -104,12 +93,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public List<ResourceChangeLogRecord> changes(int resourceCount, Instant fromLastModified, Long afterResourceId, String resourceTypeName)
-            throws FHIRPersistenceException {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ResourceChangeLogRecord> changes(int resourceCount, Instant fromLastModified, Instant beforeLastModified, Long afterResourceId, List<String> resourceTypeNames, 
             boolean excludeTransactionTimeoutWindow, HistorySortOrder historySortOrder) throws FHIRPersistenceException {
         return Collections.emptyList();
@@ -121,7 +104,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> updateWithMeta(FHIRPersistenceContext context, T resource)
+    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, T resource)
             throws FHIRPersistenceException {
         return null;
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCanonicalTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCanonicalTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +31,7 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  *  This class tests the persistence layer support for the FHIR canonical search parameters.
@@ -63,7 +64,7 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                                 .version(string("1.0"))
                                 .name(string(uuid + "library1"))
                                 .build();
-        savedLibrary1 = persistence.create(getDefaultPersistenceContext(), savedLibrary1).getResource();
+        savedLibrary1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedLibrary1).getResource();
 
         // a Library with a different version that is referenced by a Measure
         savedLibrary2 = library.toBuilder()
@@ -71,14 +72,14 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                                 .version(string("2.0"))
                                 .name(string(uuid + "library2"))
                                 .build();
-        savedLibrary2 = persistence.create(getDefaultPersistenceContext(), savedLibrary2).getResource();
+        savedLibrary2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedLibrary2).getResource();
 
         // a Library with no version that is referenced by a Measure
         savedLibrary3 = library.toBuilder()
                                 .url(Uri.of("http://example.com/Library/" + uuid))
                                 .name(string(uuid + "library3"))
                                 .build();
-        savedLibrary3 = persistence.create(getDefaultPersistenceContext(), savedLibrary3).getResource();
+        savedLibrary3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedLibrary3).getResource();
 
         // a Measure that references a Library and is referenced by a CarePlan
         savedMeasure1 = measure.toBuilder()
@@ -87,7 +88,7 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                 .library(Canonical.of("http://example.com/Library/" + uuid, "1.0"))
                 .name(string(uuid + "measure1"))
                 .build();
-        savedMeasure1 = persistence.create(getDefaultPersistenceContext(), savedMeasure1).getResource();
+        savedMeasure1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedMeasure1).getResource();
 
         // another Measure that references a Library
         savedMeasure2 = measure.toBuilder()
@@ -96,7 +97,7 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                 .library(Canonical.of("http://example.com/Library/" + uuid))
                 .name(string(uuid + "measure2"))
                 .build();
-        savedMeasure2 = persistence.create(getDefaultPersistenceContext(), savedMeasure2).getResource();
+        savedMeasure2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedMeasure2).getResource();
 
         // another Measure that references a Library and contains a reference fragment
         savedMeasure3 = measure.toBuilder()
@@ -104,28 +105,28 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                 .library(Canonical.of("http://example.com/Library/" + uuid + "|2.0#ignore"))
                 .name(string(uuid + "measure3"))
                 .build();
-        savedMeasure3 = persistence.create(getDefaultPersistenceContext(), savedMeasure3).getResource();
+        savedMeasure3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedMeasure3).getResource();
 
         // a Measure with depends-on missing
         savedMeasure4 = measure.toBuilder()
                 .url(Uri.of("http://example.com/Measure/" + uuid + "measure4"))
                 .name(string(uuid + "measure4"))
                 .build();
-        savedMeasure4 = persistence.create(getDefaultPersistenceContext(), savedMeasure4).getResource();
+        savedMeasure4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedMeasure4).getResource();
 
         // a CarePlan that references a Measure
         savedCarePlan1 = carePlan.toBuilder()
                 .instantiatesCanonical(Canonical.of("http://example.com/Measure/" + uuid + "measure1", "1.0"))
                 .instantiatesUri(Uri.of(uuid + "carePlan1"))
                 .build();
-        savedCarePlan1 = persistence.create(getDefaultPersistenceContext(), savedCarePlan1).getResource();
+        savedCarePlan1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedCarePlan1).getResource();
 
         // another CarePlan that references a Measure, but does not specify a version
         savedCarePlan2 = carePlan.toBuilder()
                 .instantiatesCanonical(Canonical.of("http://example.com/Measure/" + uuid + "measure1"))
                 .instantiatesUri(Uri.of(uuid + "carePlan2"))
                 .build();
-        savedCarePlan2 = persistence.create(getDefaultPersistenceContext(), savedCarePlan2).getResource();
+        savedCarePlan2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedCarePlan2).getResource();
 
         // a CarePlan that references a different Measure
         savedCarePlan3 = carePlan.toBuilder()
@@ -133,7 +134,7 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
                 .instantiatesUri(Uri.of(uuid + "carePlan3"))
                 .basedOn(Reference.builder().reference(string("CarePlan/" + savedCarePlan1.getId())).build())
                 .build();
-        savedCarePlan3 = persistence.create(getDefaultPersistenceContext(), savedCarePlan3).getResource();
+        savedCarePlan3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedCarePlan3).getResource();
     }
 
     @AfterClass
@@ -149,7 +150,7 @@ public abstract class AbstractCanonicalTest extends AbstractPersistenceTest {
 
             try {
                 for (Resource resource : resources) {
-                    persistence.delete(getDefaultPersistenceContext(), resource.getClass(), resource.getId());
+                    FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
                 }
             } catch (Throwable t) {
                 if (persistence.isTransactional()) {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -27,6 +27,7 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.util.ModelSupport;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  * This class contains a collection of tests that will be run against
@@ -65,36 +66,36 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
         Observation.Builder observation2Builder = ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
 
         Patient patient = TestUtil.getMinimalResource(Patient.class);
-        savedPatient = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
         observationBuilder.subject(buildReference(savedPatient));
         observationBuilder.performer(buildReference(savedPatient));
         // a logical ID-only reference to a patient
         observation2Builder.subject(Reference.builder().reference(string(savedPatient.getId())).build());
 
         Device device = TestUtil.getMinimalResource(Device.class);
-        savedDevice = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        savedDevice = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), device).getResource();
         observationBuilder.device(buildReference(savedDevice));
 
         Encounter encounter = TestUtil.getMinimalResource(Encounter.class);
-        savedEncounter = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
+        savedEncounter = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), encounter).getResource();
         observationBuilder.encounter(buildReference(savedEncounter));
 
         Practitioner practitioner = TestUtil.getMinimalResource(Practitioner.class);
-        savedPractitioner = persistence.create(getDefaultPersistenceContext(), practitioner).getResource();
+        savedPractitioner = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), practitioner).getResource();
         observationBuilder.performer(buildReference(savedPractitioner));
 
         RelatedPerson relatedPerson = TestUtil.getMinimalResource(RelatedPerson.class);
-        savedRelatedPerson = persistence.create(getDefaultPersistenceContext(), relatedPerson).getResource();
+        savedRelatedPerson = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), relatedPerson).getResource();
         observationBuilder.performer(buildReference(savedRelatedPerson));
 
-        savedObservation = persistence.create(getDefaultPersistenceContext(), observationBuilder.build()).getResource();
+        savedObservation = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), observationBuilder.build()).getResource();
         assertNotNull(savedObservation);
         assertNotNull(savedObservation.getId());
         assertNotNull(savedObservation.getMeta());
         assertNotNull(savedObservation.getMeta().getVersionId().getValue());
         assertEquals("1", savedObservation.getMeta().getVersionId().getValue());
 
-        savedObservation2 = persistence.create(getDefaultPersistenceContext(), observation2Builder.build()).getResource();
+        savedObservation2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), observation2Builder.build()).getResource();
         assertNotNull(savedObservation2);
         assertNotNull(savedObservation2.getId());
         assertNotNull(savedObservation2.getMeta());
@@ -114,7 +115,7 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
 
             try {
                 for (Resource resource : resources) {
-                    persistence.delete(getDefaultPersistenceContext(), resource.getClass(), resource.getId());
+                    FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
                 }
             } catch (Throwable t) {
                 if (persistence.isTransactional()) {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractDeleteTest.java
@@ -30,6 +30,7 @@ import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  * This class contains resource deletion tests.
@@ -45,14 +46,14 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         Device device = TestUtil.getMinimalResource(Device.class);
 
-        Device device1 = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        Device device1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), device).getResource();
         assertNotNull(device1.getId());
         assertNotNull(device1.getMeta());
         assertNotNull(device1.getMeta().getVersionId().getValue());
         assertEquals("1", device1.getMeta().getVersionId().getValue());
         this.deviceId1 = device1.getId();
 
-        Device device2 = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        Device device2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), device).getResource();
         assertNotNull(device2.getId());
         assertNotNull(device2.getMeta());
         assertNotNull(device2.getMeta().getVersionId().getValue());
@@ -63,8 +64,13 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
     @Test(expectedExceptions = FHIRPersistenceResourceNotFoundException.class)
     public void testDeleteInvalidDevice() throws Exception {
 
-        SingleResourceResult<Device> result = persistence.delete(getDefaultPersistenceContext(), Device.class, "invalid-device-id");
-        assertNull(result.getResource());
+        // The persistence delete operation simply inserts a resource version with
+        // the is_deleted flag set. This means that for invalid devices we won't
+        // ever get a FHIRPersistenceResourceNotFoundException but instead it will
+        // be a version mismatch (because version 1 shouldn't exist.
+        Device device = TestUtil.getMinimalResource(Device.class);
+        device = FHIRPersistenceTestSupport.setIdAndMeta(persistence, device, "invalid-device-id", 1);
+        persistence.delete(getDefaultPersistenceContext(), device);
     }
 
     @Test
@@ -77,7 +83,12 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
     @Test
     public void testDeleteValidDevice() throws Exception {
 
-        persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId1);
+        Device device = TestUtil.getMinimalResource(Device.class);
+        
+        // remember that the current device version is 1, so the delete marker
+        // must be version 2
+        device = FHIRPersistenceTestSupport.setIdAndMeta(persistence, device, this.deviceId1, 2);
+        persistence.delete(getDefaultPersistenceContext(), device);
     }
 
     @Test(dependsOnMethods = { "testDeleteValidDevice" },
@@ -130,10 +141,17 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
         assertEquals(deletedResources.get(0).getVersion(), 2);
     }
 
-    @Test(dependsOnMethods = { "testDeleteValidDevice" })
+    @Test(dependsOnMethods = { "testDeleteValidDevice" }, expectedExceptions = FHIRPersistenceResourceDeletedException.class)
     public void testReDeleteValidDevice() throws Exception {
 
-        persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId1);
+        Device device = TestUtil.getMinimalResource(Device.class);
+
+        // Deleted version is 2, so the new delete request needs would be version 3
+        // in order to get past the concurrent update check. But because the
+        // resource is currently deleted, we expect the delete call to throw
+        // an exception
+        device = FHIRPersistenceTestSupport.setIdAndMeta(persistence, device, this.deviceId1, 3);
+        persistence.delete(getDefaultPersistenceContext(), device);
     }
 
     @Test
@@ -147,8 +165,8 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
         Device device = persistence.read(getDefaultPersistenceContext(), Device.class, this.deviceId2).getResource();
 
         // Delete previously created device
-        persistence.delete(getDefaultPersistenceContext(), Device.class, this.deviceId2);
-        
+        FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), device); // deviceId2
+
         // Update the meta so that the version matches
         final com.ibm.fhir.model.type.Instant lastUpdated = com.ibm.fhir.model.type.Instant.now(ZoneOffset.UTC);
         final int newVersionId = Integer.parseInt(device.getMeta().getVersionId().getValue()) + 2; // skip the version created by delete
@@ -156,7 +174,7 @@ public abstract class AbstractDeleteTest extends AbstractPersistenceTest {
 
         // Then update deleted device
         device = device.toBuilder().udiCarrier(UdiCarrier.builder().deviceIdentifier(string(updatedUdiValue)).build()).build();
-        persistence.updateWithMeta(getDefaultPersistenceContext(), device);
+        persistence.update(getDefaultPersistenceContext(), device);
 
         // Verify device history
         List<ResourceResult<? extends Resource>> resources = persistence.history(context, Device.class, this.deviceId2).getResourceResults();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractEraseTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractEraseTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -36,6 +36,7 @@ import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.persistence.ResourceEraseRecord;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.erase.EraseDTO;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  * Tests related to the erase method in FHIRPersistence.
@@ -103,7 +104,7 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
             startTrx();
             for (Resource resource : resources) {
                 try {
-                    persistence.delete(getDefaultPersistenceContext(), Basic.class, resource.getId());
+                    FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
                 } catch (Exception e) {
                     // Swallow any exception.
                 }
@@ -117,10 +118,10 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
     public void testEraseResourceWithHistory() throws Exception {
         // Resource 1 - C - U - U (with multiple values)
         // Erases all resources
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
 
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
@@ -135,7 +136,7 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
 
     @Test
     public void testEraseSingleResource() throws Exception {
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
@@ -151,9 +152,9 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
     @Test
     public void testEraseLastIsDeleted() throws Exception {
         // Resource where the last is deleted (C - D)
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
-        persistence.delete(getDefaultPersistenceContext(), resource1.getClass(), resource1.getId());
+        resource1 = FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource1);
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
         dto.setResourceType("Basic");
@@ -179,10 +180,10 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
     public void testEraseSpecificVersionGreater() throws Exception {
         // Resource_1 C-U-U - Latest is 3
         // This test sets 4, since it exceeds the value.
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
 
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
@@ -199,10 +200,10 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
     @Test
     public void testEraseSpecificVersion() throws Exception {
         // The payload is erased (so the last check is for null on the resource)
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
 
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
@@ -222,10 +223,10 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
     public void testEraseLatestSpecificVersion() throws Exception {
         // Resource_1 C-U-U - Latest is 3
         // This test sets 3, since it is the value.
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
-        resource1 = persistence.update(getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
+        resource1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource1.getId(), resource1).getResource();
 
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());
@@ -241,7 +242,7 @@ public abstract class AbstractEraseTest extends AbstractPersistenceTest {
 
     @Test
     public void testEraseSingleResourceWithVersion1() throws Exception {
-        Basic resource1 = persistence.create(getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
+        Basic resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), allTypesBuilder.meta(tag("eraseTest")).build()).getResource();
         resources.add(resource1);
         EraseDTO dto = new EraseDTO();
         dto.setLogicalId(resource1.getId());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractExportTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractExportTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -31,6 +31,7 @@ import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.Integer;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.persistence.ResourcePayload;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  * Tests related to the high-speed export method in FHIRPersistence.
@@ -59,17 +60,17 @@ public abstract class AbstractExportTest extends AbstractPersistenceTest {
         resource4Builder.extension(extension("http://example.org/integer", Integer.of(4)));
 
         // save them in-order so that lastUpdated goes from 1 -> 3 as well
-        resource1 = persistence.create(getDefaultPersistenceContext(), resource1Builder.meta(tag("pagingTest")).build()).getResource();
-        resource2 = persistence.create(getDefaultPersistenceContext(), resource2Builder.meta(tag("pagingTest")).build()).getResource();
-        resource3 = persistence.create(getDefaultPersistenceContext(), resource3Builder.meta(tag("pagingTest")).build()).getResource();
-        resource4 = persistence.create(getDefaultPersistenceContext(), resource4Builder.meta(tag("pagingTest")).build()).getResource();
+        resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource1Builder.meta(tag("pagingTest")).build()).getResource();
+        resource2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource2Builder.meta(tag("pagingTest")).build()).getResource();
+        resource3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource3Builder.meta(tag("pagingTest")).build()).getResource();
+        resource4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource4Builder.meta(tag("pagingTest")).build()).getResource();
 
         // update resource3 two times so we have 3 different versions
-        resource3 = persistence.update(getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
-        resource3 = persistence.update(getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
+        resource3 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
+        resource3 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
 
         // delete resource4
-        persistence.delete(getDefaultPersistenceContext(), resource4.getClass(), resource4.getId());
+        resource4 = FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource4);
     }
 
     @AfterClass
@@ -79,7 +80,7 @@ public abstract class AbstractExportTest extends AbstractPersistenceTest {
             // as this is AfterClass, we need to manually start/end the transaction
             startTrx();
             for (Resource resource : resources) {
-                persistence.delete(getDefaultPersistenceContext(), Basic.class, resource.getId());
+                persistence.delete(getDefaultPersistenceContext(), resource);
             }
             commitTrx();
         }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractIncludeRevincludeTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2021
+ * (C) Copyright IBM Corp. 2018, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -37,6 +37,7 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.HumanName;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.code.LinkType;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  *  This class tests the persistence layer support for the FHIR _include and _revinclude search result parameters.
@@ -76,68 +77,68 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
         DeviceRequest deviceRequest = TestUtil.getMinimalResource(DeviceRequest.class);
 
         // an Organization that will be referenced by a Patient
-        savedOrg1 = persistence.create(getDefaultPersistenceContext(), org).getResource();
+        savedOrg1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), org).getResource();
 
         // an Encounter that will be used as a reference within an Observation
-        savedEncounter1 = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
+        savedEncounter1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), encounter).getResource();
 
         // an Observation that has no references to any other resource types
-        savedObservation1 = persistence.create(getDefaultPersistenceContext(), observation).getResource();
+        savedObservation1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), observation).getResource();
 
         // a Patient that will be used as a reference within an Observation
-        savedPatient1 = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
 
         // an Observation with a reference to a patient and a logical ID-only reference to another observation
         savedObservation2 = observation.toBuilder()
                                         .subject(reference("Patient/" + savedPatient1.getId()))
                                         .hasMember(reference(savedObservation1.getId()))
                                         .build();
-        savedObservation2 = persistence.create(getDefaultPersistenceContext(), savedObservation2).getResource();
+        savedObservation2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation2).getResource();
 
         // an Observation with a reference to a patient and a reference to an Encounter
         savedObservation3 = observation.toBuilder()
                                        .subject(reference("Patient/" + savedPatient1.getId()))
                                        .encounter(reference("Encounter/" + savedEncounter1.getId()))
                                        .build();
-        savedObservation3 = persistence.create(getDefaultPersistenceContext(), savedObservation3).getResource();
+        savedObservation3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation3).getResource();
 
         // a Patient that will be used as a reference within an Observation, and which references itself
-        savedPatient2 = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
         // update the patient
         savedPatient2 = savedPatient2.toBuilder()
                                         .name(humanName("Vito", "Corleone"))
                                         .link(Link.builder().type(LinkType.REFER).other(reference("Patient/" + savedPatient2.getId())).build())
                                         .build();
-        savedPatient2 = persistence.update(getDefaultPersistenceContext(), savedPatient2.getId(), savedPatient2).getResource();
+        savedPatient2 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedPatient2.getId(), savedPatient2).getResource();
 
         // an Observation with a reference to a patient and a reference to an Encounter
         savedObservation4 = observation.toBuilder()
                                        .subject(reference("Patient/" + savedPatient2.getId()))
                                        .encounter(reference("Encounter/" + savedEncounter1.getId()))
                                        .build();
-        savedObservation4 = persistence.create(getDefaultPersistenceContext(), savedObservation4).getResource();
+        savedObservation4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation4).getResource();
 
         // a Patient that will be used as a reference within an Observation and a Device
         // also, it will contain a reference to a managing organization
         savedPatient3 = patient.toBuilder().managingOrganization(reference("Organization/" + savedOrg1.getId())).build();
-        savedPatient3 = persistence.create(getDefaultPersistenceContext(), savedPatient3).getResource();
+        savedPatient3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedPatient3).getResource();
 
         // an Observation with a reference to a patient
         savedObservation5 = observation.toBuilder().subject(reference("Patient/" + savedPatient3.getId())).build();
-        savedObservation5 = persistence.create(getDefaultPersistenceContext(), savedObservation5).getResource();
+        savedObservation5 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation5).getResource();
 
         // a Device with a reference to a patient and an organization
         savedDevice1 = device.toBuilder()
                                     .patient(reference("Patient/" + savedPatient3.getId()))
                                     .owner(reference("Organization/" + savedOrg1.getId()))
                                     .build();
-        savedDevice1 = persistence.create(getDefaultPersistenceContext(), savedDevice1).getResource();
+        savedDevice1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedDevice1).getResource();
         // update the device
         savedDevice1 = savedDevice1.toBuilder().manufacturer(string("Updated Manufacturer")).build();
-        savedDevice1 = persistence.update(getDefaultPersistenceContext(), savedDevice1.getId(), savedDevice1).getResource();
+        savedDevice1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedDevice1.getId(), savedDevice1).getResource();
 
         // a Patient that will have no other resources referencing it
-        savedPatient4 = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
 
         // An Observation with versioned references to a device
         savedObservation6 = observation.toBuilder()
@@ -146,7 +147,7 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
                 .device(reference("Device/" + savedDevice1.getId() + "/_history/3"))
                 .specimen(reference("Specimen/1"))
                 .build();
-        savedObservation6 = persistence.create(getDefaultPersistenceContext(), savedObservation6).getResource();
+        savedObservation6 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation6).getResource();
 
         // A DeviceRequest with non-versioned references to a device
         savedDeviceRequest1 = deviceRequest.toBuilder()
@@ -154,19 +155,19 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
                 .performer(reference("Device/" + savedDevice1.getId()))
                 .code(reference("Device/" + savedDevice1.getId()))
                 .build();
-        savedDeviceRequest1 = persistence.create(getDefaultPersistenceContext(), savedDeviceRequest1).getResource();
+        savedDeviceRequest1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedDeviceRequest1).getResource();
 
         // an Encounter with a reference to another encounter
         savedEncounter2 = encounter.toBuilder()
                                         .partOf(reference("Encounter/" + savedEncounter1.getId()))
                                         .build();
-        savedEncounter2 = persistence.create(getDefaultPersistenceContext(), savedEncounter2).getResource();
+        savedEncounter2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedEncounter2).getResource();
 
         // an Encounter with a reference to another encounter
         savedEncounter3 = encounter.toBuilder()
                                         .partOf(reference("Encounter/" + savedEncounter2.getId()))
                                         .build();
-        savedEncounter3 = persistence.create(getDefaultPersistenceContext(), savedEncounter3).getResource();
+        savedEncounter3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedEncounter3).getResource();
     }
 
     @AfterClass
@@ -183,7 +184,7 @@ public abstract class AbstractIncludeRevincludeTest extends AbstractPersistenceT
 
             try {
                 for (Resource resource : resources) {
-                    persistence.delete(getDefaultPersistenceContext(), resource.getClass(), resource.getId());
+                    FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
                 }
             } catch (Throwable t) {
                 if (persistence.isTransactional()) {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractMultiResourceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractMultiResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2018, 2021
+ * (C) Copyright IBM Corp. 2018, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -47,7 +47,7 @@ public abstract class AbstractMultiResourceTest extends AbstractPersistenceTest 
         // Inject meta data
         encounter = copyAndSetResourceMetaFields(encounter, commonId, versionId, lastUpdated);
         
-        encounter = persistence.updateWithMeta(getDefaultPersistenceContext(), encounter).getResource();
+        encounter = persistence.update(getDefaultPersistenceContext(), encounter).getResource();
         assertNotNull(encounter);
         assertNotNull(encounter.getId());
         assertNotNull(encounter.getMeta());
@@ -59,7 +59,7 @@ public abstract class AbstractMultiResourceTest extends AbstractPersistenceTest 
         // update the id on the resource
         observation = observation.toBuilder().id(commonId).build();
         observation = copyAndSetResourceMetaFields(observation, commonId, versionId, lastUpdated);
-        observation = persistence.updateWithMeta(getDefaultPersistenceContext(), observation).getResource();
+        observation = persistence.update(getDefaultPersistenceContext(), observation).getResource();
         assertNotNull(observation);
         assertNotNull(observation.getId());
         assertNotNull(observation.getMeta());

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPagingTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPagingTest.java
@@ -39,6 +39,7 @@ import com.ibm.fhir.persistence.ResourceResult;
 import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.util.SearchUtil;
 
@@ -67,13 +68,13 @@ public abstract class AbstractPagingTest extends AbstractPersistenceTest {
         resource3Builder.extension(extension("http://example.org/integer", Integer.of(3)));
 
         // save them in-order so that lastUpdated goes from 1 -> 3 as well
-        resource1 = persistence.create(getDefaultPersistenceContext(), resource1Builder.meta(tag("pagingTest")).build()).getResource();
-        resource2 = persistence.create(getDefaultPersistenceContext(), resource2Builder.meta(tag("pagingTest")).build()).getResource();
-        resource3 = persistence.create(getDefaultPersistenceContext(), resource3Builder.meta(tag("pagingTest")).build()).getResource();
+        resource1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource1Builder.meta(tag("pagingTest")).build()).getResource();
+        resource2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource2Builder.meta(tag("pagingTest")).build()).getResource();
+        resource3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource3Builder.meta(tag("pagingTest")).build()).getResource();
 
         // update resource3 two times so we have 3 different versions
-        resource3 = persistence.update(getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
-        resource3 = persistence.update(getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
+        resource3 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
+        resource3 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), resource3.getId(), resource3).getResource();
     }
 
     @AfterClass
@@ -83,7 +84,7 @@ public abstract class AbstractPagingTest extends AbstractPersistenceTest {
             // as this is AfterClass, we need to manually start/end the transaction
             startTrx();
             for (Resource resource : resources) {
-                persistence.delete(getDefaultPersistenceContext(), Basic.class, resource.getId());
+                FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
             }
             commitTrx();
         }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -11,7 +11,6 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import java.io.InputStream;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -37,6 +36,7 @@ import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.parameters.QueryParameter;
@@ -270,9 +270,8 @@ public abstract class AbstractPersistenceTest {
      * @param resource
      * @return
      */
-    protected <T extends Resource> T updateVersionMeta(T resource) {
-        final com.ibm.fhir.model.type.Instant lastUpdated = com.ibm.fhir.model.type.Instant.now(ZoneOffset.UTC);
+    protected <T extends Resource> T updateVersionMeta(T resource) throws FHIRPersistenceException {
         final int newVersionId = Integer.parseInt(resource.getMeta().getVersionId().getValue()) + 1;
-        return copyAndSetResourceMetaFields(resource, resource.getId(), newVersionId, lastUpdated);
+        return FHIRPersistenceTestSupport.setIdAndMeta(persistence, resource, resource.getId(), newVersionId);
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractReverseChainTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractReverseChainTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -44,6 +44,7 @@ import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.ObservationStatus;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 
 /**
  *  This class tests the persistence layer support for the FHIR _has search parameter.
@@ -89,18 +90,18 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
         startTrx();
         // Organizations that will be referenced by a Patient
         savedOrg1 = org.toBuilder().active(com.ibm.fhir.model.type.Boolean.of(true)).build();
-        savedOrg1 = persistence.create(getDefaultPersistenceContext(), savedOrg1).getResource();
+        savedOrg1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedOrg1).getResource();
         savedOrg2 = org.toBuilder().active(com.ibm.fhir.model.type.Boolean.of(true)).name(com.ibm.fhir.model.type.String.of("org2")).build();
-        savedOrg2 = persistence.create(getDefaultPersistenceContext(), savedOrg2).getResource();
-        savedOrg3 = persistence.create(getDefaultPersistenceContext(), org).getResource();
+        savedOrg2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedOrg2).getResource();
+        savedOrg3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), org).getResource();
         savedOrg3 = savedOrg3.toBuilder().name(com.ibm.fhir.model.type.String.of("org3")).build();
-        savedOrg3 = persistence.update(getDefaultPersistenceContext(), savedOrg3.getId(), savedOrg3).getResource();
+        savedOrg3 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedOrg3.getId(), savedOrg3).getResource();
 
         // an Encounter that will be referenced by Observations
-        savedEncounter1 = persistence.create(getDefaultPersistenceContext(), encounter).getResource();
+        savedEncounter1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), encounter).getResource();
 
         // an Observation that has no references to any other resource types
-        savedObservation1 = persistence.create(getDefaultPersistenceContext(), observation).getResource();
+        savedObservation1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), observation).getResource();
 
         // a Patient that will be referenced by Observations and references an Organization
         savedPatient1 = patient.toBuilder()
@@ -110,27 +111,27 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
                     .profile(Canonical.of("http://ibm.com/fhir/profile/" + now.toString())).build())
                 .managingOrganization(reference("Organization/" + savedOrg2.getId()))
                 .build();
-        savedPatient1 = persistence.create(getDefaultPersistenceContext(), savedPatient1).getResource();
+        savedPatient1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedPatient1).getResource();
 
         // an Observation with a reference to a Patient and a logical ID-only reference to another observation
         savedObservation2 = observation.toBuilder()
                                         .subject(reference("Patient/" + savedPatient1.getId()))
                                         .hasMember(reference(savedObservation1.getId()))
                                         .build();
-        savedObservation2 = persistence.create(getDefaultPersistenceContext(), savedObservation2).getResource();
+        savedObservation2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation2).getResource();
 
         // an Observation with a reference to a Patient and a reference to an Encounter
         savedObservation3 = observation.toBuilder()
                                        .subject(reference("Patient/" + savedPatient1.getId()))
                                        .encounter(reference("Encounter/" + savedEncounter1.getId()))
                                        .build();
-        savedObservation3 = persistence.create(getDefaultPersistenceContext(), savedObservation3).getResource();
+        savedObservation3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation3).getResource();
 
         // a Patient that will be referenced by an Observation and references an Organization
         savedPatient2 = patient.toBuilder().managingOrganization(reference("Organization/" + savedOrg3.getId())).build();
-        savedPatient2 = persistence.create(getDefaultPersistenceContext(), savedPatient2).getResource();
+        savedPatient2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedPatient2).getResource();
         savedPatient2 = savedPatient2.toBuilder().name(humanName("Vito", "Corleone")).build();
-        savedPatient2 = persistence.update(getDefaultPersistenceContext(), savedPatient2.getId(), savedPatient2).getResource();
+        savedPatient2 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedPatient2.getId(), savedPatient2).getResource();
 
         // an Observation with a reference to a Patient and a reference to an Encounter
         savedObservation4 = observation.toBuilder()
@@ -139,15 +140,15 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
                                        .value(com.ibm.fhir.model.type.String.of("test"))
                                        .code(CodeableConcept.builder().coding(Coding.builder().code(Code.of("code")).build()).build())
                                        .build();
-        savedObservation4 = persistence.create(getDefaultPersistenceContext(), savedObservation4).getResource();
+        savedObservation4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation4).getResource();
 
         // a Patient that references an Organization and is referenced by an Observation and a Device
         savedPatient3 = patient.toBuilder().managingOrganization(reference("Organization/" + savedOrg1.getId())).build();
-        savedPatient3 = persistence.create(getDefaultPersistenceContext(), savedPatient3).getResource();
+        savedPatient3 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedPatient3).getResource();
 
         // a Library that is referenced by an Observation
         savedLibrary1 = library.toBuilder().url(Uri.of("http://ibm.com/fhir/Library/abc")).version(string("1.0")).build();
-        savedLibrary1 = persistence.create(getDefaultPersistenceContext(), savedLibrary1).getResource();
+        savedLibrary1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedLibrary1).getResource();
 
         // an Observation with a reference to a Patient and a Library
         savedObservation5 = observation.toBuilder()
@@ -155,24 +156,24 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
                                        .status(ObservationStatus.FINAL)
                                        .focus(reference("Library/" + savedLibrary1.getId()))
                                        .build();
-        savedObservation5 = persistence.create(getDefaultPersistenceContext(), savedObservation5).getResource();
+        savedObservation5 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation5).getResource();
 
         // a Device with a reference to a Patient and a versioned reference to an Organization
         savedDevice1 = device.toBuilder().patient(reference("Patient/" + savedPatient3.getId())).build();
-        savedDevice1 = persistence.create(getDefaultPersistenceContext(), savedDevice1).getResource();
+        savedDevice1 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedDevice1).getResource();
         savedDevice1 = savedDevice1.toBuilder()
                                    .manufacturer(string("Updated Manufacturer"))
                                    .owner(reference("Organization/" + savedOrg3.getId() + "/_history/2"))
                                    .build();
-        savedDevice1 = persistence.update(getDefaultPersistenceContext(), savedDevice1.getId(), savedDevice1).getResource();
+        savedDevice1 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedDevice1.getId(), savedDevice1).getResource();
 
         // a Device with a versioned reference to an Organization
-        savedDevice2 = persistence.create(getDefaultPersistenceContext(), device).getResource();
+        savedDevice2 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), device).getResource();
         savedDevice2 = savedDevice2.toBuilder().owner(reference("Organization/" + savedOrg3.getId() + "/_history/1")).build();
-        savedDevice2 = persistence.update(getDefaultPersistenceContext(), savedDevice2.getId(), savedDevice2).getResource();
+        savedDevice2 = FHIRPersistenceTestSupport.update(persistence, getDefaultPersistenceContext(), savedDevice2.getId(), savedDevice2).getResource();
 
         // a Patient that will have no other resources referencing it
-        savedPatient4 = persistence.create(getDefaultPersistenceContext(), patient).getResource();
+        savedPatient4 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
 
         // An Observation with versioned references to a Device
         savedObservation6 = observation.toBuilder()
@@ -180,7 +181,7 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
                 .focus(reference("Device/" + savedDevice1.getId() + "/_history/2"))
                 .device(reference("Device/" + savedDevice2.getId() + "/_history/2"))
                 .build();
-        savedObservation6 = persistence.create(getDefaultPersistenceContext(), savedObservation6).getResource();
+        savedObservation6 = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), savedObservation6).getResource();
         commitTrx();
     }
 
@@ -198,7 +199,7 @@ public abstract class AbstractReverseChainTest extends AbstractPersistenceTest {
 
             try {
                 for (Resource resource : resources) {
-                    persistence.delete(getDefaultPersistenceContext(), resource.getClass(), resource.getId());
+                    FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
                 }
             } catch (Throwable t) {
                 if (persistence.isTransactional()) {

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSortTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractSortTest.java
@@ -39,6 +39,7 @@ import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.persistence.ResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 import com.ibm.fhir.search.util.SearchUtil;
@@ -96,12 +97,12 @@ public abstract class AbstractSortTest extends AbstractPersistenceTest {
         resource3Builder.extension(extension("http://example.org/code", Code.of("value3")));
         
         // save them in-order so that lastUpdated goes from 1 -> 3 as well
-        resource1a = persistence.create(getDefaultPersistenceContext(), resource1Builder.meta(tag("a")).build()).getResource();
-        resource1b = persistence.create(getDefaultPersistenceContext(), resource1Builder.meta(tag("b")).build()).getResource();
-        resource2a = persistence.create(getDefaultPersistenceContext(), resource2Builder.meta(tag("a")).build()).getResource();
-        resource2b = persistence.create(getDefaultPersistenceContext(), resource2Builder.meta(tag("b")).build()).getResource();
-        resource3a = persistence.create(getDefaultPersistenceContext(), resource3Builder.meta(tag("a")).build()).getResource();
-        resource3b = persistence.create(getDefaultPersistenceContext(), resource3Builder.meta(tag("b")).build()).getResource();
+        resource1a = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource1Builder.meta(tag("a")).build()).getResource();
+        resource1b = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource1Builder.meta(tag("b")).build()).getResource();
+        resource2a = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource2Builder.meta(tag("a")).build()).getResource();
+        resource2b = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource2Builder.meta(tag("b")).build()).getResource();
+        resource3a = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource3Builder.meta(tag("a")).build()).getResource();
+        resource3b = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), resource3Builder.meta(tag("b")).build()).getResource();
     }
     
     @AfterClass
@@ -112,7 +113,7 @@ public abstract class AbstractSortTest extends AbstractPersistenceTest {
                 persistence.getTransaction().begin();
             }
             for (Resource resource : resources) {
-                persistence.delete(getDefaultPersistenceContext(), Basic.class, resource.getId());
+                FHIRPersistenceTestSupport.delete(persistence, getDefaultPersistenceContext(), resource);
             }
             if (persistence.isTransactional()) {
                 persistence.getTransaction().end();

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/util/FHIRPersistenceTestSupport.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/util/FHIRPersistenceTestSupport.java
@@ -100,7 +100,7 @@ public class FHIRPersistenceTestSupport {
 
     /**
      * Convenience method for unit tests to make sure a synthesized resource has valid
-     * id and meta.versionId values
+     * id, meta.versionId and meta.lastUpdated values
      * @param <T>
      * @param persistence the FHIRPersistence implementation
      * @param resource the resource to be copied and modified

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/util/FHIRPersistenceTestSupport.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/util/FHIRPersistenceTestSupport.java
@@ -1,0 +1,119 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+package com.ibm.fhir.persistence.util;
+
+import java.time.ZoneOffset;
+
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.type.Instant;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.SingleResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
+
+/**
+ * Methods supporting persistence unit tests
+ */
+public class FHIRPersistenceTestSupport {
+    /**
+     * Helper function to replace the previously deprecated persistence layer method which has
+     * now been removed. Injects the meta elements into the resource before calling the
+     * persistence create method.
+     * 
+     * @param <T>
+     * @param persistence
+     * @param context
+     * @param resource
+     * @return
+     * @throws FHIRPersistenceException
+     */
+    public static <T extends Resource> SingleResourceResult<T> create(FHIRPersistence persistence, FHIRPersistenceContext context, T resource) throws FHIRPersistenceException  {
+
+        // Generate a new logical resource id
+        final String logicalId = persistence.generateResourceId();
+
+        // Set the resource id and meta fields.
+        final int newVersionNumber = 1;
+        final Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+        T updatedResource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionNumber, lastUpdated);
+        return persistence.create(context, updatedResource);
+    }
+
+    /**
+     * Helper function to replace the previously deprecated persistence layer method which has
+     * now been removed. Injects the meta elements into the resource before calling the
+     * persistence update method.
+     * 
+     * @param <T>
+     * @param persistence
+     * @param context
+     * @param logicalId
+     * @param resource
+     * @return
+     * @throws FHIRPersistenceException
+     */
+    public static <T extends Resource> SingleResourceResult<T> update(FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, T resource)
+            throws FHIRPersistenceException {
+
+        final com.ibm.fhir.model.type.Instant lastUpdated = com.ibm.fhir.model.type.Instant.now(ZoneOffset.UTC);
+        final int newVersionId = resource.getMeta() == null || resource.getMeta().getVersionId() == null ? 1 : Integer.parseInt(resource.getMeta().getVersionId().getValue()) + 1;
+        resource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionId, lastUpdated);
+        return persistence.update(context, resource);
+    }
+
+    /**
+     * Helper funciton to replace the previously deprecated persistence layer method which has
+     * now been removed. Injects/replaces the meta elements in the resource before calling the
+     * persistence delete method.
+     * 
+     * @param <T>
+     * @param persistence
+     * @param context
+     * @param resource
+     * @throws FHIRPersistenceException
+     */
+    public static <T extends Resource> T delete(FHIRPersistence persistence, FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+        // cannot delete a resource which hasn't been created - we expect the id to be present
+        // and the meta.versionId current. If the version in the resource parameter isn't the latest, the
+        // persistence layer will fail the delete thinking there's a concurrent update issue.
+        if (resource.getId() == null) {
+            throw new FHIRPersistenceException("test error - resource must have a valid id");
+        }
+        
+        if (resource.getMeta() == null || resource.getMeta().getVersionId() == null) {
+            // this is most likely an issue with the test implementation
+            throw new FHIRPersistenceException("test error - resource must have a valid meta.versionId");
+        }
+        
+        final com.ibm.fhir.model.type.Instant lastUpdated = com.ibm.fhir.model.type.Instant.now(ZoneOffset.UTC);
+        final int newVersionId = Integer.parseInt(resource.getMeta().getVersionId().getValue()) + 1;
+        resource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, resource.getId(), newVersionId, lastUpdated);
+        persistence.delete(context, resource);
+
+        // return the modified resource which may be used for subsequent tests
+        return resource;
+    }
+
+    /**
+     * Convenience method for unit tests to make sure a synthesized resource has valid
+     * id and meta.versionId values
+     * @param <T>
+     * @param persistence the FHIRPersistence implementation
+     * @param resource the resource to be copied and modified
+     * @param id the resource logical id. If null, the persistence layer will be asked to generate one
+     * @param version the version of the resource
+     * @return
+     */
+    public static <T extends Resource> T setIdAndMeta(FHIRPersistence persistence, T resource, String id, int version) {
+        if (id == null) {
+            id = persistence.generateResourceId();
+        }
+        // Set the resource id and meta fields.
+        final Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+        return FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, id, version, lastUpdated);
+    }
+}

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -360,7 +360,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             // For 1869 bundle processing, the resource is updated first and is no longer mutated by the
             // persistence layer.
-            SingleResourceResult<Resource> result = persistence.createWithMeta(persistenceContext, resource);
+            SingleResourceResult<Resource> result = persistence.create(persistenceContext, resource);
             if (result.isSuccess() && result.getOutcome() != null) {
                 warnings.addAll(result.getOutcome().getIssue());
             }
@@ -762,10 +762,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             final SingleResourceResult<Resource> result;
             if (createOnUpdate) {
                 // resource shouldn't exist, so we assume it's a create
-                result = persistence.createWithMeta(persistenceContext, newResource);
+                result = persistence.create(persistenceContext, newResource);
             } else {
                 // resource already exists, so we know it's an update
-                result = persistence.updateWithMeta(persistenceContext, newResource);
+                result = persistence.update(persistenceContext, newResource);
             }
 
             if (result.isSuccess() && result.getOutcome() != null) {
@@ -1004,7 +1004,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                             .withOffloadResponse(offloadResponse)
                             .build();
 
-                    persistence.deleteWithMeta(persistenceContext, resource);
+                    persistence.delete(persistenceContext, resource);
 
                     if (responseBundle.getEntry().size() == 1) {
                         ior.setResource(resource);

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
@@ -156,15 +156,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @Override
     public <T extends Resource> void delete(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
         // NOP. No need to do anything in this very simple mock
-        
-        // TODO REMOVE
-//        T updatedResource = (T) Patient.builder().id("test").meta(Meta.builder().versionId(Id.of("1")).lastUpdated(Instant.now()).build()).build();
-//        return updatedResource;
-//        SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
-//                .success(true)
-//                .interactionStatus(InteractionStatus.MODIFIED)
-//                .resource(updatedResource);
-//        return resultBuilder.build();
     }
 
     @Override

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
@@ -40,12 +40,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @Override
     public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) 
             throws FHIRPersistenceException {
-        throw new IllegalStateException("API no longer used; provided for backward compatibility only");
-    }
-
-    @Override
-    public <T extends Resource> SingleResourceResult<T> createWithMeta(FHIRPersistenceContext context, T resource) 
-            throws FHIRPersistenceException {
         
         SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                 .success(true)
@@ -92,13 +86,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException {
-        // For this mock, the versionId doesn't matter
-        return updateWithMeta(context, resource);
-    }
-
-    @Override
-    public <T extends Resource> SingleResourceResult<T> updateWithMeta(FHIRPersistenceContext context, T resource)
+    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, T resource)
             throws FHIRPersistenceException {
         OperationOutcome operationOutcome = null;
         if (resource.getLanguage() != null && resource.getLanguage().getValue().equals("en-US")) {
@@ -166,31 +154,22 @@ public class MockPersistenceImpl implements FHIRPersistence {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Resource> SingleResourceResult<T> delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId) throws FHIRPersistenceException {
-        T updatedResource = (T) Patient.builder().id("test").meta(Meta.builder().versionId(Id.of("1")).lastUpdated(Instant.now()).build()).build();
-        SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
-                .success(true)
-                .interactionStatus(InteractionStatus.MODIFIED)
-                .resource(updatedResource);
-        return resultBuilder.build();
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <T extends Resource> void deleteWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+    public <T extends Resource> void delete(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
         // NOP. No need to do anything in this very simple mock
+        
+        // TODO REMOVE
+//        T updatedResource = (T) Patient.builder().id("test").meta(Meta.builder().versionId(Id.of("1")).lastUpdated(Instant.now()).build()).build();
+//        return updatedResource;
+//        SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
+//                .success(true)
+//                .interactionStatus(InteractionStatus.MODIFIED)
+//                .resource(updatedResource);
+//        return resultBuilder.build();
     }
 
     @Override
     public ResourcePayload fetchResourcePayloads(Class<? extends Resource> resourceType, java.time.Instant fromLastModified,
         java.time.Instant toLastModified, Function<ResourcePayload, Boolean> process) throws FHIRPersistenceException {
-        // NOP
-        return null;
-    }
-
-    @Override
-    public List<ResourceChangeLogRecord> changes(int resourceCount, java.time.Instant fromLastModified, Long afterResourceId, String resourceTypeName)
-            throws FHIRPersistenceException {
         // NOP
         return null;
     }

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/ServerResolveFunctionTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/ServerResolveFunctionTest.java
@@ -58,6 +58,7 @@ import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.helper.PersistenceHelper;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
+import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.server.resolve.ServerResolveFunction;
 
 public class ServerResolveFunctionTest {
@@ -72,6 +73,52 @@ public class ServerResolveFunctionTest {
                 return "https://localhost:9443/fhir-server/api/v4/".equals(baseUrl);
             }
         });
+    }
+
+    /**
+     * Helper function to replace the previously deprecated persistence layer method which has
+     * now been removed. Injects the meta elements into the resource before calling the
+     * persistence create method.
+     * 
+     * @param <T>
+     * @param persistence
+     * @param context
+     * @param resource
+     * @return
+     * @throws FHIRPersistenceException
+     */
+    private <T extends Resource> SingleResourceResult<T> create(FHIRPersistence persistence, FHIRPersistenceContext context, T resource) throws FHIRPersistenceException  {
+
+        // Generate a new logical resource id
+        final String logicalId = persistence.generateResourceId();
+
+        // Set the resource id and meta fields.
+        final int newVersionNumber = 1;
+        final Instant lastUpdated = Instant.now(ZoneOffset.UTC);
+        T updatedResource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionNumber, lastUpdated);
+        return persistence.create(context, updatedResource);
+    }
+
+    /**
+     * Helper function to replace the previously deprecated persistence layer method which has
+     * now been removed. Injects the meta elements into the resource before calling the
+     * persistence update method.
+     * 
+     * @param <T>
+     * @param persistence
+     * @param context
+     * @param logicalId
+     * @param resource
+     * @return
+     * @throws FHIRPersistenceException
+     */
+    private <T extends Resource> SingleResourceResult<T> update(FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, T resource)
+            throws FHIRPersistenceException {
+
+        final com.ibm.fhir.model.type.Instant lastUpdated = com.ibm.fhir.model.type.Instant.now(ZoneOffset.UTC);
+        final int newVersionId = resource.getMeta() == null || resource.getMeta().getVersionId() == null ? 1 : Integer.parseInt(resource.getMeta().getVersionId().getValue()) + 1;
+        resource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionId, lastUpdated);
+        return persistence.update(context, resource);
     }
 
     @Test
@@ -91,7 +138,7 @@ public class ServerResolveFunctionTest {
         FHIRPersistence persistence = persistenceHelper.getFHIRPersistenceImplementation();
         FHIRPersistenceContext context = FHIRPersistenceContextFactory.createPersistenceContext(null);
 
-        SingleResourceResult<? extends Resource> result = persistence.update(context, "12345", patient);
+        SingleResourceResult<? extends Resource> result = update(persistence, context, "12345", patient);
         assertNotNull(result);
         assertNotNull(result.getResource());
         assertTrue(result.isSuccess());
@@ -117,7 +164,7 @@ public class ServerResolveFunctionTest {
 
         FHIRPersistence persistence = persistenceHelper.getFHIRPersistenceImplementation();
         FHIRPersistenceContext context = FHIRPersistenceContextFactory.createPersistenceContext(null);
-        SingleResourceResult<? extends Resource> result = persistence.update(context, "54321", observation);
+        SingleResourceResult<? extends Resource> result = update(persistence, context, "54321", observation);
         assertNotNull(result);
         assertNotNull(result.getResource());
         assertTrue(result.isSuccess());
@@ -137,7 +184,7 @@ public class ServerResolveFunctionTest {
 
         FHIRPersistence persistence = persistenceHelper.getFHIRPersistenceImplementation();
         FHIRPersistenceContext context = FHIRPersistenceContextFactory.createPersistenceContext(null);
-        SingleResourceResult<? extends Resource> result = persistence.update(context, "67890", organization);
+        SingleResourceResult<? extends Resource> result = update(persistence, context, "67890", organization);
         assertNotNull(result);
         assertNotNull(result.getResource());
         assertTrue(result.isSuccess());
@@ -278,16 +325,9 @@ public class ServerResolveFunctionTest {
     public static class PersistenceImpl implements FHIRPersistence {
         private final Map<Class<? extends Resource>, Map<String, List<Resource>>> map = new HashMap<>();
 
-        @Override
-        public <T extends Resource> SingleResourceResult<T> create(
-                FHIRPersistenceContext context,
-                T resource) throws FHIRPersistenceException {
-            return createOrUpdate(resource);
-        }
-
         @SuppressWarnings("unchecked")
         @Override
-        public <T extends Resource> SingleResourceResult<T> createWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+        public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
             Class<? extends Resource> resourceType = resource.getClass();
 
             // We no longer need to update the resource meta, so all that's required is
@@ -343,14 +383,6 @@ public class ServerResolveFunctionTest {
 
         @Override
         public <T extends Resource> SingleResourceResult<T> update(
-                FHIRPersistenceContext context,
-                String logicalId,
-                T resource) throws FHIRPersistenceException {
-            return createOrUpdate(resource);
-        }
-        
-        @Override
-        public <T extends Resource> SingleResourceResult<T> updateWithMeta(
                 FHIRPersistenceContext context,
                 T resource) throws FHIRPersistenceException {
             return createOrUpdate(resource);
@@ -421,15 +453,6 @@ public class ServerResolveFunctionTest {
                 java.time.Instant fromLastModified,
                 java.time.Instant toLastModified,
                 Function<ResourcePayload, Boolean> process) throws FHIRPersistenceException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public List<ResourceChangeLogRecord> changes(
-                int resourceCount,
-                java.time.Instant fromLastModified,
-                Long afterResourceId,
-                String resourceTypeName) throws FHIRPersistenceException {
             throw new UnsupportedOperationException();
         }
 

--- a/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/util/FHIRRestHelperTest.java
@@ -2057,18 +2057,18 @@ public class FHIRRestHelperTest {
         when(persistence.getTransaction()).thenReturn(new MockTransactionAdapter());
         when(persistence.read(any(), any(), any())).thenReturn(mockResult);
         // when(persistence.create(any(), any())).thenReturn(mockResult);
-        when(persistence.createWithMeta(any(), any())).thenReturn(mockResult);
-        when(persistence.updateWithMeta(any(), any())).thenReturn(mockResult);
+        when(persistence.create(any(), any())).thenReturn(mockResult);
+        when(persistence.update(any(), any())).thenReturn(mockResult);
         FHIRRestHelper helper = new FHIRRestHelper(persistence);
 
         // The helper must pass the resource updated by the interceptor to the persistence#create method
         ArgumentCaptor<Patient> patientCaptor = ArgumentCaptor.forClass(Patient.class);
         helper.doCreate("Patient", patientNoId, null);
-        Mockito.verify(persistence).createWithMeta(any(), patientCaptor.capture());
+        Mockito.verify(persistence).create(any(), patientCaptor.capture());
         assertEquals(patientCaptor.getValue().getMeta().getTag().get(0), TAG);
 
         helper.doUpdate("Patient", "123", patientWithId, null, null, false, null);
-        Mockito.verify(persistence).updateWithMeta(any(), patientCaptor.capture());
+        Mockito.verify(persistence).update(any(), patientCaptor.capture());
         assertEquals(patientCaptor.getValue().getMeta().getTag().get(0), TAG);
     }
 

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
@@ -66,11 +66,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> createWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
-        return null;
-    }
-
-    @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
         throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
 
@@ -135,12 +130,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, String logicalId, T resource) throws FHIRPersistenceException {
-    	return null;
-    }
-    
-    @Override
-    public <T extends Resource> SingleResourceResult<T> updateWithMeta(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
+    public <T extends Resource> SingleResourceResult<T> update(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
         return null;
     }
 
@@ -183,12 +173,6 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @Override
     public ResourcePayload fetchResourcePayloads(Class<? extends Resource> resourceType, Instant fromLastModified, Instant toLastModified,
             Function<ResourcePayload, Boolean> process) throws FHIRPersistenceException {
-        return null;
-    }
-
-    @Override
-    public List<ResourceChangeLogRecord> changes(int resourceCount, Instant fromLastModified, Long afterResourceId, String resourceTypeName)
-        throws FHIRPersistenceException {
         return null;
     }
 


### PR DESCRIPTION
Signed-off-by: Robin Arnold <robin.arnold@ibm.com>

1. Removed deprecated methods from FHIRPersistence
2. Renamed xxWithMeta methods back to their original names (e.g. createWithMeta is now just called create).
3. Because the FHIRPersistence delete method no longer modifies the resource, the resource needs to be updated prior to the call (just like the other methods). This required some extra finesse in handling double-delete tests, so some additional protection was added to the stored procedures to deal with this.