### PR TITLE
issue #3501 - apply fix for #2965 more universally

### DIFF
--- a/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,11 +8,12 @@ package com.ibm.fhir.client;
 
 import java.security.KeyStore;
 
-import jakarta.json.JsonObject;
 import javax.ws.rs.client.WebTarget;
 
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Resource;
+
+import jakarta.json.JsonObject;
 
 /**
  * This interface provides a client API for invoking the FHIR Server's REST API.
@@ -125,6 +126,12 @@ public interface FHIRClient {
      * The tenant identifier to use for requests (using the header X-FHIR-TENANT-ID)
      */
     public static final String PROPNAME_TENANT_ID = "fhirclient.tenant.id";
+
+    /**
+     * Returns the default FHIR base URL that is configured for this client instance
+     * @return the FHIR base URL with scheme, host, and path
+     */
+    String getDefaultBaseUrl();
 
     /**
      * Returns a JAX-RS 2.0 WebTarget object associated with the REST API endpoint.

--- a/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -820,6 +820,11 @@ public class FHIRClientImpl implements FHIRClient {
     }
 
     @Override
+    public String getDefaultBaseUrl() {
+        return baseEndpointURL;
+    }
+
+    @Override
     public WebTarget getWebTarget() throws Exception {
         return client.target(getBaseEndpointURL());
     }
@@ -973,7 +978,7 @@ public class FHIRClientImpl implements FHIRClient {
         this.clientProperties = clientProperties;
     }
 
-    private String getBaseEndpointURL() {
+    public String getBaseEndpointURL() {
         return baseEndpointURL;
     }
 

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -200,12 +200,15 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
      * @param conn
      * @param parameterDao
      * @param ifNoneMatch 0 for conditional create-on-update behavior; otherwise null
+     * @param resourcePayloadKey
+     * @param outInteractionStatus
+     * @param outIfNoneMatchVersion
      * @return the resource_id for the entry we created
      * @throws Exception
      */
