### PR TITLE
 Datasource hits an I/IO exception with bulkdata datasource #3039

### DIFF
--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/db2-cloud/bulkdata.xml
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/db2-cloud/bulkdata.xml
@@ -36,7 +36,7 @@
     <variable name="BATCH_DB_SCHEMA" defaultValue="FHIR_JBATCH"/>
     <variable name="BATCH_DB_PORT" defaultValue="50001"/>
 
-    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB"  type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true">
+    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB"  type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
         <jdbcDriver javax.sql.XADataSource="com.ibm.db2.jcc.DB2XADataSource" libraryRef="sharedLibDb2"/>
         <properties.db2.jcc
             apiKey="${BATCH_DB_APIKEY}"

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/db2/bulkdata.xml
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/db2/bulkdata.xml
@@ -40,7 +40,7 @@
     <variable name="BATCH_DB_PASS" defaultValue=""/>
     <variable name="BATCH_DB_SSL" defaultValue="true"/>
 
-    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true">
+    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
         <jdbcDriver javax.sql.XADataSource="com.ibm.db2.jcc.DB2XADataSource" libraryRef="sharedLibDb2"/>
         <properties.db2.jcc
             serverName="${BATCH_DB_HOSTNAME}"

--- a/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/postgres/bulkdata.xml
+++ b/fhir-server-webapp/src/main/liberty/config/configDropins/disabled/postgres/bulkdata.xml
@@ -40,7 +40,7 @@
     <variable name="BATCH_DB_SSL" defaultValue="true"/>
     <variable name="BATCH_DB_SSL_CERT_PATH" defaultValue=""/>
 
-    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true">
+    <dataSource id="fhirbatchDS" jndiName="jdbc/fhirbatchDB" type="javax.sql.XADataSource" statementCacheSize="200" syncQueryTimeoutWithTransactionTimeout="true" validationTimeout="30s">
         <jdbcDriver javax.sql.XADataSource="org.postgresql.xa.PGXADataSource" libraryRef="sharedLibPostgres"/>
         <properties.postgresql
             databaseName="${BATCH_DB_NAME}"


### PR DESCRIPTION
- add validationTimeout=30s to the bulkdata datasources

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>