### PR TITLE
issue #3091 - Add resources to their own compartment

### DIFF
--- a/docs/src/pages/guides/FHIRSearchConfiguration.md
+++ b/docs/src/pages/guides/FHIRSearchConfiguration.md
@@ -202,7 +202,7 @@ For each compartment type, the rules for determining if a resource is a member o
 
 For example, for the `Patient` compartment, to determine if an `Observation` is a member, the inclusion criteria search parameters are `subject` and `performer`. If the `Observation` resource fields associated with these search parameters reference a `Patient` resource, the `Observation` resource is a member of that `Patient` compartment.
 
-As of version 5.0.0, compartment membership is always evaluated during ingestion, even if the search parameters that define compartment membership have been filtered out in fhir-server-config.json.
+As of IBM FHIR Server 4.11.0, compartment membership is always evaluated during ingestion, even if the search parameters that define compartment membership have been filtered out in fhir-server-config.json.
 However, in cases where the inclusion criteria parameters have been overridden, it is still possible for server config to affect compartment membership.
 
 ##  2 Re-index

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractCompartmentTest.java
@@ -28,6 +28,7 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
+import com.ibm.fhir.search.exception.FHIRSearchException;
 
 /**
  * This class contains a collection of tests that will be run against
@@ -62,8 +63,8 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
     public void createResources() throws Exception {
         checkReferenceTypes = FHIRModelConfig.getCheckReferenceTypes();
         FHIRModelConfig.setCheckReferenceTypes(false);
-        Observation.Builder observationBuilder = ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
-        Observation.Builder observation2Builder = ((Observation) TestUtil.getMinimalResource(Observation.class)).toBuilder();
+        Observation.Builder observationBuilder = TestUtil.getMinimalResource(Observation.class).toBuilder();
+        Observation.Builder observation2Builder = TestUtil.getMinimalResource(Observation.class).toBuilder();
 
         Patient patient = TestUtil.getMinimalResource(Patient.class);
         savedPatient = FHIRPersistenceTestSupport.create(persistence, getDefaultPersistenceContext(), patient).getResource();
@@ -144,42 +145,93 @@ public abstract class AbstractCompartmentTest extends AbstractPersistenceTest {
     @Test
     public void testPatientCompartment() throws Exception {
         List<Resource> results = runCompartmentQueryTest("Patient", savedPatient.getId(),
-                                    Observation.class, "_id", savedObservation.getId());
+                Observation.class, "_id", savedObservation.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testPatientCompartmentViaLogicalId() throws Exception {
         List<Resource> results = runCompartmentQueryTest("Patient", savedPatient.getId(),
-                                    Observation.class, "_id", savedObservation2.getId());
+                Observation.class, "_id", savedObservation2.getId());
         assertEquals(0, results.size());
+    }
+
+    /**
+     * Per https://github.com/IBM/FHIR/issues/3091 a Patient resource should be in its own compartment
+     */
+    @Test
+    public void testPatientCompartmentIdentity() throws Exception {
+        List<Resource> results = runCompartmentQueryTest("Patient", savedPatient.getId(),
+                Patient.class, "_id", savedPatient.getId());
+        assertEquals(1, results.size());
     }
 
     @Test
     public void testDeviceCompartment() throws Exception {
         List<Resource> results = runCompartmentQueryTest("Device", savedDevice.getId(),
-                                    Observation.class, "_id", savedObservation.getId());
+                Observation.class, "_id", savedObservation.getId());
+        assertEquals(1, results.size());
+    }
+
+    /**
+     * Per https://github.com/IBM/FHIR/issues/3091 a Device resource should be in its own compartment.
+     * However, Device is the one compartment definition where this resource type isn't valid for its own compartment.
+     */
+    @Test(expectedExceptions = FHIRSearchException.class)
+    public void testDeviceCompartmentIdentity() throws Exception {
+        List<Resource> results = runCompartmentQueryTest("Device", savedDevice.getId(),
+                Device.class, "_id", savedDevice.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testEncounterCompartment() throws Exception {
         List<Resource> results = runCompartmentQueryTest("Encounter", savedEncounter.getId(),
-                                    Observation.class, "_id", savedObservation.getId());
+                Observation.class, "_id", savedObservation.getId());
+        assertEquals(1, results.size());
+    }
+
+    /**
+     * Per https://github.com/IBM/FHIR/issues/3091 an Encounter resource should be in its own compartment
+     */
+    @Test
+    public void testEncounterCompartmentIdentity() throws Exception {
+        List<Resource> results = runCompartmentQueryTest("Encounter", savedEncounter.getId(),
+                Encounter.class, "_id", savedEncounter.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testPractitionerCompartment() throws Exception {
         List<Resource> results = runCompartmentQueryTest("Practitioner", savedPractitioner.getId(),
-                                    Observation.class, "_id", savedObservation.getId());
+                Observation.class, "_id", savedObservation.getId());
+        assertEquals(1, results.size());
+    }
+
+    /**
+     * Per https://github.com/IBM/FHIR/issues/3091 a Practitioner resource should be in its own compartment
+     */
+    @Test
+    public void testPractitionerCompartmentIdentity() throws Exception {
+        List<Resource> results = runCompartmentQueryTest("Practitioner", savedPractitioner.getId(),
+                Practitioner.class, "_id", savedPractitioner.getId());
         assertEquals(1, results.size());
     }
 
     @Test
     public void testRelatedPersonCompartment() throws Exception {
         List<Resource> results = runCompartmentQueryTest("RelatedPerson", savedRelatedPerson.getId(),
-                                    Observation.class, "_id", savedObservation.getId());
+                Observation.class, "_id", savedObservation.getId());
+        assertEquals(1, results.size());
+    }
+
+    /**
+     * Per https://github.com/IBM/FHIR/issues/3091 a Practitioner resource should be in its own compartment
+     */
+    @Test
+    public void testRelatedPersonCompartmentIdentity() throws Exception {
+        List<Resource> results = runCompartmentQueryTest("RelatedPerson", savedRelatedPerson.getId(),
+                RelatedPerson.class, "_id", savedRelatedPerson.getId());
         assertEquals(1, results.size());
     }
 }

