### PR TITLE
ImportPartitionAnalyzer not reporting infly rate on threshold #3000

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportCheckPointData.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportCheckPointData.java
@@ -61,6 +61,9 @@ public class ImportCheckPointData implements Serializable {
     // ETags for COS/S3 multiple-parts upload.
     protected List<PartETag> dataPacksForFailureOperationOutcomes = new ArrayList<>();
 
+    // Used to track last resource count when in fly rate was logged
+    protected long lastChecked = 0;
+
     protected ImportCheckPointData() {
         super();
     }
@@ -135,6 +138,14 @@ public class ImportCheckPointData implements Serializable {
 
     public void setCurrentBytes(long currentBytes) {
         this.currentBytes = currentBytes;
+    }
+
+    public long getLastChecked() {
+        return lastChecked;
+    }
+
+    public void setLastChecked(long lastChecked) {
+        this.lastChecked = lastChecked;
     }
 
     public static ImportCheckPointData fromImportTransientUserData(ImportTransientUserData userData) {


### PR DESCRIPTION
ImportPartitionAnalyzer - modify the infly rate reporting message and changed the message to report out Resources/second and report which  workitem is triggering the message.
Improve accuracy of the infly rate calculation

Sample Message: 

```
[INFO ] Import in-fly rate:
        [286/286/r4_AllergyIntolerance.ndjson/AllergyIntolerance]
        reportingThreshold=[2000] resources imported in 12610 milliseconds,
        ImportRate: [0.064] Resources/milliseconds
            Instance/Execution/File/ResourceType threshold milliseconds and
            rate.
```

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>