### PR TITLE
Bulk Data import fails when disableOperationOutcomes is false #2910

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/context/BatchContextAdapter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -158,6 +158,7 @@ public class BatchContextAdapter {
         BulkDataContext ctx = new BulkDataContext();
         context(ctx);
         source(ctx);
+        ctx.setCosBucketPathPrefix(props.getProperty(OperationFields.COS_BUCKET_PATH_PREFIX));
         return ctx;
     }
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkReader.java
@@ -105,10 +105,8 @@ public class ChunkReader extends AbstractItemReader {
                     // Note: for those good imports, we don't really generate any meaningful OperationOutcome,
                     // so only error import
                     // OperationOutcomes are supported for now.
-                    .uniqueIDForImportOperationOutcomes(ctx.getCosBucketPathPrefix() + "/"
-                            + ctx.getImportPartitionWorkitem() + "_oo_success.ndjson")
-                    .uniqueIDForImportFailureOperationOutcomes(
-                            ctx.getCosBucketPathPrefix() + "/" + ctx.getImportPartitionWorkitem() + "_oo_errors.ndjson")
+                    .uniqueIDForImportOperationOutcomes(ctx.getImportPartitionWorkitem() + "_oo_success.ndjson")
+                    .uniqueIDForImportFailureOperationOutcomes(ctx.getImportPartitionWorkitem() + "_oo_errors.ndjson")
                     .partNumForOperationOutcomes(1)
                     .partNumForFailureOperationOutcomes(1)
                     .inFlyRateBeginMilliSeconds(System.currentTimeMillis())

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkReader.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkReader.java
@@ -105,8 +105,12 @@ public class ChunkReader extends AbstractItemReader {
                     // Note: for those good imports, we don't really generate any meaningful OperationOutcome,
                     // so only error import
                     // OperationOutcomes are supported for now.
-                    .uniqueIDForImportOperationOutcomes(ctx.getImportPartitionWorkitem() + "_oo_success.ndjson")
-                    .uniqueIDForImportFailureOperationOutcomes(ctx.getImportPartitionWorkitem() + "_oo_errors.ndjson")
+                    .uniqueIDForImportOperationOutcomes(ctx.getCosBucketPathPrefix() + "/"
+                            + ctx.getImportPartitionWorkitem() + "_oo_success.ndjson")
+                    .uniqueIDForImportFailureOperationOutcomes(
+                            ctx.getCosBucketPathPrefix() + "/" + ctx.getImportPartitionWorkitem() + "_oo_errors.ndjson")
+                    .partNumForOperationOutcomes(1)
+                    .partNumForFailureOperationOutcomes(1)
                     .inFlyRateBeginMilliSeconds(System.currentTimeMillis())
                     .build();
 

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -11,6 +11,8 @@ import static com.ibm.fhir.model.type.String.string;
 import java.io.Serializable;
 import java.sql.Date;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -18,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import javax.batch.api.BatchProperty;
 import javax.batch.api.chunk.AbstractItemWriter;
@@ -45,11 +46,10 @@ import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.CodeableConcept;
+import com.ibm.fhir.model.type.Extension;
 import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.IssueType;
-import com.ibm.fhir.model.util.FHIRUtil;
-import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.SaltHash;
 import com.ibm.fhir.model.visitor.ResourceFingerprintVisitor;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
@@ -90,7 +90,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
     @Inject
     @Any
-    @BatchProperty (name = OperationFields.PARTITION_WORKITEM)
+    @BatchProperty(name = OperationFields.PARTITION_WORKITEM)
     private String workItem;
 
     @Inject
@@ -100,7 +100,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
     @Inject
     @Any
-    @BatchProperty (name = OperationFields.PARTITION_RESOURCETYPE)
+    @BatchProperty(name = OperationFields.PARTITION_RESOURCETYPE)
     private String resourceType;
 
     public ChunkWriter() {
@@ -141,6 +141,9 @@ public class ChunkWriter extends AbstractItemWriter {
             int failedNum = 0;
             ImportTransientUserData chunkData = (ImportTransientUserData) stepCtx.getTransientUserData();
 
+            boolean shouldCollectOperationOutcomes = adapter
+                    .shouldStorageProviderCollectOperationOutcomes(ctx.getSource());
+
             // Validates the Resources are valid for included profiles
             if (adapter.shouldStorageProviderValidateResources(ctx.getSource())) {
                 long validationStartTimeInMilliSeconds = System.currentTimeMillis();
@@ -148,19 +151,35 @@ public class ChunkWriter extends AbstractItemWriter {
                     @SuppressWarnings("unchecked")
                     List<Resource> fhirResourceList = (List<Resource>) objResJsonList;
 
+                    // Used to indicate line number in the OperationOutcomes
+                    long cur = 1;
                     for (Resource fhirResource : fhirResourceList) {
                         long startTime = System.currentTimeMillis();
                         javax.ws.rs.core.Response.Status status = javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
                         try {
-                            BulkDataUtils.validateInput(fhirResource);
+                            List<Issue> issues = BulkDataUtils.validateInput(fhirResource);
+
+                            if (shouldCollectOperationOutcomes) {
+                                OperationOutcome oo;
+                                if (issues.isEmpty()) {
+                                    oo = generateAllOkValidation(chunkData.getNumOfProcessedResources() + cur);
+                                } else {
+                                    oo = generateError(chunkData.getNumOfProcessedResources() + cur, issues);
+                                }
+
+                                FHIRGenerator.generator(Format.JSON).generate(oo,
+                                        chunkData.getBufferStreamForImport());
+                                chunkData.getBufferStreamForImportError().write(NDJSON_LINESEPERATOR);
+                            }
                             status = javax.ws.rs.core.Response.Status.OK;
                         } catch (FHIRValidationException | FHIROperationException e) {
                             logger.warning("Failed to validate '" + fhirResource.getId() + "' due to error: " + e.getMessage());
                             failedNum++;
                             failValidationIds.add(fhirResource.getClass().getName() + "/" + fhirResource.getId());
 
-                            if (adapter.shouldStorageProviderCollectOperationOutcomes(ctx.getSource())) {
-                                OperationOutcome operationOutCome = FHIRUtil.buildOperationOutcome(e, false);
+                            if (shouldCollectOperationOutcomes) {
+                                OperationOutcome operationOutCome = generateException(
+                                        chunkData.getNumOfProcessedResources() + cur, e);
                                 FHIRGenerator.generator(Format.JSON).generate(operationOutCome, chunkData.getBufferStreamForImportError());
                                 chunkData.getBufferStreamForImportError().write(NDJSON_LINESEPERATOR);
                             }
@@ -171,6 +190,7 @@ public class ChunkWriter extends AbstractItemWriter {
                                 auditLogger.logValidateOnImport(fhirResource, new Date(startTime), new Date(endTime), status, location, ctx.getUsers());
                             }
                         }
+                        cur++;
                     }
                 }
                 chunkData.addTotalValidationMilliSeconds(System.currentTimeMillis() - validationStartTimeInMilliSeconds);
@@ -178,6 +198,7 @@ public class ChunkWriter extends AbstractItemWriter {
 
             // Validates the ResourceType matches
             if (!adapter.shouldStorageProviderAllowAllResources(ctx.getSource())) {
+                long cur = 1;
                 for (Object objResJsonList : arg0) {
                     @SuppressWarnings("unchecked")
                     List<Resource> fhirResourceList = (List<Resource>) objResJsonList;
@@ -187,10 +208,10 @@ public class ChunkWriter extends AbstractItemWriter {
                         if (!this.resourceType.equals(assertedResourceType)) {
                             failValidationIds.add(assertedResourceType + "/" + fhirResource.getId());
 
-                            if (adapter.shouldStorageProviderCollectOperationOutcomes(ctx.getSource())) {
-                                OperationOutcome operationOutCome = FHIRUtil.buildOperationOutcome(
-                                    "The resource being imported does not match the declared resource - '" + this.resourceType 
-                                        + " '" + assertedResourceType + "/" + fhirResource.getId() + "'", IssueType.SECURITY, IssueSeverity.ERROR);
+                            if (shouldCollectOperationOutcomes) {
+                                OperationOutcome operationOutCome = generateSecurityException(
+                                        failedNum + cur + chunkData.getNumOfProcessedResources(), fhirResource.getId(),
+                                        assertedResourceType, this.resourceType);
                                 FHIRGenerator.generator(Format.JSON).generate(operationOutCome, chunkData.getBufferStreamForImportError());
                                 chunkData.getBufferStreamForImportError().write(NDJSON_LINESEPERATOR);
                             }
@@ -199,6 +220,7 @@ public class ChunkWriter extends AbstractItemWriter {
                                 + " '" + assertedResourceType + "/" + fhirResource.getId() + "'");
                         }
                     }
+                    cur++;
                 }
             }
 
@@ -218,6 +240,7 @@ public class ChunkWriter extends AbstractItemWriter {
             // Get the Skippable Update status
             boolean skip = adapter.enableSkippableUpdates();
             try {
+                long cur = 1;
                 for (Object objResJsonList : arg0) {
                     @SuppressWarnings("unchecked")
                     List<Resource> fhirResourceList = (List<Resource>) objResJsonList;
@@ -259,7 +282,9 @@ public class ChunkWriter extends AbstractItemWriter {
 
                                 // Set up the persistence context to include the deleted resources when we read
                                 FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event, true);
-                                operationOutcome = conditionalFingerprintUpdate(chunkData, skip, fhirPersistence, persistenceContext, id, fhirResource, ctx);
+                                operationOutcome = conditionalFingerprintUpdate(chunkData, skip, fhirPersistence,
+                                        persistenceContext, id, fhirResource, ctx,
+                                        failedNum + cur + chunkData.getNumOfProcessedResources());
                             }
 
                             succeededNum++;
@@ -271,11 +296,13 @@ public class ChunkWriter extends AbstractItemWriter {
                             logger.warning("Failed to import '" + fhirResource.getId() + "' due to error: " + e.getMessage());
                             failedNum++;
                             if (collectImportOperationOutcomes) {
-                                OperationOutcome operationOutCome = FHIRUtil.buildOperationOutcome(e, false);
+                                OperationOutcome operationOutCome = generateException(
+                                        failedNum + cur + chunkData.getNumOfProcessedResources(), e);
                                 FHIRGenerator.generator(Format.JSON).generate(operationOutCome, chunkData.getBufferStreamForImportError());
                                 chunkData.getBufferStreamForImportError().write(NDJSON_LINESEPERATOR);
                             }
                         }
+                        cur++;
                     }
                 }
             } finally {
@@ -314,40 +341,48 @@ public class ChunkWriter extends AbstractItemWriter {
     }
 
     /**
-     * conditional update checks to see if our cache contains the key, if not reads from the db, and calculates the cache.
-     * The cache is saved within the context of this particular execution, and then destroyed.
+     * conditional update checks to see if our cache contains the key, if not reads
+     * from the db, and calculates the cache. The cache is saved within the context
+     * of this particular execution, and then destroyed.
      *
-     * @implNote considered using a shared cache, a few things with that to consider:
-     * 1 - the shared cache would have to be updated at the end of a transaction (we don't control it).
-     * 2 - we would have to use a transaction sync registry to control the synchronization of the cache.
-     * 3 - Instead, we're doing a read then update.
+     * @implNote considered using a shared cache, a few things with that to
+     *           consider: 1 - the shared cache would have to be updated at the end
+     *           of a transaction (we don't control it). 2 - we would have to use a
+     *           transaction sync registry to control the synchronization of the
+     *           cache. 3 - Instead, we're doing a read then update.
      *
-     * @param chunkData the transient user data used increment the number of skips
-     * @param skip should skip the resource if it matches
+     * @param chunkData   the transient user data used increment the number of skips
+     * @param skip        should skip the resource if it matches
      * @param persistence used to facilitate the calls to the underlying db
-     * @param context used in db calls
-     * @param logicalId the logical id of the FHIR resource (e.g. 1-2-3-4)
-     * @param resource the FHIR Resource
-     * @param ctx the bulk data context
+     * @param context     used in db calls
+     * @param logicalId   the logical id of the FHIR resource (e.g. 1-2-3-4)
+     * @param resource    the FHIR Resource
+     * @param ctx         the bulk data context
+     * @param line        the line number
      * @return outcomes including information or warnings
      * @throws Exception
      */
-    public OperationOutcome conditionalFingerprintUpdate(ImportTransientUserData chunkData, boolean skip, FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, Resource resource, BulkDataContext ctx) throws Exception {
+    public OperationOutcome conditionalFingerprintUpdate(ImportTransientUserData chunkData, boolean skip,
+            FHIRPersistence persistence, FHIRPersistenceContext context, String logicalId, Resource resource,
+            BulkDataContext ctx, long line) throws Exception {
         long startTime = System.currentTimeMillis();
         Response.Status status = Response.Status.OK;
 
-        // Since issue 1869, we must perform the read at this point in order to obtain the
+        // Since issue 1869, we must perform the read at this point in order to obtain
+        // the
         // latest version id. The persistence layer no longer makes any changes to the
         // resource so the resource needs to be fully prepared before the persistence
         // create/update call is made
-        SingleResourceResult<? extends Resource> oldResourceResult = persistence.read(context, resource.getClass(), logicalId);
+        SingleResourceResult<? extends Resource> oldResourceResult = persistence.read(context, resource.getClass(),
+                logicalId);
         Resource oldResource = oldResourceResult.getResource();
 
         final com.ibm.fhir.model.type.Instant lastUpdated = FHIRPersistenceSupport.getCurrentInstant();
         final int newVersionNumber = oldResourceResult.getVersion() + 1;
         resource = FHIRPersistenceUtil.copyAndSetResourceMetaFields(resource, logicalId, newVersionNumber, lastUpdated);
 
-        // If the resource was previously deleted, we need to treat this as a not to skip, otherwise we end up with really inconsistent data
+        // If the resource was previously deleted, we need to treat this as a not to
+        // skip, otherwise we end up with really inconsistent data
         // when there is a DELETED resource.
         boolean skipped = false;
         OperationOutcome oo;
@@ -376,15 +411,21 @@ public class ChunkWriter extends AbstractItemWriter {
                     logger.fine("Skipping $import - update for '" + key + "'");
                 }
                 chunkData.addToNumOfSkippedResources(1);
-                oo =  OperationOutcome.builder()
-                    .issue(Issue.builder()
-                        .severity(IssueSeverity.INFORMATION)
-                        .code(IssueType.INFORMATIONAL)
-                        .details(CodeableConcept.builder()
-                            .text(string("Update to an existing resource matches the stored resource's hash; skipping the update for '" + key + "'"))
-                            .build())
-                        .build())
-                    .build();
+                oo = OperationOutcome.builder()
+                        .issue(Issue.builder()
+                                .severity(IssueSeverity.INFORMATION)
+                                .code(IssueType.INFORMATIONAL)
+                                .details(CodeableConcept.builder()
+                                        .text(string(
+                                                "Update to an existing resource matches the stored resource's hash; skipping the update for '"
+                                                        + key + "'"))
+                                        .build())
+                                .extension(Extension.builder()
+                                        .url("https://ibm.com/fhir/bulkdata/linenumber")
+                                        .value(Long.toString(line))
+                                        .build())
+                                .build())
+                        .build();
                 skipped = true;
             } else {
                 // Outcome is an Update
@@ -401,11 +442,122 @@ public class ChunkWriter extends AbstractItemWriter {
             long endTime = System.currentTimeMillis();
             String location = "@source:" + ctx.getSource() + "/" + ctx.getImportPartitionWorkitem();
             if (!skipped) {
-                auditLogger.logUpdateOnImport(resource, new Date(startTime), new Date(endTime), status, location, "BulkDataOperator");
+                auditLogger.logUpdateOnImport(resource, new Date(startTime), new Date(endTime), status, location,
+                        "BulkDataOperator");
             } else {
-                auditLogger.logUpdateOnImportSkipped(oldResource, new Date(startTime), new Date(endTime), status, location, "BulkDataOperator");
+                auditLogger.logUpdateOnImportSkipped(oldResource, new Date(startTime), new Date(endTime), status,
+                        location, "BulkDataOperator");
             }
         }
         return oo;
+    }
+
+    /**
+     * Generates ALL_OK along with a line number.
+     * 
+     * @param lineNumber the location in the file.
+     * @return
+     */
+    private OperationOutcome generateAllOkValidation(long lineNumber) {
+        return OperationOutcome.builder()
+                .issue(Issue.builder()
+                        .severity(IssueSeverity.INFORMATION)
+                        .code(IssueType.INFORMATIONAL)
+                        .details(
+                                CodeableConcept.builder()
+                                        .text(string("All OK"))
+                                        .build())
+                        .extension(Extension.builder()
+                                .url("https://ibm.com/fhir/bulkdata/linenumber")
+                                .value(Long.toString(lineNumber))
+                                .build())
+                        .build())
+                .build();
+    }
+
+    /**
+     * Generates Warning and Informational along with a line number.
+     * 
+     * @param lineNumber the location in the file.
+     * @param issues     to be added
+     * @return
+     */
+    private OperationOutcome generateError(long lineNumber, List<Issue> issues) {
+        Issue issue = Issue.builder()
+                .severity(IssueSeverity.WARNING)
+                .code(IssueType.INFORMATIONAL)
+                .details(
+                        CodeableConcept.builder()
+                                .text(string("There is a warning included on the cited line"))
+                                .build())
+                .extension(Extension.builder()
+                        .url("https://ibm.com/fhir/bulkdata/linenumber")
+                        .value(Long.toString(lineNumber))
+                        .build())
+                .build();
+
+        List<Issue> newIssues = new ArrayList<>();
+        newIssues.addAll(issues);
+        newIssues.add(issue);
+        return OperationOutcome.builder()
+                .issue(newIssues)
+                .build();
+    }
+
+    /**
+     * generate exception
+     * 
+     * @param lineNumber the location in the file
+     * @param ex         exception to log
+     * @return
+     */
+    private OperationOutcome generateException(long lineNumber, Exception ex) {
+        Issue issue = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.EXCEPTION)
+                .details(
+                        CodeableConcept.builder()
+                                .text(string("There is an exception: name=[" + ex.getClass().getName() + "] msg=["
+                                        + ex.getMessage() + "]"))
+                                .build())
+                .extension(Extension.builder()
+                        .url("https://ibm.com/fhir/bulkdata/linenumber")
+                        .value(Long.toString(lineNumber))
+                        .build())
+                .build();
+        return OperationOutcome.builder()
+                .issue(Arrays.asList(issue))
+                .build();
+    }
+
+    /**
+     * generate exception
+     * 
+     * @param lineNumber           the location in the file
+     * @param lineNumber
+     * @param id
+     * @param assertedResourceType
+     * @param actualResourceType
+     * @return
+     */
+    private OperationOutcome generateSecurityException(long lineNumber, String id, String assertedResourceType,
+            String actualResourceType) {
+        Issue issue = Issue.builder()
+                .severity(IssueSeverity.ERROR)
+                .code(IssueType.SECURITY)
+                .details(
+                        CodeableConcept.builder()
+                                .text(string("The resource being imported does not match the declared resource - '"
+                                        + actualResourceType
+                                        + " '" + assertedResourceType + "/" + id + "'"))
+                                .build())
+                .extension(Extension.builder()
+                        .url("https://ibm.com/fhir/bulkdata/linenumber")
+                        .value(Long.toString(lineNumber))
+                        .build())
+                .build();
+        return OperationOutcome.builder()
+                .issue(Arrays.asList(issue))
+                .build();
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -346,10 +346,10 @@ public class ChunkWriter extends AbstractItemWriter {
      * of this particular execution, and then destroyed.
      *
      * @implNote considered using a shared cache, a few things with that to
-     *           consider: 1 - the shared cache would have to be updated at the end
-     *           of a transaction (we don't control it). 2 - we would have to use a
-     *           transaction sync registry to control the synchronization of the
-     *           cache. 3 - Instead, we're doing a read then update.
+     *           consider: 
+     *  1 - the shared cache would have to be updated at the end of a transaction (we don't control it).
+     *  2 - we would have to use a transaction sync registry to control the synchronization of the cache
+     *  3 - Instead, we're doing a read then update.
      *
      * @param chunkData   the transient user data used increment the number of skips
      * @param skip        should skip the resource if it matches

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -164,7 +164,7 @@ public class ChunkWriter extends AbstractItemWriter {
                                 if (issues.isEmpty()) {
                                     oo = generateAllOkValidation(chunkData.getNumOfProcessedResources() + cur);
                                 } else {
-                                    oo = generateError(chunkData.getNumOfProcessedResources() + cur, issues);
+                                    oo = generateWarning(chunkData.getNumOfProcessedResources() + cur, issues);
                                 }
 
                                 FHIRGenerator.generator(Format.JSON).generate(oo,
@@ -369,8 +369,7 @@ public class ChunkWriter extends AbstractItemWriter {
         Response.Status status = Response.Status.OK;
 
         // Since issue 1869, we must perform the read at this point in order to obtain
-        // the
-        // latest version id. The persistence layer no longer makes any changes to the
+        // the latest version id. The persistence layer no longer makes any changes to the
         // resource so the resource needs to be fully prepared before the persistence
         // create/update call is made
         SingleResourceResult<? extends Resource> oldResourceResult = persistence.read(context, resource.getClass(),
@@ -482,7 +481,7 @@ public class ChunkWriter extends AbstractItemWriter {
      * @param issues     to be added
      * @return
      */
-    private OperationOutcome generateError(long lineNumber, List<Issue> issues) {
+    private OperationOutcome generateWarning(long lineNumber, List<Issue> issues) {
         Issue issue = Issue.builder()
                 .severity(IssueSeverity.WARNING)
                 .code(IssueType.INFORMATIONAL)
@@ -533,8 +532,7 @@ public class ChunkWriter extends AbstractItemWriter {
     /**
      * generate exception
      * 
-     * @param lineNumber           the location in the file
-     * @param lineNumber
+     * @param lineNumber the location in the file
      * @param id
      * @param assertedResourceType
      * @param actualResourceType

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionCollector.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionCollector.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.bulkdata.jbatch.load;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -20,11 +21,13 @@ import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 import com.ibm.fhir.bulkdata.common.BulkDataUtils;
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportCheckPointData;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportTransientUserData;
-import com.ibm.fhir.bulkdata.provider.impl.S3Provider;
+import com.ibm.fhir.bulkdata.provider.Provider;
+import com.ibm.fhir.bulkdata.provider.ProviderFactory;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
@@ -33,9 +36,9 @@ import com.ibm.fhir.operation.bulkdata.model.type.StorageType;
 
 @Dependent
 public class ImportPartitionCollector implements PartitionCollector {
-    private static final Logger logger = Logger.getLogger(ImportPartitionCollector.class.getName());
+    private static final Logger LOG = Logger.getLogger(ImportPartitionCollector.class.getName());
 
-    private S3Provider wrapper = null;
+    private Provider provider = null;
 
     @Inject
     StepContext stepCtx;
@@ -63,11 +66,12 @@ public class ImportPartitionCollector implements PartitionCollector {
 
             StorageType type = adapter.getStorageProviderStorageType(ctx.getOutcome());
             boolean collectImportOperationOutcomes = adapter.shouldStorageProviderCollectOperationOutcomes(ctx.getSource())
-                    && (StorageType.AWSS3.equals(type) || StorageType.IBMCOS.equals(type));
+                    && !StorageType.HTTPS.equals(type);
 
             String cosOperationOutcomesBucketName = adapter.getStorageProviderBucketName(ctx.getOutcome());
             if (collectImportOperationOutcomes) {
-                wrapper = new S3Provider(ctx.getOutcome());
+                provider = ProviderFactory.getSourceWrapper(ctx.getOutcome(),
+                        adapter.getStorageProviderType(ctx.getOutcome()));
             }
 
             ImportTransientUserData partitionSummaryData  = (ImportTransientUserData)stepCtx.getTransientUserData();
@@ -88,20 +92,23 @@ public class ImportPartitionCollector implements PartitionCollector {
                 if (collectImportOperationOutcomes) {
                     // Upload remaining OperationOutcomes.
                     if (partitionSummaryData.getBufferStreamForImport().size() > 0) {
-                        if (partitionSummaryData.getUploadIdForOperationOutcomes()  == null) {
-                            partitionSummaryData.setUploadIdForOperationOutcomes(BulkDataUtils.startPartUpload(wrapper.getClient(),
+                        if (partitionSummaryData.getUploadIdForOperationOutcomes() == null) {
+                            partitionSummaryData.setUploadIdForOperationOutcomes(BulkDataUtils.startPartUpload(provider.getClient(),
                                     cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportOperationOutcomes()));
                         }
 
-                        partitionSummaryData.getDataPacksForOperationOutcomes().add(BulkDataUtils.multiPartUpload(wrapper.getClient(),
+                        ByteArrayOutputStream baos = partitionSummaryData.getBufferStreamForImportError();
+
+                        PartETag tag = BulkDataUtils.multiPartUpload(provider.getClient(),
                                 cosOperationOutcomesBucketName,
                                 partitionSummaryData.getUniqueIDForImportOperationOutcomes(),
                                 partitionSummaryData.getUploadIdForOperationOutcomes(),
-                                new ByteArrayInputStream(partitionSummaryData.getBufferStreamForImport().toByteArray()),
-                                partitionSummaryData.getBufferStreamForImport().size(),
-                                partitionSummaryData.getPartNumForOperationOutcomes()));
-                        if (logger.isLoggable(Level.FINE)) {
-                            logger.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImport().size()
+                                new ByteArrayInputStream(baos.toByteArray()), baos.size(),
+                                partitionSummaryData.getPartNumForOperationOutcomes());
+                        partitionSummaryData.getDataPacksForOperationOutcomes().add(tag);
+
+                        if (LOG.isLoggable(Level.FINE)) {
+                            LOG.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImport().size()
                                 + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueIDForImportOperationOutcomes());
                         }
                         partitionSummaryData.setPartNumForOperationOutcomes(partitionSummaryData.getPartNumForOperationOutcomes() + 1);
@@ -109,26 +116,26 @@ public class ImportPartitionCollector implements PartitionCollector {
                     }
                     // Finish uploading OperationOutcomes.
                     if (partitionSummaryData.getUploadIdForOperationOutcomes() != null) {
-                        BulkDataUtils.finishMultiPartUpload(wrapper.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportOperationOutcomes(),
+                        BulkDataUtils.finishMultiPartUpload(provider.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportOperationOutcomes(),
                                 partitionSummaryData.getUploadIdForOperationOutcomes(), partitionSummaryData.getDataPacksForOperationOutcomes());
                     }
 
                     // Upload remaining failure OperationOutcomes.
                     if (partitionSummaryData.getBufferStreamForImportError().size() > 0) {
                         if (partitionSummaryData.getUploadIdForFailureOperationOutcomes()  == null) {
-                            partitionSummaryData.setUploadIdForFailureOperationOutcomes(BulkDataUtils.startPartUpload(wrapper.getClient(),
+                            partitionSummaryData.setUploadIdForFailureOperationOutcomes(BulkDataUtils.startPartUpload(provider.getClient(),
                                     cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes()));
                         }
 
-                        partitionSummaryData.getDataPacksForFailureOperationOutcomes().add(BulkDataUtils.multiPartUpload(wrapper.getClient(),
+                        partitionSummaryData.getDataPacksForFailureOperationOutcomes().add(BulkDataUtils.multiPartUpload(provider.getClient(),
                                 cosOperationOutcomesBucketName,
                                 partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes(),
                                 partitionSummaryData.getUploadIdForFailureOperationOutcomes(),
                                 new ByteArrayInputStream(partitionSummaryData.getBufferStreamForImportError().toByteArray()),
                                 partitionSummaryData.getBufferStreamForImportError().size(),
                                 partitionSummaryData.getPartNumForFailureOperationOutcomes()));
-                        if (logger.isLoggable(Level.FINE)) {
-                            logger.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImportError().size()
+                        if (LOG.isLoggable(Level.FINE)) {
+                            LOG.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImportError().size()
                                 + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes());
                         }
                         partitionSummaryData.setPartNumForFailureOperationOutcomes(partitionSummaryData.getPartNumForFailureOperationOutcomes() + 1);
@@ -136,7 +143,7 @@ public class ImportPartitionCollector implements PartitionCollector {
                     }
                     // Finish uploading failure OperationOutcomes.
                     if (partitionSummaryData.getUploadIdForFailureOperationOutcomes() != null) {
-                        BulkDataUtils.finishMultiPartUpload(wrapper.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes(),
+                        BulkDataUtils.finishMultiPartUpload(provider.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes(),
                                 partitionSummaryData.getUploadIdForFailureOperationOutcomes(), partitionSummaryData.getDataPacksForFailureOperationOutcomes());
                     }
                 }
@@ -148,15 +155,15 @@ public class ImportPartitionCollector implements PartitionCollector {
             ImportCheckPointData partitionSummaryForMetrics = ImportCheckPointData.fromImportTransientUserData(partitionSummaryData);
             partitionSummaryForMetrics.setNumOfToBeImported(partitionSummaryData.getNumOfToBeImported());
 
-            if (logger.isLoggable(Level.FINE)) {
-                logger.info("collected partition data: " + partitionSummaryForMetrics);
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.info("collected partition data: " + partitionSummaryForMetrics);
             }
             return partitionSummaryForMetrics;
         }catch (FHIRException e) {
-            logger.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "] - " + e.getMessage(), e);
+            LOG.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "] - " + e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "]", e);
+            LOG.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "]", e);
             throw e;
         }
     }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionCollector.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ImportPartitionCollector.java
@@ -1,12 +1,11 @@
 /*
- * (C) Copyright IBM Corp. 2020, 2021
+ * (C) Copyright IBM Corp. 2020, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package com.ibm.fhir.bulkdata.jbatch.load;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.util.logging.Level;
@@ -21,7 +20,6 @@ import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 import com.ibm.fhir.bulkdata.common.BulkDataUtils;
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
 import com.ibm.fhir.bulkdata.jbatch.load.data.ImportCheckPointData;
@@ -59,96 +57,47 @@ public class ImportPartitionCollector implements PartitionCollector {
             JobExecution jobExecution = BatchRuntime.getJobOperator().getJobExecution(executionId);
 
             BatchContextAdapter ctxAdapter = new BatchContextAdapter(jobExecution.getJobParameters());
-
             BulkDataContext ctx = ctxAdapter.getStepContextForImportPartitionCollector();
 
-            ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
-
-            StorageType type = adapter.getStorageProviderStorageType(ctx.getOutcome());
-            boolean collectImportOperationOutcomes = adapter.shouldStorageProviderCollectOperationOutcomes(ctx.getSource())
-                    && !StorageType.HTTPS.equals(type);
-
-            String cosOperationOutcomesBucketName = adapter.getStorageProviderBucketName(ctx.getOutcome());
-            if (collectImportOperationOutcomes) {
-                provider = ProviderFactory.getSourceWrapper(ctx.getOutcome(),
-                        adapter.getStorageProviderType(ctx.getOutcome()));
-            }
-
-            ImportTransientUserData partitionSummaryData  = (ImportTransientUserData)stepCtx.getTransientUserData();
+            ImportTransientUserData partitionSummaryData = (ImportTransientUserData) stepCtx.getTransientUserData();
             BatchStatus batchStatus = stepCtx.getBatchStatus();
 
-            // If the job is being stopped or in other status except for "started", then do cleanup for the partition.
+            // If the job is being stopped or in other status except for "started", then do
+            // cleanup for the partition.
             if (!batchStatus.equals(BatchStatus.STARTED)) {
                 BulkDataUtils.cleanupTransientUserData(partitionSummaryData, true);
                 return null;
             }
 
+            ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
+            StorageType type = adapter.getStorageProviderStorageType(ctx.getOutcome());
+            boolean collectImportOperationOutcomes = adapter.shouldStorageProviderCollectOperationOutcomes(ctx.getSource())
+                    && !StorageType.HTTPS.equals(type);
+
+            if (collectImportOperationOutcomes) {
+                provider = ProviderFactory.getSourceWrapper(ctx.getOutcome(),
+                        adapter.getStorageProviderType(ctx.getOutcome()));
+            }
+
             // This function is called at partition chunk check points and also at the end of partition processing.
             // So, check the NumOfToBeImported to make sure at the end of partition processing:
-            // (1) upload the remaining OperationOutcomes to COS/S3.
-            // (2) finish the multiple-parts uploads.
-            // (3) release the resources hold by this partition.
-            if (partitionSummaryData.getNumOfToBeImported() == 0) {
-                if (collectImportOperationOutcomes) {
-                    // Upload remaining OperationOutcomes.
-                    if (partitionSummaryData.getBufferStreamForImport().size() > 0) {
-                        if (partitionSummaryData.getUploadIdForOperationOutcomes() == null) {
-                            partitionSummaryData.setUploadIdForOperationOutcomes(BulkDataUtils.startPartUpload(provider.getClient(),
-                                    cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportOperationOutcomes()));
-                        }
+            // (1) upload the remaining OperationOutcomes to the StorageProviders (!HTTPS).
+            // (2) finish the uploads.
+            // (3) release the resources held by this partition.
+            if (partitionSummaryData.getNumOfToBeImported() == 0 && collectImportOperationOutcomes) {
+                String folder = ctx.getCosBucketPathPrefix();
 
-                        ByteArrayOutputStream baos = partitionSummaryData.getBufferStreamForImportError();
+                // Success Messages
+                ByteArrayOutputStream baosSuccess = partitionSummaryData.getBufferStreamForImport();
+                String fileNameSuccess = partitionSummaryData.getUniqueIDForImportOperationOutcomes();
+                provider.pushEndOfJobOperationOutcomes(baosSuccess, folder, fileNameSuccess);
 
-                        PartETag tag = BulkDataUtils.multiPartUpload(provider.getClient(),
-                                cosOperationOutcomesBucketName,
-                                partitionSummaryData.getUniqueIDForImportOperationOutcomes(),
-                                partitionSummaryData.getUploadIdForOperationOutcomes(),
-                                new ByteArrayInputStream(baos.toByteArray()), baos.size(),
-                                partitionSummaryData.getPartNumForOperationOutcomes());
-                        partitionSummaryData.getDataPacksForOperationOutcomes().add(tag);
+                // Failure Messages
+                ByteArrayOutputStream baosFailure = partitionSummaryData.getBufferStreamForImportError();
+                String fileNameFailure = partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes();
+                provider.pushEndOfJobOperationOutcomes(baosFailure, folder, fileNameFailure);
 
-                        if (LOG.isLoggable(Level.FINE)) {
-                            LOG.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImport().size()
-                                + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueIDForImportOperationOutcomes());
-                        }
-                        partitionSummaryData.setPartNumForOperationOutcomes(partitionSummaryData.getPartNumForOperationOutcomes() + 1);
-                        partitionSummaryData.getBufferStreamForImport().reset();
-                    }
-                    // Finish uploading OperationOutcomes.
-                    if (partitionSummaryData.getUploadIdForOperationOutcomes() != null) {
-                        BulkDataUtils.finishMultiPartUpload(provider.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportOperationOutcomes(),
-                                partitionSummaryData.getUploadIdForOperationOutcomes(), partitionSummaryData.getDataPacksForOperationOutcomes());
-                    }
-
-                    // Upload remaining failure OperationOutcomes.
-                    if (partitionSummaryData.getBufferStreamForImportError().size() > 0) {
-                        if (partitionSummaryData.getUploadIdForFailureOperationOutcomes()  == null) {
-                            partitionSummaryData.setUploadIdForFailureOperationOutcomes(BulkDataUtils.startPartUpload(provider.getClient(),
-                                    cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes()));
-                        }
-
-                        partitionSummaryData.getDataPacksForFailureOperationOutcomes().add(BulkDataUtils.multiPartUpload(provider.getClient(),
-                                cosOperationOutcomesBucketName,
-                                partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes(),
-                                partitionSummaryData.getUploadIdForFailureOperationOutcomes(),
-                                new ByteArrayInputStream(partitionSummaryData.getBufferStreamForImportError().toByteArray()),
-                                partitionSummaryData.getBufferStreamForImportError().size(),
-                                partitionSummaryData.getPartNumForFailureOperationOutcomes()));
-                        if (LOG.isLoggable(Level.FINE)) {
-                            LOG.fine("pushImportOperationOutcomesToCOS: " + partitionSummaryData.getBufferStreamForImportError().size()
-                                + " bytes were successfully appended to COS object - " + partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes());
-                        }
-                        partitionSummaryData.setPartNumForFailureOperationOutcomes(partitionSummaryData.getPartNumForFailureOperationOutcomes() + 1);
-                        partitionSummaryData.getBufferStreamForImportError().reset();
-                    }
-                    // Finish uploading failure OperationOutcomes.
-                    if (partitionSummaryData.getUploadIdForFailureOperationOutcomes() != null) {
-                        BulkDataUtils.finishMultiPartUpload(provider.getClient(), cosOperationOutcomesBucketName, partitionSummaryData.getUniqueIDForImportFailureOperationOutcomes(),
-                                partitionSummaryData.getUploadIdForFailureOperationOutcomes(), partitionSummaryData.getDataPacksForFailureOperationOutcomes());
-                    }
-                }
-
-                // Clean up.
+                // Clean up
                 BulkDataUtils.cleanupTransientUserData(partitionSummaryData, false);
             }
 
@@ -156,11 +105,13 @@ public class ImportPartitionCollector implements PartitionCollector {
             partitionSummaryForMetrics.setNumOfToBeImported(partitionSummaryData.getNumOfToBeImported());
 
             if (LOG.isLoggable(Level.FINE)) {
-                LOG.info("collected partition data: " + partitionSummaryForMetrics);
+                LOG.fine("collected partition data: " + partitionSummaryForMetrics);
             }
             return partitionSummaryForMetrics;
         }catch (FHIRException e) {
-            LOG.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "] - " + e.getMessage(), e);
+            LOG.throwing(ImportPartitionCollector.class.getName(), "collectPartitionData", e);
+            LOG.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "] - "
+                    + e.getMessage(), e);
             throw e;
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "Import PartitionCollector.collectPartitionData during job[" + executionId + "]", e);

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportCheckPointData.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportCheckPointData.java
@@ -8,7 +8,9 @@ package com.ibm.fhir.bulkdata.jbatch.load.data;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
 
@@ -305,10 +307,10 @@ public class ImportCheckPointData implements Serializable {
         protected String uniqueIDForImportFailureOperationOutcomes;
         protected String uniqueIDForImportOperationOutcomes;
         protected String uploadIdForOperationOutcomes;
-        protected List<PartETag> dataPacksForOperationOutcomes;
+        protected Set<PartETag> dataPacksForOperationOutcomes = new LinkedHashSet<>();
         protected int partNumForOperationOutcomes;
         protected String uploadIdForFailureOperationOutcomes;
-        protected List<PartETag> dataPacksForFailureOperationOutcomes;
+        protected Set<PartETag> dataPacksForFailureOperationOutcomes = new LinkedHashSet<>();
         protected int partNumForFailureOperationOutcomes;
         protected long totalReadMilliSeconds;
         protected long totalValidationMilliSeconds;
@@ -377,7 +379,9 @@ public class ImportCheckPointData implements Serializable {
         }
 
         public Builder dataPacksForOperationOutcomes(List<PartETag> dataPacksForOperationOutcomes) {
-            this.dataPacksForOperationOutcomes = dataPacksForOperationOutcomes;
+            if (dataPacksForOperationOutcomes != null) {
+                this.dataPacksForOperationOutcomes.addAll(dataPacksForOperationOutcomes);
+            }
             return this;
         }
 
@@ -392,7 +396,9 @@ public class ImportCheckPointData implements Serializable {
         }
 
         public Builder dataPacksForFailureOperationOutcomes(List<PartETag> dataPacksForFailureOperationOutcomes) {
-            this.dataPacksForFailureOperationOutcomes = dataPacksForFailureOperationOutcomes;
+            if (dataPacksForFailureOperationOutcomes != null) {
+                this.dataPacksForFailureOperationOutcomes.addAll(dataPacksForFailureOperationOutcomes);
+            }
             return this;
         }
 
@@ -442,10 +448,11 @@ public class ImportCheckPointData implements Serializable {
             importCheckPointData.uniqueIDForImportFailureOperationOutcomes = this.uniqueIDForImportFailureOperationOutcomes;
             importCheckPointData.uniqueIDForImportOperationOutcomes = this.uniqueIDForImportOperationOutcomes;
             importCheckPointData.uploadIdForOperationOutcomes = this.uploadIdForOperationOutcomes;
-            importCheckPointData.dataPacksForOperationOutcomes = this.dataPacksForOperationOutcomes;
+            importCheckPointData.dataPacksForOperationOutcomes = new ArrayList<>(this.dataPacksForOperationOutcomes);
             importCheckPointData.partNumForOperationOutcomes = this.partNumForOperationOutcomes;
             importCheckPointData.uploadIdForFailureOperationOutcomes = this.uploadIdForFailureOperationOutcomes;
-            importCheckPointData.dataPacksForFailureOperationOutcomes = this.dataPacksForFailureOperationOutcomes;
+            importCheckPointData.dataPacksForFailureOperationOutcomes = new ArrayList<>(
+                    this.dataPacksForFailureOperationOutcomes);
             importCheckPointData.partNumForFailureOperationOutcomes = this.partNumForFailureOperationOutcomes;
             importCheckPointData.totalReadMilliSeconds = this.totalReadMilliSeconds;
             importCheckPointData.totalValidationMilliSeconds = this.totalValidationMilliSeconds;

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportTransientUserData.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/data/ImportTransientUserData.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.bulkdata.jbatch.load.data;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.ibm.cloud.objectstorage.services.s3.model.PartETag;
@@ -203,10 +204,11 @@ public class ImportTransientUserData extends ImportCheckPointData {
             importTransientUserData.uniqueIDForImportFailureOperationOutcomes = this.uniqueIDForImportFailureOperationOutcomes;
             importTransientUserData.uniqueIDForImportOperationOutcomes = this.uniqueIDForImportOperationOutcomes;
             importTransientUserData.uploadIdForOperationOutcomes = this.uploadIdForOperationOutcomes;
-            importTransientUserData.dataPacksForOperationOutcomes = this.dataPacksForOperationOutcomes;
+            importTransientUserData.dataPacksForOperationOutcomes = new ArrayList<>(this.dataPacksForOperationOutcomes);
             importTransientUserData.partNumForOperationOutcomes = this.partNumForOperationOutcomes;
             importTransientUserData.uploadIdForFailureOperationOutcomes = this.uploadIdForFailureOperationOutcomes;
-            importTransientUserData.dataPacksForFailureOperationOutcomes = this.dataPacksForFailureOperationOutcomes;
+            importTransientUserData.dataPacksForFailureOperationOutcomes = new ArrayList<>(
+                    this.dataPacksForFailureOperationOutcomes);
             importTransientUserData.partNumForFailureOperationOutcomes = this.partNumForFailureOperationOutcomes;
             importTransientUserData.totalReadMilliSeconds = this.totalReadMilliSeconds;
             importTransientUserData.totalValidationMilliSeconds = this.totalValidationMilliSeconds;

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/Provider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/Provider.java
@@ -1,10 +1,12 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.ibm.fhir.bulkdata.provider;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 
 import com.ibm.fhir.bulkdata.dto.ReadResultDTO;
@@ -77,8 +79,27 @@ public interface Provider {
      * Pushes the Operation Outcomes
      */
     default void pushOperationOutcomes() throws FHIRException {
-        // No Operation
+        // NOP
     }
 
+    /**
+     * Closes the StorageProvider wrapped resources.
+     * 
+     * @throws Exception
+     */
     void close() throws Exception;
+
+    /**
+     * Pushes End of Job OperationOutcomes and closes the Outcomes StorageProvider
+     * 
+     * @param baos     the byte array output stream that is passed in
+     * @param folder   the folder where the file is to be stored
+     * @param fileName the output filename to be used
+     * 
+     * @throws FHIRException
+     */
+    default void pushEndOfJobOperationOutcomes(ByteArrayOutputStream baos, String folder, String fileName)
+            throws FHIRException {
+        // NOP
+    }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,6 +8,8 @@ package com.ibm.fhir.bulkdata.provider.impl;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -497,5 +499,20 @@ public class AzureProvider implements Provider {
         this.cosBucketPathPrefix = cosBucketPathPrefix;
         this.fhirResourceType = fhirResourceType;
         this.chunkData = transientUserData;
+    }
+
+    @Override
+    public void pushEndOfJobOperationOutcomes(ByteArrayOutputStream baos, String folder, String fileName)
+            throws FHIRException {
+        String fn = folder + File.separator + fileName;
+        initializeBlobClient(fn);
+
+        AppendBlobClient aClient = client.getAppendBlobClient();
+        if (!client.exists().booleanValue()) {
+            aClient.create();
+        }
+        aClient.appendBlock(new ByteArrayInputStream(baos.toByteArray()), baos.size());
+
+        baos.reset();
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/AzureProvider.java
@@ -9,7 +9,6 @@ package com.ibm.fhir.bulkdata.provider.impl;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -504,7 +503,7 @@ public class AzureProvider implements Provider {
     @Override
     public void pushEndOfJobOperationOutcomes(ByteArrayOutputStream baos, String folder, String fileName)
             throws FHIRException {
-        String fn = folder + File.separator + fileName;
+        String fn = folder + "/" + fileName;
         initializeBlobClient(fn);
 
         AppendBlobClient aClient = client.getAppendBlobClient();

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/provider/impl/FileProvider.java
@@ -215,8 +215,7 @@ public class FileProvider implements Provider {
     }
 
     @Override
-    public void pushEndOfJobOperationOutcomes(ByteArrayOutputStream baos, String folder, String fileName)
-            throws FHIRException {
+    public void pushEndOfJobOperationOutcomes(ByteArrayOutputStream baos, String folder, String fileName) throws FHIRException {
             String base = configuration.getBaseFileLocation(source);
 
             if (baos.size() > 0) {

--- a/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
+++ b/fhir-bulkdata-webapp/src/main/resources/META-INF/batch-jobs/FhirBulkImportChunkJob.xml
@@ -27,9 +27,9 @@
                     <property name="fhir.incomingUrl" value="#{jobParameters['fhir.incomingUrl']}"/>
                     <property name="fhir.bulkdata.source" value="#{jobParameters['fhir.bulkdata.source']}"/>
                     <property name="fhir.bulkdata.outcome" value="#{jobParameters['fhir.bulkdata.outcome']}"/>
-                    
+
                     <property name="import.fhir.storagetype" value="#{jobParameters['import.fhir.storagetype']}"/>
-                    
+
                     <property name="partition.workitem" value="#{partitionPlan['partition.workitem']}"/>
                     <property name="partition.matrix" value="#{partitionPlan['partition.matrix']}"/>
                     <property name="partition.resourcetype" value="#{partitionPlan['partition.resourcetype']}"/>
@@ -67,6 +67,7 @@
                     <property name="fhir.incomingUrl" value="#{jobParameters['fhir.incomingUrl']}"/>
                     <property name="fhir.bulkdata.source" value="#{jobParameters['fhir.bulkdata.source']}"/>
                     <property name="fhir.bulkdata.outcome" value="#{jobParameters['fhir.bulkdata.outcome']}"/>
+                    <property name="cos.bucket.pathprefix" value="#{jobParameters['cos.bucket.pathprefix']}"/>
                 </properties>
             </collector>
             <analyzer ref="com.ibm.fhir.bulkdata.jbatch.load.ImportPartitionAnalyzer"/>

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/impl/V2ConfigurationImpl.java
@@ -142,8 +142,9 @@ public class V2ConfigurationImpl extends AbstractSystemConfigurationImpl {
 
     @Override
     public boolean shouldStorageProviderCollectOperationOutcomes(String provider) {
-        // Double negation... carefully change this line.
-        return !FHIRConfigHelper.getBooleanProperty("fhirServer/bulkdata/storageProviders/" + provider + "/disableOperationOutcomes", Boolean.FALSE);
+        // 2910: Switches the default to TRUE meaning we don't record them.
+        return !FHIRConfigHelper.getBooleanProperty(
+                "fhirServer/bulkdata/storageProviders/" + provider + "/disableOperationOutcomes", Boolean.TRUE);
     }
 
     @Override

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -82,7 +82,7 @@ public class BulkDataExportUtil {
      * @param resourceTypes
      * @throws FHIROperationException
      */
-    public void checkExportPatientResourceTypes(List<String> resourceTypes) throws FHIROperationException {
+    public void checkExportPatientResourceTypes(Set<String> resourceTypes) throws FHIROperationException {
         boolean valid = false;
         try {
             // Also Check to see if the Export is valid for the Compartment.
@@ -210,12 +210,14 @@ public class BulkDataExportUtil {
 
     /**
      * processes both the Parameters object and the query parameters
+     * 
+     * @param exportType
      * @param parameters
      * @param queryParameters
      * @return
      * @throws FHIROperationException
      */
-    public List<String> checkAndValidateTypes(Parameters parameters, MultivaluedMap<String, String> queryParameters) throws FHIROperationException {
+    public List<String> checkAndValidateTypes(OperationConstants.ExportType exportType, Parameters parameters, MultivaluedMap<String, String> queryParameters) throws FHIROperationException {
         /*
          * Only resources of the specified resource types(s) SHALL be included in the response. If this parameter is
          * omitted, the server SHALL return all supported resources within the scope of the client authorization. For
@@ -271,10 +273,15 @@ public class BulkDataExportUtil {
             }
         }
 
-        // The case where no resourceTypes are specified, inlining only the supported
-        // ResourceTypes
-        if (result.isEmpty()) {
+        // The case where no resourceTypes are specified, inlining only the supported ResourceTypes
+        if (result.isEmpty() && ExportType.SYSTEM.equals(exportType)) {
             result = new HashSet<>(supportedResourceTypes);
+        } else if (ExportType.PATIENT.equals(exportType) || ExportType.GROUP.equals(exportType)) {
+            if (!result.isEmpty()) {
+                checkExportPatientResourceTypes(result);
+            } else {
+                return addDefaultsForPatientCompartment();
+            }
         }
         return new ArrayList<>(result);
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.MediaType;
@@ -43,6 +44,8 @@ import com.ibm.fhir.server.spi.operation.FHIROperationContext;
  * BulkData Util captures common methods
  */
 public class BulkDataExportUtil {
+    private static final Logger LOG = Logger.getLogger(BulkDataExportUtil.class.getName());
+
     private static Set<String> RESOURCE_TYPES = ModelSupport.getResourceTypes(false).stream()
                                                     .map(Class::getSimpleName)
                                                     .collect(Collectors.toSet());
@@ -103,16 +106,17 @@ public class BulkDataExportUtil {
      */
     public Set<String> getSupportedResourceTypes() {
         try {
-            if (!FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN, Boolean.TRUE)) {
+            if (!FHIRConfigHelper.getBooleanProperty("fhirServer/resources/" + FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN, Boolean.TRUE)) {
                 List<String> rts = FHIRConfigHelper.getSupportedResourceTypes();
-                if (rts == null || !rts.isEmpty()) {
+                System.out.println("RTS -> " + rts);
+                if (rts != null && !rts.isEmpty()) {
                     rts.remove("Resource");
                     rts.remove("DomainResource");
                     return new HashSet<>(rts);
                 }
             }
         } catch (FHIRException e) {
-            // NOP
+            LOG.throwing(BulkDataExportUtil.class.getName(), "getSupportedResourceTypes", e);
         }
         return RESOURCE_TYPES;
     }
@@ -265,6 +269,12 @@ public class BulkDataExportUtil {
                     }
                 }
             }
+        }
+
+        // Where there are none specified.
+        if (result.isEmpty()) {
+            System.out.println(result + "" + supportedResourceTypes);
+            result = supportedResourceTypes;
         }
         return new ArrayList<>(result);
     }

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
@@ -322,7 +322,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        util.checkAndValidateTypes(ps, null);
+        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         fail();
     }
 
@@ -337,7 +337,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        util.checkAndValidateTypes(ps, null);
+        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         fail();
     }
 
@@ -352,7 +352,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        util.checkAndValidateTypes(ps, new MultivaluedHashMap<String, String>());
+        util.checkAndValidateTypes(ExportType.SYSTEM, ps, new MultivaluedHashMap<String, String>());
         fail();
     }
 
@@ -367,7 +367,7 @@ public class BulkDataExportUtilTest {
         Parameters ps = builder.build();
 
         BulkDataExportUtil util = new BulkDataExportUtil();
-        List<String> types = util.checkAndValidateTypes(ps, null);
+        List<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         assertNotNull(types);
     }
 
@@ -382,7 +382,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        List<String> types = util.checkAndValidateTypes(ps, null);
+        List<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         assertNotNull(types);
     }
 
@@ -397,7 +397,7 @@ public class BulkDataExportUtilTest {
         Parameters ps = builder.build();
 
         BulkDataExportUtil util = new BulkDataExportUtil();
-        List<String> types = util.checkAndValidateTypes(ps, null);
+        List<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         assertNotNull(types);
     }
 
@@ -412,7 +412,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        util.checkAndValidateTypes(ps, null);
+        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         fail();
     }
 
@@ -427,7 +427,7 @@ public class BulkDataExportUtilTest {
         Parameters ps = builder.build();
 
         BulkDataExportUtil util = new BulkDataExportUtil();
-        List<String> result = util.checkAndValidateTypes(ps, null);
+        List<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
@@ -443,7 +443,7 @@ public class BulkDataExportUtilTest {
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        List<String> result = util.checkAndValidateTypes(ps, null);
+        List<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
@@ -451,7 +451,7 @@ public class BulkDataExportUtilTest {
     @Test
     public void testCheckAndValidateTypesEmptyParameters() throws FHIROperationException {
         BulkDataExportUtil util = new BulkDataExportUtil();
-        List<String> result = util.checkAndValidateTypes(null, null);
+        List<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, null, null);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }


### PR DESCRIPTION
- Enabled OperationOutcomes to be Recorded for S3
- Added Prefixes to the Outcomes
- Added to the BatchContextAdapter to propagate the prefixes.
- Switched the default to disable operationoutcomes
- Support outcomes for Azure, File, S3
- Add Success Outcomes
