### PR TITLE
Issue #3276 - Set both resource and prevResource for beforeDelete event in FHIRRestHelper

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1014,7 +1014,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     }
 
                     // Invoke the 'afterDelete' interceptor methods.
-                    event.setFhirResource(resource);
                     getInterceptorMgr().fireAfterDeleteEvent(event);
                 }
 


### PR DESCRIPTION
Issue #3276 - now both resource and prevResource should be available in the beforeDelete method, preventing the NPE.

Signed-off-by: Jorn van Wier <mail@jornvanwier.com>