### PR TITLE
issues #3184 and #3186 - update Capabilities

### DIFF
--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/CapabilitiesTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/CapabilitiesTest.java
@@ -28,6 +28,8 @@ import com.ibm.fhir.search.util.SearchHelper;
 import com.ibm.fhir.server.resources.Capabilities;
 
 public class CapabilitiesTest {
+    private static final boolean DEBUG = true;
+
     SearchHelper searchHelper = new SearchHelper();
 
     @BeforeClass
@@ -53,7 +55,7 @@ public class CapabilitiesTest {
         assertEquals(capabilityStatement.getRest().size(), 1, "Number of REST Elements");
         CapabilityStatement.Rest restDefinition = capabilityStatement.getRest().get(0);
 
-        assertRestDefinition(restDefinition, 146, 8, 0, 0, 8, 0, 0);
+        assertRestDefinition(restDefinition, 4, 146, 9, 1, 1, 9, 1, 1);
     }
 
     @Test
@@ -68,7 +70,7 @@ public class CapabilitiesTest {
         assertEquals(capabilityStatement.getRest().size(), 1, "Number of REST Elements");
         CapabilityStatement.Rest restDefinition = capabilityStatement.getRest().get(0);
 
-        assertRestDefinition(restDefinition, 146, 0, 0, 0, 0, 0, 0);
+        assertRestDefinition(restDefinition, 2, 146, 0, 0, 0, 0, 0, 0);
     }
 
     @Test
@@ -83,12 +85,16 @@ public class CapabilitiesTest {
         assertEquals(capabilityStatement.getRest().size(), 1, "Number of REST Elements");
         CapabilityStatement.Rest restDefinition = capabilityStatement.getRest().get(0);
 
-        assertRestDefinition(restDefinition, 2, 2, 1, 0, 4, 0, 1);
+        assertRestDefinition(restDefinition, 4, 2, 2, 1, 1, 5, 1, 1);
     }
 
-    private void assertRestDefinition(CapabilityStatement.Rest restDefinition, int numOfResources,
-        int patientInteractions, int patientIncludes, int patientRevIncludes,
-        int practitionerInteractions, int practitionerIncludes, int practitionerRevIncludes) {
+    private void assertRestDefinition(CapabilityStatement.Rest restDefinition, int systemInteractions, int numOfResources,
+            int patientInteractions, int patientIncludes, int patientRevIncludes,
+            int practitionerInteractions, int practitionerIncludes, int practitionerRevIncludes) {
+        if (DEBUG) {
+            System.out.println(restDefinition);
+        }
+        assertEquals(restDefinition.getInteraction().size(), systemInteractions, "Number of supported system-level interactions");
         assertEquals(restDefinition.getResource().size(), numOfResources, "Number of supported resources");
         assertFalse(restDefinition.getResource().stream().anyMatch(r -> r.getType().getValueAsEnum() == ResourceType.Value.RESOURCE));
         assertFalse(restDefinition.getResource().stream().anyMatch(r -> r.getType().getValueAsEnum() == ResourceType.Value.DOMAIN_RESOURCE));
@@ -98,7 +104,7 @@ public class CapabilitiesTest {
     }
 
     private void assertResourceDefinition(CapabilityStatement.Rest restDefinition, ResourceType.Value resourceType, int numOfInteractions,
-        int numIncludes, int numRevIncludes) {
+            int numIncludes, int numRevIncludes) {
         Optional<CapabilityStatement.Rest.Resource> resource = restDefinition.getResource().stream()
                 .filter(r -> r.getType().getValueAsEnum() == resourceType)
                 .findFirst();

--- a/fhir-server/src/test/resources/config/empty/fhir-server-config.json
+++ b/fhir-server/src/test/resources/config/empty/fhir-server-config.json
@@ -6,14 +6,14 @@
             "Patient": {
                 "interactions": [],
                 "searchParameters": {},
-                "searchInclude": [],
-                "searchRevInclude": []
+                "searchIncludes": [],
+                "searchRevIncludes": []
             },
             "Resource": {
                 "interactions": [],
                 "searchParameters": {},
-                "searchInclude": [],
-                "searchRevInclude": []
+                "searchIncludes": [],
+                "searchRevIncludes": []
             }
         },
         "security": {


### PR DESCRIPTION
1. Advertise support for the system and type-level history interactions
2. Update Capabilities.getSupportedResourceTypes to use the new
ResourcesConfigAdapter

Backported from https://github.com/IBM/FHIR/commit/c9cadcb75bc6b5d1ba44004190c51fd5e2867f38

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>