### PR TITLE
issue #3319 - normalize handling of _type parameters

### DIFF
--- a/docs/src/pages/Conformance.md
+++ b/docs/src/pages/Conformance.md
@@ -145,7 +145,7 @@ To return all changes that have occurred before a known point in time, use `_bef
     curl -k -u '<username>:<password>' 'https://<host>:<port>/fhir-server/api/v4/_history?_before=2021-02-21T00:00:00Z&_sort=-_lastUpdated'
 ```
 
-To return changes within a known window of time, specify both the `_since` and `_before` query parameters and choose either ascending or descending sort. 
+To return changes within a known window of time, specify both the `_since` and `_before` query parameters and choose either ascending or descending sort.
 
 When sorting with ascending time, the `_since` parameter in the `next` link is calculated to fetch the next page of resources and the `_before` parameter (if given) remains constant. When sorting with descending time, the `_before` parameter in the `next` link is calculated to fetch the next page of resources and the `_since` parameter (if given) remains constant.
 
@@ -201,7 +201,7 @@ The IBM FHIR Server requires clocks in a cluster to be synchronized and expects 
 ### Whole System History - The Transaction Timeout Window
 Clients must exercise caution when reading recently ingested resources. When processing large bundles in parallel, an id may be assigned by the database but ACID isolation means that the record will not be visible to a reader until the transaction is committed. This could be up to 120s or longer if a larger transaction-timeout property has been defined. If a smaller bundle starts after the larger bundle and its transaction is committed first, its change ids and timestamps will be visible to readers before the resources from the other bundle, which will have some earlier change ids and timestamps. If clients do not take this into account, they may miss some resources. This behavior is a common concern in databases and not specific to the IBM FHIR Server.
 
-To guarantee no data is skipped, clients should not process resources with a `_lastUpdated` timestamp which is after `{current_time} - {transaction_timeout} - {max_cluster_clock_drift}`. By waiting for this time window to close, the client can be sure the data being returned is complete and in order, and can safely checkpoint using the `_since`, `_before` or `_changeIdMarker` values depending on the chosen sort option. The default value for transaction timeout is 120s but this is configurable. A value of 2 seconds is a reasonable default to consider for `max_cluster_clock_drift` in lieu of specific information about the infrastructure. Implementers should check with server administrators on the appropriate values to use. 
+To guarantee no data is skipped, clients should not process resources with a `_lastUpdated` timestamp which is after `{current_time} - {transaction_timeout} - {max_cluster_clock_drift}`. By waiting for this time window to close, the client can be sure the data being returned is complete and in order, and can safely checkpoint using the `_since`, `_before` or `_changeIdMarker` values depending on the chosen sort option. The default value for transaction timeout is 120s but this is configurable. A value of 2 seconds is a reasonable default to consider for `max_cluster_clock_drift` in lieu of specific information about the infrastructure. Implementers should check with server administrators on the appropriate values to use.
 
 To simplify the handling of this scenario, clients may specify the optional query parameter `_excludeTransactionTimeoutWindow=true` to perform this filtering within the server. This relies on the IBM FHIR Server transaction timeout having been configured using the `FHIR_TRANSACTION_MANAGER_TIMEOUT` environment variable. If this environment variable is not configured, a default transaction timeout of 120s is assumed, although this may not be the actual timeout if the server is otherwise configured in a non-standard way.
 
@@ -238,9 +238,7 @@ In addition, the following search parameters are supported on all resources:
 
 These parameters can be used while searching any single resource type or while searching across resource types (whole system search).
 
-The `_type` parameter has two restrictions:
-* It may only be used with whole system search.
-* It may only be specified once in a search. In `lenient` mode, only the first occurrence is used; additional occurrences are ignored.
+The `_type` parameter may only be used with whole system search.
 
 The `_has` parameter has two restrictions:
 * It cannot be used with whole system search.
@@ -470,10 +468,11 @@ The IBM FHIR Server implements a handful of extended operations and provides ext
 
 Operations are invoked via HTTP POST.
 * All operations can be invoked by passing a Parameters resource instance in the body of the request.
-* For operations with no input parameters, no body is required.
 * For operations with a single input parameter named "resource", the Parameters wrapper can be omitted.
 
 Alternatively, for operations with only primitive input parameters (i.e. no complex datatypes like 'Identifier' or 'Reference'), operations can be invoked via HTTP GET by passing the parameters in the URL.
+
+Note: operations invoked via POST will ignore all query parameters and operations invoked via GET will ignore any body.
 
 ### System operations
 System operations are invoked at `[base]/$[operation]`

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -5,7 +5,7 @@
 # ----------------------------------------------------------------------------
 # Stage: Base
 
-FROM openliberty/open-liberty:21.0.0.12-kernel-slim-java11-openj9-ubi as base
+FROM openliberty/open-liberty:22.0.0.3-kernel-slim-java11-openj9-ubi as base
 
 USER root
 RUN yum install -y unzip
@@ -22,10 +22,10 @@ COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 # ----------------------------------------------------------------------------
 # Stage: Runnable
 
-FROM openliberty/open-liberty:21.0.0.12-kernel-slim-java11-openj9-ubi
+FROM openliberty/open-liberty:22.0.0.3-kernel-slim-java11-openj9-ubi
 
 ARG VERBOSE=true
