### PR TITLE
Issue #3446 reference version missing from parameter hash

### DIFF
--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfigHelper.java
@@ -83,9 +83,10 @@ public class FHIRConfigHelper {
         // let's try to find it in the default config.
         if (result == null && !FHIRConfiguration.DEFAULT_TENANT_ID.equals(tenantId)) {
             try {
-                if (propertyName.startsWith(FHIRConfiguration.PROPERTY_DATASOURCES)) {
-                    // Issue #639. Prevent datasource lookups from falling back to 
-                    // the default datasource which breaks tenant isolation.
+                if (propertyName.startsWith(FHIRConfiguration.PROPERTY_DATASOURCES)
+                        || propertyName.startsWith(FHIRConfiguration.PROPERTY_PERSISTENCE_PAYLOAD)) {
+                    // Issue #639 and #3416. Prevent datasource/payload lookups from falling back to 
+                    // the default configuration which breaks tenant isolation.
                     result = null;
                 } else {
                     // Non-datasource property, which we allow to fall back to default

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2021
+ * (C) Copyright IBM Corp. 2017, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
+++ b/fhir-config/src/test/java/com/ibm/fhir/config/test/FHIRConfigHelperTest.java
@@ -388,4 +388,34 @@ public class FHIRConfigHelperTest {
         PropertyGroup dsPG = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
         assertNull(dsPG);
     }
+
+    /**
+     * Look up the payload persistence configuration for default/default
+     * and check that the payload type field is found
+     * @throws Exception
+     */
+    @Test
+    public void testPayloadLookup() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext("default"));
+        final String datastoreId = "default";
+        String dsPropertyName = FHIRConfiguration.PROPERTY_PERSISTENCE_PAYLOAD + "/" + datastoreId;
+        PropertyGroup dsPG = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
+        assertNotNull(dsPG);
+        String type = dsPG.getStringProperty("type");
+        assertEquals(type, "azure.blob");
+    }
+
+    /**
+     * Check that we do not fall back to the default tenant config when
+     * reading payload persistence configuration.
+     * @throws Exception
+     */
+    @Test
+    public void testPayloadNoFallback() throws Exception {
+        FHIRRequestContext.set(new FHIRRequestContext("tenant1"));
+        final String datastoreId = "default";
+        String dsPropertyName = FHIRConfiguration.PROPERTY_DATASOURCES + "/" + datastoreId;
+        PropertyGroup dsPG = FHIRConfigHelper.getPropertyGroup(dsPropertyName);
+        assertNull(dsPG);
+    }
 }

--- a/fhir-config/src/test/resources/config/default/fhir-server-config.json
+++ b/fhir-config/src/test/resources/config/default/fhir-server-config.json
@@ -23,10 +23,15 @@
         }
     },
     "fhirServer": {
-	    "persistence": {
+        "persistence": {
             "datasources": {
                 "default": {
                     "type": "db2"
+                }
+            },
+            "payload": {
+                "default": {
+                    "type": "azure.blob"
                 }
             }
         }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1460,14 +1460,16 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             }
 
             // Check to make sure we got a Resource if we asked for it and expect there to be one
-            for (ResourceResult<? extends Resource> resourceResult: resourceResults) {
-                if (resourceResult.getResource() == null && includeResourceData && !resourceResult.isDeleted()) {
-                    String resourceTypeName = resourceResult.getResourceTypeName();
-                    if (resourceTypeName == null) {
-                        resourceTypeName = resourceType.getSimpleName();
+            if (includeResourceData) {
+                for (ResourceResult<? extends Resource> resourceResult: resourceResults) {
+                    if (resourceResult.getResource() == null && !resourceResult.isDeleted()) {
+                        String resourceTypeName = resourceResult.getResourceTypeName();
+                        if (resourceTypeName == null) {
+                            resourceTypeName = resourceType.getSimpleName();
+                        }
+                        throw new FHIRPersistenceException("convertResourceDTO returned no resource for '"
+                                + resourceTypeName + "/" + resourceResult.getLogicalId() + "'");
                     }
-                    throw new FHIRPersistenceException("convertResourceDTO returned no resource for '"
-                            + resourceTypeName + "/" + resourceResult.getLogicalId() + "'");
                 }
             }
 
@@ -2269,6 +2271,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         log.entering(CLASSNAME, METHODNAME);
         Objects.requireNonNull(resourceDTO, "resourceDTO must be not null");
         T resource;
+        boolean treatErasedAsDeleted = false;
 
         if (includeData) {
             // original impl - the resource, if any, was read from the RDBMS
@@ -2288,11 +2291,14 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                     }
                 }
             } else {
-                // Queries may return a NULL for the DATA column if the resource has been erased
-                // or the query was asked not to fetch DATA in the first place
+                // Queries may return a NULL for the DATA column if the resource has been erased.
                 resource = null;
+                treatErasedAsDeleted = true;
             }
         } else {
+            // Because we never selected the data column, we don't know if this resource
+            // version has been erased or not. The only thing we can do is return a null
+            // resource.
             resource = null;
         }
 
@@ -2312,6 +2318,14 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
         builder.resource(resource); // can be null
         builder.version(resourceDTO.getVersionId());
         builder.lastUpdated(resourceDTO.getLastUpdated().toInstant());
+
+        // If we encounter a resource version that was erased, its data column will be
+        // null so we can't parse a resource value. We need to treat it as a deleted
+        // resource because otherwise the REST layer will expect the resource value to
+        // be present
+        if (treatErasedAsDeleted && !resourceDTO.isDeleted()) {
+            builder.deleted(true);
+        }
 
         log.exiting(CLASSNAME, METHODNAME);
         return builder.build();

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -744,8 +744,10 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                             newSearchForIncludeResources(searchContext, resourceType, queryBuilder, resourceDao, resourceDTOList);
                     List<ResourceResult<? extends Resource>> includeResult = this.convertResourceDTOList(resourceDao, includeDTOList, resourceType, null, searchContext.isIncludeResourceData());
                     // erased version referenced via a versioned reference will be missing the resource
-                    // data field, so we need to filter those out here
-                    includeResult = includeResult.stream().filter(rr -> rr.getResource() != null).collect(Collectors.toList());
+                    // data field, so we need to filter those out here if resource data is being requested
+                    if (searchContext.isIncludeResourceData()) {
+                        includeResult = includeResult.stream().filter(rr -> rr.getResource() != null).collect(Collectors.toList());
+                    }
                     resourceResults.addAll(includeResult);
                 }
             }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -743,6 +743,9 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                     List<com.ibm.fhir.persistence.jdbc.dto.Resource> includeDTOList =
                             newSearchForIncludeResources(searchContext, resourceType, queryBuilder, resourceDao, resourceDTOList);
                     List<ResourceResult<? extends Resource>> includeResult = this.convertResourceDTOList(resourceDao, includeDTOList, resourceType, null, searchContext.isIncludeResourceData());
