### PR TITLE
Patch ModelResolver to return Resource.id as FHIR.string

### DIFF
--- a/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/engine/model/FHIRModelResolver.java
+++ b/cql/fhir-cql/src/main/java/com/ibm/fhir/cql/engine/model/FHIRModelResolver.java
@@ -71,7 +71,10 @@ public class FHIRModelResolver implements ModelResolver {
             TYPE_PACKAGE_NAME,
             CODE_PACKAGE_NAME }; 
 
+    public static final Pattern idPattern = Pattern.compile("(^|.+\\.)id$");
+    
     public static final Pattern urlPattern = Pattern.compile("(^|.+\\.)url$");
+
 
     private static final Map<String, Class<?>> TYPE_MAP = buildTypeMap();
 
@@ -244,9 +247,13 @@ public class FHIRModelResolver implements ModelResolver {
 
 
     protected Object patchResult(String path, Object result) {
-        if( result instanceof java.lang.String && urlPattern.matcher(path).matches() ) {
-            // Patch the model to match the CQL translator modelinfo expectations
-            result = Uri.of((String) result);
+        // Patch the model to match the CQL translator modelinfo expectations
+        if( result instanceof java.lang.String ) {
+            if( urlPattern.matcher(path).matches() ) {
+                result = Uri.of((String) result);
+            } else if( idPattern.matcher(path).matches() ) {
+                result = com.ibm.fhir.model.type.String.of((String) result);
+            }
         } else if( result instanceof TemporalAccessor ) {
             TemporalAccessor ta = (TemporalAccessor) result;
             result = DateHelper.toCqlTemporal(ta);

--- a/cql/fhir-cql/src/test/java/com/ibm/fhir/cql/engine/model/FHIRModelResolverTest.java
+++ b/cql/fhir-cql/src/test/java/com/ibm/fhir/cql/engine/model/FHIRModelResolverTest.java
@@ -310,7 +310,7 @@ public class FHIRModelResolverTest {
         Patient patient = john_doe().build();
         Object result = resolver.resolvePath(patient, "id");
         assertNotNull( result, "Null result" );
-        assertEquals( result.getClass(), java.lang.String.class );
+        assertEquals( result.getClass(), com.ibm.fhir.model.type.String.class );
     }
     
     @Test
@@ -319,7 +319,7 @@ public class FHIRModelResolverTest {
         Bundle bundle = Bundle.builder().type(BundleType.SEARCHSET).entry(Bundle.Entry.builder().resource(patient).build()).build();
         Object result = resolver.resolvePath(bundle, "entry[0].resource.id");
         assertNotNull( result, "Null result" );
-        assertEquals( result.getClass(), java.lang.String.class );
+        assertEquals( result.getClass(), com.ibm.fhir.model.type.String.class );
     }
 
     @Test
@@ -327,7 +327,7 @@ public class FHIRModelResolverTest {
         Patient patient = john_doe().build();
         Object result = resolver.resolvePath(patient, "name[0].id");
         assertNotNull( result, "Null result" );
-        assertEquals( result.getClass(), java.lang.String.class );
+        assertEquals( result.getClass(), com.ibm.fhir.model.type.String.class );
     }
     
     @Test
@@ -335,7 +335,7 @@ public class FHIRModelResolverTest {
         Patient patient = john_doe().build();
         Object result = resolver.resolvePath( patient.getName().get(0), "id");
         assertNotNull( result, "Null result" );
-        assertEquals( result.getClass(), java.lang.String.class );
+        assertEquals( result.getClass(), com.ibm.fhir.model.type.String.class );
     }
     
     @Test

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cpg/ServerCqlOperationTest.java
@@ -68,6 +68,22 @@ public class ServerCqlOperationTest extends BaseCPGOperationTest {
     }
     
     @Test
+    public void testEvaluateArbitraryCqlUsesResourceID() {
+        Response response = getWebTarget().path("$cql").queryParam("expression", "[Patient] p return Last(Split(p.id,'/'))").queryParam("subject", TEST_PATIENT_ID).request().get();
+        assertResponse( response, 200 );
+        
+        Parameters parameters = response.readEntity(Parameters.class);
+        assertNotNull(parameters.getParameter(), "Null parameters list");
+        assertEquals(parameters.getParameter().size(), 1);
+        
+        Parameter pReturn = parameters.getParameter().get(0);
+        assertEquals(pReturn.getName().getValue(), "return");
+        
+        Parameter pPart = pReturn.getPart().get(0);
+        assertEquals(pPart.getValue(), com.ibm.fhir.model.type.String.of("sally-fields"));
+    }
+    
+    @Test
     public void testEvaluateArbitraryCqlCompileError() {
         Response response = getWebTarget().path("$cql").queryParam("expression", "[NonResource]").queryParam("subject", TEST_PATIENT_ID).request().get();
         assertResponse( response, 400 );


### PR DESCRIPTION
We found while testing the EXM104 measure from the fhir401 connectathon repo that when the CQL tries to reference the Resource.id field (such as in `[Encounter] e return Last(Split(e.id,'/'))`) that we would get an error saying could not resolve function 
FHIRHelpers.ToString(java.lang.String). The core problem is that the IBM FHIR model implements Resource.id as java.lang.String and the HAPI model which is used as the reference for the CQL implementation defines Resource.id as a FHIR.String. The CQL translator automatically inserts a FHIRHelpers.ToString into the ELM whenever Resource.id is used and the only way around that would be to create a complete new modelinfo and I don't really want to do that, so I patched our ModelResolver to do the type conversion to FHIR String whenever an `id` property is referenced. 

Signed-off-by: Corey Sanders <corey.thecolonel@gmail.com>