-ARG FHIR_VERSION=4.10.0-SNAPSHOT
+ARG FHIR_VERSION=4.11.0-SNAPSHOT
 
 # The following labels are required:
 LABEL name='IBM FHIR Server'

--- a/fhir-install/src/main/resources/scripts/install.bat
+++ b/fhir-install/src/main/resources/scripts/install.bat
@@ -7,7 +7,7 @@
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-set LIBERTY_VERSION=21.0.0.12
+set LIBERTY_VERSION=22.0.0.3
 
 echo Executing %0 to deploy the fhir-server web application...
 

--- a/fhir-install/src/main/resources/scripts/install.sh
+++ b/fhir-install/src/main/resources/scripts/install.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
 
-export LIBERTY_VERSION="21.0.0.12"
+export LIBERTY_VERSION="22.0.0.3"
 
 echo "
 Executing $0 to deploy the fhir-server web application...

--- a/fhir-parent/pom.xml
+++ b/fhir-parent/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>io.openliberty</groupId>
                 <artifactId>openliberty-runtime</artifactId>
-                <version>21.0.0.12</version>
+                <version>22.0.0.3</version>
                 <type>zip</type>
             </dependency>
             <dependency>

--- a/fhir-server-spi/pom.xml
+++ b/fhir-server-spi/pom.xml
@@ -35,6 +35,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
@@ -173,7 +173,7 @@ public final class FHIROperationUtil {
                         .severity(IssueSeverity.ERROR)
                         .code(IssueType.INVALID)
                         .details(CodeableConcept.builder()
-                                .text("Unable to process query parameters")
+                                .text(msg)
                                 .build())
                         .build());
         }

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIROperationUtil.java
@@ -26,6 +26,7 @@ import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.CodeableConcept;
 import com.ibm.fhir.model.type.Date;
 import com.ibm.fhir.model.type.DateTime;
 import com.ibm.fhir.model.type.Element;
@@ -72,76 +73,35 @@ public final class FHIROperationUtil {
         }
     }
 