+                    // erased version referenced via a versioned reference will be missing the resource
+                    // data field, so we need to filter those out here
+                    includeResult = includeResult.stream().filter(rr -> rr.getResource() != null).collect(Collectors.toList());
                     resourceResults.addAll(includeResult);
                 }
             }

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
@@ -98,7 +98,6 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         updateDigestWithParmValKey(param);
         updateDigestWithString(param.getValueSystem());
         updateDigestWithString(param.getValueCode());
-        updateDigestWithString(param.getVersion());
     }
 
     @Override
@@ -173,6 +172,7 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         if (value != null) {
             ByteBuffer bb = ByteBuffer.allocate(Double.SIZE);
             bb.putDouble(value.doubleValue());
+            bb.flip();
             digest.update(bb);
         }
         digest.update(DELIMITER);
@@ -186,6 +186,7 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         if (value != null) {
             ByteBuffer bb = ByteBuffer.allocate(Integer.SIZE);
             bb.putInt(value.intValue());
+            bb.flip();
             digest.update(bb);
         }
         digest.update(DELIMITER);
@@ -199,6 +200,7 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         if (value != null) {
             ByteBuffer bb = ByteBuffer.allocate(Double.SIZE);
             bb.putDouble(value.doubleValue());
+            bb.flip();
             digest.update(bb);
         }
         digest.update(DELIMITER);