-    public long storeResource(String tablePrefix, List<ExtractedParameterValue> parameters, 
+    public long storeResource(String tablePrefix, List<ExtractedParameterValue> parameters,
             String p_logical_id, InputStream p_payload, Timestamp p_last_updated, boolean p_is_deleted,
-            String p_source_key, Integer p_version, String p_parameterHashB64, Connection conn, 
+            String p_source_key, Integer p_version, String p_parameterHashB64, Connection conn,
             ParameterDAO parameterDao, Integer ifNoneMatch, String resourcePayloadKey,
             AtomicInteger outInteractionStatus, AtomicInteger outIfNoneMatchVersion) throws Exception {
 
@@ -452,7 +455,7 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
             stmt.setLong(1, v_resource_id);
             stmt.setLong(2, v_logical_resource_id);
             stmt.setInt(3, p_version);
-            
+
             if (p_payload != null) {
                 stmt.setBinaryStream(4, p_payload);
             } else {
@@ -521,7 +524,7 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
 
         // Finally, write a record to RESOURCE_CHANGE_LOG which records each event
         // related to resources changes (issue-1955)
-        String changeType = p_is_deleted ? "D" : v_new_resource ? "C" :  "U";
+        String changeType = p_is_deleted ? "D" : v_new_resource ? "C" : "U";
         String INSERT_CHANGE_LOG = "INSERT INTO resource_change_log(resource_id, change_tstamp, resource_type_id, logical_resource_id, version_id, change_type)"
                 + " VALUES (?,?,?,?,?,?)";
         try (PreparedStatement ps = conn.prepareStatement(INSERT_CHANGE_LOG)) {

--- a/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/test/TypeParameterParseTest.java
@@ -24,8 +24,7 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 
 /**
- * This testng test class contains methods that test the parsing of the search result _type parameter in the
- * SearchUtil class.
+ * Test the parsing of the search result _type parameter in the SearchUtil class.
  */
 public class TypeParameterParseTest extends BaseSearchTest {
 
@@ -75,7 +74,6 @@ public class TypeParameterParseTest extends BaseSearchTest {
         } catch(Exception ex) {
             isExceptionThrown = true;
             assertEquals(ex.getMessage(), "_type parameter is only supported for whole-system search");
-
         }
         assertTrue(isExceptionThrown);
     }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BasicServerTest.java
@@ -7,8 +7,8 @@
 package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.type.String.string;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
@@ -32,6 +32,7 @@ import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.generator.FHIRGenerator;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.CapabilityStatement;
 import com.ibm.fhir.model.resource.Immunization;
 import com.ibm.fhir.model.resource.Observation;
@@ -78,7 +79,7 @@ public class BasicServerTest extends FHIRServerTestBase {
         CapabilityStatement conf = response.readEntity(CapabilityStatement.class);
         assertNotNull(conf);
         assertNotNull(conf.getFormat());
-        assertEquals(6, conf.getFormat().size());
+        assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
         assertNotNull(conf.getName());
 
@@ -160,12 +161,12 @@ public class BasicServerTest extends FHIRServerTestBase {
         WebTarget target = getWebTarget();
         Response response = target.path("metadata").request(FHIRMediaType.APPLICATION_FHIR_XML).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
-        assertEquals(FHIRMediaType.APPLICATION_FHIR_XML_TYPE, response.getMediaType());
+        assertEquals(response.getMediaType(), FHIRMediaType.APPLICATION_FHIR_XML_TYPE);
 
         CapabilityStatement conf = response.readEntity(CapabilityStatement.class);
         assertNotNull(conf);
         assertNotNull(conf.getFormat());
-        assertEquals(6, conf.getFormat().size());
+        assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
         assertNotNull(conf.getName());
     }
@@ -180,12 +181,12 @@ public class BasicServerTest extends FHIRServerTestBase {
             Collections.singletonMap(FHIRMediaType.FHIR_VERSION_PARAMETER, "4.0"));
         Response response = target.path("metadata").request(mediaType).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
-        assertEquals(mediaType, response.getMediaType());
+        assertEquals(response.getMediaType(), mediaType);
 
         CapabilityStatement conf = response.readEntity(CapabilityStatement.class);
         assertNotNull(conf);
         assertNotNull(conf.getFormat());
-        assertEquals(6, conf.getFormat().size());
+        assertEquals(conf.getFormat().size(), 6);
         assertNotNull(conf.getVersion());
         assertNotNull(conf.getName());
     }
@@ -554,22 +555,26 @@ public class BasicServerTest extends FHIRServerTestBase {
     }
 
     /**
-     * Tests the retrieval of the history for a previously saved and updated
-     * patient.
+     * Tests the retrieval of the history for a previously saved and updated patient.
      */
     @Test(groups = { "server-basic" }, dependsOnMethods = { "testCreatePatient", "testUpdatePatient" })
     public void testHistoryPatient() {
         WebTarget target = getWebTarget();
 
-        // Call the 'history' API to retrieve both the original and updated versions of
-        // the patient.
+        // Call the 'history' API to retrieve both the original and updated versions of the patient.
         String targetPath = "Patient/" + savedCreatedPatient.getId() + "/_history";
         Response response = target.path(targetPath).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
 
         Bundle resources = response.readEntity(Bundle.class);
         assertNotNull(resources);
-        assertEquals(2, resources.getEntry().size());
+        assertEquals(resources.getEntry().size(), 2);
+
+        for (Entry entry : resources.getEntry()) {
+            String fullUrl = entry.getFullUrl().getValue();
+            assertEquals(fullUrl, getRestBaseURL() + "/Patient/" + savedCreatedPatient.getId());
+        }
+
         Patient updatedPatient = (Patient) resources.getEntry().get(0).getResource();
         Patient originalPatient = (Patient) resources.getEntry().get(1).getResource();
         // Make sure patient ids are equal, and versionIds are NOT equal.
@@ -583,22 +588,26 @@ public class BasicServerTest extends FHIRServerTestBase {
     }
 
     /**
-     * Tests the retrieval of the history for a previously saved and updated
-     * observation.
+     * Tests the retrieval of the history for a previously saved and updated observation.
      */
     @Test(groups = { "server-basic" }, dependsOnMethods = { "testCreateObservation", "testUpdateObservation" })
     public void testHistoryObservation() {
         WebTarget target = getWebTarget();
 
-        // Call the 'history' API to retrieve both the original and updated versions of
-        // the observation.
+        // Call the 'history' API to retrieve both the original and updated versions of the observation.
         String targetPath = "Observation/" + savedCreatedObservation.getId() + "/_history";
         Response response = target.path(targetPath).request(FHIRMediaType.APPLICATION_FHIR_JSON).get();
         assertResponse(response, Response.Status.OK.getStatusCode());
 
         Bundle resources = response.readEntity(Bundle.class);
         assertNotNull(resources);
-        assertEquals(2, resources.getEntry().size());
+        assertEquals(resources.getEntry().size(), 2);
+
+        for (Entry entry : resources.getEntry()) {
+            String fullUrl = entry.getFullUrl().getValue();
+            assertEquals(fullUrl, getRestBaseURL() + "/Observation/" + savedCreatedObservation.getId());
+        }
+
         Observation updatedObservation = (Observation) resources.getEntry().get(0).getResource();
         Observation originalObservation = (Observation) resources.getEntry().get(1).getResource();
         // Make sure observation ids are equal, and versionIds are NOT equal.
@@ -728,6 +737,6 @@ public class BasicServerTest extends FHIRServerTestBase {
         assertResponse(response, Response.Status.OK.getStatusCode());
         Bundle bundle = response.readEntity(Bundle.class);
         assertNotNull(bundle);
-        assertEquals(1, bundle.getEntry().size());
+        assertEquals(bundle.getEntry().size(), 1);
     }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/BundleTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2017, 2021
+ * (C) Copyright IBM Corp. 2017, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,10 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonObjectBuilder;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
@@ -53,6 +49,11 @@ import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.HTTPVerb;
 import com.ibm.fhir.model.type.code.IssueType;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 /**
  * This class tests 'batch' and 'transaction' interactions.
@@ -761,7 +762,7 @@ public class BundleTest extends FHIRServerTestBase {
         String method = "testBatchHistory";
         WebTarget target = getWebTarget();
 
-        // Perform a 'read' and a 'vread'.
+        // Get the history for patientB1
         Bundle bundle = buildBundle(BundleType.BATCH);
         bundle = addRequestToBundle(null, bundle, HTTPVerb.GET, "Patient/" + patientB1.getId() + "/_history",
                 null, null);
@@ -778,18 +779,18 @@ public class BundleTest extends FHIRServerTestBase {
         assertGoodGetResponse(responseBundle.getEntry().get(0), Status.OK.getStatusCode());
 
         // Take a peek at the result bundle.
-        Bundle resultSet = (Bundle) responseBundle.getEntry().get(0).getResource();
-        assertNotNull(resultSet);
-        assertTrue(resultSet.getEntry().size() > 1);
+        Bundle historyBundle = (Bundle) responseBundle.getEntry().get(0).getResource();
+        assertNotNull(historyBundle);
+
+        List<Bundle.Entry> resultSet = historyBundle.getEntry();
+        assertTrue(resultSet.size() > 1);
 
         boolean result = false;
-        for(Bundle.Entry entry : resultSet.getEntry()) {
-            if(entry.getResponse() != null){
-                String returnedStatus = entry.getResponse().getStatus().getValue();
-                assertNotNull(returnedStatus);
-                assertTrue(returnedStatus.startsWith("200"));
-                result = true;
-            }
+        for(Bundle.Entry entry : resultSet) {
+            String returnedStatus = entry.getResponse().getStatus().getValue();
+            assertNotNull(returnedStatus);
+            assertTrue(returnedStatus.startsWith("200") || returnedStatus.startsWith("201"));
+            result = true;
         }
         assertTrue("Test the entries are processed", result);
     }
@@ -1431,7 +1432,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertHistoryResults(target, "Patient/" + patientT1.getId() + "/_history", 2);
         assertHistoryResults(target, "Patient/" + patientT2.getId() + "/_history", 2);
     }
-    
+
     @Test(groups = { "transaction" }, dependsOnMethods = { "testTransactionUpdates" })
     public void testTransactionInvalidRequestError() throws Exception {
         String method = "testTransactionInvalidRequestError";
@@ -1451,8 +1452,8 @@ public class BundleTest extends FHIRServerTestBase {
                 patientT1);
         bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, "Patient/" + patientT2.getId(), null,
                 patientT2);
-        
-        
+
+
         // the URL does not have an id and nor is it a conditional update, so this is an error
         // which should be picked up when translating the bundle entry into an interaction
         bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, "Observation", null,
@@ -2041,7 +2042,7 @@ public class BundleTest extends FHIRServerTestBase {
         Resource patientResource = patientEntry.getResource();
         assertTrue(patientResource instanceof Patient);
         patient = (Patient) patientResource;
-        
+
         // Verify the Patient.managingOrganization field.
         assertNotNull(patient.getManagingOrganization());
         assertNotNull(patient.getManagingOrganization().getReference());
@@ -2055,7 +2056,7 @@ public class BundleTest extends FHIRServerTestBase {
         actualReference = patient.getGeneralPractitioner().get(0).getReference().getValue();
         assertNotNull(actualReference);
         assertEquals(actualReference, expectedPractitionerReference);
-        
+
         // Next, check each observation to make sure their local references were
         // processed correctly.
         for (int i = 3; i < 5; i++) {
@@ -2382,10 +2383,10 @@ public class BundleTest extends FHIRServerTestBase {
 
         Bundle bundle = buildBundle(BundleType.BATCH);
         bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, urlString, null, patient);
-        
+
         // Removed for 1869. We no longer support bundles with multiple updates for the same resource.
         // bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, urlString, null, patient.toBuilder().id(null).build());
-        
+
         bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, multipleMatches, null, patient);
         bundle = addRequestToBundle(null, bundle, HTTPVerb.PUT, badSearch, null, patient);
 
@@ -2641,7 +2642,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertEquals(entry1.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
         Patient responsePatient = entry1.getResource().as(Patient.class);
 
-        
+
         // Transaction 2. PUT the same patient again. Should be skipped because the resource matches
         Bundle.Entry bundleEntry2 = Bundle.Entry.builder()
                 .fullUrl(Uri.of("urn:2"))
@@ -2715,7 +2716,7 @@ public class BundleTest extends FHIRServerTestBase {
     }
 
     /**
-     * To test If-None-Match (conditional create-on-update) we must use 
+     * To test If-None-Match (conditional create-on-update) we must use
      * multiple requests because:
      *   "A resource can only appear in a transaction once (by identity)."
      * Requests:
@@ -2767,7 +2768,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertEquals(entry1.getResponse().getStatus().getValue(), "201");
         assertEquals(entry1.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
 
-        
+
         // Interaction 2. PUT the same patient again. Should be skipped because IfNoneMatch - because the
         // processing error for the entry is 412, this should fail the bundle with a 400
         Bundle.Entry bundleEntry2 = Bundle.Entry.builder()
@@ -2794,7 +2795,7 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response3 = client.delete(Patient.class.getSimpleName(), randomId);
         assertNotNull(response3);
         assertResponse(response3.getResponse(), Response.Status.OK.getStatusCode());
-        
+
         // Interaction 4. Undelete
         Bundle.Entry bundleEntry4 = Bundle.Entry.builder()
                 .fullUrl(Uri.of("urn:2"))
@@ -2821,13 +2822,13 @@ public class BundleTest extends FHIRServerTestBase {
 
         // Undelete uses 201 Created to pass Touchstone
         assertEquals(entry4.getResponse().getStatus().getValue(), "201");
-        
+
         // Version 2 is the delete marker, so should be version 3 after undelete
         assertEquals(entry4.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/3");
     }
 
     /**
-     * To test If-None-Match (conditional create-on-update) we must use 
+     * To test If-None-Match (conditional create-on-update) we must use
      * multiple requests because:
      *   "A resource can only appear in a transaction once (by identity)."
      * Requests:
@@ -2877,7 +2878,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertEquals(entry1.getResponse().getStatus().getValue(), "201");
         assertEquals(entry1.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/1");
 
-        
+
         // Interaction 2. PUT the same patient again. Should be skipped because IfNoneMatch
         Bundle.Entry bundleEntry2 = Bundle.Entry.builder()
                 .fullUrl(Uri.of("urn:2"))
@@ -2907,7 +2908,7 @@ public class BundleTest extends FHIRServerTestBase {
         FHIRResponse response3 = client.delete(Patient.class.getSimpleName(), randomId);
         assertNotNull(response3);
         assertResponse(response3.getResponse(), Response.Status.OK.getStatusCode());
-        
+
         // Interaction 4. Undelete
         Bundle.Entry bundleEntry4 = Bundle.Entry.builder()
                 .fullUrl(Uri.of("urn:2"))
@@ -2934,7 +2935,7 @@ public class BundleTest extends FHIRServerTestBase {
 
         // Undelete uses 201 Created to pass Touchstone
         assertEquals(entry4.getResponse().getStatus().getValue(), "201");
-        
+
         // Version 2 is the delete marker, so should be version 3 after undelete
         assertEquals(entry4.getResponse().getLocation().getValue(), "Patient/"+randomId+"/_history/3");
     }
@@ -3005,7 +3006,7 @@ public class BundleTest extends FHIRServerTestBase {
         assertNotNull(response);
 
         assertNotNull(response.getStatus());
-        
+
         // TestNG: ACTUAL, EXPECTED
         assertEquals(response.getStatus().getValue(), Integer.toString(expectedStatusCode));
 

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SystemHistoryTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SystemHistoryTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.model.resource.Bundle;
+import com.ibm.fhir.model.resource.Bundle.Entry;
 import com.ibm.fhir.model.resource.Bundle.Link;
 import com.ibm.fhir.model.resource.Observation;
 import com.ibm.fhir.model.resource.OperationOutcome;
@@ -151,7 +152,7 @@ public class SystemHistoryTest extends FHIRServerTestBase {
             for (Bundle.Entry be: bundle.getEntry()) {
                 // simple way to see if our patient has appeared
                 String fullUrl = be.getFullUrl().getValue();
-                if (fullUrl.contains("Patient/" + patientId)) {
+                if (fullUrl.equals(getRestBaseURL() + "/Patient/" + patientId)) {
                     found = true;
                 }
             }
@@ -225,6 +226,17 @@ public class SystemHistoryTest extends FHIRServerTestBase {
         assertNotNull(bundle);
         assertNotNull(bundle.getEntry());
         assertTrue(bundle.getEntry().size() >= 5);
+
+        for (Entry entry : bundle.getEntry()) {
+            String fullUrl = entry.getFullUrl().getValue();
+            Resource resource = entry.getResource();
+            if (resource == null) {
+                assertTrue(fullUrl.startsWith(getRestBaseURL()));
+            } else {
+                assertEquals(fullUrl, getRestBaseURL() + "/" +
+                        resource.getClass().getSimpleName() + "/" + resource.getId());
+            }
+        }
     }
 
     @Test(dependsOnMethods = {"populateResourcesForHistory"})
@@ -280,7 +292,7 @@ public class SystemHistoryTest extends FHIRServerTestBase {
             for (Bundle.Entry be: bundle.getEntry()) {
                 // simple way to see if our patient has appeared
                 String fullUrl = be.getFullUrl().getValue();
-                if (fullUrl.contains("Patient/" + patientId)) {
+                if (fullUrl.equals(getRestBaseURL() + "/Patient/" + patientId)) {
                     found = true;
                 }
 
@@ -358,7 +370,7 @@ public class SystemHistoryTest extends FHIRServerTestBase {
             for (Bundle.Entry be: bundle.getEntry()) {
                 // simple way to see if our patient has appeared
                 String fullUrl = be.getFullUrl().getValue();
-                if (fullUrl.contains("Patient/" + patientId)) {
+                if (fullUrl.equals(getRestBaseURL() + "/Patient/" + patientId)) {
                     found = true;
                 }
 
@@ -435,7 +447,7 @@ public class SystemHistoryTest extends FHIRServerTestBase {
             for (Bundle.Entry be: bundle.getEntry()) {
                 // simple way to see if our patient has appeared
                 String fullUrl = be.getFullUrl().getValue();
-                if (fullUrl.contains("Patient/" + patientId)) {
+                if (fullUrl.equals(getRestBaseURL() + "/Patient/" + patientId)) {
                     found = true;
                 }
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Create.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.server.resources;
 
+import static com.ibm.fhir.server.util.FHIRRestHelper.getRequestBaseUri;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.util.Date;
@@ -75,7 +76,7 @@ public class Create extends FHIRResource {
             ior = helper.doCreate(type, resource, ifNoneExist);
 
             ResponseBuilder response =
-                    Response.created(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    Response.created(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
             resource = ior.getResource();
 
             HTTPReturnPreference returnPreference = FHIRRequestContext.get().getReturnPreference();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -216,7 +216,7 @@ public class FHIRResource {
      *            the path and query parts
      * @return the full URI value as a String
      */
-    protected String getAbsoluteUri(String baseUri, String relativeUri) {
+    protected String buildAbsoluteUri(String baseUri, String relativeUri) {
         StringBuilder fullUri = new StringBuilder();
         fullUri.append(baseUri);
         if (!baseUri.endsWith("/")) {
@@ -438,59 +438,6 @@ public class FHIRResource {
      */
     protected String getRequestUri() throws Exception {
         return FHIRRequestContext.get().getOriginalRequestUri();
-    }
-
-    /**
-     * This method returns the "base URI" associated with the current request. For example, if a client invoked POST
-     * https://myhost:9443/fhir-server/api/v4/Patient to create a Patient resource, this method would return
-     * "https://myhost:9443/fhir-server/api/v4".
-     *
-     * @param type
-     *      The resource type associated with the request URI (e.g. "Patient" in the case of
-     *      https://myhost:9443/fhir-server/api/v4/Patient), or null if there is no such resource type
-     * @return The base endpoint URI associated with the current request.
-     * @throws Exception if an error occurs while reading the config
-     * @implNote This method uses {@link #getRequestUri()} to get the original request URI and then strips it to the
-     *           <a href="https://www.hl7.org/fhir/http.html#general">Service Base URL</a>
-     */
-    protected String getRequestBaseUri(String type) throws Exception {
-        String baseUri = null;
-
-        String requestUri = getRequestUri();
-
-        // Strip off everything after the path
-        int queryPathSeparatorLoc = requestUri.indexOf("?");
-        if (queryPathSeparatorLoc != -1) {
-            baseUri = requestUri.substring(0, queryPathSeparatorLoc);
-        } else {
-            baseUri = requestUri;
-        }
-
-        // Strip off any path elements after the base
-        if (type != null && !type.isEmpty()) {
-            int resourceNamePathLocation = baseUri.indexOf("/" + type + "/");
-            if (resourceNamePathLocation != -1) {
-                baseUri = requestUri.substring(0, resourceNamePathLocation);
-            } else {
-                resourceNamePathLocation = baseUri.lastIndexOf("/" + type);
-                if (resourceNamePathLocation != -1) {
-                    baseUri = requestUri.substring(0, resourceNamePathLocation);
-                } else {
-                    // Assume the request was a batch/transaction and just use the requestUri as the base
-                    baseUri = requestUri;
-                }
-            }
-        } else {
-            if (baseUri.endsWith("/_history")) {
-                baseUri = baseUri.substring(0, baseUri.length() - "/_history".length());
-            } else if (baseUri.endsWith("/_search")) {
-                baseUri = baseUri.substring(0, baseUri.length() - "/_search".length());
-            } else if (baseUri.contains("/$")) {
-                baseUri = baseUri.substring(0, baseUri.lastIndexOf("/$"));
-            }
-        }
-
-        return baseUri;
     }
 
     /**

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.server.resources;
 
 import static com.ibm.fhir.server.spi.operation.FHIROperationUtil.checkAndVerifyOperationAllowed;
+import static com.ibm.fhir.server.util.FHIRRestHelper.getRequestBaseUri;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.net.URI;
@@ -505,7 +506,7 @@ public class Operation extends FHIRResource {
                 (URI) operationContext.getProperty(FHIROperationContext.PROPNAME_LOCATION_URI);
         if (locationURI != null) {
             return Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(resourceTypeName), locationURI.toString())))
+                    .location(toUri(buildAbsoluteUri(getRequestBaseUri(resourceTypeName), locationURI.toString())))
                     .entity(resource)
                     .build();
         }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.server.resources;
 
+import static com.ibm.fhir.server.util.FHIRRestHelper.getRequestBaseUri;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.util.Date;
@@ -83,7 +84,7 @@ public class Patch extends FHIRResource {
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    .location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
 
             Resource resource = ior.getResource();
             if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {
@@ -140,7 +141,7 @@ public class Patch extends FHIRResource {
             ior = helper.doPatch(type, id, patch, ifMatch, null, onlyIfModified);
 
             ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    Response.ok().location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
             status = ior.getStatus();
             response.status(status);
 
@@ -203,7 +204,7 @@ public class Patch extends FHIRResource {
             ior = helper.doPatch(type, null, patch, ifMatch, searchQueryString, onlyIfModified);
 
             ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    Response.ok().location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
             status = ior.getStatus();
             response.status(status);
 
@@ -272,7 +273,7 @@ public class Patch extends FHIRResource {
 
             status = ior.getStatus();
             ResponseBuilder response = Response.status(status)
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    .location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
 
             Resource resource = ior.getResource();
             if (resource != null && HTTPReturnPreference.REPRESENTATION == FHIRRequestContext.get().getReturnPreference()) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.server.resources;
 
+import static com.ibm.fhir.server.util.FHIRRestHelper.getRequestBaseUri;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.util.Date;
@@ -75,7 +76,7 @@ public class Update extends FHIRResource {
             ior = helper.doUpdate(type, id, resource, ifMatch, null, onlyIfModified, ifNoneMatch);
 
             ResponseBuilder response = Response.ok()
-                    .location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    .location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
             status = ior.getStatus();
             response.status(status);
 
@@ -147,7 +148,7 @@ public class Update extends FHIRResource {
             ior = helper.doUpdate(type, null, resource, ifMatch, searchQueryString, onlyIfModified, IF_NONE_MATCH_NULL);
 
             ResponseBuilder response =
-                    Response.ok().location(toUri(getAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
+                    Response.ok().location(toUri(buildAbsoluteUri(getRequestBaseUri(type), ior.getLocationURI().toString())));
             status = ior.getStatus();
             response.status(status);
 


### PR DESCRIPTION
We had duplicate logic in two classes:
* FHIRResource.getRequestBaseUri
* FHIRRestHelper.getRequestBaseUri

For #2965, we fixed the version in FHIRResource but missed the one in
FHIRRestHelper.

Now I combined the two implementations into FHIRRestHelper, made it
static, and removed the version from FHIRResource.

I also added commits for the discrepencies between system-level and
instance-level history identified in #3501

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>