+    /**
+     * Construct a Parameters object from the input parameters passed via query parameters
+     *
+     * @param definition not null
+     * @param queryParameters not null
+     * @return
+     * @throws FHIROperationException
+     */
     public static Parameters getInputParameters(OperationDefinition definition,
-        Map<String, List<String>> queryParameters) throws FHIROperationException {
+            Map<String, List<String>> queryParameters) throws FHIROperationException {
         try {
             Parameters.Builder parametersBuilder = Parameters.builder();
             parametersBuilder.id("InputParameters");
-            if (definition != null) {
-                for (OperationDefinition.Parameter parameter : definition.getParameter()) {
-                    if (OperationParameterUse.IN.getValue().equals(parameter.getUse().getValue())) {
-                        String name = parameter.getName().getValue();
-                        FHIRAllTypes type = parameter.getType();
-                        if (type == null) {
-                            continue;
-                        }
-                        String typeName = type.getValue();
-                        List<String> values = queryParameters.get(name);
-                        if (values != null) {
-                            String value = values.get(0);
-                            Parameter.Builder parameterBuilder = Parameter.builder().name(string(name));
-                            if ("boolean".equals(typeName)) {
-                                parameterBuilder.value(com.ibm.fhir.model.type.Boolean.of(value));
-                            } else if ("integer".equals(typeName)) {
-                                parameterBuilder.value(com.ibm.fhir.model.type.Integer.of(value));
-                            } else if ("string".equals(typeName)) {
-                                parameterBuilder.value(com.ibm.fhir.model.type.String.of(value));
-                            } else if ("decimal".equals(typeName)) {
-                                parameterBuilder.value(com.ibm.fhir.model.type.Decimal.of(value));
-                            } else if ("uri".equals(typeName)) {
-                                parameterBuilder.value(Uri.of(value));
-                            } else if ("url".equals(typeName)) {
-                                parameterBuilder.value(Url.of(value));
-                            } else if ("canonical".equals(typeName)) {
-                                parameterBuilder.value(Canonical.of(value));
-                            } else if ("instant".equals(typeName)) {
-                                parameterBuilder.value(Instant.of(value));
-                            } else if ("date".equals(typeName)) {
-                                parameterBuilder.value(Date.of(value));
-                            } else if ("dateTime".equals(typeName)) {
-                                parameterBuilder.value(DateTime.of(value));
-                            } else if ("time".equals(typeName)) {
-                                parameterBuilder.value(Time.of(value));
-                            } else if ("code".equals(typeName)) {
-                                parameterBuilder.value(Code.of(value));
-                            } else if ("oid".equals(typeName)) {
-                                parameterBuilder.value(Oid.of(value));
-                            } else if ("id".equals(typeName)) {
-                                parameterBuilder.value(Id.of(value));
-                            } else if ("unsignedInt".equals(typeName)) {
-                                parameterBuilder.value(UnsignedInt.of(value));
-                            } else if ("positiveInt".equals(typeName)) {
-                                parameterBuilder.value(PositiveInt.of(value));
-                            } else if ("uuid".equals(typeName)) {
-                                parameterBuilder.value(Uuid.of(value));
-                            } else {
-                                // Originally returned 500 when it should be 400 (it's on the client).
-                                FHIROperationException operationException =
-                                        new FHIROperationException("Query parameter '" + name + "' is an invalid type: '" + typeName + "'");
 
-                                List<Issue> issues = new ArrayList<>();
-                                Issue.Builder builder = Issue.builder();
-                                builder.code(IssueType.INVALID);
-                                builder.diagnostics(string("Query parameter '" + name + "' is an invalid type: '" + typeName + "'"));
-                                builder.severity(IssueSeverity.ERROR);
-                                issues.add(builder.build());
+            for (OperationDefinition.Parameter parameter : definition.getParameter()) {
+                if (OperationParameterUse.IN.getValue().equals(parameter.getUse().getValue())) {
+                    String paramName = parameter.getName().getValue();
+                    if (!queryParameters.containsKey(paramName)) {
+                        continue;
+                    }
 
-                                operationException.setIssues(issues);
+                    FHIRAllTypes type = parameter.getType();
+                    if (type == null) {
+                        continue;
+                    }
+                    String typeName = type.getValue();
 
-                                throw operationException;
-                            }
-                            parametersBuilder.parameter(parameterBuilder.build());
-                        }
+                    for (String value : queryParameters.get(paramName)) {
+                        parametersBuilder.parameter(parseParameter(typeName, paramName, value));
                     }
                 }
             }
@@ -149,26 +109,88 @@ public final class FHIROperationUtil {
         } catch (FHIROperationException e) {
             throw e;
         } catch (Exception e) {
-            // Originally returned 500 when it should be 400 (it's on the client).
-            FHIROperationException operationException =
-                    new FHIROperationException("Unable to process query parameters", e);
-
-            List<Issue> issues = new ArrayList<>();
-            Issue.Builder builder = Issue.builder();
-            builder.code(IssueType.INVALID);
-            builder.diagnostics(string("Unable to process query parameters"));
-            builder.severity(IssueSeverity.ERROR);
-            issues.add(builder.build());
-
-            operationException.setIssues(issues);
-
-            throw operationException;
+            throw new FHIROperationException("Unable to process query parameters", e);
         }
     }
 
+    private static Parameter parseParameter(String typeName, String paramName, String value) throws FHIROperationException {
 
-    public static Parameters getInputParameters(OperationDefinition definition, Resource resource)
-        throws Exception {
+        Parameter.Builder parameterBuilder = Parameter.builder().name(paramName);
+        try {
+            if ("boolean".equals(typeName)) {
+                parameterBuilder.value(com.ibm.fhir.model.type.Boolean.of(value));
+            } else if ("integer".equals(typeName)) {
+                parameterBuilder.value(com.ibm.fhir.model.type.Integer.of(value));
+            } else if ("string".equals(typeName)) {
+                parameterBuilder.value(com.ibm.fhir.model.type.String.of(value));
+            } else if ("decimal".equals(typeName)) {
+                parameterBuilder.value(com.ibm.fhir.model.type.Decimal.of(value));
+            } else if ("uri".equals(typeName)) {
+                parameterBuilder.value(Uri.of(value));
+            } else if ("url".equals(typeName)) {
+                parameterBuilder.value(Url.of(value));
+            } else if ("canonical".equals(typeName)) {
+                parameterBuilder.value(Canonical.of(value));
+            } else if ("instant".equals(typeName)) {
+                parameterBuilder.value(Instant.of(value));
+            } else if ("date".equals(typeName)) {
+                parameterBuilder.value(Date.of(value));
+            } else if ("dateTime".equals(typeName)) {
+                parameterBuilder.value(DateTime.of(value));
+            } else if ("time".equals(typeName)) {
+                parameterBuilder.value(Time.of(value));
+            } else if ("code".equals(typeName)) {
+                parameterBuilder.value(Code.of(value));
+            } else if ("oid".equals(typeName)) {
+                parameterBuilder.value(Oid.of(value));
+            } else if ("id".equals(typeName)) {
+                parameterBuilder.value(Id.of(value));
+            } else if ("unsignedInt".equals(typeName)) {
+                parameterBuilder.value(UnsignedInt.of(value));
+            } else if ("positiveInt".equals(typeName)) {
+                parameterBuilder.value(PositiveInt.of(value));
+            } else if ("uuid".equals(typeName)) {
+                parameterBuilder.value(Uuid.of(value));
+            } else {
+                String msg = "Query parameter '" + paramName + "' is an invalid type: '" + typeName + "'";
+                FHIROperationException operationException =
+                        new FHIROperationException(msg);
+
+                operationException.withIssue(Issue.builder()
+                        .code(IssueType.INVALID)
+                        .details(CodeableConcept.builder()
+                                .text(msg)
+                                .build())
+                        .severity(IssueSeverity.ERROR)
+                        .build());
+
+                throw operationException;
+            }
+        } catch (NullPointerException | IllegalStateException e) {
+            String msg = "Unable to parse query parameter '" + paramName + "' to its expected type: '" + typeName + "'";
+            throw new FHIROperationException(msg, e)
+                    .withIssue(Issue.builder()
+                        .severity(IssueSeverity.ERROR)
+                        .code(IssueType.INVALID)
+                        .details(CodeableConcept.builder()
+                                .text("Unable to process query parameters")
+                                .build())
+                        .build());
+        }
+
+        return parameterBuilder.build();
+    }
+
+
+    /**
+     * Construct a Parameters object with a single parameter named resource
+     *
+     * @param definition
+     * @param resource
+     * @return
+     * @throws Exception
+     */
+    public static Parameters getInputParameters(OperationDefinition definition, Resource resource) throws Exception {
         Parameters.Builder parametersBuilder = Parameters.builder();
         parametersBuilder.id("InputParameters");
         for (OperationDefinition.Parameter parameterDefinition : definition.getParameter()) {

--- a/fhir-server-spi/src/test/java/com/ibm/fhir/server/spi/operation/test/FHIROperationUtilTest.java
+++ b/fhir-server-spi/src/test/java/com/ibm/fhir/server/spi/operation/test/FHIROperationUtilTest.java
@@ -1,0 +1,171 @@
+ /*
+ * (C) Copyright IBM Corp. 2017, 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ package com.ibm.fhir.server.spi.operation.test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.exception.FHIROperationException;
+import com.ibm.fhir.model.resource.OperationDefinition;
+import com.ibm.fhir.model.resource.OperationDefinition.Parameter;
+import com.ibm.fhir.model.resource.Parameters;
+import com.ibm.fhir.model.type.Code;
+import com.ibm.fhir.model.type.code.FHIRAllTypes;
+import com.ibm.fhir.model.type.code.OperationKind;
+import com.ibm.fhir.model.type.code.OperationParameterUse;
+import com.ibm.fhir.model.type.code.PublicationStatus;
+import com.ibm.fhir.server.spi.operation.FHIROperationUtil;
+
+public class FHIROperationUtilTest {
+
+    Set<FHIRAllTypes> PRIMITIVE_TYPES = Set.of(FHIRAllTypes.BOOLEAN, FHIRAllTypes.INTEGER, FHIRAllTypes.STRING, FHIRAllTypes.DECIMAL,
+            FHIRAllTypes.URI, FHIRAllTypes.URL, FHIRAllTypes.CANONICAL, FHIRAllTypes.INSTANT, FHIRAllTypes.DATE,
+            FHIRAllTypes.DATE_TIME, FHIRAllTypes.TIME, FHIRAllTypes.CODE, FHIRAllTypes.OID, FHIRAllTypes.ID,
+            FHIRAllTypes.UNSIGNED_INT, FHIRAllTypes.POSITIVE_INT, FHIRAllTypes.UUID);
+
+    OperationDefinition opDef = OperationDefinition.builder()
+            .name("test")
+            .status(PublicationStatus.DRAFT)
+            .kind(OperationKind.OPERATION)
+            .code(Code.of("test"))
+            .system(false)
+            .type(false)
+            .instance(false)
+            // add an input parameter for each primitive type
+            .parameter(PRIMITIVE_TYPES.stream()
+                    .map(t -> buildParameter(t))
+                    .collect(Collectors.toList()))
+            // add an input parameter that isn't a primitive type
+            .parameter(buildParameter(FHIRAllTypes.CODEABLE_CONCEPT))
+            // add an input parameter of type resource (abstract and concrete)
+            .parameter(buildParameter(FHIRAllTypes.RESOURCE))
+            .parameter(buildParameter(FHIRAllTypes.DOMAIN_RESOURCE))
+            .parameter(buildParameter(FHIRAllTypes.PATIENT))
+            // add an input parameter with no type
+            .parameter(Parameter.builder()
+                    .name(Code.of("unknown"))
+                    .use(OperationParameterUse.IN)
+                    .min(1).max("1")
+                    .build())
+            .build();
+
+    Parameter buildParameter(FHIRAllTypes type) {
+        return Parameter.builder()
+                .name(type)
+                .use(OperationParameterUse.IN)
+                .min(1).max("1")
+                .type(type)
+                .build();
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters constructs a Parameters object
+     * from query parameters
+     */
+    @Test
+    void testGetInputParametersFromQueryParameters() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        queryParams.put("boolean", List.of("true"));                        // 1
+        queryParams.put("integer", List.of("-1"));                          // 2
+        queryParams.put("string", List.of("test"));                         // 3
+        queryParams.put("decimal", List.of("0.123"));                       // 4
+        queryParams.put("uri", List.of("uri"));                             // 5
+        queryParams.put("url", List.of("http://example.com"));              // 6
+        queryParams.put("canonical", List.of("http://example.com|1"));      // 7
+        queryParams.put("instant", List.of("2022-03-18T03:58:00.123Z"));    // 8
+        queryParams.put("date", List.of("2022-03-18"));                     // 9
+        queryParams.put("dateTime", List.of("2022-03-18T22:00:00Z"));       // 10
+        queryParams.put("time", List.of("12:30:00"));                       // 11
+        queryParams.put("code", List.of("test"));                           // 12
+        queryParams.put("oid", List.of("urn:oid:1.2.3"));                   // 13
+        queryParams.put("id", List.of("test"));                             // 14
+        queryParams.put("unsignedInt", List.of("100000000"));               // 15
+        queryParams.put("positiveInt", List.of("1"));                       // 16
+        queryParams.put("uuid", List.of("urn:uuid:" + UUID.randomUUID()));  // 17
+
+        Parameters inputParameters = FHIROperationUtil.getInputParameters(opDef, queryParams);
+        assertNotNull(inputParameters);
+        assertEquals(inputParameters.getParameter().size(), 17);
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters constructs a Parameters object
+     * with entries for each query parameter, even when a single param is repeated
+     */
+    @Test
+    void testGetInputParametersFromQueryParameters_multiple() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        queryParams.put("boolean", List.of("true", "false"));               // 2
+        queryParams.put("string", List.of("a,b,c"));                        // 3
+
+        Parameters inputParameters = FHIROperationUtil.getInputParameters(opDef, queryParams);
+        assertNotNull(inputParameters);
+        assertEquals(inputParameters.getParameter().size(), 3);
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters constructs a Parameters object
+     * even when queryParams is empty
+     */
+    @Test
+    void testGetInputParametersFromQueryParameters_empty() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        Parameters inputParameters = FHIROperationUtil.getInputParameters(opDef, queryParams);
+
+        assertNotNull(inputParameters);
+        assertTrue(inputParameters.getParameter().isEmpty());
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters skips input parameters with an unknown type
+     */
+    @Test
+    void testGetInputParametersFromQueryParameters_unknownType() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        queryParams.put("unknown", List.of("anything"));
+        Parameters inputParameters = FHIROperationUtil.getInputParameters(opDef, queryParams);
+
+        assertNotNull(inputParameters);
+        assertTrue(inputParameters.getParameter().isEmpty());
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters skips input parameters that are not defined
+     */
+    @Test
+    void testGetInputParametersFromQueryParameters_unknownParam() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        queryParams.put("bogus", List.of("anything"));
+        Parameters inputParameters = FHIROperationUtil.getInputParameters(opDef, queryParams);
+
+        assertNotNull(inputParameters);
+        assertTrue(inputParameters.getParameter().isEmpty());
+    }
+
+    /**
+     * FHIROperationUtil.getInputParameters fails to construct a Parameters object
+     * for a parameter whose type is complex (i.e. not a primitive)
+     */
+    @Test(expectedExceptions = FHIROperationException.class)
+    void testGetInputParametersFromQueryParameters_complex() throws FHIROperationException {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        queryParams.put("CodeableConcept", List.of("http://example.com|bogus"));
+
+        FHIROperationUtil.getInputParameters(opDef, queryParams);
+        fail();
+    }
+}

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ExportOperationTest.java
@@ -7,8 +7,8 @@
 package com.ibm.fhir.server.test.bulkdata;
 
 import static com.ibm.fhir.model.type.String.string;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 
@@ -40,6 +40,22 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.EntityUtils;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.exception.FHIRGeneratorException;
@@ -56,22 +72,6 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Instant;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.server.test.FHIRServerTestBase;
-
-import org.apache.http.HttpEntity;
-import org.apache.http.client.HttpRequestRetryHandler;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.protocol.HttpContext;
-import org.apache.http.util.EntityUtils;
-import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -192,43 +192,35 @@ public class ExportOperationTest extends FHIRServerTestBase {
         List<Parameter> parameters = new ArrayList<>();
 
         if (outputFormat != null) {
-            //@formatter:off
             parameters.add(
                 Parameter.builder()
                     .name(string("_outputFormat"))
                     .value(string(outputFormat))
                     .build());
-            //@formatter:on
         }
 
         if (since != null) {
-            //@formatter:off
             parameters.add(
                 Parameter.builder()
                     .name(string("_since"))
                     .value(since)
                     .build());
-            //@formatter:on
         }
 
         if (types != null) {
-            //@formatter:off
             parameters.add(
                 Parameter.builder()
                     .name(string("_type"))
                     .value(string(types.stream().collect(Collectors.joining(","))))
                     .build());
-            //@formatter:on
         }
 
         if (typeFilters != null) {
-            //@formatter:off
             parameters.add(
                 Parameter.builder()
                     .name(string("_typeFilters"))
                     .value(string(types.stream().collect(Collectors.joining(","))))
                     .build());
-            //@formatter:on
         }
 
         Parameters.Builder builder = Parameters.builder();
@@ -323,7 +315,7 @@ public class ExportOperationTest extends FHIRServerTestBase {
                 }
             }
         }
-        
+
         System.out.println("The list of resources is " + types);
         System.out.println("The actual list of resources is " + tmpTypes);
 
@@ -680,15 +672,19 @@ public class ExportOperationTest extends FHIRServerTestBase {
     public void testBaseExportWithMultipleTypes_Post() throws Exception {
         if (ON) {
             Parameters parameters = generateParameters(FORMAT_NDJSON, null, null, null);
+            parameters = parameters.toBuilder()
+                    .parameter(Parameter.builder().name("_type").value("Patient,Observation").build())
+                    .parameter(Parameter.builder().name("_type").value("Patient").build())
+                    .parameter(Parameter.builder().name("_type").value("Observation").build())
+                    .parameter(Parameter.builder().name("_type").value("Condition").build())
+                    .build();
             Entity<Parameters> entity = Entity.entity(parameters, FHIRMediaType.APPLICATION_FHIR_JSON);
 
             Response response = getWebTarget()
                                     .path(BASE_VALID_URL)
                                     .queryParam("_outputFormat", FORMAT_NDJSON)
-                                    .queryParam("_type", "Patient,Observation")
-                                    .queryParam("_type", "Patient")
-                                    .queryParam("_type", "Observation")
-                                    .queryParam("_type", "Condition")
+                                    .queryParam("_type", "Organization")     // just confirms this is ignored
+                                    .queryParam("_type", "Bogus")            // just confirms this is ignored
                                     .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                                     .header("X-FHIR-TENANT-ID", tenantName)
                                     .header("X-FHIR-DSID", dataStoreId)
@@ -713,8 +709,6 @@ public class ExportOperationTest extends FHIRServerTestBase {
     @Test(groups = { TEST_GROUP_NAME }, dependsOnMethods = { "testGroup" })
     public void testBaseExportWithMultipleTypes_Get() throws Exception {
         if (ON) {
-            Parameters parameters = generateParameters(FORMAT_NDJSON, null, null, null);
-
             Response response = getWebTarget()
                                     .path(BASE_VALID_URL)
                                     .queryParam("_outputFormat", FORMAT_NDJSON)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1396,25 +1396,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
         }
     }
 
-    /**
-     * Helper method which invokes a custom operation.
-     *
-     * @param operationContext
-     *            the FHIROperationContext associated with the request
-     * @param resourceTypeName
-     *            the resource type associated with the request
-     * @param logicalId
-     *            the resource logical id associated with the request
-     * @param versionId
-     *            the resource version id associated with the request
-     * @param resource
-     *            the input resource associated with the custom operation to be invoked
-     * @param queryParameters
-     *            query parameters may be passed instead of a Parameters resource for certain custom operations invoked
-     *            via GET
-     * @return a Resource that represents the response to the custom operation
-     * @throws Exception
-     */
     @Override
     public Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName, String logicalId,
             String versionId, Resource resource, MultivaluedMap<String, String> queryParameters) throws Exception {

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.exception.FHIROperationException;
@@ -57,10 +56,6 @@ public class ExportOperation extends AbstractOperation {
         COMMON.checkEnabled();
         COMMON.checkAllowed(operationContext, false);
 
-        // Pick off parameters
-        javax.ws.rs.core.UriInfo uriInfo = (javax.ws.rs.core.UriInfo) operationContext.getProperty(FHIROperationContext.PROPNAME_URI_INFO);
-        MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
-
         MediaType outputFormat = export.checkAndConvertToMediaType(parameters);
 
         Instant since = export.checkAndExtractSince(parameters);
@@ -71,7 +66,7 @@ public class ExportOperation extends AbstractOperation {
         Parameters response = null;
         OperationConstants.ExportType exportType = export.checkExportType(operationContext.getType(), resourceType);
 
-        Set<String> types = export.checkAndValidateTypes(exportType, parameters, queryParameters);
+        Set<String> types = export.checkAndValidateTypes(exportType, getParameters(parameters, OperationConstants.PARAM_TYPE));
 
         if (!ExportType.INVALID.equals(exportType)) {
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/client/BulkDataClient.java
@@ -144,7 +144,7 @@ public class BulkDataClient {
 
     /**
      * Submit the export job.
-     * 
+     *
      * @param since
      * @param types
      * @param exportType
@@ -558,7 +558,6 @@ public class BulkDataClient {
                 String[] resourceCounts =
                         resourceTypeInf.substring(resourceTypeInf.indexOf("[") + 1, resourceTypeInf.indexOf("]")).split("\\s*,\\s*");
                 for (int i = 0; i < resourceCounts.length; i++) {
-                    boolean parquet = adapter.isStorageProviderParquetEnabled(source);
                     StorageType storageType = adapter.getStorageProviderStorageType(source);
                     String sUrl;
 
@@ -570,16 +569,12 @@ public class BulkDataClient {
                         String accessKey = adapter.getStorageProviderAuthTypeHmacAccessKey(source);
                         String secretKey = adapter.getStorageProviderAuthTypeHmacSecretKey(source);
                         boolean presigned = adapter.isStorageProviderHmacPresigned(source);
-                        DownloadUrl url = new DownloadUrl(baseUrl, region, bucketName, cosBucketPathPrefix, objectKey, accessKey, secretKey, parquet, presigned, adapter.getS3HostStyleByStorageProvider(source));
+                        DownloadUrl url = new DownloadUrl(baseUrl, region, bucketName, cosBucketPathPrefix, objectKey,
+                                accessKey, secretKey, presigned, adapter.getS3HostStyleByStorageProvider(source));
                         sUrl = url.getUrl();
                     } else {
                         // Must be File
-                        String ext;
-                        if (parquet) {
-                            ext = ".parquet";
-                        } else {
-                            ext = ".ndjson";
-                        }
+                        String ext = ".ndjson";
                         // Originally we set i to resourceCounts[i], however we don't always know the count when create the file.
                         sUrl = cosBucketPathPrefix + File.separator + resourceType + "_" + (i + 1) + ext;
                     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/url/DownloadUrl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/url/DownloadUrl.java
@@ -42,12 +42,12 @@ public class DownloadUrl {
     private String objectKey = null;
     private String accessKey = null;
     private String secretKey = null;
-    private boolean parquet = false;
     private boolean presigned = false;
     private boolean path = true;
     private ZonedDateTime time = ZonedDateTime.now(ZoneOffset.UTC);
 
-    public DownloadUrl(String server, String region, String bucketName, String cosBucketPathPrefix, String objectKey, String accessKey, String secretKey, boolean parquet, boolean presigned, S3HostStyle hostStyle) {
+    public DownloadUrl(String server, String region, String bucketName, String cosBucketPathPrefix, String objectKey,
+            String accessKey, String secretKey, boolean presigned, S3HostStyle hostStyle) {
         this.server = server;
         this.region = region;
         this.bucketName = bucketName;
@@ -55,7 +55,6 @@ public class DownloadUrl {
         this.objectKey = objectKey;
         this.accessKey = accessKey;
         this.secretKey = secretKey;
-        this.parquet = parquet;
         this.presigned = presigned;
         this.path = S3HostStyle.PATH.equals(hostStyle);
     }
@@ -97,20 +96,12 @@ public class DownloadUrl {
         }
         builder.append('/');
         builder.append(objectKey);
-        if(parquet) {
-            builder.append(".parquet");
-        } else {
-            builder.append(".ndjson");
-        }
+        builder.append(".ndjson");
         return builder.toString();
     }
 
     public String getSignedUrl() throws Exception {
-        if(parquet) {
-            objectKey += ".parquet";
-        } else {
-            objectKey += ".ndjson";
-        }
+        objectKey += ".ndjson";
         // assemble the standardized request
 
         String datestamp = time.format(DateTimeFormatter.ofPattern("yyyyMMdd"));

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/url/DownloadUrl.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/model/url/DownloadUrl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.UUID;
 
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -55,15 +54,16 @@ import com.ibm.fhir.server.spi.operation.FHIROperationContext.Type;
  * Test Export util
  */
 public class BulkDataExportUtilTest {
+    BulkDataExportUtil util;
 
     @BeforeClass
     public void setup() {
         FHIRConfiguration.setConfigHome("target/test-classes");
+        util = new BulkDataExportUtil();
     }
 
     @BeforeMethod
     public void startMethod(Method method) throws FHIRException {
-
         // Configure the request context for our search tests
         FHIRRequestContext context = FHIRRequestContext.get();
         context.setTenantId("default");
@@ -76,7 +76,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckExportTypeInstance() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         FHIROperationContext.Type type = Type.INSTANCE;
 
         Class<? extends Resource> resourceType = Patient.class;
@@ -94,7 +93,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckExportTypeResourceType() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         FHIROperationContext.Type type = Type.RESOURCE_TYPE;
 
         Class<? extends Resource> resourceType = Patient.class;
@@ -112,7 +110,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckExportTypeSystem() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         FHIROperationContext.Type type = Type.SYSTEM;
 
         Class<? extends Resource> resourceType = Patient.class;
@@ -130,7 +127,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndConvertToMediaType() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         // QueryParameters Map
         Map<String, List<String>> _mvm = new HashMap<>();
         _mvm.put("_outputFormat", Arrays.asList("application/fhir+ndjson"));
@@ -159,14 +155,6 @@ public class BulkDataExportUtilTest {
         // Multiple values
         _mvm.clear();
         _mvm.put("_outputFormat", Arrays.asList("application/fhir+parquet", "ndjson"));
-        type = util.checkAndConvertToMediaType(generateParametersFromMap(_mvm));
-        assertNotNull(type);
-        assertEquals(type.getType(), "application");
-        assertEquals(type.getSubtype(), "fhir+parquet");
-
-        // Parquet Format
-        _mvm.clear();
-        _mvm.put("_outputFormat", Arrays.asList("application/fhir+parquet"));
         type = util.checkAndConvertToMediaType(generateParametersFromMap(_mvm));
         assertNotNull(type);
         assertEquals(type.getType(), "application");
@@ -217,13 +205,10 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndExtractSinceNull() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         // No Parameters
         assertNull(util.checkAndExtractSince(null));
 
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_since")).value((Element)null).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_since")).value((Element)null).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -235,8 +220,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndExtractSinceEmpty() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
         List<Parameter> parameters = new ArrayList<>();
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
@@ -249,10 +232,7 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndExtractSinceWithString() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_since")).value(string("2018-07-01T00:00:00Z")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_since")).value(string("2018-07-01T00:00:00Z")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -264,10 +244,7 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndExtractSinceWithInvalidString() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("invalid")).value(string("2018-07-01T00:00:00Z")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("invalid")).value(string("2018-07-01T00:00:00Z")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -279,25 +256,19 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndExtractSinceWithInstant() {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_since")).value(Instant.of("2018-07-01T00:00:00Z")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_since")).value(Instant.of("2018-07-01T00:00:00Z")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        BulkDataExportUtil util = new BulkDataExportUtil();
         Instant inst = util.checkAndExtractSince(ps);
         assertNotNull(inst);
     }
 
     @Test
     public void testCheckAndExtractSinceWithInvalidType() {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_since")).value(PositiveInt.of(1)).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_since")).value(PositiveInt.of(1)).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -309,153 +280,81 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesEmpty() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        // Value requires a string greater than 1
-        parameters.add(Parameter.builder().name(string("_type")).value(string("1")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("1")).build());
+        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesNull() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value((Element)null).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value((Element)null).build());
+        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesNullQPS() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value((Element) null).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        util.checkAndValidateTypes(ExportType.SYSTEM, ps, new MultivaluedHashMap<String, String>());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value((Element) null).build());
+        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         fail();
     }
 
     @Test
     public void testCheckAndValidateTypesPatientWithoutComma() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value(string("Patient")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient")).build());
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         assertNotNull(types);
     }
 
     @Test
     public void testCheckAndValidateTypesPatientWithComma() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value(string("Patient,")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,")).build());
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         assertNotNull(types);
     }
 
     @Test
     public void testCheckAndValidateTypesPatientMedicationWithComma() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value(string("Patient,Medication")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,Medication")).build());
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         assertNotNull(types);
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesPatientMedicationWithExtraComma() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value(string("Patient,,Medication")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,,Medication")).build());
+        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         fail();
     }
 
     @Test
     public void testCheckAndValidateTypesWithExtraComma() throws FHIROperationException {
         // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_type")).value(string(",,")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string(",,")).build());
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
 
     @Test
     public void testCheckAndValidateTypesNoParameters() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("french")).value(string("Patient,,Medication")).build());
-        Parameters.Builder builder = Parameters.builder();
-        builder.id(UUID.randomUUID().toString());
-        builder.parameter(parameters);
-        Parameters ps = builder.build();
-
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, ps, null);
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("french")).value(string("Patient,,Medication")).build());
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
 
     @Test
     public void testCheckAndValidateTypesEmptyParameters() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, null, null);
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, null);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
 
     @Test
     public void testCheckAndValidateTypeFilters() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         List<String> result = util.checkAndValidateTypeFilters(null);
         assertNotNull(result);
         assertTrue(result.isEmpty());
@@ -463,10 +362,7 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndValidateTypeFiltersNoParameters() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("french")).value(string("Patient,,Medication")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("french")).value(string("Patient,,Medication")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -479,15 +375,12 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndValidateTypeFiltersParameters() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_typeFilter")).value(string("type1")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_typeFilter")).value(string("type1")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        BulkDataExportUtil util = new BulkDataExportUtil();
         List<String> result = util.checkAndValidateTypeFilters(ps);
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -495,14 +388,11 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndValidateTypeFiltersParametersTypes() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_typeFilter")).value(string("type1,type2")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_typeFilter")).value(string("type1,type2")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
-        BulkDataExportUtil util = new BulkDataExportUtil();
         List<String> result = util.checkAndValidateTypeFilters(ps);
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -510,15 +400,12 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypeFiltersParametersTypesComma() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_typeFilter")).value(string(",,2")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_typeFilter")).value(string(",,2")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
 
-        BulkDataExportUtil util = new BulkDataExportUtil();
         List<String> result = util.checkAndValidateTypeFilters(ps);
         assertNotNull(result);
         assertFalse(result.isEmpty());
@@ -526,14 +413,11 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypeFiltersParametersTypesInvalidType() throws FHIROperationException {
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_typeFilter")).value(PositiveInt.of(2)).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_typeFilter")).value(PositiveInt.of(2)).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
-        BulkDataExportUtil util = new BulkDataExportUtil();
         util.checkAndValidateTypeFilters(ps);
         fail();
     }
