### PR TITLE
Issue #3276 - Fix NPE in fhir-smart beforeDelete

### DIFF
--- a/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
+++ b/fhir-smart/src/main/java/com/ibm/fhir/smart/AuthzPolicyEnforcementPersistenceInterceptor.java
@@ -399,7 +399,7 @@ public class AuthzPolicyEnforcementPersistenceInterceptor implements FHIRPersist
     @Override
     public void beforeDelete(FHIRPersistenceEvent event) throws FHIRPersistenceInterceptorException {
         DecodedJWT jwt = JWT.decode(getAccessToken());
-        enforce(event.getPrevFhirResource(), getPatientIdFromToken(jwt), Permission.WRITE, getScopesFromToken(jwt));
+        enforce(event.getFhirResource(), getPatientIdFromToken(jwt), Permission.WRITE, getScopesFromToken(jwt));
     }
 
     @Override

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -205,7 +205,7 @@ public class AuthzPolicyEnforcementTest {
         try {
             properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Patient");
             FHIRPersistenceEvent event = new FHIRPersistenceEvent();
-            event.setPrevFhirResource(patient);
+            event.setFhirResource(patient);
             interceptor.beforeDelete(event);
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, PATIENT, WRITE_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {
@@ -214,7 +214,7 @@ public class AuthzPolicyEnforcementTest {
 
         try {properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Observation");
             FHIRPersistenceEvent event = new FHIRPersistenceEvent();
-            event.setPrevFhirResource(observation);
+            event.setFhirResource(observation);
             interceptor.beforeDelete(event);
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, OBSERVATION, WRITE_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {
@@ -223,7 +223,7 @@ public class AuthzPolicyEnforcementTest {
 
         try {properties.put(FHIRPersistenceEvent.PROPNAME_RESOURCE_TYPE, "Condition");
             FHIRPersistenceEvent event = new FHIRPersistenceEvent();
-            event.setPrevFhirResource(condition);
+            event.setFhirResource(condition);
             interceptor.beforeDelete(event);
             assertTrue(shouldSucceed(resourceTypesPermittedByScope, CONDITION, WRITE_APPROVED, permission));
         } catch (FHIRPersistenceInterceptorException e) {


### PR DESCRIPTION
Use `event.getFhirResource()` instead of `event.getPrevResource()` in beforeDelete method of fhir-smart.

`FHIRRestHelper.doDelete` sends an event with only `event.setFhirResource()`, not `event.setPrevFhirResource()`. I assume that the code in `FHIRRestHelper` is correct given that it is used in more places, so I changed the code in `fhir-smart` to get the correct resource from the event.

If this is not the correct solution I'd be happy to make changes.