### PR TITLE
Issue #2300 - Add calls to beforeHistory and afterHistory

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2760,6 +2760,8 @@ This component uses the IBM FHIR Server's PersistenceInterceptor feature to auto
 
 Additionally, before returning resources to the client, the `fhir-smart` component performs authorization policy enforcement based on the list of SMART scopes included in the token's `scope` claim and the list of patient compartments in the `patient_id` claim.
 
+When the HTTP header `Prefer: return=minimal` is specified on a search or history request, only minimal resource metadata is retrieved. In those cases, either `user` or `system` SMART scopes must be used, since the resource data necessary to enforce access via `patient` SMART scopes is not available.
+
 For an example of using the IBM FHIR Server together with a SMART-enabled Keycloak authorization server, please see the data-access pattern at https://github.com/Alvearie/health-patterns/tree/main/data-access.
 
 ## 5.4 Custom HTTP Headers

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2762,7 +2762,7 @@ Additionally, before returning resources to the client, the `fhir-smart` compone
 
 When the HTTP header `Prefer: return=minimal` is specified on a search or history request, only minimal resource metadata is retrieved. In those cases, either `user` or `system` SMART scopes must be used, since the resource data necessary to enforce access via `patient` SMART scopes is not available.
 
-For an example of using the IBM FHIR Server together with a SMART-enabled Keycloak authorization server, please see the data-access pattern at https://github.com/Alvearie/health-patterns/tree/main/data-access.
+For an example of using the IBM FHIR Server together with a SMART-enabled Keycloak authorization server, please see the data-access pattern at https://github.com/LinuxForHealth/health-patterns/tree/main/data-access.
 
 ## 5.4 Custom HTTP Headers
 IBM FHIR Server Supports the following custom HTTP Headers:

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -42,6 +42,7 @@ public class FHIRPersistenceEvent {
      * This property is of type String and contains the resource id associated with an
      * update, read, vread, history, or delete operation.
      * For update and delete it may be null (i.e. for conditional updates/deletes)
+     * For whole-system history, this property will be null.
      * For other operations, this property will be null.
      */
     public static final String PROPNAME_RESOURCE_ID = "RESOURCE_ID";
@@ -149,7 +150,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the resource id associated with the FHIR REST API request that triggered the
-     * interceptor invocation.   This will be non-null for a read, vread, history, or non-conditional update/delete operation.
+     * interceptor invocation.   This will be non-null for a read, vread, non-whole-system history, or non-conditional update/delete operation.
      */
     public String getFhirResourceId() {
         return (String) getProperty(PROPNAME_RESOURCE_ID);

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
@@ -65,6 +65,14 @@ public class FHIRPersistenceEvent {
      */
     public static final String PROPNAME_SEARCH_CONTEXT_IMPL = "SEARCH_CONTEXT_IMPL";
 
+    /**
+     * This property is of type FHIRSystemHistoryContext and is the system history context
+     * associated with a system history request, but it may be null.
+     * For other operations, this property will be null.
+     */
+    public static final String PROPNAME_SYSTEM_HISTORY_CONTEXT_IMPL = "SYSTEM_HISTORY_CONTEXT_IMPL";
+
+
     private Resource fhirResource;
     private Resource prevFhirResource = null;
     private boolean  prevFhirResourceSet = false;
@@ -207,4 +215,11 @@ public class FHIRPersistenceEvent {
         return (FHIRSearchContext) getProperty(PROPNAME_SEARCH_CONTEXT_IMPL);
     }
 
+    /**
+     * Returns the FHIRSystemHistoryContext instance currently being used by the FHIR REST API layer
+     * to process the current request.
+     */
+    public FHIRSystemHistoryContext getSystemHistoryContextImpl() {
+        return (FHIRSystemHistoryContext) getProperty(PROPNAME_SYSTEM_HISTORY_CONTEXT_IMPL);
+    }
 }

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -22,6 +22,7 @@ import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
 import com.ibm.fhir.persistence.ResourceEraseRecord;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
+import com.ibm.fhir.persistence.context.FHIRSystemHistoryContext;
 import com.ibm.fhir.persistence.erase.EraseDTO;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
@@ -36,10 +37,10 @@ public interface FHIRResourceHelpers {
     public static final boolean DO_VALIDATION = true;
     // Constant for indicating whether an update can be skipped when the requested update resource matches the existing one
     public static final boolean SKIPPABLE_UPDATE = true;
-    
+
     // Constant for when we don't use the If-Not-Match header value
     public static final Integer IF_NOT_MATCH_NULL = null;
-    
+
     public enum Interaction {
         CREATE("create"),
         DELETE("delete"),
@@ -186,11 +187,13 @@ public interface FHIRResourceHelpers {
      *            the resource version
      * @param searchContext
      *            the request search context
+     * @param systemHistoryContext
+     *            the request system history context
      * @return a map of persistence event properties
      * @throws FHIRPersistenceException
      */
     Map<String, Object> buildPersistenceEventProperties(String type, String id,
-        String version, FHIRSearchContext searchContext) throws FHIRPersistenceException;
+        String version, FHIRSearchContext searchContext, FHIRSystemHistoryContext systemHistoryContext) throws FHIRPersistenceException;
 
     /**
      * Performs an update operation (a new version of the Resource will be stored). Validates the resource.
@@ -208,7 +211,7 @@ public interface FHIRResourceHelpers {
      * @param skippableUpdate
      *            if true, and the resource content in the update matches the existing resource on the server, then skip the update;
      *            if false, then always attempt the update
-     * @param ifNoneMatch 
+     * @param ifNoneMatch
      *            conditional create-on-update
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
@@ -236,7 +239,7 @@ public interface FHIRResourceHelpers {
      *            if false, then always attempt the update
      * @param doValidation
      *            if true, validate the resource; if false, assume the resource has already been validated
-     * @param ifNoneMatch 
+     * @param ifNoneMatch
      *            conditional create-on-update
      * @return a FHIRRestOperationResponse that contains the results of the operation
      * @throws Exception
@@ -391,7 +394,7 @@ public interface FHIRResourceHelpers {
      * Implement the system level history operation to obtain a list of changes to resources
      * with an optional resourceType which supports for example [base]/Patient/_history
      * requests to return the complete history of changes filtered to a specific resource type.
-     * Because the resource type is included in the path, this variant allows only a single 
+     * Because the resource type is included in the path, this variant allows only a single
      * resource type to be specified. To obtain history for more than one resource type, the
      * [base]/_history whole system history endpoint should be used instead with a list of
      * resource types specified using the _type query parameter.

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -387,7 +387,7 @@ public class FHIRRestBundleHelper {
 
         // Build the event we'll use when executing the interaction command
         // - the resource gets injected later when we have it
-        FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, helpers.buildPersistenceEventProperties(resourceType, resourceId, null, null));
+        FHIRPersistenceEvent event = new FHIRPersistenceEvent(null, helpers.buildPersistenceEventProperties(resourceType, resourceId, null, null, null));
 
         // We don't perform the actual operation here, just generate the command
         // we want to execute later
@@ -575,7 +575,7 @@ public class FHIRRestBundleHelper {
 
             // Create the event
             FHIRPersistenceEvent event =
-                    new FHIRPersistenceEvent(resource, helpers.buildPersistenceEventProperties(resource.getClass().getSimpleName(), null, null, null));
+                    new FHIRPersistenceEvent(resource, helpers.buildPersistenceEventProperties(resource.getClass().getSimpleName(), null, null, null, null));
 
             result = new FHIRRestInteractionCreate(entryIndex, event, validationResponseEntry, requestDescription, requestURL, pathTokens[0], resource, ifNoneExist, localIdentifier);
         } else {
@@ -667,7 +667,7 @@ public class FHIRRestBundleHelper {
         }
 
         // Create the event we'll use for this resource interaction
-        FHIRPersistenceEvent event = new FHIRPersistenceEvent(resource, helpers.buildPersistenceEventProperties(type, id, null, null));
+        FHIRPersistenceEvent event = new FHIRPersistenceEvent(resource, helpers.buildPersistenceEventProperties(type, id, null, null, null));
         result = new FHIRRestInteractionUpdate(entryIndex, event, validationResponseEntry, requestDescription, requestURL,
             type, id, resource, ifMatchBundleValue, requestURL.getQuery(), skippableUpdate, localIdentifier, ifNoneMatch);
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -153,7 +153,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     private static final com.ibm.fhir.model.type.String SC_BAD_REQUEST_STRING = string(Integer.toString(SC_BAD_REQUEST));
     private static final com.ibm.fhir.model.type.String SC_ACCEPTED_STRING = string(Integer.toString(SC_ACCEPTED));
     private static final ZoneId UTC = ZoneId.of("UTC");
-    
+
     // Convenience constants to make call parameters more readable
     private static final boolean THROW_EXC_ON_NULL = true;
     private static final boolean INCLUDE_DELETED = true;
@@ -354,7 +354,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             checkIdAndMeta(resource);
 
             // create the resource and return the location header.
-            final FHIRPersistenceContext persistenceContext = 
+            final FHIRPersistenceContext persistenceContext =
                     FHIRPersistenceContextImpl.builder(event)
                     .withOffloadResponse(offloadResponse)
                     .build();
@@ -763,7 +763,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     .withIfNoneMatch(ifNoneMatch)
                     .withOffloadResponse(offloadResponse)
                     .build();
-            
+
             boolean createOnUpdate = (prevResource == null);
             final SingleResourceResult<Resource> result;
             if (createOnUpdate) {
@@ -987,7 +987,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 for (Entry entry: responseBundle.getEntry()) {
                     id = entry.getResource().getId();
                     Resource resourceToDelete = entry.getResource();
-                    
+
                     // For soft-delete we store a new version of the resource with the deleted
                     // flag set. Because we've read the resource already, we need to check that
                     // the version we are deleting matches the version we just read, so the
@@ -1019,7 +1019,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                         ior.setVersionForETag(newVersionNumber);
                     }
 
-                    // Invoke the 'afterDelete' interceptor methods. To support the notification service, we 
+                    // Invoke the 'afterDelete' interceptor methods. To support the notification service, we
                     // need to provide a resource with the lastUpdated element set. This is just to simplify
                     // passing values, even though the resource itself doesn't really exist
                     final int newVersionNumber = currentVersionNumber + 1;
@@ -2166,10 +2166,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     issues.add(FHIRUtil.buildOperationOutcomeIssue(IssueSeverity.WARNING, IssueType.NOT_SUPPORTED, msg));
                 } else {
                     // Off-spec - simply provide the url without the resource body. But in order
-                    // to satisfy "Rule: must be a resource unless there's a request or response" 
+                    // to satisfy "Rule: must be a resource unless there's a request or response"
                     // we also add a minimal response element
                     final Uri uri = Uri.of(getRequestBaseUri(type) + "/" + resourceResult.getResourceTypeName() + "/" + resourceResult.getLogicalId());
-                    com.ibm.fhir.model.resource.Bundle.Entry.Response response = 
+                    com.ibm.fhir.model.resource.Bundle.Entry.Response response =
                             com.ibm.fhir.model.resource.Bundle.Entry.Response.builder()
                             .status("200")
                             .build();
@@ -3023,7 +3023,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
         // extract the query parameters
         FHIRRequestContext requestContext = FHIRRequestContext.get();
-        
+
         if (requestContext.isReturnPreferenceDefault()) {
             // For _history, override the default preference to be REPRESENTATION so resources
             // are returned in the response bundle per the R4 spec.
@@ -3038,6 +3038,11 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         List<ResourceChangeLogRecord> records;
         List<Resource> resources = null;
 
+        // First, invoke the 'beforeHistory' interceptor methods.
+        FHIRPersistenceEvent event =
+                new FHIRPersistenceEvent(null, buildPersistenceEventProperties(resourceType == null ? "Resource" : resourceType, null, null, null));
+        getInterceptorMgr().fireBeforeHistoryEvent(event);
+
         // Start a new txn in the persistence layer if one is not already active.
         Integer count = historyContext.getCount();
         Instant since = historyContext.getSince() != null && historyContext.getSince().getValue() != null ? historyContext.getSince().getValue().toInstant() : null;
@@ -3050,7 +3055,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             } else if (count > MAX_HISTORY_ENTRIES) {
                 count = MAX_HISTORY_ENTRIES;
             }
-            
+
             if (resourceType != null) {
                 // Use the resource type on the path, ignoring any _type parameter
                 records = persistence.changes(count, since, before, historyContext.getChangeIdMarker(), Collections.singletonList(resourceType), historyContext.isExcludeTransactionTimeoutWindow(),
@@ -3061,15 +3066,15 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 for (String rt: historyContext.getResourceTypes()) {
                     validateInteraction(Interaction.HISTORY, rt);
                 }
-                records = persistence.changes(count, since, before, historyContext.getChangeIdMarker(), historyContext.getResourceTypes(), 
+                records = persistence.changes(count, since, before, historyContext.getChangeIdMarker(), historyContext.getResourceTypes(),
                         historyContext.isExcludeTransactionTimeoutWindow(), historyContext.getHistorySortOrder());
             } else {
                 // no resource type filter
                 final List<String> NULL_RESOURCE_TYPE_NAMES = null;
-                records = persistence.changes(count, since, before, historyContext.getChangeIdMarker(), NULL_RESOURCE_TYPE_NAMES, historyContext.isExcludeTransactionTimeoutWindow(), 
+                records = persistence.changes(count, since, before, historyContext.getChangeIdMarker(), NULL_RESOURCE_TYPE_NAMES, historyContext.isExcludeTransactionTimeoutWindow(),
                         historyContext.getHistorySortOrder());
             }
-            
+
             if (historyContext.getReturnPreference() == HTTPReturnPreference.REPRESENTATION
                     || historyContext.getReturnPreference() == HTTPReturnPreference.OPERATION_OUTCOME) {
                 // vread the resources so that we can include them in the response bundle
@@ -3077,7 +3082,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     log.fine("Fetching resources for history response bundle, count=" + records.size());
                 }
                 resources = persistence.readResourcesForRecords(records);
-                
+
                 if (resources.size() != records.size()) {
                     // very unlikely...unless we overlap with a patient erase operation
                     throw new FHIRPersistenceException("Could not read all required resource records");
@@ -3178,12 +3183,12 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             }
             nextRequest.append("?");
             nextRequest.append("_count=").append(count);
-            
+
             if (resourceType == null && historyContext.getResourceTypes().size() > 0) {
                 nextRequest.append("&_type=");
                 nextRequest.append(String.join(",", historyContext.getResourceTypes()));
             }
-            
+
             if (historyContext.isExcludeTransactionTimeoutWindow()) {
                 nextRequest.append("&_excludeTransactionTimeoutWindow=true");
             }
@@ -3196,7 +3201,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                     // make sure we keep including the before filter specified in the original request
                     nextRequest.append("&_before=").append(historyContext.getBefore().getValue().format(DateTime.PARSER_FORMATTER));
                 }
-                
+
                 if (changeIdMarker != null) {
                     // good way to exclude this resource on the next call
                     nextRequest.append("&_changeIdMarker=").append(changeIdMarker);
@@ -3249,7 +3254,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         if (historyContext.getChangeIdMarker() != null) {
             selfRequest.append("&_changeIdMarker=").append(historyContext.getChangeIdMarker());
         }
-        
+
         if (historyContext.getSince() != null && historyContext.getSince().getValue() != null) {
             selfRequest.append("&_since=").append(historyContext.getSince().getValue().format(DateTime.PARSER_FORMATTER));
         }
@@ -3284,8 +3289,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         linkBuilder.relation(com.ibm.fhir.model.type.String.of("self"));
         bundleBuilder.link(linkBuilder.build());
         bundleBuilder.type(BundleType.HISTORY);
+        Bundle bundle = bundleBuilder.build();
 
-        return bundleBuilder.build();
+        event.setFhirResource(bundle);
+
+        // Invoke the 'afterHistory' interceptor methods.
+        getInterceptorMgr().fireAfterHistoryEvent(event);
+
+        return bundle;
     }
 
     @Override

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -67,8 +67,10 @@ import com.ibm.fhir.smart.Scope.Permission;
 
 public class AuthzPolicyEnforcementTest {
     private static final String PATIENT_ID =     "11111111-1111-1111-1111-111111111111";
-    private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111111";
-    private static final String CONDITION_ID =   "11111111-1111-1111-1111-111111111111";
+    private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111112";
+    private static final String CONDITION_ID =   "11111111-1111-1111-1111-111111111113";
+    private static final String PROVENANCE_1_ID =   "11111111-1111-1111-1111-111111111114";
+    private static final String PROVENANCE_2_ID =   "11111111-1111-1111-1111-111111111115";
 
     private static final List<Permission> READ_APPROVED = Arrays.asList(Permission.READ, Permission.ALL);
     private static final List<Permission> WRITE_APPROVED = Arrays.asList(Permission.WRITE, Permission.ALL);
@@ -100,6 +102,7 @@ public class AuthzPolicyEnforcementTest {
                 .build();
 
         patientProvenance = provenanceBase.toBuilder()
+                .id(PROVENANCE_1_ID)
                 .target(Reference.builder()
                     .reference(string("Patient/" + PATIENT_ID))
                     .build())
@@ -115,6 +118,7 @@ public class AuthzPolicyEnforcementTest {
                 .build();
 
         observationProvenance = provenanceBase.toBuilder()
+                .id(PROVENANCE_2_ID)
                 .target(Reference.builder()
                     .reference(string("Observation/" + OBSERVATION_ID))
                     .build())
@@ -123,8 +127,9 @@ public class AuthzPolicyEnforcementTest {
 
         condition = TestUtil.getMinimalResource(Condition.class);
         condition = condition.toBuilder()
+                .id(CONDITION_ID)
                 .subject(Reference.builder()
-                    .reference(string("Patient/" + CONDITION_ID + "/_history/1"))
+                    .reference(string("Patient/" + PATIENT_ID + "/_history/1"))
                     .build())
                 .meta(Meta.builder().lastUpdated(Instant.now()).versionId(Id.of("1")).build())
                 .build();

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/AuthzPolicyEnforcementTest.java
@@ -68,10 +68,10 @@ import com.ibm.fhir.smart.Scope.Permission;
 
 public class AuthzPolicyEnforcementTest {
     private static final String PATIENT_ID =     "11111111-1111-1111-1111-111111111111";
-    private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111112";
-    private static final String CONDITION_ID =   "11111111-1111-1111-1111-111111111113";
-    private static final String PATIENT_PROVENANCE_ID =   "11111111-1111-1111-1111-111111111114";
-    private static final String OBSERVATION_PROVENANCE_ID =   "11111111-1111-1111-1111-111111111115";
+    private static final String OBSERVATION_ID = "11111111-1111-1111-1111-111111111111";
+    private static final String CONDITION_ID =   "11111111-1111-1111-1111-111111111111";
+    private static final String PATIENT_PROVENANCE_ID =   "11111111-1111-1111-1111-111111111111";
+    private static final String OBSERVATION_PROVENANCE_ID =   "11111111-1111-1111-1111-111111111111";
 
     private static final List<Permission> READ_APPROVED = Arrays.asList(Permission.READ, Permission.ALL);
     private static final List<Permission> WRITE_APPROVED = Arrays.asList(Permission.WRITE, Permission.ALL);

--- a/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
+++ b/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
@@ -26,6 +26,7 @@ import com.ibm.fhir.persistence.ResourceEraseRecord;
 import com.ibm.fhir.persistence.ResourceEraseRecord.Status;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
+import com.ibm.fhir.persistence.context.FHIRSystemHistoryContext;
 import com.ibm.fhir.persistence.erase.EraseDTO;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
@@ -219,7 +220,7 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext)
+    public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext, FHIRSystemHistoryContext systemHistoryContext)
         throws FHIRPersistenceException {
         return null;
     }

--- a/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
+++ b/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
@@ -80,6 +80,7 @@ import com.ibm.fhir.operation.davinci.hrex.provider.strategy.MemberMatchStrategy
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
+import com.ibm.fhir.persistence.context.FHIRSystemHistoryContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.search.context.FHIRSearchContext;
@@ -1741,7 +1742,7 @@ public class MemberMatchTest {
         }
 
         @Override
-        public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext)
+        public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext, FHIRSystemHistoryContext systemHistoryContext)
             throws FHIRPersistenceException {
             throw new AssertionError("Unused");
         }


### PR DESCRIPTION
Issue #2300 - Add calls to beforeHistory and afterHistory

1. System-level history: Requires `user/*.read` or `system/*.read` authority

    Example: https://localhost:9443/fhir-server/api/v4/_history

1. System-level history (with `_type` parameter): Requires `user/<resource_type>.read` or `system/<resource_type>.read` authority to each resource type in the `_type` parameter.

    Example: https://localhost:9443/fhir-server/api/v4/_history?_type=Patient,Observation

1. Type-level history: Requires `user/<resource_type>.read` or `system/<resource_type>.read` authority to the resource type.

    Example: https://localhost:9443/fhir-server/api/v4/Patient/_history

Signed-off-by: Troy Biesterfeld <tbieste@us.ibm.com>