@@ -541,23 +425,18 @@ public class BulkDataExportUtilTest {
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypeFiltersParametersTypesNull() throws FHIROperationException {
         // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("_typeFilter")).value((Element)null).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("_typeFilter")).value((Element)null).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
         Parameters ps = builder.build();
-        BulkDataExportUtil util = new BulkDataExportUtil();
         util.checkAndValidateTypeFilters(ps);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobNull() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("job")).value((Element)null).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("job")).value((Element)null).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -569,10 +448,7 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobInvalidType() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("job")).value(PositiveInt.of(2)).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("job")).value(PositiveInt.of(2)).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -584,10 +460,7 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobNoJob() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("fred")).value(PositiveInt.of(2)).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("fred")).value(PositiveInt.of(2)).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -599,17 +472,14 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobNullParameters() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         util.checkAndValidateJob(null);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobInvalidQuestion() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("job")).value(string("1?")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("job")).value(string("1?")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -621,10 +491,7 @@ public class BulkDataExportUtilTest {
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateJobInvalidSlash() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("job")).value(string("1/")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("job")).value(string("1/")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -636,10 +503,7 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testCheckAndValidateJobValid() throws FHIROperationException {
-        BulkDataExportUtil util = new BulkDataExportUtil();
-        // parameters
-        List<Parameter> parameters = new ArrayList<>();
-        parameters.add(Parameter.builder().name(string("job")).value(string("1234q346")).build());
+        List<Parameter> parameters = List.of(Parameter.builder().name(string("job")).value(string("1234q346")).build());
         Parameters.Builder builder = Parameters.builder();
         builder.id(UUID.randomUUID().toString());
         builder.parameter(parameters);
@@ -652,7 +516,6 @@ public class BulkDataExportUtilTest {
 
     @Test
     public void testGetOutputParametersWithJson() throws Exception {
-        BulkDataExportUtil util = new BulkDataExportUtil();
         PollingLocationResponse pollingLocationResponse = new PollingLocationResponse();
         Parameters result = util.getOutputParametersWithJson(pollingLocationResponse);
         assertNotNull(result);


### PR DESCRIPTION
Previously, I updated whole-system search to support combining multiple
instances of the `_type` parameter.  Now we will handle multiple '_type'
parameters in the extended operations $everything and $export as well.

I updated the search section in Conformance.md to indicate this change
and added a note in the extended operations section to indicate that
query parameters will be ignored for operations invoked via POST.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>