### PR TITLE
EverythingOperation fixup

### DIFF
--- a/build/audit/kafka/docker-compose.yml
+++ b/build/audit/kafka/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     command: bash -c "
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/profile --prop db.create=Y
-          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
+          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
           --update-schema &&
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/reference --prop db.create=Y

--- a/build/derby-bootstrap.sh
+++ b/build/derby-bootstrap.sh
@@ -26,7 +26,7 @@ java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-
   --update-schema
 java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
   --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
+  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
   --update-schema
 java -jar ${WORKSPACE}/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
   --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     command: bash -c "
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/profile --prop db.create=Y
-          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
+          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
           --update-schema &&
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/reference --prop db.create=Y

--- a/build/migration/db2/2_compose.sh
+++ b/build/migration/db2/2_compose.sh
@@ -141,7 +141,7 @@ bringup(){
     mkdir -p ${DB_LOC}
     java -jar ${WORKSPACE}/prev/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
         --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet \
+        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet \
         --update-schema
     java -jar ${WORKSPACE}/prev/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
         --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/build/migration/db2/4_current-migrate.sh
+++ b/build/migration/db2/4_current-migrate.sh
@@ -60,7 +60,7 @@ rm -rf ${WORKSPACE}/fhir/build/migration/db2/workarea/volumes/dist/derby
 mkdir -p ${DB_LOC}
 java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-    --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
+    --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
     --update-schema
 java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/build/migration/postgres/2_compose.sh
+++ b/build/migration/postgres/2_compose.sh
@@ -154,7 +154,7 @@ bringup(){
     mkdir -p ${DB_LOC}
     java -jar ${WORKSPACE}/prev/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
         --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet \
+        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet \
         --update-schema
     java -jar ${WORKSPACE}/prev/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
         --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/build/migration/postgres/4_current-migrate.sh
+++ b/build/migration/postgres/4_current-migrate.sh
@@ -67,7 +67,7 @@ rm -rf ${WORKSPACE}/fhir/build/migration/postgres/workarea/volumes/dist/derby
 mkdir -p ${DB_LOC}
 java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-    --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
+    --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
     --update-schema
 java -jar ${WORKSPACE}/fhir/fhir-persistence-schema/target/fhir-persistence-schema-*-cli.jar \
     --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/build/notifications/kafka/docker-compose.yml
+++ b/build/notifications/kafka/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     command: bash -c "
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/profile --prop db.create=Y
-          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
+          --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
           --update-schema &&
         java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
           --db-type derby --prop db.database=/output/derby/reference --prop db.create=Y

--- a/build/persistence/postgres/docker-compose.yml
+++ b/build/persistence/postgres/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     command: bash -c "
       java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
         --db-type derby --prop db.database=/output/derby/profile --prop db.create=Y
-        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
+        --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent
         --update-schema &&
       java -jar /opt/ibm-fhir-server/tools/fhir-persistence-schema-*-cli.jar
         --db-type derby --prop db.database=/output/derby/reference --prop db.create=Y

--- a/build/pre-integration-test.ps1
+++ b/build/pre-integration-test.ps1
@@ -58,7 +58,7 @@ java -jar $SCHEMATOOL `
   --update-schema
 java -jar $SCHEMATOOL `
   --db-type derby --prop db.database=${DB_LOC}\profile --prop db.create=Y `
-  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent `
+  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent `
   --update-schema
 java -jar $SCHEMATOOL `
   --db-type derby --prop db.database=${DB_LOC}\reference --prop db.create=Y `

--- a/build/pre-integration-test.sh
+++ b/build/pre-integration-test.sh
@@ -50,7 +50,7 @@ java -jar ${SIT}/fhir-server-dist/tools/fhir-persistence-schema-*-cli.jar \
   --update-schema
 java -jar ${SIT}/fhir-server-dist/tools/fhir-persistence-schema-*-cli.jar \
   --db-type derby --prop db.database=${DB_LOC}/profile --prop db.create=Y \
-  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
+  --prop resourceTypes=Patient,Group,Practitioner,PractitionerRole,Person,RelatedPerson,Organization,Location,AllergyIntolerance,Observation,MedicationAdministration,Procedure,Substance,StructureDefinition,ElementDefinition,CodeSystem,ValueSet,Encounter,Condition,MedicationRequest,Coverage,ServiceRequest,CarePlan,CareTeam,Claim,DiagnosticReport,ExplanationOfBenefit,Immunization,Medication,Provenance,Consent \
   --update-schema
 java -jar ${SIT}/fhir-server-dist/tools/fhir-persistence-schema-*-cli.jar \
   --db-type derby --prop db.database=${DB_LOC}/reference --prop db.create=Y \

--- a/fhir-server-webapp/src/test/liberty/config/config/tenant1/fhir-server-config.json
+++ b/fhir-server-webapp/src/test/liberty/config/config/tenant1/fhir-server-config.json
@@ -2,7 +2,8 @@
     "__comment": "FHIR Server configuration for mythical tenant id 'tenant1'",
     "fhirServer": {
         "resources": {
-            "open": true,
+            "open": false,
+            "AllergyIntolerance": {},
             "CarePlan": {
                 "searchIncludes": [
                     "CarePlan:date",
@@ -29,7 +30,9 @@
                     "patient": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
                     "status": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status"
                 }
-            },            
+            },
+            "CodeSystem": {},
+            "Condition": {},
             "Consent" : {
                 "searchIncludes": [
                     "Consent:actor",
@@ -44,6 +47,7 @@
                     "organization": "http://hl7.org/fhir/SearchParameter/Consent-organization"
                 }
             },
+            "Encounter": {},
             "Location": {
                 "searchIncludes": [
                 ],
@@ -55,6 +59,7 @@
                     "name": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name"
                 }
             },
+            "MedicationAdministration": {},
             "Observation": {
                 "searchParameters": {
                     "_id": "http://hl7.org/fhir/SearchParameter/Resource-id",
@@ -102,6 +107,7 @@
                     "name": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name"
                 }
             },
+            "PractitionerRole": {},
             "Provenance": {
                 "searchIncludes": [
                     "Provenance:agent",
@@ -114,6 +120,8 @@
                     "target": "http://hl7.org/fhir/SearchParameter/Provenance-target"
                 }
             },
+            "StructureDefinition": {},
+            "ValueSet": {},
             "Resource": {
                 "searchParameters": {
                     "_id": "http://hl7.org/fhir/SearchParameter/Resource-id"


### PR DESCRIPTION
1. Use SearchUtil.getSearchParameters(compartmentMemberType) instead of loading them from the ParametersUtil
2. Change the tenant1 fhir-server-config to use `"open": false`, otherwise the set of supportedResourceTypes includes types that aren't actually included in the db schema (e.g. Appointment)
3. Added in other fhirServer/resources resource configs as needed by the e2e tests

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>