### PR TITLE
update demo env

### DIFF
--- a/demo/fhir/config/default/fhir-server-config.json
+++ b/demo/fhir/config/default/fhir-server-config.json
@@ -2,7 +2,7 @@
   "__comment": "config for internal fhir-server deployments",
   "fhirServer": {
     "core": {
-      "conditionalDeleteMaxNumber": 1,
+      "conditionalDeleteMaxNumber": 100,
       "defaultPrettyPrint": true,
       "serverRegistryResourceProviderEnabled": false,
       "ifNoneMatchReturnsNotModified": true
@@ -289,11 +289,6 @@
         "__comment": "Configuration properties common to all persistence layer implementations",
         "updateCreateEnabled": true
       },
-      "jdbc": {
-        "enableCodeSystemsCache": true,
-        "enableParameterNamesCache": true,
-        "enableResourceTypesCache": true
-      },
       "datasources": {
         "default": {
           "type": "postgresql",
@@ -326,6 +321,15 @@
           "type": "file",
           "fileBase": "/output/bulkdata/out"
         }
+      }
+    },
+    "operations": {
+      "erase": {
+        "enabled": true,
+        "allowedRoles": [
+            "FHIROperationAdmin",
+            "FHIRUsers"
+        ]
       }
     }
   }

--- a/demo/postgres/Dockerfile
+++ b/demo/postgres/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 
-FROM postgres:12.6-alpine
+FROM postgres:14.2-alpine
 
 # Hard Coded environment values
 ENV POSTGRES_DB fhirdb


### PR DESCRIPTION
1. updates to fhir-server-config to stay in line with our default config
2. updates to openapi.json to reflect the latest updates in main
3. update to postgresql 14.2

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>