### PR TITLE
bulkdata preflight checks should verify output provider config #2709

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
@@ -133,7 +133,7 @@ public class S3Provider implements Provider {
      * @return
      */
     private AmazonS3 getClient(boolean iam, String cosApiKeyProperty, String cosSrvinstId, String cosEndpointUrl, String cosLocation, boolean useFhirServerTrustStore) {
-    	 return GENERATOR.getClient(iam, cosApiKeyProperty, cosSrvinstId, cosEndpointUrl, cosLocation, useFhirServerTrustStore, pathStyle);
+        return GENERATOR.getClient(iam, cosApiKeyProperty, cosSrvinstId, cosEndpointUrl, cosLocation, useFhirServerTrustStore, pathStyle);
     }
 
     /**

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/S3Provider.java
@@ -13,18 +13,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-
-import com.ibm.cloud.objectstorage.ApacheHttpClientConfig;
-import com.ibm.cloud.objectstorage.ClientConfiguration;
-import com.ibm.cloud.objectstorage.SDKGlobalConfiguration;
-import com.ibm.cloud.objectstorage.auth.AWSCredentials;
-import com.ibm.cloud.objectstorage.auth.AWSStaticCredentialsProvider;
-import com.ibm.cloud.objectstorage.auth.BasicAWSCredentials;
-import com.ibm.cloud.objectstorage.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.ibm.cloud.objectstorage.oauth.BasicIBMOAuthCredentials;
 import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
-import com.ibm.cloud.objectstorage.services.s3.AmazonS3ClientBuilder;
 import com.ibm.cloud.objectstorage.services.s3.model.Bucket;
 import com.ibm.cloud.objectstorage.services.s3.model.CreateBucketRequest;
 import com.ibm.cloud.objectstorage.services.s3.model.GetObjectRequest;
@@ -38,7 +27,7 @@ import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
 import com.ibm.fhir.bulkdata.provider.Provider;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.operation.bulkdata.client.HttpWrapper;
+import com.ibm.fhir.operation.bulkdata.client.S3ClientGenerator;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
 import com.ibm.fhir.operation.bulkdata.config.s3.S3HostStyle;
@@ -51,6 +40,8 @@ public class S3Provider implements Provider {
     private static final Logger logger = Logger.getLogger(S3Provider.class.getName());
 
     private static final long COS_PART_MINIMALSIZE = ConfigurationFactory.getInstance().getCoreCosPartUploadTriggerSize();
+    
+    private static final S3ClientGenerator GENERATOR = new S3ClientGenerator();
 
     private ImportTransientUserData transientUserData = null;
     private ExportTransientUserData chunkData = null;
@@ -142,44 +133,7 @@ public class S3Provider implements Provider {
      * @return
      */
     private AmazonS3 getClient(boolean iam, String cosApiKeyProperty, String cosSrvinstId, String cosEndpointUrl, String cosLocation, boolean useFhirServerTrustStore) {
-        ConfigurationAdapter configAdapter = ConfigurationFactory.getInstance();
-
-        AWSCredentials credentials;
-        if (iam) {
-            SDKGlobalConfiguration.IAM_ENDPOINT = configAdapter.getCoreIamEndpoint();
-            credentials = new BasicIBMOAuthCredentials(cosApiKeyProperty, cosSrvinstId);
-        } else {
-            credentials = new BasicAWSCredentials(cosApiKeyProperty, cosSrvinstId);
-        }
-
-        ClientConfiguration clientConfig =
-                new ClientConfiguration()
-                    .withRequestTimeout(configAdapter.getCoreCosRequestTimeout())
-                    .withTcpKeepAlive(configAdapter.getCoreCosTcpKeepAlive())
-                    .withSocketTimeout(configAdapter.getCoreCosSocketTimeout());
-
-        if (useFhirServerTrustStore) {
-            ApacheHttpClientConfig apacheClientConfig = clientConfig.getApacheHttpClientConfig();
-            // The following line configures COS/S3 SDK to use SSLConnectionSocketFactory of liberty server,
-            // it makes sure the certs added in fhirTrustStore.p12 can be used for SSL connection with any S3
-            // compatible object store, e.g, minio object store with self signed cert.
-            if (configAdapter.shouldCoreApiBatchTrustAll()) {
-                apacheClientConfig.setSslSocketFactory(HttpWrapper.generateSSF());
-            } else {
-                apacheClientConfig.setSslSocketFactory(SSLConnectionSocketFactory.getSystemSocketFactory());
-            }
-        }
-
-        logger.fine(() -> "The Path Style access is '" + pathStyle + "'");
-
-        // A useful link for the builder describing the pathStyle:
-        // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withPathStyleAccessEnabled-java.lang.Boolean-
-        return AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withEndpointConfiguration(new EndpointConfiguration(cosEndpointUrl, cosLocation))
-                .withClientConfiguration(clientConfig)
-                .withPathStyleAccessEnabled(pathStyle)
-                .build();
+    	 return GENERATOR.getClient(iam, cosApiKeyProperty, cosSrvinstId, cosEndpointUrl, cosLocation, useFhirServerTrustStore, pathStyle);
     }
 
     /**

--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -169,6 +169,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.ibm.cos</groupId>
+            <artifactId>ibm-cos-java-sdk</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2019, 2021
+ * (C) Copyright IBM Corp. 2019, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -76,7 +76,7 @@ public class ImportOperation extends AbstractOperation {
 
         Preflight preflight =  PreflightFactory.getInstance(operationContext, inputs, null, inputFormat);
         preflight.checkStorageAllowed(storageDetail);
-        preflight.preflight();
+        preflight.preflight(true);
         return BulkDataFactory.getInstance(operationContext, true)
                 .importBulkData(inputFormat, inputSource, inputs, storageDetail, operationContext);
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/S3ClientGenerator.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/S3ClientGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.ibm.fhir.operation.bulkdata.client;
+
+import java.util.logging.Logger;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+
+import com.ibm.cloud.objectstorage.ApacheHttpClientConfig;
+import com.ibm.cloud.objectstorage.ClientConfiguration;
+import com.ibm.cloud.objectstorage.SDKGlobalConfiguration;
+import com.ibm.cloud.objectstorage.auth.AWSCredentials;
+import com.ibm.cloud.objectstorage.auth.AWSStaticCredentialsProvider;
+import com.ibm.cloud.objectstorage.auth.BasicAWSCredentials;
+import com.ibm.cloud.objectstorage.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.ibm.cloud.objectstorage.oauth.BasicIBMOAuthCredentials;
+import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
+import com.ibm.cloud.objectstorage.services.s3.AmazonS3ClientBuilder;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
+
+/**
+ * Generates an S3 Client.
+ */
+public class S3ClientGenerator {
+
+    private static final Logger LOG = Logger.getLogger(S3ClientGenerator.class.getName());
+
+    public S3ClientGenerator() {
+        // NOP
+    }
+
+    /**
+     * Gets a client based on the values related to a storage provider.
+     *
+     * @param iam identifies the access credentials are for IAM
+     * @param accessKey (user or access Key or apiKey) for the credentials
+     * @param accessSecret (resourceId, secretKey or password) for the credentials
+     * @param cosEndpointUrl the endpoint url
+     * @param cosLocation the location/region of the S3 bucket
+     * @param useFhirServerTrustStore should use trust store
+     * @param withPathStyle path or host
+     * @return
+     */
+    public AmazonS3 getClient(boolean iam, String accessKey, String accessSecret, String cosEndpointUrl,
+        String cosLocation, boolean useFhirServerTrustStore, boolean withPathStyle) {
+        ConfigurationAdapter configAdapter = ConfigurationFactory.getInstance();
+
+        AWSCredentials credentials;
+        if (iam) {
+            SDKGlobalConfiguration.IAM_ENDPOINT = configAdapter.getCoreIamEndpoint();
+            credentials = new BasicIBMOAuthCredentials(accessKey, accessSecret);
+        } else {
+            credentials = new BasicAWSCredentials(accessKey, accessSecret);
+        }
+
+        ClientConfiguration clientConfig =
+                new ClientConfiguration()
+                    .withRequestTimeout(configAdapter.getCoreCosRequestTimeout())
+                    .withTcpKeepAlive(configAdapter.getCoreCosTcpKeepAlive())
+                    .withSocketTimeout(configAdapter.getCoreCosSocketTimeout());
+
+        if (useFhirServerTrustStore) {
+            ApacheHttpClientConfig apacheClientConfig = clientConfig.getApacheHttpClientConfig();
+            // The following line configures COS/S3 SDK to use SSLConnectionSocketFactory of liberty server,
+            // it makes sure the certs added in fhirTrustStore.p12 can be used for SSL connection with any S3
+            // compatible object store, e.g, minio object store with self signed cert.
+            if (configAdapter.shouldCoreApiBatchTrustAll()) {
+                apacheClientConfig.setSslSocketFactory(HttpWrapper.generateSSF());
+            } else {
+                apacheClientConfig.setSslSocketFactory(SSLConnectionSocketFactory.getSystemSocketFactory());
+            }
+        }
+
+        LOG.fine(() -> "The Path Style access is '" + withPathStyle + "'");
+
+        // A useful link for the builder describing the pathStyle:
+        // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#withPathStyleAccessEnabled-java.lang.Boolean-
+        return AmazonS3ClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withEndpointConfiguration(new EndpointConfiguration(cosEndpointUrl, cosLocation))
+                    .withClientConfiguration(clientConfig)
+                    .withPathStyleAccessEnabled(withPathStyle)
+                    .build();
+    }
+}

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/AbstractSystemConfigurationImpl.java
@@ -72,7 +72,7 @@ public abstract class AbstractSystemConfigurationImpl implements ConfigurationAd
 
     private static final byte[] NDJSON_LINESEPERATOR = "\r\n".getBytes();
 
-    public static final int IMPORT_NUMOFFHIRRESOURCES_PERREAD = 20;
+    public static final int IMPORT_NUMOFFHIRRESOURCES_PERREAD = 50;
     public static final int IMPORT_INFLY_RATE_NUMOFFHIRRESOURCES = 2000;
 
     // The following are set on startup:

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/Preflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/Preflight.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,6 +19,15 @@ public interface Preflight {
      * @throws FHIROperationException
      */
     void preflight() throws FHIROperationException;
+
+    /**
+     * checks the preflight execution for a conditional-write
+     * @param write
+     * @throws FHIROperationException
+     */
+    default void preflight(boolean write) throws FHIROperationException {
+        preflight();
+    }
 
     /**
      * Checks the storage type is allowed.

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/S3Preflight.java
@@ -1,32 +1,31 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.operation.bulkdata.config.preflight.impl;
 
-import static com.ibm.fhir.operation.bulkdata.util.CommonUtil.buildExceptionWithIssue;
-
-import java.net.URL;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
-import javax.net.ssl.HttpsURLConnection;
-
-import com.ibm.fhir.exception.FHIRException;
+import com.ibm.cloud.objectstorage.services.s3.AmazonS3;
+import com.ibm.cloud.objectstorage.services.s3.model.HeadBucketRequest;
+import com.ibm.cloud.objectstorage.services.s3.model.HeadBucketResult;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.operation.bulkdata.OperationConstants;
+import com.ibm.fhir.operation.bulkdata.client.S3ClientGenerator;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
+import com.ibm.fhir.operation.bulkdata.config.s3.S3HostStyle;
 import com.ibm.fhir.operation.bulkdata.model.type.Input;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageDetail;
 import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
@@ -36,8 +35,10 @@ import com.ibm.fhir.operation.bulkdata.util.BulkDataExportUtil;
  * Checks the S3 Configuration.
  */
 public class S3Preflight extends NopPreflight {
+    private static final Logger LOG = Logger.getLogger(S3Preflight.class.getName());
 
-    private static final BulkDataExportUtil export = new BulkDataExportUtil();
+    private static final S3ClientGenerator GENERATOR = new S3ClientGenerator();
+    private static final BulkDataExportUtil EXPORT = new BulkDataExportUtil();
 
     public S3Preflight(String source, String outcome, List<Input> inputs, OperationConstants.ExportType exportType, String format) {
         super(source, outcome, inputs, exportType, format);
@@ -45,38 +46,56 @@ public class S3Preflight extends NopPreflight {
 
     @Override
     public void preflight() throws FHIROperationException {
+        preflight(false);
+    }
+
+    @Override
+    public void preflight(boolean write) throws FHIROperationException {
         super.preflight();
 
         ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
         boolean outcomes = adapter.shouldStorageProviderCollectOperationOutcomes(getSource());
+        String bucketName = adapter.getStorageProviderBucketName(getSource());
 
         // Check that we can access it.
-        Set<Callable<Boolean>> callables = new HashSet<>(2);
-        BucketHostCallable sourceCallable = new BucketHostCallable(getSource());
-        callables.add(sourceCallable);
+        List<Callable<BucketResult>> callables = new ArrayList<>(2);
+        AmazonS3 s3Source = validate(getSource());
+        BucketHostS3Callable s3Callable = new BucketHostS3Callable(getOutcome(), s3Source, bucketName, write);
 
-        // Check Configuration for Type.
-        validate(getSource());
-
-        if (outcomes) {
-            validate(getOutcome());
-
-            BucketHostCallable outcomeCallable = new BucketHostCallable(getOutcome());
-            callables.add(outcomeCallable);
+        // Only add to the list to check IFF there is a different outcome storageProvider
+        // And the StorageProvider is S3... this means we don't mix preflights with different outcome StorageTypes.
+        StorageType type = adapter.getStorageProviderStorageType(getOutcome());
+        if (outcomes && !getSource().equals(getOutcome())
+                && (StorageType.AWSS3.equals(type) || StorageType.IBMCOS.equals(type))) {
+            AmazonS3 s3Outcome = validate(getOutcome());
+            String bucketNameOutcome = adapter.getStorageProviderBucketName(getOutcome());
+            callables.add(new BucketHostS3Callable(getOutcome(), s3Outcome, bucketNameOutcome, true));
+        } else if (getSource().equals(getOutcome())
+                    && adapter.shouldStorageProviderCollectOperationOutcomes(getSource())) {
+            s3Callable.setWrite();
         }
+        callables.add(s3Callable);
 
+        /*
+         * The executor stops execution at the expiration of the 60 second timeout.
+         * The callable unit executes and then wraps the failure
+         */
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
-            List<Future<Boolean>> futures = executor.invokeAll(callables, 60, TimeUnit.SECONDS);
-            for (Future<Boolean> future : futures) {
-                if (!future.get()) {
-                    throw export.buildOperationException("Unable to access s3 source or outcome during timeout", IssueType.EXCEPTION);
+            List<Future<BucketResult>> futures = executor.invokeAll(callables, 60, TimeUnit.SECONDS);
+            for (Future<BucketResult> future : futures) {
+                if (!future.get().result) {
+                    if (future.get().ex == null) {
+                        throw EXPORT.buildOperationException("Unable to access s3 storageProvider during timeout '" + future.get().source + "'", IssueType.EXCEPTION, future.get().ex);
+                    } else {
+                        throw future.get().ex;
+                    }
                 }
             }
         } catch (ExecutionException ee) {
-            throw export.buildOperationException("Failed to execute the s3 access, check the s3 configuration", IssueType.NO_STORE, ee);
+            throw EXPORT.buildOperationException("Failed to execute the s3 access, check the s3 configuration", IssueType.NO_STORE, ee);
         } catch (InterruptedException e) {
-            throw export.buildOperationException("Timeout hit trying to access s3, check the s3 configuration", IssueType.NO_STORE, e);
+            throw EXPORT.buildOperationException("Timeout hit trying to access s3, check the s3 configuration", IssueType.NO_STORE, e);
         }
         executor.shutdown();
     }
@@ -85,82 +104,138 @@ public class S3Preflight extends NopPreflight {
      * validates the s3 is properly configured.
      *
      * @param source
+     * @return AmazonS3
      * @throws FHIROperationException
      */
-    public void validate(String source) throws FHIROperationException {
+    public AmazonS3 validate(String source) throws FHIROperationException {
         ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
+        boolean iam = false;
+        String access = null;
+        String secret = null;
         if (adapter.isStorageProviderAuthTypeIam(source)) {
             String apiKey = adapter.getStorageProviderAuthTypeIamApiKey(source);
             String resourceId = adapter.getStorageProviderAuthTypeIamApiResourceInstanceId(source);
             if (apiKey == null || resourceId == null || apiKey.isEmpty() || resourceId.isEmpty()) {
-                throw export.buildOperationException("bad configuration for the iam configuration", IssueType.EXCEPTION);
+                throw EXPORT.buildOperationException("bad configuration for the iam configuration", IssueType.EXCEPTION);
             }
+            iam = true;
+            access = apiKey;
+            secret = resourceId;
         } else if (adapter.isStorageProviderAuthTypeHmac(source)) {
             String accessKey = adapter.getStorageProviderAuthTypeHmacAccessKey(source);
             String secretKey = adapter.getStorageProviderAuthTypeHmacSecretKey(source);
             if (accessKey == null || secretKey == null || accessKey.isEmpty() || secretKey.isEmpty()) {
-                throw export.buildOperationException("bad configuration for the hmac configuration", IssueType.EXCEPTION);
+                throw EXPORT.buildOperationException("bad configuration for the hmac configuration", IssueType.EXCEPTION);
             }
+            access = accessKey;
+            secret = secretKey;
         } else if (adapter.isStorageProviderAuthTypeBasic(source)) {
             String user = adapter.getStorageProviderAuthTypeUsername(source);
             String password = adapter.getStorageProviderAuthTypePassword(source);
             if (user == null || password == null || user.isEmpty() || password.isEmpty()) {
-                throw export.buildOperationException("bad configuration for the basic configuration", IssueType.EXCEPTION);
+                throw EXPORT.buildOperationException("bad configuration for the basic configuration", IssueType.EXCEPTION);
             }
+            access = user;
+            secret = password;
         } else if (adapter.getStorageProviderBucketName(source) == null || adapter.getStorageProviderBucketName(source).isEmpty()) {
-            throw export.buildOperationException("bad configuration for the basic configuration with bucketname", IssueType.EXCEPTION);
+            throw EXPORT.buildOperationException("bad configuration for the basic configuration with bucketname", IssueType.EXCEPTION);
         } else {
-            throw export.buildOperationException("Failed to specify the source or outcome bucket's authentication mechanism", IssueType.EXCEPTION);
+            throw EXPORT.buildOperationException("Failed to specify the source or outcome bucket's authentication mechanism", IssueType.EXCEPTION);
         }
+
+        String url = adapter.getStorageProviderEndpointInternal(source);
+        if (url == null || url.isEmpty()) {
+            throw EXPORT.buildOperationException("endpoint internal is undefined.", IssueType.EXCEPTION);
+        }
+        // There are two styles PATH/VIRTUAL_HOST
+        S3HostStyle kind = adapter.getS3HostStyleByStorageProvider(source);
+        boolean withPathStyle = S3HostStyle.PATH.equals(kind);
+
+        String location = adapter.getStorageProviderLocation(source);
+        if (location == null || location.isEmpty()) {
+            throw EXPORT.buildOperationException("endpoint location is undefined.", IssueType.EXCEPTION);
+        }
+
+        // Create a COS/S3 client if it's not created yet.
+        boolean useFhirServerTrustStore = adapter.shouldCoreCosUseServerTruststore();
+        return GENERATOR.getClient(iam, access, secret, url, location, useFhirServerTrustStore, withPathStyle);
     }
 
     /*
      * @implNote Checks the Access to the url/input.
      */
-    private class BucketHostCallable implements Callable<Boolean> {
+    protected static class BucketHostS3Callable implements Callable<BucketResult> {
+        private AmazonS3 client;
+        private String source;
+        private String bucketName;
+        @SuppressWarnings("unused")
+        private boolean write;
 
-        private String source = null;
-        private String url = null;
+        // Result
+        BucketResult result = new BucketResult();
 
-        public BucketHostCallable(String source) throws FHIROperationException {
+        public BucketHostS3Callable(String source, AmazonS3 client, String bucketName, boolean write) throws FHIROperationException {
             this.source = source;
-            ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
-            url = adapter.getStorageProviderEndpointExternal(source);
-            if (url == null || url.isEmpty()) {
-                throw export.buildOperationException("endpoint-internal is undefined.", IssueType.EXCEPTION);
-            }
+            this.bucketName = bucketName;
+            this.client = client;
+            this.write = write;
+        }
+
+        /**
+         * Identifies this as a write (not just a read)
+         */
+        public void setWrite() {
+            this.write = true;
         }
 
         @Override
-        public Boolean call() throws Exception {
-            boolean result = false;
-            // Check can connect to host (HEAD)
-            HttpsURLConnection httpsConnection = null;
+        public BucketResult call() throws Exception {
+            result.source = source;
             try {
-                httpsConnection = (HttpsURLConnection) new URL(url).openConnection();
-                httpsConnection.setRequestMethod("HEAD");
-                httpsConnection.getContentLengthLong();
-                result = true;
-            } catch (Exception e) {
-                throw new FHIRException("Unable to connect to s3 endpoint '" + source + '"', e);
-            } finally {
-                if (httpsConnection != null) {
-                    httpsConnection.disconnect();
+                HeadBucketRequest req = new HeadBucketRequest(bucketName)
+                                            .withSdkRequestTimeout(59000);
+                HeadBucketResult r = client.headBucket(req);
+                LOG.fine(() -> "Source is valid and in region " + source + "/" + r.getBucketRegion());
+
+                // We don't check if the bucket is writeable, as the call to check the ACL
+                // can be unintentionally costly. If there is a further optimization...
+                // We want to make it right here.
+
+                result.result = true;
+            } catch (com.ibm.cloud.objectstorage.AmazonServiceException ex) {
+                LOG.throwing("S3Preflight.BucketHostS3Callable", "call", ex);
+                switch (ex.getStatusCode()) {
+                case 301: // the bucket is in a different region than the client is configured with
+                    result.ex = EXPORT.buildOperationException("Storage provider's region is incorrect" + source + "'", IssueType.EXCEPTION);
+                    break;
+                case 403: // if the user does not have access to the bucket
+                    result.ex = EXPORT.buildOperationException("Storage provider's credentials are incorrect '" + source + "'", IssueType.EXCEPTION);
+                    break;
+                case 404: // the bucket does not exist
+                    result.ex = EXPORT.buildOperationException("The bucket does not exist '" + source + "/" + bucketName + "'", IssueType.EXCEPTION);
+                    break;
+                default:
+                    LOG.throwing("S3Preflight.BucketHostS3Callable", "call()", ex);
+                    result.ex = EXPORT.buildOperationException("Unexpected Exception '" + source + "'", IssueType.EXCEPTION, ex);
                 }
             }
             return result;
         }
     }
 
-    @Override
-    public void checkStorageAllowed(StorageDetail storageDetail) throws FHIROperationException {
-        if (storageDetail != null && !(StorageType.AWSS3.value().equals(storageDetail.getType()) || StorageType.IBMCOS.value().equals(storageDetail.getType()))){
-            throw buildExceptionWithIssue("S3: Configuration not set to import from storageDetail '" + getSource() + "'", IssueType.INVALID);
-        }
+    /**
+     * Wraps the results of the Callable
+     */
+    private static class BucketResult {
+        private String source = null;
+        private boolean result = false;
+        private FHIROperationException ex;
     }
 
     @Override
-    public boolean checkParquet() {
-        return ConfigurationFactory.getInstance().isStorageProviderParquetEnabled(getSource());
+    public void checkStorageAllowed(StorageDetail storageDetail) throws FHIROperationException {
+        if (storageDetail != null && !(StorageType.AWSS3.value().equals(storageDetail.getType()) || StorageType.IBMCOS.value().equals(storageDetail.getType()))){
+            throw EXPORT.buildOperationException("S3: Configuration not set to import from storageDetail '" + getSource() + "'", IssueType.INVALID);
+        }
     }
 }


### PR DESCRIPTION
- Move the Client Generation to the Server (AmazonS3) 
- Added cos to the fhir-server/pom.xml 
- Enhanced preflight with a write check 
- Example warning that occurs with the operation now (storageProvider id/bad
bucketName)

```
{
    "resourceType": "OperationOutcome",
    "id": "c0-a8-56-25-977e7573-20c9-4a0b-ba92-b07e640ddc1c",
    "issue": [
        {
            "severity": "error",
            "code": "exception",
            "diagnostics": "The bucket does not exist
&#39;minio/fhirbulkdataxx&#39;"
        }
    ]
}
```

And 

https://github.com/IBM/FHIR/issues/3003

- Relaxed the S3Preflight to support http connection with warning

```
        MSG: BulkData Request is using a provider that connects to an
        insecure url: http://bucket.bucket:9000/
```

- Improved the Response Handling to capture the ex and package it back up the stack