### PR TITLE
issue #3232- add the extra IN clause more selectively

### DIFF
--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/domain/SearchQuery.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/domain/SearchQuery.java
@@ -29,7 +29,7 @@ public abstract class SearchQuery {
     private final List<SearchParam> searchParams = new ArrayList<>();
 
     // A list of non-parameter related extensions (e.g. location processing)
-    private final List<SearchExtension> extensions = new ArrayList<>();
+    protected final List<SearchExtension> extensions = new ArrayList<>();
 
     /**
      * Public constructor
@@ -76,11 +76,8 @@ public abstract class SearchQuery {
         T query = getRoot(visitor);
         visitExtensions(query, visitor);
 
-        // Add the parameters subquery and add the extensions there too
+        // Add the parameters subquery
         T parameterBase = visitor.getParameterBaseQuery(query);
-        for (SearchExtension ext: this.extensions) {
-            ext.visit(parameterBase, visitor);
-        }
         visitSearchParams(parameterBase, visitor);
 
         logger.exiting(CLASSNAME, "visit");


### PR DESCRIPTION
Previously, we were adding this extra IN clause for the _type parameter
in all cases.
In the case of a whole-system search *count* query, this was slowing
things down a bit. We still add the IN clause to the query where it
seemed to help, but now we avoid that for the count query.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>