### PR TITLE
issue #3469 - add missing jar to shaded jar and fixup test data for conformance to us core 4.0

### DIFF
--- a/cql/operation/fhir-operation-cqf/pom.xml
+++ b/cql/operation/fhir-operation-cqf/pom.xml
@@ -146,6 +146,7 @@
                                     <include>org.jvnet.jaxb2_commons</include>
                                     <include>org.eclipse.persistence</include>
                                     <include>commons-beanutils:commons-beanutils</include>
+                                    <include>org.apache.commons:commons-collections4</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureSubmitDataOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureSubmitDataOperationTest.java
@@ -187,11 +187,4 @@ public class ServerMeasureSubmitDataOperationTest extends BaseMeasureOperationTe
             assertNotNull(output);
         }
     }
-
-    @Test
-    public void validatePatient() throws Exception {
-        Resource patient = TestUtil.readLocalResource("testdata/MeasureReport-EXM104.json");
-        List<Issue> issues = FHIRValidator.validator().validate(patient);
-        issues.forEach(System.out::println);
-    }
 }

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureSubmitDataOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/cqf/ServerMeasureSubmitDataOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -10,6 +10,7 @@ import static org.testng.Assert.assertNotNull;
 
 import java.io.InputStream;
 import java.io.StringReader;
+import java.util.List;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
@@ -22,9 +23,11 @@ import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Encounter;
 import com.ibm.fhir.model.resource.MeasureReport;
 import com.ibm.fhir.model.resource.OperationOutcome;
+import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Patient;
+import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Code;
@@ -41,6 +44,7 @@ import com.ibm.fhir.model.type.code.AdministrativeGender;
 import com.ibm.fhir.model.type.code.EncounterStatus;
 import com.ibm.fhir.model.type.code.MeasureReportStatus;
 import com.ibm.fhir.model.type.code.MeasureReportType;
+import com.ibm.fhir.validation.FHIRValidator;
 
 public class ServerMeasureSubmitDataOperationTest extends BaseMeasureOperationTest {
 
@@ -182,5 +186,12 @@ public class ServerMeasureSubmitDataOperationTest extends BaseMeasureOperationTe
             Bundle output = (Bundle) FHIRParser.parser(Format.JSON).parse(new StringReader(responseBody));
             assertNotNull(output);
         }
+    }
+
+    @Test
+    public void validatePatient() throws Exception {
+        Resource patient = TestUtil.readLocalResource("testdata/MeasureReport-EXM104.json");
+        List<Issue> issues = FHIRValidator.validator().validate(patient);
+        issues.forEach(System.out::println);
     }
 }

--- a/fhir-server-test/src/test/resources/testdata/MeasureReport-EXM104.json
+++ b/fhir-server-test/src/test/resources/testdata/MeasureReport-EXM104.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "MeasureReport",
-	"id": "measurereport-denom-EXM104",
+  "id": "measurereport-denom-EXM104",
   "meta": {
     "versionId": "1",
     "lastUpdated": "2021-11-19T21:08:23.612324Z"
@@ -58,6 +58,10 @@
                       "code": "2054-5",
                       "display": "Black or African American"
                     }
+                  },
+                  {
+                    "url": "text",
+                    "valueString": "Black or African American"
                   }
                 ],
                 "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
@@ -71,6 +75,10 @@
                       "code": "2135-2",
                       "display": "Hispanic or Latino"
                     }
+                  },
+                  {
+                    "url": "text",
+                    "valueString": "Hispanic or Latino"
                   }
                 ],
                 "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"


### PR DESCRIPTION
the test data had a contained Patient resource that was not valid per US
Core 4.0.0 because its race and ethnicity extensions were missing a
required "text" value

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>