### PR TITLE
Refactor ResourceTypeHelper and update callers

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/ResourcesConfigAdapter.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/ResourcesConfigAdapter.java
@@ -64,7 +64,7 @@ public class ResourcesConfigAdapter {
      * @throws Exception
      */
     private Set<String> computeSupportedResourceTypes(PropertyGroup resourcesConfig, FHIRVersionParam fhirVersion) throws Exception {
-        Set<String> applicableTypes = ResourceTypeHelper.getResourceTypesFor(fhirVersion);
+        Set<String> applicableTypes = ResourceTypeHelper.getCompatibleResourceTypes(fhirVersion, FHIRVersionParam.VERSION_43);
 
         Set<String> result;
         if (resourcesConfig == null || resourcesConfig.getBooleanProperty("open", true)) {

--- a/fhir-core/src/main/java/com/ibm/fhir/core/FHIRVersionParam.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/FHIRVersionParam.java
@@ -7,6 +7,9 @@ package com.ibm.fhir.core;
 
 /**
  * Enum constants for the allowed values of the fhirVersion MIME-type parameter
+ *
+ * @implSpec The enum versions are comparable; we use the default {@link Enum#compareTo(Enum)} implementation
+ *     and so the versions MUST be declared in the natural order desired for comparison.
  */
 public enum FHIRVersionParam {
     VERSION_40("4.0"),

--- a/fhir-core/src/main/java/com/ibm/fhir/core/ResourceTypeName.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/ResourceTypeName.java
@@ -5,158 +5,19 @@
  */
 package com.ibm.fhir.core;
 
+import static com.ibm.fhir.core.FHIRVersionParam.VERSION_40;
+import static com.ibm.fhir.core.FHIRVersionParam.VERSION_43;
+
 /**
  * Enum constants for all resource type names across all versions of HL7 FHIR
  */
 public enum ResourceTypeName {
     /**
-     * EffectEvidenceSynthesis
-     *
-     * <p>The EffectEvidenceSynthesis resource describes the difference in an outcome between exposures states in a
-     * population where the effect estimate is derived from a combination of research studies.
-     */
-    EFFECT_EVIDENCE_SYNTHESIS("EffectEvidenceSynthesis"),
-
-    /**
-     * MedicinalProduct
-     *
-     * <p>Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).
-     */
-    MEDICINAL_PRODUCT("MedicinalProduct"),
-
-    /**
-     * MedicinalProductAuthorization
-     *
-     * <p>The regulatory authorization of a medicinal product.
-     */
-    MEDICINAL_PRODUCT_AUTHORIZATION("MedicinalProductAuthorization"),
-
-    /**
-     * MedicinalProductContraindication
-     *
-     * <p>The clinical particulars - indications, contraindications etc. of a medicinal product, including for regulatory
-     * purposes.
-     */
-    MEDICINAL_PRODUCT_CONTRAINDICATION("MedicinalProductContraindication"),
-
-    /**
-     * MedicinalProductIndication
-     *
-     * <p>Indication for the Medicinal Product.
-     */
-    MEDICINAL_PRODUCT_INDICATION("MedicinalProductIndication"),
-
-    /**
-     * MedicinalProductIngredient
-     *
-     * <p>An ingredient of a manufactured item or pharmaceutical product.
-     */
-    MEDICINAL_PRODUCT_INGREDIENT("MedicinalProductIngredient"),
-
-    /**
-     * MedicinalProductInteraction
-     *
-     * <p>The interactions of the medicinal product with other medicinal products, or other forms of interactions.
-     */
-    MEDICINAL_PRODUCT_INTERACTION("MedicinalProductInteraction"),
-
-    /**
-     * MedicinalProductManufactured
-     *
-     * <p>The manufactured item as contained in the packaged medicinal product.
-     */
-    MEDICINAL_PRODUCT_MANUFACTURED("MedicinalProductManufactured"),
-
-    /**
-     * MedicinalProductPackaged
-     *
-     * <p>A medicinal product in a container or package.
-     */
-    MEDICINAL_PRODUCT_PACKAGED("MedicinalProductPackaged"),
-
-    /**
-     * MedicinalProductPharmaceutical
-     *
-     * <p>A pharmaceutical product described in terms of its composition and dose form.
-     */
-    MEDICINAL_PRODUCT_PHARMACEUTICAL("MedicinalProductPharmaceutical"),
-
-    /**
-     * MedicinalProductUndesirableEffect
-     *
-     * <p>Describe the undesirable effects of the medicinal product.
-     */
-    MEDICINAL_PRODUCT_UNDESIRABLE_EFFECT("MedicinalProductUndesirableEffect"),
-
-    /**
-     * RiskEvidenceSynthesis
-     *
-     * <p>The RiskEvidenceSynthesis resource describes the likelihood of an outcome in a population plus exposure state where
-     * the risk estimate is derived from a combination of research studies.
-     */
-    RISK_EVIDENCE_SYNTHESIS("RiskEvidenceSynthesis"),
-
-    /**
-     * SubstanceNucleicAcid
-     *
-     * <p>Nucleic acids are defined by three distinct elements: the base, sugar and linkage. Individual substance/moiety IDs
-     * will be created for each of these elements. The nucleotide sequence will be always entered in the 5’-3’ direction.
-     */
-    SUBSTANCE_NUCLEIC_ACID("SubstanceNucleicAcid"),
-
-    /**
-     * SubstancePolymer
-     *
-     * <p>Todo.
-     */
-    SUBSTANCE_POLYMER("SubstancePolymer"),
-
-    /**
-     * SubstanceProtein
-     *
-     * <p>A SubstanceProtein is defined as a single unit of a linear amino acid sequence, or a combination of subunits that
-     * are either covalently linked or have a defined invariant stoichiometric relationship. This includes all synthetic,
-     * recombinant and purified SubstanceProteins of defined sequence, whether the use is therapeutic or prophylactic. This
-     * set of elements will be used to describe albumins, coagulation factors, cytokines, growth factors,
-     * peptide/SubstanceProtein hormones, enzymes, toxins, toxoids, recombinant vaccines, and immunomodulators.
-     */
-    SUBSTANCE_PROTEIN("SubstanceProtein"),
-
-    /**
-     * SubstanceReferenceInformation
-     *
-     * <p>Todo.
-     */
-    SUBSTANCE_REFERENCE_INFORMATION("SubstanceReferenceInformation"),
-
-    /**
-     * SubstanceSourceMaterial
-     *
-     * <p>Source material shall capture information on the taxonomic and anatomical origins as well as the fraction of a
-     * material that can result in or can be modified to form a substance. This set of data elements shall be used to define
-     * polymer substances isolated from biological matrices. Taxonomic and anatomical origins shall be described using a
-     * controlled vocabulary as required. This information is captured for naturally derived polymers ( . starch) and
-     * structurally diverse substances. For Organisms belonging to the Kingdom Plantae the Substance level defines the fresh
-     * material of a single species or infraspecies, the Herbal Drug and the Herbal preparation. For Herbal preparations, the
-     * fraction information will be captured at the Substance information level and additional information for herbal
-     * extracts will be captured at the Specified Substance Group 1 information level. See for further explanation the
-     * Substance Class: Structurally Diverse and the herbal annex.
-     */
-    SUBSTANCE_SOURCE_MATERIAL("SubstanceSourceMaterial"),
-
-    /**
-     * SubstanceSpecification
-     *
-     * <p>The detailed description of a substance, typically at a level beyond what is used for prescribing.
-     */
-    SUBSTANCE_SPECIFICATION("SubstanceSpecification"),
-
-    /**
      * Resource
      *
      * <p>--- Abstract Type! ---This is the base resource type for everything.
      */
-    RESOURCE("Resource"),
+    RESOURCE("Resource", VERSION_40),
 
     /**
      * Binary
@@ -164,21 +25,21 @@ public enum ResourceTypeName {
      * <p>A resource that represents the data of a single raw artifact as digital content accessible in its native format. A
      * Binary resource can contain any content, whether text, image, pdf, zip archive, etc.
      */
-    BINARY("Binary"),
+    BINARY("Binary", VERSION_40),
 
     /**
      * Bundle
      *
      * <p>A container for a collection of resources.
      */
-    BUNDLE("Bundle"),
+    BUNDLE("Bundle", VERSION_40),
 
     /**
      * DomainResource
      *
      * <p>--- Abstract Type! ---A resource that includes narrative, extensions, and contained resources.
      */
-    DOMAIN_RESOURCE("DomainResource"),
+    DOMAIN_RESOURCE("DomainResource", VERSION_40),
 
     /**
      * Account
@@ -186,7 +47,7 @@ public enum ResourceTypeName {
      * <p>A financial tool for tracking value accrued for a particular purpose. In the healthcare field, used to track
      * charges for a patient, cost centers, etc.
      */
-    ACCOUNT("Account"),
+    ACCOUNT("Account", VERSION_40),
 
     /**
      * ActivityDefinition
@@ -194,7 +55,7 @@ public enum ResourceTypeName {
      * <p>This resource allows for the definition of some activity to be performed, independent of a particular patient,
      * practitioner, or other performance context.
      */
-    ACTIVITY_DEFINITION("ActivityDefinition"),
+    ACTIVITY_DEFINITION("ActivityDefinition", VERSION_40),
 
     /**
      * AdministrableProductDefinition
@@ -202,7 +63,7 @@ public enum ResourceTypeName {
      * <p>A medicinal product in the final form which is suitable for administering to a patient (after any mixing of
      * multiple components, dissolution etc. has been performed).
      */
-    ADMINISTRABLE_PRODUCT_DEFINITION("AdministrableProductDefinition"),
+    ADMINISTRABLE_PRODUCT_DEFINITION("AdministrableProductDefinition", VERSION_43),
 
     /**
      * AdverseEvent
@@ -211,7 +72,7 @@ public enum ResourceTypeName {
      * care, a research study or other healthcare setting factors that requires additional monitoring, treatment, or
      * hospitalization, or that results in death.
      */
-    ADVERSE_EVENT("AdverseEvent"),
+    ADVERSE_EVENT("AdverseEvent", VERSION_40),
 
     /**
      * AllergyIntolerance
@@ -219,7 +80,7 @@ public enum ResourceTypeName {
      * <p>Risk of harmful or undesirable, physiological response which is unique to an individual and associated with
      * exposure to a substance.
      */
-    ALLERGY_INTOLERANCE("AllergyIntolerance"),
+    ALLERGY_INTOLERANCE("AllergyIntolerance", VERSION_40),
 
     /**
      * Appointment
@@ -227,14 +88,14 @@ public enum ResourceTypeName {
      * <p>A booking of a healthcare event among patient(s), practitioner(s), related person(s) and/or device(s) for a
      * specific date/time. This may result in one or more Encounter(s).
      */
-    APPOINTMENT("Appointment"),
+    APPOINTMENT("Appointment", VERSION_40),
 
     /**
      * AppointmentResponse
      *
      * <p>A reply to an appointment request for a patient and/or practitioner(s), such as a confirmation or rejection.
      */
-    APPOINTMENT_RESPONSE("AppointmentResponse"),
+    APPOINTMENT_RESPONSE("AppointmentResponse", VERSION_40),
 
     /**
      * AuditEvent
@@ -242,7 +103,7 @@ public enum ResourceTypeName {
      * <p>A record of an event made for purposes of maintaining a security log. Typical uses include detection of intrusion
      * attempts and monitoring for inappropriate usage.
      */
-    AUDIT_EVENT("AuditEvent"),
+    AUDIT_EVENT("AuditEvent", VERSION_40),
 
     /**
      * Basic
@@ -250,7 +111,7 @@ public enum ResourceTypeName {
      * <p>Basic is used for handling concepts not yet defined in FHIR, narrative-only resources that don't map to an existing
      * resource, and custom resources not appropriate for inclusion in the FHIR specification.
      */
-    BASIC("Basic"),
+    BASIC("Basic", VERSION_40),
 
     /**
      * BiologicallyDerivedProduct
@@ -258,7 +119,7 @@ public enum ResourceTypeName {
      * <p>A material substance originating from a biological entity intended to be transplanted or infused
      * <p>into another (possibly the same) biological entity.
      */
-    BIOLOGICALLY_DERIVED_PRODUCT("BiologicallyDerivedProduct"),
+    BIOLOGICALLY_DERIVED_PRODUCT("BiologicallyDerivedProduct", VERSION_40),
 
     /**
      * BodyStructure
@@ -266,7 +127,7 @@ public enum ResourceTypeName {
      * <p>Record details about an anatomical structure. This resource may be used when a coded concept does not provide the
      * necessary detail needed for the use case.
      */
-    BODY_STRUCTURE("BodyStructure"),
+    BODY_STRUCTURE("BodyStructure", VERSION_40),
 
     /**
      * CapabilityStatement
@@ -275,7 +136,7 @@ public enum ResourceTypeName {
      * FHIR that may be used as a statement of actual server functionality or a statement of required or desired server
      * implementation.
      */
-    CAPABILITY_STATEMENT("CapabilityStatement"),
+    CAPABILITY_STATEMENT("CapabilityStatement", VERSION_40),
 
     /**
      * CarePlan
@@ -283,7 +144,7 @@ public enum ResourceTypeName {
      * <p>Describes the intention of how one or more practitioners intend to deliver care for a particular patient, group or
      * community for a period of time, possibly limited to care for a specific condition or set of conditions.
      */
-    CARE_PLAN("CarePlan"),
+    CARE_PLAN("CarePlan", VERSION_40),
 
     /**
      * CareTeam
@@ -291,14 +152,14 @@ public enum ResourceTypeName {
      * <p>The Care Team includes all the people and organizations who plan to participate in the coordination and delivery of
      * care for a patient.
      */
-    CARE_TEAM("CareTeam"),
+    CARE_TEAM("CareTeam", VERSION_40),
 
     /**
      * CatalogEntry
      *
      * <p>Catalog entries are wrappers that contextualize items included in a catalog.
      */
-    CATALOG_ENTRY("CatalogEntry"),
+    CATALOG_ENTRY("CatalogEntry", VERSION_40),
 
     /**
      * ChargeItem
@@ -308,7 +169,7 @@ public enum ResourceTypeName {
      * participating organizations and persons. Main Usage of the ChargeItem is to enable the billing process and internal
      * cost allocation.
      */
-    CHARGE_ITEM("ChargeItem"),
+    CHARGE_ITEM("ChargeItem", VERSION_40),
 
     /**
      * ChargeItemDefinition
@@ -317,7 +178,7 @@ public enum ResourceTypeName {
      * costs and prices. The properties may differ largely depending on type and realm, therefore this resource gives only a
      * rough structure and requires profiling for each type of billing code system.
      */
-    CHARGE_ITEM_DEFINITION("ChargeItemDefinition"),
+    CHARGE_ITEM_DEFINITION("ChargeItemDefinition", VERSION_40),
 
     /**
      * Citation
@@ -326,7 +187,7 @@ public enum ResourceTypeName {
      * The Citation Resource supports existing reference structures and developing publication practices such as versioning,
      * expressing complex contributorship roles, and referencing computable resources.
      */
-    CITATION("Citation"),
+    CITATION("Citation", VERSION_43),
 
     /**
      * Claim
@@ -334,14 +195,14 @@ public enum ResourceTypeName {
      * <p>A provider issued list of professional services and products which have been provided, or are to be provided, to a
      * patient which is sent to an insurer for reimbursement.
      */
-    CLAIM("Claim"),
+    CLAIM("Claim", VERSION_40),
 
     /**
      * ClaimResponse
      *
      * <p>This resource provides the adjudication details from the processing of a Claim resource.
      */
-    CLAIM_RESPONSE("ClaimResponse"),
+    CLAIM_RESPONSE("ClaimResponse", VERSION_40),
 
     /**
      * ClinicalImpression
@@ -352,7 +213,7 @@ public enum ResourceTypeName {
      * called "ClinicalImpression" rather than "ClinicalAssessment" to avoid confusion with the recording of assessment tools
      * such as Apgar score.
      */
-    CLINICAL_IMPRESSION("ClinicalImpression"),
+    CLINICAL_IMPRESSION("ClinicalImpression", VERSION_40),
 
     /**
      * ClinicalUseDefinition
@@ -360,7 +221,7 @@ public enum ResourceTypeName {
      * <p>A single issue - either an indication, contraindication, interaction or an undesirable effect for a medicinal
      * product, medication, device or procedure.
      */
-    CLINICAL_USE_DEFINITION("ClinicalUseDefinition"),
+    CLINICAL_USE_DEFINITION("ClinicalUseDefinition", VERSION_43),
 
     /**
      * CodeSystem
@@ -368,7 +229,7 @@ public enum ResourceTypeName {
      * <p>The CodeSystem resource is used to declare the existence of and describe a code system or code system supplement
      * and its key properties, and optionally define a part or all of its content.
      */
-    CODE_SYSTEM("CodeSystem"),
+    CODE_SYSTEM("CodeSystem", VERSION_40),
 
     /**
      * Communication
@@ -376,7 +237,7 @@ public enum ResourceTypeName {
      * <p>An occurrence of information being transmitted; e.g. an alert that was sent to a responsible provider, a public
      * health agency that was notified about a reportable condition.
      */
-    COMMUNICATION("Communication"),
+    COMMUNICATION("Communication", VERSION_40),
 
     /**
      * CommunicationRequest
@@ -384,14 +245,14 @@ public enum ResourceTypeName {
      * <p>A request to convey information; e.g. the CDS system proposes that an alert be sent to a responsible provider, the
      * CDS system proposes that the public health agency be notified about a reportable condition.
      */
-    COMMUNICATION_REQUEST("CommunicationRequest"),
+    COMMUNICATION_REQUEST("CommunicationRequest", VERSION_40),
 
     /**
      * CompartmentDefinition
      *
      * <p>A compartment definition that defines how resources are accessed on a server.
      */
-    COMPARTMENT_DEFINITION("CompartmentDefinition"),
+    COMPARTMENT_DEFINITION("CompartmentDefinition", VERSION_40),
 
     /**
      * Composition
@@ -403,7 +264,7 @@ public enum ResourceTypeName {
      * Bundle.type=document, and any other resources referenced from Composition must be included as subsequent entries in
      * the Bundle (for example Patient, Practitioner, Encounter, etc.).
      */
-    COMPOSITION("Composition"),
+    COMPOSITION("Composition", VERSION_40),
 
     /**
      * ConceptMap
@@ -411,7 +272,7 @@ public enum ResourceTypeName {
      * <p>A statement of relationships from one set of concepts to one or more other concepts - either concepts in code
      * systems, or data element/data element concepts, or classes in class models.
      */
-    CONCEPT_MAP("ConceptMap"),
+    CONCEPT_MAP("ConceptMap", VERSION_40),
 
     /**
      * Condition
@@ -419,7 +280,7 @@ public enum ResourceTypeName {
      * <p>A clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a
      * level of concern.
      */
-    CONDITION("Condition"),
+    CONDITION("Condition", VERSION_40),
 
     /**
      * Consent
@@ -427,14 +288,14 @@ public enum ResourceTypeName {
      * <p>A record of a healthcare consumer’s choices, which permits or denies identified recipient(s) or recipient role(s)
      * to perform one or more actions within a given policy context, for specific purposes and periods of time.
      */
-    CONSENT("Consent"),
+    CONSENT("Consent", VERSION_40),
 
     /**
      * Contract
      *
      * <p>Legally enforceable, formally recorded unilateral or bilateral directive i.e., a policy or agreement.
      */
-    CONTRACT("Contract"),
+    CONTRACT("Contract", VERSION_40),
 
     /**
      * Coverage
@@ -442,7 +303,7 @@ public enum ResourceTypeName {
      * <p>Financial instrument which may be used to reimburse or pay for health care products and services. Includes both
      * insurance and self-payment.
      */
-    COVERAGE("Coverage"),
+    COVERAGE("Coverage", VERSION_40),
 
     /**
      * CoverageEligibilityRequest
@@ -451,14 +312,14 @@ public enum ResourceTypeName {
      * respond, in the form of an CoverageEligibilityResponse, with information regarding whether the stated coverage is
      * valid and in-force and optionally to provide the insurance details of the policy.
      */
-    COVERAGE_ELIGIBILITY_REQUEST("CoverageEligibilityRequest"),
+    COVERAGE_ELIGIBILITY_REQUEST("CoverageEligibilityRequest", VERSION_40),
 
     /**
      * CoverageEligibilityResponse
      *
      * <p>This resource provides eligibility and plan details from the processing of an CoverageEligibilityRequest resource.
      */
-    COVERAGE_ELIGIBILITY_RESPONSE("CoverageEligibilityResponse"),
+    COVERAGE_ELIGIBILITY_RESPONSE("CoverageEligibilityResponse", VERSION_40),
 
     /**
      * DetectedIssue
@@ -466,7 +327,7 @@ public enum ResourceTypeName {
      * <p>Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for
      * a patient; e.g. Drug-drug interaction, Ineffective treatment frequency, Procedure-condition conflict, etc.
      */
-    DETECTED_ISSUE("DetectedIssue"),
+    DETECTED_ISSUE("DetectedIssue", VERSION_40),
 
     /**
      * Device
@@ -474,21 +335,21 @@ public enum ResourceTypeName {
      * <p>A type of a manufactured item that is used in the provision of healthcare without being substantially changed
      * through that activity. The device may be a medical or non-medical device.
      */
-    DEVICE("Device"),
+    DEVICE("Device", VERSION_40),
 
     /**
      * DeviceDefinition
      *
      * <p>The characteristics, operational status and capabilities of a medical-related component of a medical device.
      */
-    DEVICE_DEFINITION("DeviceDefinition"),
+    DEVICE_DEFINITION("DeviceDefinition", VERSION_40),
 
     /**
      * DeviceMetric
      *
      * <p>Describes a measurement, calculation or setting capability of a medical device.
      */
-    DEVICE_METRIC("DeviceMetric"),
+    DEVICE_METRIC("DeviceMetric", VERSION_40),
 
     /**
      * DeviceRequest
@@ -496,7 +357,7 @@ public enum ResourceTypeName {
      * <p>Represents a request for a patient to employ a medical device. The device may be an implantable device, or an
      * external assistive device, such as a walker.
      */
-    DEVICE_REQUEST("DeviceRequest"),
+    DEVICE_REQUEST("DeviceRequest", VERSION_40),
 
     /**
      * DeviceUseStatement
@@ -504,7 +365,7 @@ public enum ResourceTypeName {
      * <p>A record of a device being used by a patient where the record is the result of a report from the patient or another
      * clinician.
      */
-    DEVICE_USE_STATEMENT("DeviceUseStatement"),
+    DEVICE_USE_STATEMENT("DeviceUseStatement", VERSION_40),
 
     /**
      * DiagnosticReport
@@ -514,14 +375,14 @@ public enum ResourceTypeName {
      * information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation
      * of diagnostic reports.
      */
-    DIAGNOSTIC_REPORT("DiagnosticReport"),
+    DIAGNOSTIC_REPORT("DiagnosticReport", VERSION_40),
 
     /**
      * DocumentManifest
      *
      * <p>A collection of documents compiled for a purpose together with metadata that applies to the collection.
      */
-    DOCUMENT_MANIFEST("DocumentManifest"),
+    DOCUMENT_MANIFEST("DocumentManifest", VERSION_40),
 
     /**
      * DocumentReference
@@ -530,7 +391,15 @@ public enum ResourceTypeName {
      * can be discovered and managed. The scope of a document is any seralized object with a mime-type, so includes formal
      * patient centric documents (CDA), cliical notes, scanned paper, and non-patient specific documents like policy text.
      */
-    DOCUMENT_REFERENCE("DocumentReference"),
+    DOCUMENT_REFERENCE("DocumentReference", VERSION_40),
+
+    /**
+     * EffectEvidenceSynthesis
+     *
+     * <p>The EffectEvidenceSynthesis resource describes the difference in an outcome between exposures states in a
+     * population where the effect estimate is derived from a combination of research studies.
+     */
+    EFFECT_EVIDENCE_SYNTHESIS("EffectEvidenceSynthesis", VERSION_40, VERSION_43),
 
     /**
      * Encounter
@@ -538,7 +407,7 @@ public enum ResourceTypeName {
      * <p>An interaction between a patient and healthcare provider(s) for the purpose of providing healthcare service(s) or
      * assessing the health status of a patient.
      */
-    ENCOUNTER("Encounter"),
+    ENCOUNTER("Encounter", VERSION_40),
 
     /**
      * Endpoint
@@ -546,21 +415,21 @@ public enum ResourceTypeName {
      * <p>The technical details of an endpoint that can be used for electronic services, such as for web services providing
      * XDS.b or a REST endpoint for another FHIR server. This may include any security context information.
      */
-    ENDPOINT("Endpoint"),
+    ENDPOINT("Endpoint", VERSION_40),
 
     /**
      * EnrollmentRequest
      *
      * <p>This resource provides the insurance enrollment details to the insurer regarding a specified coverage.
      */
-    ENROLLMENT_REQUEST("EnrollmentRequest"),
+    ENROLLMENT_REQUEST("EnrollmentRequest", VERSION_40),
 
     /**
      * EnrollmentResponse
      *
      * <p>This resource provides enrollment and plan details from the processing of an EnrollmentRequest resource.
      */
-    ENROLLMENT_RESPONSE("EnrollmentResponse"),
+    ENROLLMENT_RESPONSE("EnrollmentResponse", VERSION_40),
 
     /**
      * EpisodeOfCare
@@ -568,14 +437,14 @@ public enum ResourceTypeName {
      * <p>An association between a patient and an organization / healthcare provider(s) during which time encounters may
      * occur. The managing organization assumes a level of responsibility for the patient during this time.
      */
-    EPISODE_OF_CARE("EpisodeOfCare"),
+    EPISODE_OF_CARE("EpisodeOfCare", VERSION_40),
 
     /**
      * EventDefinition
      *
      * <p>The EventDefinition resource provides a reusable description of when a particular event can occur.
      */
-    EVENT_DEFINITION("EventDefinition"),
+    EVENT_DEFINITION("EventDefinition", VERSION_40),
 
     /**
      * Evidence
@@ -584,7 +453,7 @@ public enum ResourceTypeName {
      * variables (eg population, exposures/interventions, comparators, outcomes, measured variables, confounding variables),
      * the statistics, and the certainty of this evidence.
      */
-    EVIDENCE("Evidence"),
+    EVIDENCE("Evidence", VERSION_40),
 
     /**
      * EvidenceReport
@@ -592,21 +461,21 @@ public enum ResourceTypeName {
      * <p>The EvidenceReport Resource is a specialized container for a collection of resources and codable concepts, adapted
      * to support compositions of Evidence, EvidenceVariable, and Citation resources and related concepts.
      */
-    EVIDENCE_REPORT("EvidenceReport"),
+    EVIDENCE_REPORT("EvidenceReport", VERSION_43),
 
     /**
      * EvidenceVariable
      *
      * <p>The EvidenceVariable resource describes an element that knowledge (Evidence) is about.
      */
-    EVIDENCE_VARIABLE("EvidenceVariable"),
+    EVIDENCE_VARIABLE("EvidenceVariable", VERSION_40),
 
     /**
      * ExampleScenario
      *
      * <p>Example of workflow instance.
      */
-    EXAMPLE_SCENARIO("ExampleScenario"),
+    EXAMPLE_SCENARIO("ExampleScenario", VERSION_40),
 
     /**
      * ExplanationOfBenefit
@@ -614,21 +483,21 @@ public enum ResourceTypeName {
      * <p>This resource provides: the claim details; adjudication details from the processing of a Claim; and optionally
      * account balance information, for informing the subscriber of the benefits provided.
      */
-    EXPLANATION_OF_BENEFIT("ExplanationOfBenefit"),
+    EXPLANATION_OF_BENEFIT("ExplanationOfBenefit", VERSION_40),
 
     /**
      * FamilyMemberHistory
      *
      * <p>Significant health conditions for a person related to the patient relevant in the context of care for the patient.
      */
-    FAMILY_MEMBER_HISTORY("FamilyMemberHistory"),
+    FAMILY_MEMBER_HISTORY("FamilyMemberHistory", VERSION_40),
 
     /**
      * Flag
      *
      * <p>Prospective warnings of potential issues when providing care to the patient.
      */
-    FLAG("Flag"),
+    FLAG("Flag", VERSION_40),
 
     /**
      * Goal
@@ -636,7 +505,7 @@ public enum ResourceTypeName {
      * <p>Describes the intended objective(s) for a patient, group or organization care, for example, weight loss, restoring
      * an activity of daily living, obtaining herd immunity via immunization, meeting a process improvement objective, etc.
      */
-    GOAL("Goal"),
+    GOAL("Goal", VERSION_40),
 
     /**
      * GraphDefinition
@@ -644,7 +513,7 @@ public enum ResourceTypeName {
      * <p>A formal computable definition of a graph of resources - that is, a coherent set of resources that form a graph by
      * following references. The Graph Definition resource defines a set and makes rules about the set.
      */
-    GRAPH_DEFINITION("GraphDefinition"),
+    GRAPH_DEFINITION("GraphDefinition", VERSION_40),
 
     /**
      * Group
@@ -653,7 +522,7 @@ public enum ResourceTypeName {
      * expected to act collectively, and are not formally or legally recognized; i.e. a collection of entities that isn't an
      * Organization.
      */
-    GROUP("Group"),
+    GROUP("Group", VERSION_40),
 
     /**
      * GuidanceResponse
@@ -661,14 +530,14 @@ public enum ResourceTypeName {
      * <p>A guidance response is the formal response to a guidance request, including any output parameters returned by the
      * evaluation, as well as the description of any proposed actions to be taken.
      */
-    GUIDANCE_RESPONSE("GuidanceResponse"),
+    GUIDANCE_RESPONSE("GuidanceResponse", VERSION_40),
 
     /**
      * HealthcareService
      *
      * <p>The details of a healthcare service available at a location.
      */
-    HEALTHCARE_SERVICE("HealthcareService"),
+    HEALTHCARE_SERVICE("HealthcareService", VERSION_40),
 
     /**
      * ImagingStudy
@@ -678,7 +547,7 @@ public enum ResourceTypeName {
      * common context. A series is of only one modality (e.g. X-ray, CT, MR, ultrasound), but a study may have multiple
      * series of different modalities.
      */
-    IMAGING_STUDY("ImagingStudy"),
+    IMAGING_STUDY("ImagingStudy", VERSION_40),
 
     /**
      * Immunization
@@ -686,7 +555,7 @@ public enum ResourceTypeName {
      * <p>Describes the event of a patient being administered a vaccine or a record of an immunization as reported by a
      * patient, a clinician or another party.
      */
-    IMMUNIZATION("Immunization"),
+    IMMUNIZATION("Immunization", VERSION_40),
 
     /**
      * ImmunizationEvaluation
@@ -694,7 +563,7 @@ public enum ResourceTypeName {
      * <p>Describes a comparison of an immunization event against published recommendations to determine if the
      * administration is "valid" in relation to those recommendations.
      */
-    IMMUNIZATION_EVALUATION("ImmunizationEvaluation"),
+    IMMUNIZATION_EVALUATION("ImmunizationEvaluation", VERSION_40),
 
     /**
      * ImmunizationRecommendation
@@ -702,7 +571,7 @@ public enum ResourceTypeName {
      * <p>A patient's point-in-time set of recommendations (i.e. forecasting) according to a published schedule with optional
      * supporting justification.
      */
-    IMMUNIZATION_RECOMMENDATION("ImmunizationRecommendation"),
+    IMMUNIZATION_RECOMMENDATION("ImmunizationRecommendation", VERSION_40),
 
     /**
      * ImplementationGuide
@@ -711,21 +580,21 @@ public enum ResourceTypeName {
      * FHIR resources. This resource is used to gather all the parts of an implementation guide into a logical whole and to
      * publish a computable definition of all the parts.
      */
-    IMPLEMENTATION_GUIDE("ImplementationGuide"),
+    IMPLEMENTATION_GUIDE("ImplementationGuide", VERSION_40),
 
     /**
      * Ingredient
      *
      * <p>An ingredient of a manufactured item or pharmaceutical product.
      */
-    INGREDIENT("Ingredient"),
+    INGREDIENT("Ingredient", VERSION_43),
 
     /**
      * InsurancePlan
      *
      * <p>Details of a Health Insurance product/plan provided by an organization.
      */
-    INSURANCE_PLAN("InsurancePlan"),
+    INSURANCE_PLAN("InsurancePlan", VERSION_40),
 
     /**
      * Invoice
@@ -733,7 +602,7 @@ public enum ResourceTypeName {
      * <p>Invoice containing collected ChargeItems from an Account with calculated individual and total price for Billing
      * purpose.
      */
-    INVOICE("Invoice"),
+    INVOICE("Invoice", VERSION_40),
 
     /**
      * Library
@@ -742,21 +611,21 @@ public enum ResourceTypeName {
      * expose existing knowledge assets such as logic libraries and information model descriptions, as well as to describe a
      * collection of knowledge assets.
      */
-    LIBRARY("Library"),
+    LIBRARY("Library", VERSION_40),
 
     /**
      * Linkage
      *
      * <p>Identifies two or more records (resource instances) that refer to the same real-world "occurrence".
      */
-    LINKAGE("Linkage"),
+    LINKAGE("Linkage", VERSION_40),
 
     /**
      * List
      *
      * <p>A list is a curated collection of resources.
      */
-    LIST("List"),
+    LIST("List", VERSION_40),
 
     /**
      * Location
@@ -764,7 +633,7 @@ public enum ResourceTypeName {
      * <p>Details and position information for a physical place where services are provided and resources and participants
      * may be stored, found, contained, or accommodated.
      */
-    LOCATION("Location"),
+    LOCATION("Location", VERSION_40),
 
     /**
      * ManufacturedItemDefinition
@@ -772,14 +641,14 @@ public enum ResourceTypeName {
      * <p>The definition and characteristics of a medicinal manufactured item, such as a tablet or capsule, as contained in a
      * packaged medicinal product.
      */
-    MANUFACTURED_ITEM_DEFINITION("ManufacturedItemDefinition"),
+    MANUFACTURED_ITEM_DEFINITION("ManufacturedItemDefinition", VERSION_43),
 
     /**
      * Measure
      *
      * <p>The Measure resource provides the definition of a quality measure.
      */
-    MEASURE("Measure"),
+    MEASURE("Measure", VERSION_40),
 
     /**
      * MeasureReport
@@ -787,7 +656,7 @@ public enum ResourceTypeName {
      * <p>The MeasureReport resource contains the results of the calculation of a measure; and optionally a reference to the
      * resources involved in that calculation.
      */
-    MEASURE_REPORT("MeasureReport"),
+    MEASURE_REPORT("MeasureReport", VERSION_40),
 
     /**
      * Media
@@ -795,7 +664,7 @@ public enum ResourceTypeName {
      * <p>A photo, video, or audio recording acquired or used in healthcare. The actual content may be inline or provided by
      * direct reference.
      */
-    MEDIA("Media"),
+    MEDIA("Media", VERSION_40),
 
     /**
      * Medication
@@ -803,7 +672,7 @@ public enum ResourceTypeName {
      * <p>This resource is primarily used for the identification and definition of a medication for the purposes of
      * prescribing, dispensing, and administering a medication as well as for making statements about medication use.
      */
-    MEDICATION("Medication"),
+    MEDICATION("Medication", VERSION_40),
 
     /**
      * MedicationAdministration
@@ -812,7 +681,7 @@ public enum ResourceTypeName {
      * swallowing a tablet or it may be a long running infusion. Related resources tie this event to the authorizing
      * prescription, and the specific encounter between patient and health care practitioner.
      */
-    MEDICATION_ADMINISTRATION("MedicationAdministration"),
+    MEDICATION_ADMINISTRATION("MedicationAdministration", VERSION_40),
 
     /**
      * MedicationDispense
@@ -821,14 +690,14 @@ public enum ResourceTypeName {
      * description of the medication product (supply) provided and the instructions for administering the medication. The
      * medication dispense is the result of a pharmacy system responding to a medication order.
      */
-    MEDICATION_DISPENSE("MedicationDispense"),
+    MEDICATION_DISPENSE("MedicationDispense", VERSION_40),
 
     /**
      * MedicationKnowledge
      *
      * <p>Information about a medication that is used to support knowledge.
      */
-    MEDICATION_KNOWLEDGE("MedicationKnowledge"),
+    MEDICATION_KNOWLEDGE("MedicationKnowledge", VERSION_40),
 
     /**
      * MedicationRequest
@@ -838,7 +707,7 @@ public enum ResourceTypeName {
      * generalize the use across inpatient and outpatient settings, including care plans, etc., and to harmonize with
      * workflow patterns.
      */
-    MEDICATION_REQUEST("MedicationRequest"),
+    MEDICATION_REQUEST("MedicationRequest", VERSION_40),
 
     /**
      * MedicationStatement
@@ -859,7 +728,29 @@ public enum ResourceTypeName {
      * memory, from a prescription bottle or from a list of medications the patient, clinician or other party maintains.
      * Medication administration is more formal and is not missing detailed information.
      */
-    MEDICATION_STATEMENT("MedicationStatement"),
+    MEDICATION_STATEMENT("MedicationStatement", VERSION_40),
+
+    /**
+     * MedicinalProduct
+     *
+     * <p>Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use).
+     */
+    MEDICINAL_PRODUCT("MedicinalProduct", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductAuthorization
+     *
+     * <p>The regulatory authorization of a medicinal product.
+     */
+    MEDICINAL_PRODUCT_AUTHORIZATION("MedicinalProductAuthorization", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductContraindication
+     *
+     * <p>The clinical particulars - indications, contraindications etc. of a medicinal product, including for regulatory
+     * purposes.
+     */
+    MEDICINAL_PRODUCT_CONTRAINDICATION("MedicinalProductContraindication", VERSION_40, VERSION_43),
 
     /**
      * MedicinalProductDefinition
@@ -867,7 +758,56 @@ public enum ResourceTypeName {
      * <p>Detailed definition of a medicinal product, typically for uses other than direct patient care (e.g. regulatory use,
      * drug catalogs).
      */
-    MEDICINAL_PRODUCT_DEFINITION("MedicinalProductDefinition"),
+    MEDICINAL_PRODUCT_DEFINITION("MedicinalProductDefinition", VERSION_43),
+
+    /**
+     * MedicinalProductIndication
+     *
+     * <p>Indication for the Medicinal Product.
+     */
+    MEDICINAL_PRODUCT_INDICATION("MedicinalProductIndication", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductIngredient
+     *
+     * <p>An ingredient of a manufactured item or pharmaceutical product.
+     */
+    MEDICINAL_PRODUCT_INGREDIENT("MedicinalProductIngredient", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductInteraction
+     *
+     * <p>The interactions of the medicinal product with other medicinal products, or other forms of interactions.
+     */
+    MEDICINAL_PRODUCT_INTERACTION("MedicinalProductInteraction", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductManufactured
+     *
+     * <p>The manufactured item as contained in the packaged medicinal product.
+     */
+    MEDICINAL_PRODUCT_MANUFACTURED("MedicinalProductManufactured", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductPackaged
+     *
+     * <p>A medicinal product in a container or package.
+     */
+    MEDICINAL_PRODUCT_PACKAGED("MedicinalProductPackaged", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductPharmaceutical
+     *
+     * <p>A pharmaceutical product described in terms of its composition and dose form.
+     */
+    MEDICINAL_PRODUCT_PHARMACEUTICAL("MedicinalProductPharmaceutical", VERSION_40, VERSION_43),
+
+    /**
+     * MedicinalProductUndesirableEffect
+     *
+     * <p>Describe the undesirable effects of the medicinal product.
+     */
+    MEDICINAL_PRODUCT_UNDESIRABLE_EFFECT("MedicinalProductUndesirableEffect", VERSION_40, VERSION_43),
 
     /**
      * MessageDefinition
@@ -875,7 +815,7 @@ public enum ResourceTypeName {
      * <p>Defines the characteristics of a message that can be shared between systems, including the type of event that
      * initiates the message, the content to be transmitted and what response(s), if any, are permitted.
      */
-    MESSAGE_DEFINITION("MessageDefinition"),
+    MESSAGE_DEFINITION("MessageDefinition", VERSION_40),
 
     /**
      * MessageHeader
@@ -884,14 +824,14 @@ public enum ResourceTypeName {
      * the subject of the action as well as other information related to the action are typically transmitted in a bundle in
      * which the MessageHeader resource instance is the first resource in the bundle.
      */
-    MESSAGE_HEADER("MessageHeader"),
+    MESSAGE_HEADER("MessageHeader", VERSION_40),
 
     /**
      * MolecularSequence
      *
      * <p>Raw data describing a biological sequence.
      */
-    MOLECULAR_SEQUENCE("MolecularSequence"),
+    MOLECULAR_SEQUENCE("MolecularSequence", VERSION_40),
 
     /**
      * NamingSystem
@@ -899,28 +839,28 @@ public enum ResourceTypeName {
      * <p>A curated namespace that issues unique symbols within that namespace for the identification of concepts, people,
      * devices, etc. Represents a "System" used within the Identifier and Coding data types.
      */
-    NAMING_SYSTEM("NamingSystem"),
+    NAMING_SYSTEM("NamingSystem", VERSION_40),
 
     /**
      * NutritionOrder
      *
      * <p>A request to supply a diet, formula feeding (enteral) or oral nutritional supplement to a patient/resident.
      */
-    NUTRITION_ORDER("NutritionOrder"),
+    NUTRITION_ORDER("NutritionOrder", VERSION_40),
 
     /**
      * NutritionProduct
      *
      * <p>A food or fluid product that is consumed by patients.
      */
-    NUTRITION_PRODUCT("NutritionProduct"),
+    NUTRITION_PRODUCT("NutritionProduct", VERSION_43),
 
     /**
      * Observation
      *
      * <p>Measurements and simple assertions made about a patient, device or other subject.
      */
-    OBSERVATION("Observation"),
+    OBSERVATION("Observation", VERSION_40),
 
     /**
      * ObservationDefinition
@@ -928,7 +868,7 @@ public enum ResourceTypeName {
      * <p>Set of definitional characteristics for a kind of observation or measurement produced or consumed by an orderable
      * health care service.
      */
-    OBSERVATION_DEFINITION("ObservationDefinition"),
+    OBSERVATION_DEFINITION("ObservationDefinition", VERSION_40),
 
     /**
      * OperationDefinition
@@ -936,14 +876,14 @@ public enum ResourceTypeName {
      * <p>A formal computable definition of an operation (on the RESTful interface) or a named query (using the search
      * interaction).
      */
-    OPERATION_DEFINITION("OperationDefinition"),
+    OPERATION_DEFINITION("OperationDefinition", VERSION_40),
 
     /**
      * OperationOutcome
      *
      * <p>A collection of error, warning, or information messages that result from a system action.
      */
-    OPERATION_OUTCOME("OperationOutcome"),
+    OPERATION_OUTCOME("OperationOutcome", VERSION_40),
 
     /**
      * Organization
@@ -952,7 +892,7 @@ public enum ResourceTypeName {
      * form of collective action. Includes companies, institutions, corporations, departments, community groups, healthcare
      * practice groups, payer/insurer, etc.
      */
-    ORGANIZATION("Organization"),
+    ORGANIZATION("Organization", VERSION_40),
 
     /**
      * OrganizationAffiliation
@@ -960,14 +900,14 @@ public enum ResourceTypeName {
      * <p>Defines an affiliation/assotiation/relationship between 2 distinct oganizations, that is not a part-of
      * relationship/sub-division relationship.
      */
-    ORGANIZATION_AFFILIATION("OrganizationAffiliation"),
+    ORGANIZATION_AFFILIATION("OrganizationAffiliation", VERSION_40),
 
     /**
      * PackagedProductDefinition
      *
      * <p>A medically related item or items, in a container or package.
      */
-    PACKAGED_PRODUCT_DEFINITION("PackagedProductDefinition"),
+    PACKAGED_PRODUCT_DEFINITION("PackagedProductDefinition", VERSION_43),
 
     /**
      * Parameters
@@ -975,7 +915,7 @@ public enum ResourceTypeName {
      * <p>This resource is a non-persisted resource used to pass information into and back from an [operation](operations.
      * html). It has no other use, and there is no RESTful endpoint associated with it.
      */
-    PARAMETERS("Parameters"),
+    PARAMETERS("Parameters", VERSION_40),
 
     /**
      * Patient
@@ -983,7 +923,7 @@ public enum ResourceTypeName {
      * <p>Demographics and other administrative information about an individual or animal receiving care or other health-
      * related services.
      */
-    PATIENT("Patient"),
+    PATIENT("Patient", VERSION_40),
 
     /**
      * PaymentNotice
@@ -991,21 +931,21 @@ public enum ResourceTypeName {
      * <p>This resource provides the status of the payment for goods and services rendered, and the request and response
      * resource references.
      */
-    PAYMENT_NOTICE("PaymentNotice"),
+    PAYMENT_NOTICE("PaymentNotice", VERSION_40),
 
     /**
      * PaymentReconciliation
      *
      * <p>This resource provides the details including amount of a payment and allocates the payment items being paid.
      */
-    PAYMENT_RECONCILIATION("PaymentReconciliation"),
+    PAYMENT_RECONCILIATION("PaymentReconciliation", VERSION_40),
 
     /**
      * Person
      *
      * <p>Demographics and administrative information about a person independent of a specific health-related context.
      */
-    PERSON("Person"),
+    PERSON("Person", VERSION_40),
 
     /**
      * PlanDefinition
@@ -1014,14 +954,14 @@ public enum ResourceTypeName {
      * artifact. The resource is general enough to support the description of a broad range of clinical and non-clinical
      * artifacts such as clinical decision support rules, order sets, protocols, and drug quality specifications.
      */
-    PLAN_DEFINITION("PlanDefinition"),
+    PLAN_DEFINITION("PlanDefinition", VERSION_40),
 
     /**
      * Practitioner
      *
      * <p>A person who is directly or indirectly involved in the provisioning of healthcare.
      */
-    PRACTITIONER("Practitioner"),
+    PRACTITIONER("Practitioner", VERSION_40),
 
     /**
      * PractitionerRole
@@ -1029,7 +969,7 @@ public enum ResourceTypeName {
      * <p>A specific set of Roles/Locations/specialties/services that a practitioner may perform at an organization for a
      * period of time.
      */
-    PRACTITIONER_ROLE("PractitionerRole"),
+    PRACTITIONER_ROLE("PractitionerRole", VERSION_40),
 
     /**
      * Procedure
@@ -1037,7 +977,7 @@ public enum ResourceTypeName {
      * <p>An action that is or was performed on or for a patient. This can be a physical intervention like an operation, or
      * less invasive like long term services, counseling, or hypnotherapy.
      */
-    PROCEDURE("Procedure"),
+    PROCEDURE("Procedure", VERSION_40),
 
     /**
      * Provenance
@@ -1050,7 +990,7 @@ public enum ResourceTypeName {
      * Completion - has the artifact been legally authenticated), all of which may impact security, privacy, and trust
      * policies.
      */
-    PROVENANCE("Provenance"),
+    PROVENANCE("Provenance", VERSION_40),
 
     /**
      * Questionnaire
@@ -1058,7 +998,7 @@ public enum ResourceTypeName {
      * <p>A structured set of questions intended to guide the collection of answers from end-users. Questionnaires provide
      * detailed control over order, presentation, phraseology and grouping to allow coherent, consistent data collection.
      */
-    QUESTIONNAIRE("Questionnaire"),
+    QUESTIONNAIRE("Questionnaire", VERSION_40),
 
     /**
      * QuestionnaireResponse
@@ -1066,7 +1006,7 @@ public enum ResourceTypeName {
      * <p>A structured set of questions and their answers. The questions are ordered and grouped into coherent subsets,
      * corresponding to the structure of the grouping of the questionnaire being responded to.
      */
-    QUESTIONNAIRE_RESPONSE("QuestionnaireResponse"),
+    QUESTIONNAIRE_RESPONSE("QuestionnaireResponse", VERSION_40),
 
     /**
      * RegulatedAuthorization
@@ -1075,7 +1015,7 @@ public enum ResourceTypeName {
      * cited in a guidance, regulation, rule or legislative act. An example is Market Authorization relating to a Medicinal
      * Product.
      */
-    REGULATED_AUTHORIZATION("RegulatedAuthorization"),
+    REGULATED_AUTHORIZATION("RegulatedAuthorization", VERSION_43),
 
     /**
      * RelatedPerson
@@ -1083,7 +1023,7 @@ public enum ResourceTypeName {
      * <p>Information about a person that is involved in the care for a patient, but who is not the target of healthcare, nor
      * has a formal responsibility in the care process.
      */
-    RELATED_PERSON("RelatedPerson"),
+    RELATED_PERSON("RelatedPerson", VERSION_40),
 
     /**
      * RequestGroup
@@ -1091,7 +1031,7 @@ public enum ResourceTypeName {
      * <p>A group of related requests that can be used to capture intended activities that have inter-dependencies such as
      * "give this medication after that one".
      */
-    REQUEST_GROUP("RequestGroup"),
+    REQUEST_GROUP("RequestGroup", VERSION_40),
 
     /**
      * ResearchDefinition
@@ -1099,7 +1039,7 @@ public enum ResourceTypeName {
      * <p>The ResearchDefinition resource describes the conditional state (population and any exposures being compared within
      * the population) and outcome (if specified) that the knowledge (evidence, assertion, recommendation) is about.
      */
-    RESEARCH_DEFINITION("ResearchDefinition"),
+    RESEARCH_DEFINITION("ResearchDefinition", VERSION_40),
 
     /**
      * ResearchElementDefinition
@@ -1107,7 +1047,7 @@ public enum ResourceTypeName {
      * <p>The ResearchElementDefinition resource describes a "PICO" element that knowledge (evidence, assertion,
      * recommendation) is about.
      */
-    RESEARCH_ELEMENT_DEFINITION("ResearchElementDefinition"),
+    RESEARCH_ELEMENT_DEFINITION("ResearchElementDefinition", VERSION_40),
 
     /**
      * ResearchStudy
@@ -1117,63 +1057,71 @@ public enum ResourceTypeName {
      * information about medications, devices, therapies and other interventional and investigative techniques. A
      * ResearchStudy involves the gathering of information about human or animal subjects.
      */
-    RESEARCH_STUDY("ResearchStudy"),
+    RESEARCH_STUDY("ResearchStudy", VERSION_40),
 
     /**
      * ResearchSubject
      *
      * <p>A physical entity which is the primary unit of operational and/or administrative interest in a study.
      */
-    RESEARCH_SUBJECT("ResearchSubject"),
+    RESEARCH_SUBJECT("ResearchSubject", VERSION_40),
 
     /**
      * RiskAssessment
      *
      * <p>An assessment of the likely outcome(s) for a patient or other subject as well as the likelihood of each outcome.
      */
-    RISK_ASSESSMENT("RiskAssessment"),
+    RISK_ASSESSMENT("RiskAssessment", VERSION_40),
+
+    /**
+     * RiskEvidenceSynthesis
+     *
+     * <p>The RiskEvidenceSynthesis resource describes the likelihood of an outcome in a population plus exposure state where
+     * the risk estimate is derived from a combination of research studies.
+     */
+    RISK_EVIDENCE_SYNTHESIS("RiskEvidenceSynthesis", VERSION_40, VERSION_43),
 
     /**
      * Schedule
      *
      * <p>A container for slots of time that may be available for booking appointments.
      */
-    SCHEDULE("Schedule"),
+    SCHEDULE("Schedule", VERSION_40),
 
     /**
      * SearchParameter
      *
      * <p>A search parameter that defines a named search item that can be used to search/filter on a resource.
      */
-    SEARCH_PARAMETER("SearchParameter"),
+    SEARCH_PARAMETER("SearchParameter", VERSION_40),
 
     /**
      * ServiceRequest
      *
      * <p>A record of a request for service such as diagnostic investigations, treatments, or operations to be performed.
      */
-    SERVICE_REQUEST("ServiceRequest"),
+    SERVICE_REQUEST("ServiceRequest", VERSION_40),
 
     /**
      * Slot
      *
      * <p>A slot of time on a schedule that may be available for booking appointments.
      */
-    SLOT("Slot"),
+    SLOT("Slot", VERSION_40),
 
     /**
      * Specimen
      *
      * <p>A sample to be used for analysis.
      */
-    SPECIMEN("Specimen"),
+    SPECIMEN("Specimen", VERSION_40),
 
     /**
      * SpecimenDefinition
      *
      * <p>A kind of specimen with associated set of requirements.
      */
-    SPECIMEN_DEFINITION("SpecimenDefinition"),
+    SPECIMEN_DEFINITION("SpecimenDefinition", VERSION_40),
 
     /**
      * StructureDefinition
@@ -1181,14 +1129,14 @@ public enum ResourceTypeName {
      * <p>A definition of a FHIR structure. This resource is used to describe the underlying resources, data types defined in
      * FHIR, and also for describing extensions and constraints on resources and data types.
      */
-    STRUCTURE_DEFINITION("StructureDefinition"),
+    STRUCTURE_DEFINITION("StructureDefinition", VERSION_40),
 
     /**
      * StructureMap
      *
      * <p>A Map of relationships between 2 structures that can be used to transform data.
      */
-    STRUCTURE_MAP("StructureMap"),
+    STRUCTURE_MAP("StructureMap", VERSION_40),
 
     /**
      * Subscription
@@ -1198,14 +1146,14 @@ public enum ResourceTypeName {
      * resource matches the given criteria, it sends a message on the defined "channel" so that another system can take an
      * appropriate action.
      */
-    SUBSCRIPTION("Subscription"),
+    SUBSCRIPTION("Subscription", VERSION_40),
 
     /**
      * SubscriptionStatus
      *
      * <p>The SubscriptionStatus resource describes the state of a Subscription during notifications.
      */
-    SUBSCRIPTION_STATUS("SubscriptionStatus"),
+    SUBSCRIPTION_STATUS("SubscriptionStatus", VERSION_43),
 
     /**
      * SubscriptionTopic
@@ -1213,42 +1161,97 @@ public enum ResourceTypeName {
      * <p>Describes a stream of resource state changes identified by trigger criteria and annotated with labels useful to
      * filter projections from this topic.
      */
-    SUBSCRIPTION_TOPIC("SubscriptionTopic"),
+    SUBSCRIPTION_TOPIC("SubscriptionTopic", VERSION_43),
 
     /**
      * Substance
      *
      * <p>A homogeneous material with a definite composition.
      */
-    SUBSTANCE("Substance"),
+    SUBSTANCE("Substance", VERSION_40),
 
     /**
      * SubstanceDefinition
      *
      * <p>The detailed description of a substance, typically at a level beyond what is used for prescribing.
      */
-    SUBSTANCE_DEFINITION("SubstanceDefinition"),
+    SUBSTANCE_DEFINITION("SubstanceDefinition", VERSION_43),
+
+    /**
+     * SubstanceNucleicAcid
+     *
+     * <p>Nucleic acids are defined by three distinct elements: the base, sugar and linkage. Individual substance/moiety IDs
+     * will be created for each of these elements. The nucleotide sequence will be always entered in the 5’-3’ direction.
+     */
+    SUBSTANCE_NUCLEIC_ACID("SubstanceNucleicAcid", VERSION_40, VERSION_43),
+
+    /**
+     * SubstancePolymer
+     *
+     * <p>Todo.
+     */
+    SUBSTANCE_POLYMER("SubstancePolymer", VERSION_40, VERSION_43),
+
+    /**
+     * SubstanceProtein
+     *
+     * <p>A SubstanceProtein is defined as a single unit of a linear amino acid sequence, or a combination of subunits that
+     * are either covalently linked or have a defined invariant stoichiometric relationship. This includes all synthetic,
+     * recombinant and purified SubstanceProteins of defined sequence, whether the use is therapeutic or prophylactic. This
+     * set of elements will be used to describe albumins, coagulation factors, cytokines, growth factors,
+     * peptide/SubstanceProtein hormones, enzymes, toxins, toxoids, recombinant vaccines, and immunomodulators.
+     */
+    SUBSTANCE_PROTEIN("SubstanceProtein", VERSION_40, VERSION_43),
+
+    /**
+     * SubstanceReferenceInformation
+     *
+     * <p>Todo.
+     */
+    SUBSTANCE_REFERENCE_INFORMATION("SubstanceReferenceInformation", VERSION_40, VERSION_43),
+
+    /**
+     * SubstanceSourceMaterial
+     *
+     * <p>Source material shall capture information on the taxonomic and anatomical origins as well as the fraction of a
+     * material that can result in or can be modified to form a substance. This set of data elements shall be used to define
+     * polymer substances isolated from biological matrices. Taxonomic and anatomical origins shall be described using a
+     * controlled vocabulary as required. This information is captured for naturally derived polymers ( . starch) and
+     * structurally diverse substances. For Organisms belonging to the Kingdom Plantae the Substance level defines the fresh
+     * material of a single species or infraspecies, the Herbal Drug and the Herbal preparation. For Herbal preparations, the
+     * fraction information will be captured at the Substance information level and additional information for herbal
+     * extracts will be captured at the Specified Substance Group 1 information level. See for further explanation the
+     * Substance Class: Structurally Diverse and the herbal annex.
+     */
+    SUBSTANCE_SOURCE_MATERIAL("SubstanceSourceMaterial", VERSION_40, VERSION_43),
+
+    /**
+     * SubstanceSpecification
+     *
+     * <p>The detailed description of a substance, typically at a level beyond what is used for prescribing.
+     */
+    SUBSTANCE_SPECIFICATION("SubstanceSpecification", VERSION_40, VERSION_43),
 
     /**
      * SupplyDelivery
      *
      * <p>Record of delivery of what is supplied.
      */
-    SUPPLY_DELIVERY("SupplyDelivery"),
+    SUPPLY_DELIVERY("SupplyDelivery", VERSION_40),
 
     /**
      * SupplyRequest
      *
      * <p>A record of a request for a medication, substance or device used in the healthcare setting.
      */
-    SUPPLY_REQUEST("SupplyRequest"),
+    SUPPLY_REQUEST("SupplyRequest", VERSION_40),
 
     /**
      * Task
      *
      * <p>A task to be performed.
      */
-    TASK("Task"),
+    TASK("Task", VERSION_40),
 
     /**
      * TerminologyCapabilities
@@ -1256,14 +1259,14 @@ public enum ResourceTypeName {
      * <p>A TerminologyCapabilities resource documents a set of capabilities (behaviors) of a FHIR Terminology Server that
      * may be used as a statement of actual server functionality or a statement of required or desired server implementation.
      */
-    TERMINOLOGY_CAPABILITIES("TerminologyCapabilities"),
+    TERMINOLOGY_CAPABILITIES("TerminologyCapabilities", VERSION_40),
 
     /**
      * TestReport
      *
      * <p>A summary of information based on the results of executing a TestScript.
      */
-    TEST_REPORT("TestReport"),
+    TEST_REPORT("TestReport", VERSION_40),
 
     /**
      * TestScript
@@ -1271,7 +1274,7 @@ public enum ResourceTypeName {
      * <p>A structured set of tests against a FHIR server or client implementation to determine compliance against the FHIR
      * specification.
      */
-    TEST_SCRIPT("TestScript"),
+    TEST_SCRIPT("TestScript", VERSION_40),
 
     /**
      * ValueSet
@@ -1280,33 +1283,78 @@ public enum ResourceTypeName {
      * particular context. Value sets link between [[[CodeSystem]]] definitions and their use in [coded elements]
      * (terminologies.html).
      */
-    VALUE_SET("ValueSet"),
+    VALUE_SET("ValueSet", VERSION_40),
 
     /**
      * VerificationResult
      *
      * <p>Describes validation requirements, source(s), status and dates for one or more elements.
      */
-    VERIFICATION_RESULT("VerificationResult"),
+    VERIFICATION_RESULT("VerificationResult", VERSION_40),
 
     /**
      * VisionPrescription
      *
      * <p>An authorization for the provision of glasses and/or contact lenses to a patient.
      */
-    VISION_PRESCRIPTION("VisionPrescription");
+    VISION_PRESCRIPTION("VisionPrescription", VERSION_40);
 
     private final String value;
+    private final FHIRVersionParam introduced;
+    private final FHIRVersionParam retired;
 
-    ResourceTypeName(String value) {
+    /**
+     * Construct a resource type that is active in the latest supported version of HL7 FHIR.
+     *
+     * @param value
+     * @param introduced the higher of
+     *         1. the published version of HL7 FHIR that introduced this resource type; and
+     *         2. version 4.0 (because this is the first version supported by this project)
+     */
+    private ResourceTypeName(String value, FHIRVersionParam introduced) {
+        this(value, introduced, null);
+    }
+
+    /**
+     * Construct a resource type name with metadata about when it was introduced (and optionally retired).
+     *
+     * @param value
+     * @param introduced the higher of
+     *         1. the published version of HL7 FHIR that introduced this resource type; and
+     *         2. version 4.0 (because this is the first version supported by this project)
+     * @param retired the published version of HL7 FHIR in which this resource type was removed
+     *
+     * @implNote if HL7 ever *re-introduce* a retired resource type, we'll need to revisit this structure
+     */
+    private ResourceTypeName(String value, FHIRVersionParam introduced, FHIRVersionParam retired) {
         this.value = value;
+        this.introduced = introduced;
+        this.retired = retired;
     }
 
     /**
      * @return
-     *     The String value of the resource type name
+     *     the String value of the resource type name
      */
-    public java.lang.String value() {
+    public String value() {
         return value;
+    }
+
+    /**
+     * @return
+     *     the higher of
+     *         1. the published version of HL7 FHIR that introduced this resource type; and
+     *         2. version 4.0 (because this is the first version supported by this project)
+     */
+    public FHIRVersionParam getIntroduced() {
+        return introduced;
+    }
+
+    /**
+     * @return
+     *     the published version of HL7 FHIR in which this resource type was removed
+     */
+    public FHIRVersionParam getRetired() {
+        return retired;
     }
 }

--- a/fhir-core/src/main/java/com/ibm/fhir/core/util/ResourceTypeHelper.java
+++ b/fhir-core/src/main/java/com/ibm/fhir/core/util/ResourceTypeHelper.java
@@ -19,90 +19,208 @@ import com.ibm.fhir.core.ResourceTypeName;
  * Helper methods for working with FHIR Resource Type Strings
  */
 public class ResourceTypeHelper {
-    private static final Set<ResourceTypeName> REMOVED_RESOURCE_TYPES = collectRemovedResourceTypes();
-    private static final Set<ResourceTypeName> R4B_ONLY_RESOURCE_TYPES = collectR4bOnlyResourceTypes();
-    private static final Set<ResourceTypeName> ABSTRACT_TYPES = Collections.unmodifiableSet(new HashSet<>(
+    private static final Set<ResourceTypeName> R4_ENUMS = collectResourceTypesFor(FHIRVersionParam.VERSION_40);
+    private static final Set<ResourceTypeName> R4B_ENUMS = collectResourceTypesFor(FHIRVersionParam.VERSION_43);
+    private static final Set<ResourceTypeName> R4B_ONLY_RESOURCE_ENUMS = collectR4bOnlyResourceTypes();
+    private static final Set<ResourceTypeName> ABSTRACT_TYPE_ENUMS = Collections.unmodifiableSet(new HashSet<>(
             Arrays.asList(
                 ResourceTypeName.RESOURCE,
                 ResourceTypeName.DOMAIN_RESOURCE
             )));
+    /**
+     * valid instances from 4.0 may not be valid in 4.3
+     */
+    private static final Set<ResourceTypeName> BACKWARD_BREAKING_R4B_ENUMS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(
+                ResourceTypeName.DEVICE_DEFINITION,
+                ResourceTypeName.EVIDENCE,
+                ResourceTypeName.EVIDENCE_VARIABLE
+            )));
+    /**
+     * valid instances from 4.3 may not be valid in 4.0
+     */
+    private static final Set<ResourceTypeName> FORWARD_BREAKING_R4B_ENUMS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(
+                ResourceTypeName.DEVICE_DEFINITION,
+                ResourceTypeName.EVIDENCE,
+                ResourceTypeName.EVIDENCE_VARIABLE,
+                ResourceTypeName.ACTIVITY_DEFINITION,
+                ResourceTypeName.PLAN_DEFINITION
+            )));
 
-    private static final Set<String> R4_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
-            Arrays.stream(ResourceTypeName.values())
-                .filter(rtn -> !REMOVED_RESOURCE_TYPES.contains(rtn))
-                .filter(rtn -> !R4B_ONLY_RESOURCE_TYPES.contains(rtn))
-                .filter(rtn -> !ABSTRACT_TYPES.contains(rtn))
+    private static final Set<String> R4_COMPATIBLE_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
+            R4_ENUMS.stream()
+                .filter(rtn -> !ABSTRACT_TYPE_ENUMS.contains(rtn))
                 .map(ResourceTypeName::value)
                 .collect(Collectors.toList())));
 
-    private static final Set<String> R4B_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
-            Arrays.stream(ResourceTypeName.values())
-                .filter(rtn -> !REMOVED_RESOURCE_TYPES.contains(rtn))
-                .filter(rtn -> !ABSTRACT_TYPES.contains(rtn))
+    private static final Set<String> R4B_COMPATIBLE_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
+            R4B_ENUMS.stream()
+                .filter(rtn -> !ABSTRACT_TYPE_ENUMS.contains(rtn))
                 .map(ResourceTypeName::value)
                 .collect(Collectors.toList())));
 
-    private static final Set<String> R4B_ONLY_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
-            R4B_ONLY_RESOURCE_TYPES.stream()
+    private static final Set<String> R4_AND_R4B_COMPATIBLE_RESOURCES = Collections.unmodifiableSet(new LinkedHashSet<>(
+            R4B_ENUMS.stream()
+                .filter(rtn -> !R4B_ONLY_RESOURCE_ENUMS.contains(rtn))
+                .filter(rtn -> !BACKWARD_BREAKING_R4B_ENUMS.contains(rtn))
+                .filter(rtn -> !ABSTRACT_TYPE_ENUMS.contains(rtn))
                 .map(ResourceTypeName::value)
                 .collect(Collectors.toList())));
 
     private static final Set<String> ABSTRACT_RESOURCES = Collections.unmodifiableSet(
-            ABSTRACT_TYPES.stream()
+            ABSTRACT_TYPE_ENUMS.stream()
+                .map(ResourceTypeName::value)
+                .collect(Collectors.toSet()));
+
+    private static final Set<String> BACKWARD_BREAKING_R4B_RESOURCES = Collections.unmodifiableSet(
+            BACKWARD_BREAKING_R4B_ENUMS.stream()
+                .map(ResourceTypeName::value)
+                .collect(Collectors.toSet()));
+
+    private static final Set<String> FORWARD_BREAKING_R4B_RESOURCES = Collections.unmodifiableSet(
+            FORWARD_BREAKING_R4B_ENUMS.stream()
                 .map(ResourceTypeName::value)
                 .collect(Collectors.toSet()));
 
     /**
      * @param fhirVersion The value of the MIME-type parameter 'fhirVersion' for the current interaction
-     *          (e.g. "4.3" not "4.3.0")
-     * @return a set of resource type names that corresponds to the requested fhirVersion
+     * @return the set of resource type names from FHIR R4B that are backwards-compatible with the requested fhirVersion
      */
-    public static Set<String> getResourceTypesFor(FHIRVersionParam fhirVersion) {
+    public static Set<String> getR4bResourceTypesFor(FHIRVersionParam fhirVersion) {
         switch (fhirVersion) {
         case VERSION_43:
-            return R4B_RESOURCES;
+            return R4B_COMPATIBLE_RESOURCES;
         case VERSION_40:
+            return R4_AND_R4B_COMPATIBLE_RESOURCES;
         default:
-            return R4_RESOURCES;
+            throw new IllegalArgumentException("unexpected fhirVersion " + fhirVersion.value());
         }
     }
 
     /**
-     * @return the set of resource type names that were either introduced in 4.3.0 (e.g. Ingredient) or changed
-     *          in backwards-incompatible ways in the 4.3.0 release (e.g. Evidence and EvidenceVariable)
-     */
-    public static Set<String> getNewOrBreakingResourceTypeNames() {
-        return R4B_ONLY_RESOURCES;
-    }
-
-    /**
-     * @return the set of resource type names that were either introduced in 4.3.0 (e.g. Ingredient) or changed
-     *          in backwards-incompatible ways in the 4.3.0 release (e.g. Evidence and EvidenceVariable)
+     * @return the set of resource type names for all abstract resource types, as of FHIR R4B
      */
     public static Set<String> getAbstractResourceTypeNames() {
         return ABSTRACT_RESOURCES;
     }
 
-    private static Set<ResourceTypeName> collectRemovedResourceTypes() {
-        Set<ResourceTypeName> set = new HashSet<>();
-        set.add(ResourceTypeName.EFFECT_EVIDENCE_SYNTHESIS);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_AUTHORIZATION);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_CONTRAINDICATION);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_INDICATION);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_INGREDIENT);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_INTERACTION);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_MANUFACTURED);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_PACKAGED);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_PHARMACEUTICAL);
-        set.add(ResourceTypeName.MEDICINAL_PRODUCT_UNDESIRABLE_EFFECT);
-        set.add(ResourceTypeName.RISK_EVIDENCE_SYNTHESIS);
-        set.add(ResourceTypeName.SUBSTANCE_NUCLEIC_ACID);
-        set.add(ResourceTypeName.SUBSTANCE_POLYMER);
-        set.add(ResourceTypeName.SUBSTANCE_PROTEIN);
-        set.add(ResourceTypeName.SUBSTANCE_REFERENCE_INFORMATION);
-        set.add(ResourceTypeName.SUBSTANCE_SOURCE_MATERIAL);
-        set.add(ResourceTypeName.SUBSTANCE_SPECIFICATION);
+    /**
+     * @param fhirVersion The value of the MIME-type parameter 'fhirVersion' for the current interaction
+     * @return the set of resource type names that were retired with, or before, the passed version of FHIR
+     */
+    public static Set<String> getRemovedResourceTypes(FHIRVersionParam fhirVersion) {
+        return Arrays.stream(ResourceTypeName.values())
+            .filter(rt -> rt.getRetired() != null && rt.getRetired().compareTo(fhirVersion) <= 0)
+            .map(ResourceTypeName::value)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * @param sourceFhirVersion The source fhirVersion for the compatibility checks
+     * @param targetFhirVersion The target fhirVersion for the compatibility checks
+     * @return the set of resource type names for which
+     *     {@code isCompatible(resourceType, sourceFhirVersion, targetFhirVersion)} would be true
+     * @see #isCompatible(String, FHIRVersionParam, FHIRVersionParam)
+     */
+    public static Set<String> getCompatibleResourceTypes(FHIRVersionParam sourceFhirVersion, FHIRVersionParam targetFhirVersion) {
+        if (sourceFhirVersion == FHIRVersionParam.VERSION_40) {
+            switch(targetFhirVersion) {
+            case VERSION_40:
+                return R4_COMPATIBLE_RESOURCES;
+            case VERSION_43:
+                return R4_AND_R4B_COMPATIBLE_RESOURCES;
+            }
+        }
+
+        // sourceFhirVersion is 4.3
+        if (targetFhirVersion == FHIRVersionParam.VERSION_40) {
+            return new LinkedHashSet<>(R4B_ENUMS.stream()
+                    .filter(rtn -> !R4B_ONLY_RESOURCE_ENUMS.contains(rtn))
+                    .filter(rtn -> !FORWARD_BREAKING_R4B_ENUMS.contains(rtn))
+                    .filter(rtn -> !ABSTRACT_TYPE_ENUMS.contains(rtn))
+                    .map(ResourceTypeName::value)
+                    .collect(Collectors.toList()));
+        }
+        return R4B_COMPATIBLE_RESOURCES;
+    }
+
+    /**
+     * If a resourceType instance of type {@code resourceType} is known to be valid in fhirVersion
+     * {@code knownValidFhirVersion}, is it expected to also be valid for fhirVersion
+     * {@code fhirVersionUnderTest}?
+     *
+     * <p>Sample usage:
+     * <ul>
+     * <li>{@code isCompatible("Evidence", VERSION_40, VERSION_43)} returns 'false' because this resource
+     *     type has numerous breaking changes in FHIR 4.3
+     * <li>{@code isCompatible("ActivityDefinition", VERSION_40, VERSION_43)} returns 'true' because a valid ActivityDefinition
+     *     in FHIR 4.0 is also expected to be valid in FHIR 4.3
+     * <li>{@code isCompatible("ActivityDefinition", VERSION_43, VERSION_40)} returns 'false' because FHIR 4.3 adds an additional
+     *     choice type to ActivityDefinition.subject[x] which is not valid in FHIR 4.0
+     * <li>{@code isCompatible("Ingredient", VERSION_40, VERSION_43)} throws IllegalArgumentException because this resource
+     *     type was introduced in FHIR 4.3 and therefore fails the "known to be valid in 4.0" precondition
+     * </ul>
+     *
+     * @param resourceType a valid resource type string
+     * @param knownValidFhirVersion the source fhirVersion for the compatibility check
+     * @param fhirVersionUnderTest the target fhirVersion for the compatibility check
+     * @return
+     *     whether {@code resourceType} instances of fhirVersion {@code knownValidFhirVersion} are
+     *     expected to be compatible with the target {@code fhirVersionUnderTest}
+     * @throws IllegalArgumentException
+     *     if resourceType is not a valid concrete resourceType for fhirVersion knownValidFhirVersion
+     */
+    public static boolean isCompatible(String resourceType, FHIRVersionParam knownValidFhirVersion, FHIRVersionParam fhirVersionUnderTest) {
+        if (ABSTRACT_RESOURCES.contains(resourceType) || !getResourceTypesFor(knownValidFhirVersion).contains(resourceType)) {
+            throw new IllegalArgumentException(resourceType + " is not a valid concrete resourceType for fhirVersion " +
+                    knownValidFhirVersion.value());
+        }
+
+        if (knownValidFhirVersion == fhirVersionUnderTest) {
+            return true;
+        }
+
+        if (!getResourceTypesFor(fhirVersionUnderTest).contains(resourceType)) {
+            return false;
+        }
+
+        switch (knownValidFhirVersion) {
+        case VERSION_40:
+            // is a valid 4.3 instance of this resourceType expected to be valid in 4.0?
+            return !BACKWARD_BREAKING_R4B_RESOURCES.contains(resourceType);
+        case VERSION_43:
+            // is a valid 4.0 instance of this resourceType expected to be valid in 4.3?
+            return !FORWARD_BREAKING_R4B_RESOURCES.contains(resourceType);
+        default:
+            throw new IllegalArgumentException("unexpected fhirVersion " + knownValidFhirVersion.value());
+        }
+    }
+
+    /**
+     * @param fhirVersion The value of the MIME-type parameter 'fhirVersion' for the current interaction
+     * @return a set of resource type names that corresponds to the requested fhirVersion
+     */
+    private static Set<String> getResourceTypesFor(FHIRVersionParam fhirVersion) {
+        switch (fhirVersion) {
+        case VERSION_40:
+            return R4_COMPATIBLE_RESOURCES;
+        case VERSION_43:
+            return R4B_COMPATIBLE_RESOURCES;
+        default:
+            throw new IllegalArgumentException("unexpected fhirVersion " + fhirVersion.value());
+        }
+    }
+
+    private static Set<ResourceTypeName> collectResourceTypesFor(FHIRVersionParam fhirVersion) {
+        Set<ResourceTypeName> set = new LinkedHashSet<>();
+        for(ResourceTypeName r : ResourceTypeName.values()) {
+            if (r.getIntroduced().compareTo(fhirVersion) <= 0) {
+                if (r.getRetired() == null || fhirVersion.compareTo(r.getRetired()) < 0) {
+                    set.add(r);
+                }
+            }
+        }
         return set;
     }
 
@@ -121,11 +239,6 @@ public class ResourceTypeHelper {
         set.add(ResourceTypeName.SUBSCRIPTION_STATUS);
         set.add(ResourceTypeName.SUBSCRIPTION_TOPIC);
         set.add(ResourceTypeName.SUBSTANCE_DEFINITION);
-        // The following resource types existed in R4, but have breaking changes in R4B.
-        // Because we only support the R4B version, we don't want to advertise these in our 4.0.1 statement.
-        set.add(ResourceTypeName.DEVICE_DEFINITION);
-        set.add(ResourceTypeName.EVIDENCE);
-        set.add(ResourceTypeName.EVIDENCE_VARIABLE);
         return set;
     }
 }

--- a/fhir-core/src/test/java/com/ibm/fhir/core/util/test/ResourceTypeHelperTest.java
+++ b/fhir-core/src/test/java/com/ibm/fhir/core/util/test/ResourceTypeHelperTest.java
@@ -6,13 +6,18 @@
 
 package com.ibm.fhir.core.util.test;
 
+import static com.ibm.fhir.core.FHIRVersionParam.VERSION_40;
+import static com.ibm.fhir.core.FHIRVersionParam.VERSION_43;
+import static com.ibm.fhir.core.util.ResourceTypeHelper.getCompatibleResourceTypes;
+import static com.ibm.fhir.core.util.ResourceTypeHelper.isCompatible;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
 
 import org.testng.annotations.Test;
 
-import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.core.util.ResourceTypeHelper;
 
 /**
@@ -20,41 +25,45 @@ import com.ibm.fhir.core.util.ResourceTypeHelper;
  */
 public class ResourceTypeHelperTest {
     @Test
-    public void testGetNewOrBreakingResourceTypeNames() {
-        Set<String> newOrBreakingResourceTypeNames = ResourceTypeHelper.getNewOrBreakingResourceTypeNames();
-        assertEquals(newOrBreakingResourceTypeNames.size(), 16, "number of new or breaking resource types");
-    }
+    public void testGetCompatibleResourceTypes() {
+        Set<String> r4Types = getCompatibleResourceTypes(VERSION_40, VERSION_40);
+        assertEquals(r4Types.size(), 146, "number of r4 resource types");
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testGetNewOrBreakingResourceTypeNamesInvalidAddTo() {
-        Set<String> newOrBreakingResourceTypeNames = ResourceTypeHelper.getNewOrBreakingResourceTypeNames();
-        newOrBreakingResourceTypeNames.add("test");
-    }
+        Set<String> r4bTypes = ResourceTypeHelper.getCompatibleResourceTypes(VERSION_43, VERSION_43);
+        assertEquals(r4bTypes.size(), 141, "number of r4b resource types");
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testGetNewOrBreakingResourceTypeNamesInvalidRemove() {
-        Set<String> newOrBreakingResourceTypeNames = ResourceTypeHelper.getNewOrBreakingResourceTypeNames();
-        newOrBreakingResourceTypeNames.remove("Ingredient");
+        Set<String> backwardCompatibleTypes = ResourceTypeHelper.getCompatibleResourceTypes(VERSION_40, VERSION_43);
+        assertEquals(backwardCompatibleTypes.size(), 125, "number of r4b resource types that are backwards-scompatible with r4");
+
+        Set<String> forwardCompatibleTypes = ResourceTypeHelper.getCompatibleResourceTypes(VERSION_43, VERSION_40);
+        assertEquals(forwardCompatibleTypes.size(), 123, "number of r4 resource types that are forwards-compatible with r4b");
     }
 
     @Test
-    public void testGetResourceTypesFor() {
-        Set<String> r4Types = ResourceTypeHelper.getResourceTypesFor(FHIRVersionParam.VERSION_40);
-        assertEquals(r4Types.size(), 125, "number of r4 resource types");
+    public void testIsCompatible() {
+        assertFalse(isCompatible("Evidence", VERSION_40, VERSION_43));
+        assertTrue(isCompatible("ActivityDefinition", VERSION_40, VERSION_43));
+        assertTrue(isCompatible("PlanDefinition", VERSION_40, VERSION_43));
 
-        Set<String> r4bTypes = ResourceTypeHelper.getResourceTypesFor(FHIRVersionParam.VERSION_43);
-        assertEquals(r4bTypes.size(), 141, "number of r4b resource types");
+        assertFalse(isCompatible("Evidence", VERSION_43, VERSION_40));
+        assertFalse(isCompatible("ActivityDefinition", VERSION_43, VERSION_40));
+        assertFalse(isCompatible("PlanDefinition", VERSION_43, VERSION_40));
+
+        // While not particularly helpful, a valid concrete resourceType
+        // should always be compatible within the same version
+        assertTrue(isCompatible("Evidence", VERSION_40, VERSION_40));
+        assertTrue(isCompatible("Evidence", VERSION_43, VERSION_43));
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testInvalidAdd() {
-        Set<String> newOrBreakingResourceTypeNames = ResourceTypeHelper.getResourceTypesFor(FHIRVersionParam.VERSION_40);
-        newOrBreakingResourceTypeNames.add("test");
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIsCompatibleAbstractResource() {
+        isCompatible("Resource", VERSION_40, VERSION_43);
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
-    public void testInvalidRemove() {
-        Set<String> newOrBreakingResourceTypeNames = ResourceTypeHelper.getResourceTypesFor(FHIRVersionParam.VERSION_43);
-        newOrBreakingResourceTypeNames.remove("Ingredient");
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testIsCompatibleInvalidKnownFhirVersion() {
+        // ingredient was introduced in FHIR 4.3, so its not valid to ask
+        // "is a valid instance of Ingredient in 4.0 expected to be valid in 4.3"
+        isCompatible("Ingredient", VERSION_40, VERSION_43);
     }
 }

--- a/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateResourceTypes.java
+++ b/fhir-persistence-schema/src/main/java/com/ibm/fhir/schema/control/PopulateResourceTypes.java
@@ -14,7 +14,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +22,8 @@ import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.ibm.fhir.core.FHIRVersionParam;
+import com.ibm.fhir.core.util.ResourceTypeHelper;
 import com.ibm.fhir.database.utils.api.IDatabaseStatement;
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
 
@@ -39,27 +40,6 @@ public class PopulateResourceTypes implements IDatabaseStatement {
     private final Integer tenantId;
 
     private static final String Y = "Y";
-
-    private static final List<String> REMOVED_RESOURCE_TYPES = Arrays.asList(
-        "EffectEvidenceSynthesis",
-        "MedicinalProduct",
-        "MedicinalProductAuthorization",
-        "MedicinalProductContraindication",
-        "MedicinalProductIndication",
-        "MedicinalProductIngredient",
-        "MedicinalProductInteraction",
-        "MedicinalProductManufactured",
-        "MedicinalProductPackaged",
-        "MedicinalProductPharmaceutical",
-        "MedicinalProductUndesirableEffect",
-        "RiskEvidenceSynthesis",
-        "SubstanceNucleicAcid",
-        "SubstancePolymer",
-        "SubstanceProtein",
-        "SubstanceReferenceInformation",
-        "SubstanceSourceMaterial",
-        "SubstanceSpecification"
-    );
 
     public PopulateResourceTypes(String adminSchemaName, String schemaName, Integer tenantId) {
         this.adminSchemaName = adminSchemaName;
@@ -177,7 +157,7 @@ public class PopulateResourceTypes implements IDatabaseStatement {
 
     private void updateResourceTypes(List<String> alreadyRetiredTypes, PreparedStatement batch) throws SQLException {
         int numToProcess = 0;
-        for (String removedType : REMOVED_RESOURCE_TYPES) {
+        for (String removedType : ResourceTypeHelper.getRemovedResourceTypes(FHIRVersionParam.VERSION_43)) {
             if (!alreadyRetiredTypes.contains(removedType)) {
                 batch.setString(1, removedType);
                 batch.addBatch();

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/FHIRPersistenceUtil.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/FHIRPersistenceUtil.java
@@ -146,10 +146,9 @@ public class FHIRPersistenceUtil {
                                 String msg = "history interaction is not supported for _type parameter value: " + Encode.forHtml(resourceType);
                                 throw new FHIRPersistenceException(msg)
                                         .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.NOT_SUPPORTED));
-                            } else if (fhirVersion == FHIRVersionParam.VERSION_40 &&
-                                    ResourceTypeHelper.getNewOrBreakingResourceTypeNames().contains(resourceType)) {
-                                String msg = "fhirVersion 4.0 interaction for _type parameter value: '" + resourceType +
-                                        "' is not supported";
+                            } else if (!ResourceTypeHelper.isCompatible(resourceType, fhirVersion, FHIRVersionParam.VERSION_43)) {
+                                String msg = "fhirVersion " + fhirVersion.value() + " interaction for _type parameter value: '" +
+                                        resourceType + "' is not supported";
                                 throw new FHIRPersistenceException(msg)
                                     .withIssue(FHIRUtil.buildOperationOutcomeIssue(msg, IssueType.NOT_SUPPORTED));
                             } else {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchUtil.java
@@ -433,9 +433,8 @@ public class SearchUtil {
                         if (!isSearchEnabled(resType)) {
                             manageException("search interaction is not supported for _type parameter value: " + Encode.forHtml(resType),
                                     IssueType.NOT_SUPPORTED, context, false);
-                        } else if (fhirVersion == FHIRVersionParam.VERSION_40 &&
-                                ResourceTypeHelper.getNewOrBreakingResourceTypeNames().contains(resType)) {
-                            String msg = "fhirVersion 4.0 interaction for _type parameter value: '" + resType +
+                        } else if (!ResourceTypeHelper.isCompatible(resType, fhirVersion, FHIRVersionParam.VERSION_43)) {
+                            String msg = "fhirVersion " + fhirVersion.value() + " interaction for _type parameter value: '" + resType +
                                     "' is not supported";
                             manageException(msg, IssueType.NOT_SUPPORTED, context, false);
                         } else {

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -36,10 +36,10 @@ public interface FHIRResourceHelpers {
     public static final boolean DO_VALIDATION = true;
     // Constant for indicating whether an update can be skipped when the requested update resource matches the existing one
     public static final boolean SKIPPABLE_UPDATE = true;
-    
+
     // Constant for when we don't use the If-Not-Match header value
     public static final Integer IF_NOT_MATCH_NULL = null;
-    
+
     public enum Interaction {
         CREATE("create"),
         DELETE("delete"),
@@ -76,7 +76,8 @@ public interface FHIRResourceHelpers {
      * @param interaction
      *            the interaction to be performed
      * @param resourceType
-     *            the resource type against which the interaction is to be performed
+     *            the resource type against which the interaction is to be performed; use "Resource"
+     *            for whole-system interactions
      * @throws FHIROperationException
      */
     void validateInteraction(Interaction interaction, String resourceType) throws FHIROperationException;
@@ -208,7 +209,7 @@ public interface FHIRResourceHelpers {
      * @param skippableUpdate
      *            if true, and the resource content in the update matches the existing resource on the server, then skip the update;
      *            if false, then always attempt the update
-     * @param ifNoneMatch 
+     * @param ifNoneMatch
      *            conditional create-on-update
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
@@ -236,7 +237,7 @@ public interface FHIRResourceHelpers {
      *            if false, then always attempt the update
      * @param doValidation
      *            if true, validate the resource; if false, assume the resource has already been validated
-     * @param ifNoneMatch 
+     * @param ifNoneMatch
      *            conditional create-on-update
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
@@ -391,7 +392,7 @@ public interface FHIRResourceHelpers {
      * Implement the system level history operation to obtain a list of changes to resources
      * with an optional resourceType which supports for example [base]/Patient/_history
      * requests to return the complete history of changes filtered to a specific resource type.
-     * Because the resource type is included in the path, this variant allows only a single 
+     * Because the resource type is included in the path, this variant allows only a single
      * resource type to be specified. To obtain history for more than one resource type, the
      * [base]/_history whole system history endpoint should be used instead with a list of
      * resource types specified using the _type query parameter.

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -81,6 +81,7 @@ import com.ibm.fhir.model.type.code.FHIRVersion;
 import com.ibm.fhir.model.type.code.HTTPVerb;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
+import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.type.code.SearchEntryMode;
 import com.ibm.fhir.model.util.CollectingVisitor;
 import com.ibm.fhir.model.util.FHIRUtil;
@@ -3003,12 +3004,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     IssueType.NOT_FOUND, IssueSeverity.ERROR);
         }
 
-        if (fhirVersion == FHIRVersionParam.VERSION_40) {
-            // ensure that the version of this resource type in 4.0.1 is compatible with the fhirVersion of the server
-            if (ResourceTypeHelper.getNewOrBreakingResourceTypeNames().contains(resourceType)) {
-                throw buildRestException("The requested resource type '" + resourceType + "' is not supported for fhirVersion 4.0",
-                        IssueType.NOT_SUPPORTED, IssueSeverity.ERROR);
-            }
+        // ensure that the resource type and fhirVersion for the interaction is compatible with the fhirVersion of the server
+        if (!ResourceType.RESOURCE.getValue().equals(resourceType) && !ResourceTypeHelper.isCompatible(resourceType, fhirVersion, FHIRVersionParam.VERSION_43)) {
+            throw buildRestException("The requested resource type '" + resourceType + "' is not supported for fhirVersion " + fhirVersion.value(),
+                    IssueType.NOT_SUPPORTED, IssueSeverity.ERROR);
         }
     }
 


### PR DESCRIPTION
Replace getNewOrBreakingResourceTypeNames() with a more
generic `isCompatible(resType, fhirVersion1, fhirVersion2)` method.

To implement it, I introduced new members to the ResourceTypeName enums
so that we can compute which resource types are associated with which
FHIR versions.

The compatibility knowledge is still encapsulated in
ResourceTypeHelper, but now we more cleanly distinguish between
R4B_ONLY_RESOURCE_TYPES and BACKWARD_BREAKING_R4B_ENUMS (previously they
were both together in the R4B_ONLY_RESOURCE_TYPES list). And now we have
a way to get the inverse (valid 4.3 resources that maybe not be valid in
4.0), although this isn't currently used by the server.


Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>