### PR TITLE
Update BulkData 2.0.0: Update the OperationDefinitions and CapabilityStatement #3082 

### DIFF
--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
@@ -8,9 +8,7 @@ package com.ibm.fhir.bulkdata.jbatch.export.patient;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import javax.batch.api.partition.PartitionMapper;
@@ -25,20 +23,16 @@ import javax.inject.Inject;
 
 import com.ibm.fhir.bulkdata.export.system.resource.SystemExportResourceHandler;
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
-import com.ibm.fhir.model.resource.Resource;
-import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
 import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 import com.ibm.fhir.operation.bulkdata.model.type.OperationFields;
 import com.ibm.fhir.persistence.FHIRPersistence;
-import com.ibm.fhir.persistence.ResourceResult;
-import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
-import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.HistorySortOrder;
+import com.ibm.fhir.persistence.ResourceChangeLogRecord;
 import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
 import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
 import com.ibm.fhir.search.compartment.CompartmentHelper;
-import com.ibm.fhir.search.context.FHIRSearchContext;
 
 @Dependent
 public class PatientExportPartitionMapper implements PartitionMapper {
@@ -74,37 +68,27 @@ public class PatientExportPartitionMapper implements PartitionMapper {
         ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
         adapter.registerRequestContext(ctx.getTenantId(), ctx.getDatastoreId(), ctx.getIncomingUrl());
 
+        // Note we're already running inside a transaction (started by the JavaBatch framework)
+        // so this txn will just wrap it...the commit won't happen until the checkpoint
+        SystemExportResourceHandler handler = new SystemExportResourceHandler();
+        FHIRPersistenceHelper fhirPersistenceHelper = new FHIRPersistenceHelper(handler.getSearchHelper());
+        FHIRPersistence fhirPersistence = fhirPersistenceHelper.getFHIRPersistenceImplementation();
+        FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
+        txn.begin();
+
         // Check resourceType needs to be processed
         List<String> target = new ArrayList<>();
-        SystemExportResourceHandler handler = new SystemExportResourceHandler();
-        for (String resourceType : resourceTypes) {
-            FHIRPersistenceHelper fhirPersistenceHelper = new FHIRPersistenceHelper(handler.getSearchHelper());
-            FHIRPersistence fhirPersistence = fhirPersistenceHelper.getFHIRPersistenceImplementation();
-            Map<String, List<String>> queryParameters = new HashMap<>();
-            Class<? extends Resource> rt = ModelSupport.getResourceType(resourceType);
-            FHIRSearchContext searchContext = handler.getSearchHelper().parseQueryParameters(rt, queryParameters);
-            searchContext.setPageSize(1);
-            searchContext.setPageNumber(1);
-
-            // Note we're already running inside a transaction (started by the JavaBatch framework)
-            // so this txn will just wrap it...the commit won't happen until the checkpoint
-            FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
-            txn.begin();
-            try {
-                
-                // Execute the search query to obtain the page of resources
-                FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
-                @SuppressWarnings("unused")
-                List<ResourceResult<? extends Resource>> resourceResults = fhirPersistence.search(persistenceContext, rt).getResourceResults();
-                resourceResults = null;
+        try {
+            for (String resourceType : resourceTypes) {
+                List<ResourceChangeLogRecord> resourceResults = fhirPersistence.changes(1, null, null, null, Arrays.asList(resourceType), false, HistorySortOrder.NONE);
 
                 // Early Exit Logic
-                if (searchContext.getTotalCount() != 0) {
+                if (!resourceResults.isEmpty()) {
                     target.add(resourceType);
                 }
-            } finally {
-                txn.end();
             }
+        } finally {
+            txn.end();
         }
 
         PartitionPlanImpl pp = new PartitionPlanImpl();

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/patient/PatientExportPartitionMapper.java
@@ -6,8 +6,11 @@
 
 package com.ibm.fhir.bulkdata.jbatch.export.patient;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import javax.batch.api.partition.PartitionMapper;
@@ -20,12 +23,22 @@ import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.ibm.fhir.bulkdata.export.system.resource.SystemExportResourceHandler;
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
 import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 import com.ibm.fhir.operation.bulkdata.model.type.OperationFields;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.ResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
+import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
 import com.ibm.fhir.search.compartment.CompartmentHelper;
+import com.ibm.fhir.search.context.FHIRSearchContext;
 
 @Dependent
 public class PatientExportPartitionMapper implements PartitionMapper {
@@ -61,13 +74,46 @@ public class PatientExportPartitionMapper implements PartitionMapper {
         ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
         adapter.registerRequestContext(ctx.getTenantId(), ctx.getDatastoreId(), ctx.getIncomingUrl());
 
+        // Check resourceType needs to be processed
+        List<String> target = new ArrayList<>();
+        SystemExportResourceHandler handler = new SystemExportResourceHandler();
+        for (String resourceType : resourceTypes) {
+            FHIRPersistenceHelper fhirPersistenceHelper = new FHIRPersistenceHelper(handler.getSearchHelper());
+            FHIRPersistence fhirPersistence = fhirPersistenceHelper.getFHIRPersistenceImplementation();
+            Map<String, List<String>> queryParameters = new HashMap<>();
+            Class<? extends Resource> rt = ModelSupport.getResourceType(resourceType);
+            FHIRSearchContext searchContext = handler.getSearchHelper().parseQueryParameters(rt, queryParameters);
+            searchContext.setPageSize(1);
+            searchContext.setPageNumber(1);
+
+            // Note we're already running inside a transaction (started by the JavaBatch framework)
+            // so this txn will just wrap it...the commit won't happen until the checkpoint
+            FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
+            txn.begin();
+            try {
+                
+                // Execute the search query to obtain the page of resources
+                FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
+                @SuppressWarnings("unused")
+                List<ResourceResult<? extends Resource>> resourceResults = fhirPersistence.search(persistenceContext, rt).getResourceResults();
+                resourceResults = null;
+
+                // Early Exit Logic
+                if (searchContext.getTotalCount() != 0) {
+                    target.add(resourceType);
+                }
+            } finally {
+                txn.end();
+            }
+        }
+
         PartitionPlanImpl pp = new PartitionPlanImpl();
-        pp.setPartitions(resourceTypes.size());
-        pp.setThreads(Math.min(adapter.getCoreMaxPartitions(), resourceTypes.size()));
-        Properties[] partitionProps = new Properties[resourceTypes.size()];
+        pp.setPartitions(target.size());
+        pp.setThreads(Math.min(adapter.getCoreMaxPartitions(), target.size()));
+        Properties[] partitionProps = new Properties[target.size()];
 
         int propCount = 0;
-        for (String resourceType : resourceTypes) {
+        for (String resourceType : target) {
             Properties p = new Properties();
             p.setProperty(OperationFields.PARTITION_RESOURCETYPE, resourceType);
             partitionProps[propCount++] = p;

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/export/system/SystemExportPartitionMapper.java
@@ -6,8 +6,11 @@
 
 package com.ibm.fhir.bulkdata.jbatch.export.system;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import javax.batch.api.partition.PartitionMapper;
@@ -20,10 +23,21 @@ import javax.batch.runtime.context.StepContext;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import com.ibm.fhir.bulkdata.export.system.resource.SystemExportResourceHandler;
 import com.ibm.fhir.bulkdata.jbatch.context.BatchContextAdapter;
+import com.ibm.fhir.model.resource.Resource;
+import com.ibm.fhir.model.util.ModelSupport;
+import com.ibm.fhir.operation.bulkdata.config.ConfigurationAdapter;
 import com.ibm.fhir.operation.bulkdata.config.ConfigurationFactory;
 import com.ibm.fhir.operation.bulkdata.model.type.BulkDataContext;
 import com.ibm.fhir.operation.bulkdata.model.type.OperationFields;
+import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.ResourceResult;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
+import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
+import com.ibm.fhir.persistence.helper.FHIRPersistenceHelper;
+import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
+import com.ibm.fhir.search.context.FHIRSearchContext;
 
 /**
  * Generates the {@link PartitionPlan} describing how the system export work is
@@ -51,16 +65,53 @@ public class SystemExportPartitionMapper implements PartitionMapper {
 
         BulkDataContext ctx = ctxAdapter.getStepContextForExportPartitionMapper();
 
+        // Register the context to get the right configuration.
+        ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
+        adapter.registerRequestContext(ctx.getTenantId(), ctx.getDatastoreId(), ctx.getIncomingUrl());
+
         // We know these are real resource types.
         List<String> resourceTypes = Arrays.asList(ctx.getFhirResourceTypes().split("\\s*,\\s*"));
 
+        // Check resourceType needs to be processed
+        List<String> target = new ArrayList<>();
+        SystemExportResourceHandler handler = new SystemExportResourceHandler();
+        for (String resourceType : resourceTypes) {
+            FHIRPersistenceHelper fhirPersistenceHelper = new FHIRPersistenceHelper(handler.getSearchHelper());
+            FHIRPersistence fhirPersistence = fhirPersistenceHelper.getFHIRPersistenceImplementation();
+            Map<String, List<String>> queryParameters = new HashMap<>();
+            Class<? extends Resource> rt = ModelSupport.getResourceType(resourceType);
+            FHIRSearchContext searchContext = handler.getSearchHelper().parseQueryParameters(rt, queryParameters);
+            searchContext.setPageSize(1);
+            searchContext.setPageNumber(1);
+
+            // Note we're already running inside a transaction (started by the JavaBatch framework)
+            // so this txn will just wrap it...the commit won't happen until the checkpoint
+            FHIRTransactionHelper txn = new FHIRTransactionHelper(fhirPersistence.getTransaction());
+            txn.begin();
+            try {
+                
+                // Execute the search query to obtain the page of resources
+                FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(null, searchContext);
+                @SuppressWarnings("unused")
+                List<ResourceResult<? extends Resource>> resourceResults = fhirPersistence.search(persistenceContext, rt).getResourceResults();
+                resourceResults = null;
+
+                // Early Exit Logic
+                if (searchContext.getTotalCount() != 0) {
+                    target.add(resourceType);
+                }
+            } finally {
+                txn.end();
+            }
+        }
+
         PartitionPlanImpl pp = new PartitionPlanImpl();
-        pp.setPartitions(resourceTypes.size());
-        pp.setThreads(Math.min(ConfigurationFactory.getInstance().getCoreMaxPartitions(), resourceTypes.size()));
-        Properties[] partitionProps = new Properties[resourceTypes.size()];
+        pp.setPartitions(target.size());
+        pp.setThreads(Math.min(ConfigurationFactory.getInstance().getCoreMaxPartitions(), target.size()));
+        Properties[] partitionProps = new Properties[target.size()];
 
         int propCount = 0;
-        for (String resourceType : resourceTypes) {
+        for (String resourceType : target) {
             Properties p = new Properties();
             p.setProperty(OperationFields.PARTITION_RESOURCETYPE, resourceType);
             partitionProps[propCount++] = p;

--- a/fhir-server-webapp/src/main/liberty/config/config/default/fhir-server-config-db2.json
+++ b/fhir-server-webapp/src/main/liberty/config/config/default/fhir-server-config-db2.json
@@ -142,7 +142,7 @@
                 },
                 "pageSize": 100,
                 "batchIdEncryptionKey": "change-password",
-                "maxPartitions": 3, 
+                "maxPartitions": 5,
                 "maxInputs": 5
             },
             "storageProviders": {

--- a/fhir-server-webapp/src/main/liberty/config/config/default/fhir-server-config.json
+++ b/fhir-server-webapp/src/main/liberty/config/config/default/fhir-server-config.json
@@ -159,7 +159,7 @@
                 },
                 "pageSize": 100,
                 "batchIdEncryptionKey": "change-password",
-                "maxPartitions": 3, 
+                "maxPartitions": 5, 
                 "maxInputs": 5,
                 "maxChunkReadTime": "90000",
                 "systemExportImpl": "fast",


### PR DESCRIPTION
- Optimization to keep from establishing unnecessary Partitions. 
- Change the Defaults to match the actual fhir-server defaults.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>