@@ -212,6 +214,7 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         if (value != null) {
             ByteBuffer bb = ByteBuffer.allocate(Long.SIZE);
             bb.putLong(value.getTime());
+            bb.flip();
             digest.update(bb);
         }
         digest.update(DELIMITER);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/util/ParameterHashVisitor.java
@@ -98,6 +98,7 @@ public class ParameterHashVisitor implements ExtractedParameterValueVisitor {
         updateDigestWithParmValKey(param);
         updateDigestWithString(param.getValueSystem());
         updateDigestWithString(param.getValueCode());
+        updateDigestWithString(param.getVersion());
     }
 
     @Override

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
@@ -69,6 +69,26 @@ public class ParameterHashTest {
     }
 
     @Test
+    public void testTokenParams() throws Exception {
+        TokenParmVal p1 = new TokenParmVal();
+        p1.setResourceType("Patient");
+        p1.setName("code2");
+        p1.setUrl("url2");
+        p1.setVersion("1");
+        p1.setValueSystem("valueSystem2");
+        p1.setValueCode("valueCode2");
+
+        ParameterHashVisitor visitor1 = new ParameterHashVisitor();
+        p1.accept(visitor1);
+
+        // Make sure that the hash changes when changing the version
+        p1.setVersion("2");
+        ParameterHashVisitor visitor2 = new ParameterHashVisitor();
+        p1.accept(visitor2);
+        assertNotEquals(visitor1.getBase64Hash(), visitor2.getBase64Hash());
+    }
+
+    @Test
     public void testNullValues() throws Exception {
         // Create two number param values, one with null low, and one with null high
         BigDecimal value = new BigDecimal(5);

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
+++ b/fhir-persistence-jdbc/src/test/java/com/ibm/fhir/persistence/jdbc/test/util/ParameterHashTest.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import com.ibm.fhir.persistence.jdbc.dto.TokenParmVal;
 import com.ibm.fhir.persistence.jdbc.util.ParameterHashVisitor;
 import com.ibm.fhir.persistence.jdbc.util.type.NewNumberParmBehaviorUtil;
 import com.ibm.fhir.search.date.DateTimeHandler;
+import com.ibm.fhir.search.util.ReferenceUtil;
 import com.ibm.fhir.search.util.ReferenceValue;
 import com.ibm.fhir.search.util.ReferenceValue.ReferenceType;
 
@@ -69,23 +71,93 @@ public class ParameterHashTest {
     }
 
     @Test
-    public void testTokenParams() throws Exception {
-        TokenParmVal p1 = new TokenParmVal();
-        p1.setResourceType("Patient");
-        p1.setName("code2");
-        p1.setUrl("url2");
-        p1.setVersion("1");
-        p1.setValueSystem("valueSystem2");
-        p1.setValueCode("valueCode2");
+    public void testReferenceParams() throws Exception {
+        ReferenceValue rv1 = ReferenceUtil.createReferenceValueFrom("Patient/patient1/_history/1", "Patient", ReferenceUtil.getBaseUrl(null));
+        ReferenceParmVal p1 = new ReferenceParmVal();
+        p1.setName("subject");
+        p1.setRefValue(rv1);
 
         ParameterHashVisitor visitor1 = new ParameterHashVisitor();
         p1.accept(visitor1);
 
-        // Make sure that the hash changes when changing the version
-        p1.setVersion("2");
+        // Make sure that the hash changes when changing the reference version
+        ReferenceValue rv2 = ReferenceUtil.createReferenceValueFrom("Patient/patient1/_history/2", "Patient", ReferenceUtil.getBaseUrl(null));
+        p1.setRefValue(rv2);
+        
         ParameterHashVisitor visitor2 = new ParameterHashVisitor();
         p1.accept(visitor2);
         assertNotEquals(visitor1.getBase64Hash(), visitor2.getBase64Hash());
+    }
+
+    @Test
+    public void testDateParams() throws Exception {
+        DateParmVal p1 = new DateParmVal();
+        p1.setName("date");
+        p1.setValueDateStart(Timestamp.from(Instant.now()));
+        p1.setValueDateEnd(Timestamp.from(Instant.now()));
+        ParameterHashVisitor visitor1 = new ParameterHashVisitor();
+        p1.accept(visitor1);
+
+        // Modify the parameter with a different start date and check the hash changes
+        p1.setValueDateStart(Timestamp.from(Instant.now().plusMillis(1000)));
+        ParameterHashVisitor visitor2 = new ParameterHashVisitor();
+        p1.accept(visitor2);
+        assertNotEquals(visitor1.getBase64Hash(), visitor2.getBase64Hash());
+
+        // Now check it changes again when we change the date end value
+        p1.setValueDateEnd(Timestamp.from(Instant.now().plusMillis(1000)));
+        ParameterHashVisitor visitor3 = new ParameterHashVisitor();
+        p1.accept(visitor3);
+        assertNotEquals(visitor2.getBase64Hash(), visitor3.getBase64Hash());
+    }
+
+    @Test
+    public void testLocationParams() throws Exception {
+        LocationParmVal p1 = new LocationParmVal();
+        p1.setValueLatitude(0.1);
+        p1.setValueLongitude(1.1);
+        ParameterHashVisitor visitor1 = new ParameterHashVisitor();
+        p1.accept(visitor1);
+
+        // Modify latitude and check the signature changes
+        p1.setValueLatitude(0.2);
+        ParameterHashVisitor visitor2 = new ParameterHashVisitor();
+        p1.accept(visitor2);
+        assertNotEquals(visitor1.getBase64Hash(), visitor2.getBase64Hash());
+
+        // Modify longitude and check the signature changes
+        p1.setValueLongitude(1.2);
+        ParameterHashVisitor visitor3 = new ParameterHashVisitor();
+        p1.accept(visitor3);
+        assertNotEquals(visitor2.getBase64Hash(), visitor3.getBase64Hash());
+    }
+
+    @Test
+    public void testNumberParams() throws Exception {
+        NumberParmVal p1 = new NumberParmVal();
+        p1.setValueNumber(BigDecimal.valueOf(10));
+        p1.setValueNumberLow(BigDecimal.valueOf(5));
+        p1.setValueNumberHigh(BigDecimal.valueOf(100));
+        ParameterHashVisitor visitor1 = new ParameterHashVisitor();
+        p1.accept(visitor1);
+
+        // Modify number and check the signature changes
+        p1.setValueNumber(BigDecimal.valueOf(11));
+        ParameterHashVisitor visitor2 = new ParameterHashVisitor();
+        p1.accept(visitor2);
+        assertNotEquals(visitor1.getBase64Hash(), visitor2.getBase64Hash());
+
+        // Modify number low and check the signature changes
+        p1.setValueNumberLow(BigDecimal.valueOf(6));
+        ParameterHashVisitor visitor3 = new ParameterHashVisitor();
+        p1.accept(visitor3);
+        assertNotEquals(visitor2.getBase64Hash(), visitor3.getBase64Hash());
+
+        // Modify number high and check the signature changes
+        p1.setValueNumberHigh(BigDecimal.valueOf(101));
+        ParameterHashVisitor visitor4 = new ParameterHashVisitor();
+        p1.accept(visitor4);
+        assertNotEquals(visitor3.getBase64Hash(), visitor4.getBase64Hash());
     }
 
     @Test

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
@@ -40,13 +40,16 @@ import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
 import com.ibm.fhir.model.parser.exception.FHIRParserException;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Bundle.Entry.Request;
+import com.ibm.fhir.model.resource.Condition;
 import com.ibm.fhir.model.resource.OperationOutcome;
 import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Patient;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Extension;
+import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.HTTPVerb;
@@ -692,6 +695,127 @@ public class EraseOperationTest extends FHIRServerTestBase {
         checkResourceExists("Patient", id);
         checkResourceHistoryDoesNotExist("Patient", id, 1);
         checkResourceHistoryExists("Patient", id, 2, Status.OK);
+    }
+
+    /**
+     * Create a resource with multiple versions. Erase one of the versions, then
+     * request history and check that the erased resource is identified as
+     * deleted in the returned history bundle.
+     * @throws IOException
+     * @throws FHIRParserException
+     */
+    @Test
+    public void testHistoryAfterVersionErase() throws IOException, FHIRParserException {
+        WebTarget target = getWebTarget();
+        String id = null;
+        Patient r = null;
+        try (Reader example = ExamplesUtil.resourceReader(("json/ibm/fhir-operation-erase/Patient-1.json"))) {
+            r = FHIRParser.parser(Format.JSON).parse(example);
+            Entity<Resource> entity = Entity.entity(r, FHIRMediaType.APPLICATION_FHIR_JSON);
+            Response response = target.path("Patient").request().post(entity, Response.class);
+            assertResponse(response, Response.Status.CREATED.getStatusCode());
+            id = getLocationLogicalId(response);
+            response = target.path("Patient/" + id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            // Version 2 (Update)
+            r = response.readEntity(Patient.class);
+            entity = Entity.entity(r, FHIRMediaType.APPLICATION_FHIR_JSON);
+            response = target.path("Patient/" + id).request().put(entity, Response.class);
+        }
+
+        eraseResourceByVersion("Patient", id, 1, false, "message", true, true, "message");
+        checkResourceExists("Patient", id);
+        checkResourceHistoryDoesNotExist("Patient", id, 1);
+        checkResourceHistoryExists("Patient", id, 2, Status.OK);
+
+        target = target.path("/Patient/" + id + "/_history");
+        Response historyResponse = target.request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .header("X-FHIR-TENANT-ID", "default")
+                .header("X-FHIR-DSID", "default")
+                .get(Response.class);
+        assertEquals(historyResponse.getStatus(), 200);
+        Bundle historyBundle = historyResponse.readEntity(Bundle.class);
+        List<Entry> entries = historyBundle.getEntry();
+        assertEquals(entries.size(), 2);
+        assertEquals(entries.get(0).getResponse().getStatus().getValue(), "200");   // V2
+        assertEquals(entries.get(0).getRequest().getMethod().getValue(), "PUT");    // V2
+        assertEquals(entries.get(1).getResponse().getStatus().getValue(), "200");   // V1
+        assertEquals(entries.get(1).getRequest().getMethod().getValue(), "DELETE"); // V1
+    }
+
+    /**
+     * Create a resource with multiple versions. Erase one of the versions, then
+     * request history and check that the erased resource is identified as
+     * deleted in the returned history bundle.
+     * @throws IOException
+     * @throws FHIRParserException
+     */
+    @Test
+    public void testSearchAfterVersionErase() throws IOException, FHIRParserException {
+        final WebTarget target = getWebTarget();
+        String id = null;
+        String conditionId = null;
+        Patient r = null;
+        try (Reader example = ExamplesUtil.resourceReader(("json/ibm/fhir-operation-erase/Patient-1.json"))) {
+            r = FHIRParser.parser(Format.JSON).parse(example);
+            Entity<Resource> entity = Entity.entity(r, FHIRMediaType.APPLICATION_FHIR_JSON);
+            Response response = target.path("Patient").request().post(entity, Response.class);
+            assertResponse(response, Response.Status.CREATED.getStatusCode());
+            id = getLocationLogicalId(response);
+            response = target.path("Patient/" + id).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+
+            // Version 2 (Update)
+            r = response.readEntity(Patient.class);
+            entity = Entity.entity(r, FHIRMediaType.APPLICATION_FHIR_JSON);
+            response = target.path("Patient/" + id).request().put(entity, Response.class);
+        }
+
+        // Create a Condition whose subject points to version 1 of the resource we just created
+        try (Reader example = ExamplesUtil.resourceReader(("json/ibm/minimal/Condition-1.json"))) {
+            Condition condition = FHIRParser.parser(Format.JSON).parse(example);
+            // inject a subject reference into the Condition we just read
+            condition = condition.toBuilder().subject(Reference.builder().reference("Patient/" + id + "/_history/1").build()).build();
+            Entity<Resource> entity = Entity.entity(condition, FHIRMediaType.APPLICATION_FHIR_JSON);
+            Response response = target.path("Condition").request().post(entity, Response.class);
+            assertResponse(response, Response.Status.CREATED.getStatusCode());
+            conditionId = getLocationLogicalId(response);
+            response = target.path("Condition/" + conditionId).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
+            assertResponse(response, Response.Status.OK.getStatusCode());
+        }
+        
+        // Perform a search showing that we can include Patient version 1 before we erase it
+        WebTarget searchTarget = target.path("Condition").queryParam("_id", conditionId).queryParam("_include", "Condition:subject");
+        Response searchResponse = searchTarget.request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .header("X-FHIR-TENANT-ID", "default")
+                .header("X-FHIR-DSID", "default")
+                .get(Response.class);
+        assertEquals(searchResponse.getStatus(), 200);
+        Bundle searchBundle = searchResponse.readEntity(Bundle.class);
+        List<Entry> entries = searchBundle.getEntry();
+        assertEquals(entries.size(), 2);
+        assertEquals(entries.get(0).getResource().getId(), conditionId); // the condition
+        assertEquals(entries.get(1).getResource().getId(), id); // the included patient
+
+        // Perform the erase of version 1 of the patient
+        eraseResourceByVersion("Patient", id, 1, false, "message", true, true, "message");
+        checkResourceExists("Patient", id);
+        checkResourceHistoryDoesNotExist("Patient", id, 1);
+        checkResourceHistoryExists("Patient", id, 2, Status.OK);
+
+        // Repeat the same search now after the erase operation. The patient
+        // should no longer be included
+        searchResponse = searchTarget.request(FHIRMediaType.APPLICATION_FHIR_JSON)
+                .header("X-FHIR-TENANT-ID", "default")
+                .header("X-FHIR-DSID", "default")
+                .get(Response.class);
+        assertEquals(searchResponse.getStatus(), 200);
+        searchBundle = searchResponse.readEntity(Bundle.class);
+        System.out.println(searchBundle);
+        entries = searchBundle.getEntry();
+        assertEquals(entries.size(), 1);
+        assertEquals(entries.get(0).getResource().getId(), conditionId); // the condition
     }
 
     /**

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/operation/EraseOperationTest.java
@@ -812,7 +812,6 @@ public class EraseOperationTest extends FHIRServerTestBase {
                 .get(Response.class);
         assertEquals(searchResponse.getStatus(), 200);
         searchBundle = searchResponse.readEntity(Bundle.class);
-        System.out.println(searchBundle);
         entries = searchBundle.getEntry();
         assertEquals(entries.size(), 1);
         assertEquals(entries.get(0).getResource().getId(), conditionId); // the condition


### PR DESCRIPTION
Includes fixes for the following issues:
* #3446 fixes computation of parameter hash for fields using ByteBuffer
* #3416 prevent payload configuration falling back to default tenant
* #3439 handle null data after version-specific erase
