### PR TITLE
bulk data delete followed by status caused no output #3034

### DIFF
--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -391,6 +391,9 @@ public class BulkDataClient {
                 restart.releaseConnection();
                 restartResponse.close();
             }
+
+            // Don't forget to return null, so the HTTP Status Code is 202
+            return null;
         } else if (OperationConstants.SUCCESS_STATUS.contains(batchStatus)) {
             // Job has a successful batch status, so go to work
             try {


### PR DESCRIPTION
- missing null return, otherwise it hits an empty pollingresponse.

Unfortunately, this depends on calls to the batch framework underneath to test, and is not ideal for Unit or Integration Test.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>