--- a/fhir-search/src/main/java/com/ibm/fhir/search/compartment/CompartmentHelper.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/compartment/CompartmentHelper.java
@@ -155,13 +155,21 @@ public class CompartmentHelper {
     }
 
     /**
+     * @param compartment
+     * @return whether the passed string matches the name of a configured CompartmentDefinition
+     */
+    public boolean isCompartmentType(final String compartment) {
+        return compartmentMap.containsKey(compartment);
+    }
+
+    /**
      * checks that the compartment is valid and throws an exception if not
      *
      * @param compartment
      * @throws FHIRSearchException
      */
     public void checkValidCompartment(final String compartment) throws FHIRSearchException {
-        if (!compartmentMap.containsKey(compartment)) {
+        if (!isCompartmentType(compartment)) {
             String msg = String.format(INVALID_COMPARTMENT, compartment);
             throw SearchExceptionUtil.buildNewInvalidSearchException(msg);
         }
@@ -192,7 +200,8 @@ public class CompartmentHelper {
      *   ...
      * </pre>
      * @param resourceType the resource type name
-     * @return a map of parameter name to set of compartment names
+     * @return a map from parameter name to the set of compartment names
+     *      for which that parameter is an inclusion criteria
      */
     public Map<String, Set<java.lang.String>> getCompartmentParamsForResourceType(java.lang.String resourceType) {
         ResourceCompartmentCache rcc = resourceCompartmentMap.get(resourceType);

--- a/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchHelper.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/util/SearchHelper.java
@@ -2252,7 +2252,8 @@ public class SearchHelper {
      * @throws FHIRSearchException
      */
     @SuppressWarnings("unused")
-    public static void checkInclusionIterateParameters(String resourceType, FHIRSearchContext context, boolean lenient) throws FHIRSearchException {
+    public static void checkInclusionIterateParameters(String resourceType, FHIRSearchContext context, boolean lenient)
+            throws FHIRSearchException {
         // Get the valid target types. If max number of iterations allowed is just 1, then that includes
         // base resource type and types in non-iterative _include and _revinclude parameters. If max number
         // of iterations allowed is more than 1, then that also includes types in iterative _include and
@@ -2323,6 +2324,14 @@ public class SearchHelper {
         // Remove invalid inclusion parameters
         context.getIncludeParameters().removeAll(invalidIncludeParameters);
         context.getRevIncludeParameters().removeAll(invalidRevIncludeParameters);
+    }
+
+    /**
+     * @param resourceType
+     * @return whether the passed resourceType has its own CompartmentDefinition
+     */
+    public boolean isCompartmentType(String resourceType) {
+        return compartmentHelper.isCompartmentType(resourceType);
     }
 
     /**

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTenant1Test.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTenant1Test.java
@@ -131,10 +131,11 @@ public class EverythingOperationTenant1Test extends FHIRServerTestBase {
         // but keep the original so we can delete all created resources
         Map<String, List<String>> resourcesMap = SerializationUtils.clone((HashMap<String, List<String>>) createdResources);
 
-        // Ensure that the 5 resources are accounted for in the returning search set bundle
+        // Ensure that the 6 resources are accounted for in the returning search set bundle
+        // (the Patient resource and the 5 that reference it)
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle everythingBundle = response.readEntity(Bundle.class);
-        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 5);
+        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 6);
         for (Entry entry : everythingBundle.getEntry()) {
             String fullURL = entry.getFullUrl().getValue();
             String[] locationElements = fullURL.replaceAll(getWebTarget().getUri().toString(), "").split("/");
@@ -186,7 +187,7 @@ public class EverythingOperationTenant1Test extends FHIRServerTestBase {
         Bundle everythingBundle = response.readEntity(Bundle.class);
 
         // Count is ignored
-        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 5);
+        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 6);
     }
 
     @Test(groups = { "fhir-operation" })

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EverythingOperationTest.java
@@ -86,11 +86,9 @@ public class EverythingOperationTest extends FHIRServerTestBase {
     }
 
     /**
-     * Create a Bundle of 895 resources of various kinds representing a patient's history and save the
-     * resource types and IDs of the created resources to eventually ensure that all resources are included
-     * in an $everything invocation.
-     *
-     * @throws Exception
+     * Create a Bundle of 901 resources of various kinds (with 895 targeting the Patient) representing a
+     * patient's history and save the resource types and IDs of the created resources to eventually ensure
+     * that all resources are included in an $everything invocation.
      */
     @Test(groups = { "fhir-operation" })
     public void testCreatePatientWithEverything() throws Exception {
@@ -130,10 +128,11 @@ public class EverythingOperationTest extends FHIRServerTestBase {
         // but keep the original so we can delete all created resources
         Map<String, List<String>> resourcesMap = SerializationUtils.clone((HashMap<String, List<String>>) createdResources);
 
-        // Ensure that the 895 resources are accounted for in the returning search set bundle
+        // Ensure that the 896 resources are accounted for in the returning search set bundle
+        // (the Patient resource and the 895 that reference it)
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle everythingBundle = response.readEntity(Bundle.class);
-        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 895);
+        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 896);
         for (Entry entry : everythingBundle.getEntry()) {
             String fullURL = entry.getFullUrl().getValue();
             String[] locationElements = fullURL.replaceAll(getWebTarget().getUri().toString(), "").split("/");
@@ -185,7 +184,7 @@ public class EverythingOperationTest extends FHIRServerTestBase {
         Bundle everythingBundle = response.readEntity(Bundle.class);
 
         // Count is ignored
-        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 895);
+        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 896);
     }
 
     @Test(groups = { "fhir-operation" })
@@ -210,7 +209,7 @@ public class EverythingOperationTest extends FHIRServerTestBase {
         Bundle everythingBundle = response.readEntity(Bundle.class);
 
         // The number of companies was reduced as the scope was narrowed down to a decade
-        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 371);
+        assertResponseBundle(everythingBundle, BundleType.SEARCHSET, 372);
     }
 
     @Test(groups = { "fhir-operation" }, dependsOnMethods = { "testPatientEverything" })


### PR DESCRIPTION
This works for Patient, Encounter, Practitioner, and RelatedPerson compartments.
For Device, we still extract the membership parameter, but `GET
Device/{id}/Device` is considered an invalid search.

This addresses the issue outlined in #3091 because the `fhir-smart`
module is turning our searches into Patient compartment searches under the
covers. Now the Patient resource that corresponds to the in-context
patient will be returned from that.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>