### PR TITLE
$member-match should throw FHIROperationException instead of rewrapping the exception #3298

### DIFF
--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
@@ -202,6 +202,8 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
                         .responseType(ResponseType.NO_MATCH)
                         .build();
             }
+        } catch (FHIROperationException foe){
+            throw foe;
         } catch (Exception e) {
             LOG.throwing(getClass().getSimpleName(), "executeMemberMatch", e);
             throw FHIROperationUtil.buildExceptionWithIssue("Error executing the MemberMatch", IssueType.EXCEPTION);


### PR DESCRIPTION
- Facilitate throwing the actual exception

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>