### PR TITLE
issue #3536 - use ResourcesConfigAdapter from validateInteraction

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -274,9 +274,9 @@ For example, the fhir-server-config snippet from above would have a correspondin
              password="change-password"
              currentSchema="fhirdata"
          />
-        <connectionManager maxPoolSize="200" minPoolSize="20" 
-            connectionTimeout="60s" maxIdleTime="2m" 
-            numConnectionsPerThreadLocal="1"/>
+        <connectionManager maxPoolSize="200" minPoolSize="20"
+            connectionTimeout="60s" maxIdleTime="2m"
+            numConnectionsPerThreadLocal="0"/>
     </dataSource>
 </server>
 ```
@@ -450,9 +450,9 @@ Furthermore, the REST API consumers associated with Acme applications will be co
             currentSchema="DB2INST1"
             driverType="4"
          />
-        <connectionManager maxPoolSize="200" minPoolSize="20" 
-            connectionTimeout="60s" maxIdleTime="2m" 
-            numConnectionsPerThreadLocal="1"/>
+        <connectionManager maxPoolSize="200" minPoolSize="20"
+            connectionTimeout="60s" maxIdleTime="2m"
+            numConnectionsPerThreadLocal="0"/>
     </dataSource>
 
     <!-- ============================================================== -->
@@ -469,9 +469,9 @@ Furthermore, the REST API consumers associated with Acme applications will be co
             currentSchema="DB2INST1"
             driverType="4"
          />
-        <connectionManager maxPoolSize="200" minPoolSize="20" 
-            connectionTimeout="60s" maxIdleTime="2m" 
-            numConnectionsPerThreadLocal="1"/>
+        <connectionManager maxPoolSize="200" minPoolSize="20"
+            connectionTimeout="60s" maxIdleTime="2m"
+            numConnectionsPerThreadLocal="0"/>
     </dataSource>
 </server>
 ```
@@ -918,7 +918,7 @@ For examples on how to use the IBM FHIR Client, look for tests like `com.ibm.fhi
 Inter-dependencies between resources are typically defined by one resource containing a field of type `Reference` which contains an _external reference_<sup id="a5">[5](#f5)</sup> to another resource. For example, an `Observation` resource could reference a `Patient` resource via the Observation's `subject` field. The value that is stored in the `Reference.reference` field (for example, `Observation.subject.reference` in the case of the `Observation` resource) could be an absolute URL, such as `https://fhirserver1:9443/fhir-server/api/v4/Patient/12345`, or a relative URL, such as `Patient/12345`.
 
 As described above, in order to establish a reference to a resource, you must first know its resource identifier. However, if you are using a request bundle to create both the referenced resource (`Patient` in this example) and the resource which references it (`Observation`), then it is impossible to know the `Patient`resource identifier before the request bundle has been processed (that is, before the new `Patient` resource is created).
- 
+
 Thankfully, the HL7 FHIR specification defines a way to express a dependency between two resources within a request bundle by using a _local identifier_ to identify the resource being referenced, and a _local reference_<sup id="a6">[6](#f6)</sup> to reference the resource via its local identifier. In the following example, a request bundle contains a `POST` request to create a new `Patient` resource, along with a `POST` request to create a new `Observation` resource that references that `Patient`:
 
 <a id="example-obs-ref-pat"></a>
@@ -968,7 +968,7 @@ The following processing rules apply for the use of local references within a re
     - it will extract the FHIR base URL from the local identifier and append the local reference to it
     - it will then try to resolve the reference within the request bundle using the updated local reference
 
-    See the [relative local reference example](#example-ref-via-relative-local-ref) below for an illustration of this rule. 
+    See the [relative local reference example](#example-ref-via-relative-local-ref) below for an illustration of this rule.
 
 In the [example above](#example-obs-ref-pat), you can see that there are two POST requests and the `Patient` request entry appears in the bundle before the `Observation` request entry. However, based on the [order dependency processing rule](#order-dependency-rule), it would still be a valid request bundle even if the `Observation` request entry appeared before the `Patient` request entry.
 
@@ -1093,7 +1093,7 @@ Then when the FHIR server processes the POST requests for the `Encounter` and `P
 }
 ```
 
-In the above example, even though the `Patient` request entry is a conditional create request, this is still a valid request bundle, because the FHIR server resolves any conditional requests before it establishes the mapping between local identifiers and the corresponding external identifiers that will result from performing the `POST` or `PUT` operation. 
+In the above example, even though the `Patient` request entry is a conditional create request, this is still a valid request bundle, because the FHIR server resolves any conditional requests before it establishes the mapping between local identifiers and the corresponding external identifiers that will result from performing the `POST` or `PUT` operation.
 
 #### <a id="example-ref-via-relative-local-ref"></a>Example: Reference via relative local reference
 ```
@@ -2046,6 +2046,8 @@ Whole-system search and whole-system history are special cases. Since no resourc
 
 In addition to interaction configuration, the `fhirServer/resources` property group also provides the ability to configure search parameter filtering and profile validation. See [Search configuration](https://ibm.github.io/FHIR/guides/FHIRSearchConfiguration#13-filtering) and [Resource validation](#44-resource-validation) respectively for details.
 
+Unlike most other tenant-specific properties, the `fhirServer/resources` property group is processed as a single unit. In the event that `fhirServer/resources` exists in a tenant-specific config, but a particular sub-property is missing (e.g. `fhirServer/resources/open`), that sub-property will *not* inheret from the "default" tenant.
+
 ## 4.12.1 Using the IBM FHIR Server behind a proxy
 It is possible to run the IBM FHIR Server behind a reverse proxy such as Kubernetes Ingress or an API Gateway.
 
@@ -2397,175 +2399,178 @@ Depending on the context of their use, config properties can be:
 
 The following table tracks which properties can be set on a tenant-specific basis
 and which properties are loaded dynamically.
-If you change a properties that has an `N` in the `Dynamic?` column, it means you
+If you change a property that has an `N` in the `Dynamic?` column, it means you
 must restart the server for that change to take effect.
+Most tenant-specific properties support "fallback" to the default tenant config.
+Cases where that behavior is not supported are marked below with an `N` in the `Fallback?` column.
 
-| Property Name                 | Tenant-specific? | Dynamic? |
-|-------------------------------|------------------|----------|
-|`fhirServer/core/defaultPrettyPrint`|Y|Y|
-|`fhirServer/core/tenantIdHeaderName`|N|N|
-|`fhirServer/core/dataSourceIdHeaderName`|N|N|
-|`fhirServer/core/originalRequestUriHeaderName`|N|N|
-|`fhirServer/core/defaultHandling`|Y|Y|
-|`fhirServer/core/allowClientHandlingPref`|Y|Y|
-|`fhirServer/core/checkReferenceTypes`|N|N|
-|`fhirServer/core/checkControlCharacters`|N|N|
-|`fhirServer/core/serverRegistryResourceProviderEnabled`|N|N|
-|`fhirServer/core/serverResolveFunctionEnabled`|N|N|
-|`fhirServer/core/conditionalDeleteMaxNumber`|Y|Y|
-|`fhirServer/core/capabilityStatementCacheTimeout`|Y|Y|
-|`fhirServer/core/extendedCodeableConceptValidation`|N|N|
-|`fhirServer/core/disabledOperations`|N|N|
-|`fhirServer/core/defaultPageSize`|Y|Y|
-|`fhirServer/core/ifNoneMatchReturnsNotModified`|Y|Y|
-|`fhirServer/core/maxPageSize`|Y|Y|
-|`fhirServer/core/maxPageIncludeCount`|Y|Y|
-|`fhirServer/core/capabilitiesUrl`|Y|Y|
-|`fhirServer/core/externalBaseUrl`|Y|Y|
-|`fhirServer/validation/failFast`|Y|Y|
-|`fhirServer/term/cachingDisabled`|N|N|
-|`fhirServer/term/graphTermServiceProviders/enabled`|N|N|
-|`fhirServer/term/graphTermServiceProviders/timeLimit`|N|N|
-|`fhirServer/term/graphTermServiceProviders/configuration`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/enabled`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/base`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/trustStore`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/hostnameVerificationEnabled`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/basicAuth`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/headers`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/httpTimeout`|N|N|
-|`fhirServer/term/remoteTermServiceProviders/supports`|N|N|
-|`fhirServer/term/capabilitiesUrl`|Y|Y|
-|`fhirServer/resources/open`|Y|Y|
-|`fhirServer/resources/Resource/interactions`|Y|Y|
-|`fhirServer/resources/Resource/searchParameters`|Y|Y|
-|`fhirServer/resources/Resource/searchParameters/<code>`|Y|Y|
-|`fhirServer/resources/Resource/searchIncludes`|Y|Y|
-|`fhirServer/resources/Resource/searchRevIncludes`|Y|Y|
-|`fhirServer/resources/Resource/searchParameterCombinations`|Y|Y|
-|`fhirServer/resources/Resource/profiles/atLeastOne`|Y|Y|
-|`fhirServer/resources/Resource/profiles/notAllowed`|Y|Y|
-|`fhirServer/resources/Resource/profiles/allowUnknown`|Y|Y|
-|`fhirServer/resources/Resource/profiles/defaultVersions`|Y|Y|
-|`fhirServer/resources/Resource/profiles/defaultVersions/<profile>`|Y|Y|
-|`fhirServer/resources/<resourceType>/interactions`|Y|Y|
-|`fhirServer/resources/<resourceType>/searchParameters`|Y|N|
-|`fhirServer/resources/<resourceType>/searchParameters/<code>`|Y|N|
-|`fhirServer/resources/<resourceType>/searchIncludes`|Y|Y|
-|`fhirServer/resources/<resourceType>/searchRevIncludes`|Y|Y|
-|`fhirServer/resources/<resourceType>/searchParameterCombinations`|Y|Y|
-|`fhirServer/resources/<resourceType>/profiles/atLeastOne`|Y|Y|
-|`fhirServer/resources/<resourceType>/profiles/notAllowed`|Y|Y|
-|`fhirServer/resources/<resourceType>/profiles/allowUnknown`|Y|Y|
-|`fhirServer/resources/<resourceType>/profiles/defaultVersions`|Y|Y|
-|`fhirServer/resources/<resourceType>/profiles/defaultVersions/<profile>`|Y|Y|
-|`fhirServer/notifications/common/includeResourceTypes`|N|N|
-|`fhirServer/notifications/common/maxNotificationSizeBytes`|Y|N|
-|`fhirServer/notifications/common/maxNotificationSizeBehavior`|Y|N|
-|`fhirServer/notifications/websocket/enabled`|N|N|
-|`fhirServer/notifications/kafka/enabled`|N|N|
-|`fhirServer/notifications/kafka/sync`|Y|N|
-|`fhirServer/notifications/kafka/topicName`|N|N|
-|`fhirServer/notifications/kafka/connectionProperties`|N|N|
-|`fhirServer/notifications/nats/enabled`|N|N|
-|`fhirServer/notifications/nats/cluster`|N|N|
-|`fhirServer/notifications/nats/channel`|N|N|
-|`fhirServer/notifications/nats/clientId`|N|N|
-|`fhirServer/notifications/nats/servers`|N|N|
-|`fhirServer/notifications/nats/useTLS`|N|N|
-|`fhirServer/notifications/nats/truststoreLocation`|N|N|
-|`fhirServer/notifications/nats/truststorePassword`|N|N|
-|`fhirServer/notifications/nats/keystoreLocation`|N|N|
-|`fhirServer/notifications/nats/keystorePassword`|N|N|
-|`fhirServer/persistence/factoryClassname`|N|N|
-|`fhirServer/persistence/common/updateCreateEnabled`|N|N|
-|`fhirServer/persistence/datasources`|Y|N|
-|`fhirServer/persistence/datasources/<datasourceId>/type`|Y|N|
-|`fhirServer/persistence/datasources/<datasourceId>/jndiName`|Y|Y|
-|`fhirServer/persistence/datasources/<datasourceId>/currentSchema`|Y|Y|
-|`fhirServer/persistence/datasources/<datasourceId>/searchOptimizerOptions/from_collapse_limit`|Y|Y|
-|`fhirServer/persistence/datasources/<datasourceId>/searchOptimizerOptions/join_collapse_limit`|Y|Y|
-|`fhirServer/search/useBoundingRadius`|Y|Y|
-|`fhirServer/search/enableLegacyWholeSystemSearchParams`|Y|Y|
-|`fhirServer/security/cors`|Y|Y|
-|`fhirServer/security/basic/enabled`|Y|Y|
-|`fhirServer/security/certificates/enabled`|Y|Y|
-|`fhirServer/security/oauth/enabled`|Y|Y|
-|`fhirServer/security/oauth/regUrl`|Y|Y|
-|`fhirServer/security/oauth/authUrl`|Y|Y|
-|`fhirServer/security/oauth/tokenUrl`|Y|Y|
-|`fhirServer/security/oauth/manageUrl`|Y|Y|
-|`fhirServer/security/oauth/introspectUrl`|Y|Y|
-|`fhirServer/security/oauth/revokeUrl`|Y|Y|
-|`fhirServer/security/oauth/smart/enabled`|Y|Y|
-|`fhirServer/security/oauth/smart/scopes`|Y|Y|
-|`fhirServer/security/oauth/smart/capabilities`|Y|Y|
-|`fhirServer/audit/serviceClassName`|N|N|
-|`fhirServer/audit/serviceProperties/auditTopic`|N|N|
-|`fhirServer/audit/serviceProperties/geoCity`|N|N|
-|`fhirServer/audit/serviceProperties/geoState`|N|N|
-|`fhirServer/audit/serviceProperties/geoCounty`|N|N|
-|`fhirServer/audit/serviceProperties/mapper`|N|N|
-|`fhirServer/audit/serviceProperties/load`|N|N|
-|`fhirServer/audit/hostname`|N|N|
-|`fhirServer/audit/ip`|N|N|
-|`fhirServer/bulkdata/enabled`|Y|Y|
-|`fhirServer/bulkdata/core/api/url`|Y|Y|
-|`fhirServer/bulkdata/core/api/user`|Y|Y|
-|`fhirServer/bulkdata/core/api/password`|Y|Y|
-|`fhirServer/bulkdata/core/api/truststore`|Y|Y|
-|`fhirServer/bulkdata/core/api/truststorePassword`|Y|Y|
-|`fhirServer/bulkdata/core/api/trustAll`|Y|Y|
-|`fhirServer/bulkdata/core/cos/partUploadTriggerSizeMB`|N|N|
-|`fhirServer/bulkdata/core/cos/objectSizeThresholdMB`|N|N|
-|`fhirServer/bulkdata/core/cos/objectResourceCountThreshold`|N|N|
-|`fhirServer/bulkdata/core/cos/requestTimeout`|N|N|
-|`fhirServer/bulkdata/core/cos/socketTimeout`|N|N|
-|`fhirServer/bulkdata/core/cos/useServerTruststore`|Y|Y|
-|`fhirServer/bulkdata/core/cos/presignedExpiry`|Y|Y|
-|`fhirServer/bulkdata/core/azure/objectSizeThresholdMB`|N|N|
-|`fhirServer/bulkdata/core/azure/objectResourceCountThreshold`|N|N|
-|`fhirServer/bulkdata/core/batchIdEncryptionKey`|Y|N|
-|`fhirServer/bulkdata/core/pageSize`|Y|Y|
-|`fhirServer/bulkdata/core/maxPartitions`|Y|Y|
-|`fhirServer/bulkdata/core/maxInputs`|Y|Y|
-|`fhirServer/bulkdata/core/iamEndpoint`|N|N|
-|`fhirServer/bulkdata/core/fastTxTimeout`|N|N|
-|`fhirServer/bulkdata/core/defaultExportProvider`|Y|Y|
-|`fhirServer/bulkdata/core/defaultImportProvider`|Y|Y|
-|`fhirServer/bulkdata/core/defaultOutcomeProvider`|Y|Y|
-|`fhirServer/bulkdata/core/enableSkippableUpdates`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/type`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/bucketName`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/location`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/endpointInternal`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/endpointExternal`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/fileBase`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/validBaseUrls`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/disableBaseUrlValidation`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/disableOperationOutcomes`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/duplicationCheck`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/validateResources`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/presigned`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/create`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/type`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/accessKeyId`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/secretAccessKey`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/iamApiKey`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/iamResourceInstanceId`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/username`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/password`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/auth/connection`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/operationOutcomeProvider`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/accessType`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/requiresAccessToken`|Y|Y|
-|`fhirServer/bulkdata/storageProviders/<source>/allowAllResources`|Y|Y|
-|`fhirServer/operations/erase/enabled`|Y|Y|
-|`fhirServer/operations/erase/allowedRoles`|Y|Y|
-|`fhirServer/operations/membermatch/enabled`|Y|Y|
-|`fhirServer/operations/membermatch/strategy`|Y|Y|
-|`fhirServer/operations/membermatch/extendedProps`|Y|Y|
-|`fhirServer/operations/everything/includeTypes`|Y|Y|
+| Property Name                 | Tenant-specific? | Dynamic? | Fallback? |
+|-------------------------------|------------------|----------|-----------|
+|`fhirServer/core/defaultPrettyPrint`|Y|Y|Y|
+|`fhirServer/core/tenantIdHeaderName`|N|N||
+|`fhirServer/core/dataSourceIdHeaderName`|N|N||
+|`fhirServer/core/originalRequestUriHeaderName`|N|N||
+|`fhirServer/core/defaultHandling`|Y|Y|Y|
+|`fhirServer/core/allowClientHandlingPref`|Y|Y|Y|
+|`fhirServer/core/checkReferenceTypes`|N|N||
+|`fhirServer/core/checkControlCharacters`|N|N||
+|`fhirServer/core/serverRegistryResourceProviderEnabled`|N|N||
+|`fhirServer/core/serverResolveFunctionEnabled`|N|N||
+|`fhirServer/core/conditionalDeleteMaxNumber`|Y|Y|Y|
+|`fhirServer/core/capabilityStatementCacheTimeout`|Y|Y|Y|
+|`fhirServer/core/extendedCodeableConceptValidation`|N|N||
+|`fhirServer/core/disabledOperations`|N|N||
+|`fhirServer/core/defaultPageSize`|Y|Y|Y|
+|`fhirServer/core/ifNoneMatchReturnsNotModified`|Y|Y|Y|
+|`fhirServer/core/maxPageSize`|Y|Y|Y|
+|`fhirServer/core/maxPageIncludeCount`|Y|Y|Y|
+|`fhirServer/core/capabilitiesUrl`|Y|Y|Y|
+|`fhirServer/core/externalBaseUrl`|Y|Y|Y|
+|`fhirServer/validation/failFast`|Y|Y|Y|
+|`fhirServer/term/cachingDisabled`|N|N||
+|`fhirServer/term/graphTermServiceProviders/enabled`|N|N||
+|`fhirServer/term/graphTermServiceProviders/timeLimit`|N|N||
+|`fhirServer/term/graphTermServiceProviders/configuration`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/enabled`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/base`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/trustStore`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/hostnameVerificationEnabled`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/basicAuth`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/headers`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/httpTimeout`|N|N||
+|`fhirServer/term/remoteTermServiceProviders/supports`|N|N||
+|`fhirServer/term/capabilitiesUrl`|Y|Y|Y|
+|`fhirServer/resources`|Y|Y|Y|
+|`fhirServer/resources/open`|Y|Y|N|
+|`fhirServer/resources/Resource/interactions`|Y|Y|N|
+|`fhirServer/resources/Resource/searchParameters`|Y|Y|N|
+|`fhirServer/resources/Resource/searchParameters/<code>`|Y|Y|N|
+|`fhirServer/resources/Resource/searchIncludes`|Y|Y|N|
+|`fhirServer/resources/Resource/searchRevIncludes`|Y|Y|N|
+|`fhirServer/resources/Resource/searchParameterCombinations`|Y|Y|N|
+|`fhirServer/resources/Resource/profiles/atLeastOne`|Y|Y|N|
+|`fhirServer/resources/Resource/profiles/notAllowed`|Y|Y|N|
+|`fhirServer/resources/Resource/profiles/allowUnknown`|Y|Y|N|
+|`fhirServer/resources/Resource/profiles/defaultVersions`|Y|Y|N|
+|`fhirServer/resources/Resource/profiles/defaultVersions/<profile>`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/interactions`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/searchParameters`|Y|N|N|
+|`fhirServer/resources/<resourceType>/searchParameters/<code>`|Y|N|N|
+|`fhirServer/resources/<resourceType>/searchIncludes`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/searchRevIncludes`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/searchParameterCombinations`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/profiles/atLeastOne`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/profiles/notAllowed`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/profiles/allowUnknown`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/profiles/defaultVersions`|Y|Y|N|
+|`fhirServer/resources/<resourceType>/profiles/defaultVersions/<profile>`|Y|Y|N|
+|`fhirServer/notifications/common/includeResourceTypes`|N|N||
+|`fhirServer/notifications/common/maxNotificationSizeBytes`|Y|Y|Y|
+|`fhirServer/notifications/common/maxNotificationSizeBehavior`|Y|Y|Y|
+|`fhirServer/notifications/websocket/enabled`|N|N||
+|`fhirServer/notifications/kafka/enabled`|N|N||
+|`fhirServer/notifications/kafka/topicName`|N|N||
+|`fhirServer/notifications/kafka/connectionProperties`|N|N||
+|`fhirServer/notifications/kafka/sync`|Y|Y|Y|
+|`fhirServer/notifications/nats/enabled`|N|N||
+|`fhirServer/notifications/nats/cluster`|N|N||
+|`fhirServer/notifications/nats/channel`|N|N||
+|`fhirServer/notifications/nats/clientId`|N|N||
+|`fhirServer/notifications/nats/servers`|N|N||
+|`fhirServer/notifications/nats/useTLS`|N|N||
+|`fhirServer/notifications/nats/truststoreLocation`|N|N||
+|`fhirServer/notifications/nats/truststorePassword`|N|N||
+|`fhirServer/notifications/nats/keystoreLocation`|N|N||
+|`fhirServer/notifications/nats/keystorePassword`|N|N||
+|`fhirServer/persistence/factoryClassname`|N|N||
+|`fhirServer/persistence/common/updateCreateEnabled`|N|N||
+|`fhirServer/persistence/datasources`|Y|N|N|
+|`fhirServer/persistence/datasources/<datasourceId>/type`|Y|N|N|
+|`fhirServer/persistence/datasources/<datasourceId>/jndiName`|Y|Y|N|
+|`fhirServer/persistence/datasources/<datasourceId>/currentSchema`|Y|Y|N|
+|`fhirServer/persistence/datasources/<datasourceId>/searchOptimizerOptions/from_collapse_limit`|Y|Y|N|
+|`fhirServer/persistence/datasources/<datasourceId>/searchOptimizerOptions/join_collapse_limit`|Y|Y|N|
+|`fhirServer/search/useBoundingRadius`|Y|Y|Y|
+|`fhirServer/search/enableLegacyWholeSystemSearchParams`|Y|Y|Y|
+|`fhirServer/security/cors`|Y|Y|Y|
+|`fhirServer/security/basic/enabled`|Y|Y|Y|
+|`fhirServer/security/certificates/enabled`|Y|Y|Y|
+|`fhirServer/security/oauth/enabled`|Y|Y|Y|
+|`fhirServer/security/oauth/regUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/authUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/tokenUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/manageUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/introspectUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/revokeUrl`|Y|Y|Y|
+|`fhirServer/security/oauth/smart/enabled`|Y|Y|Y|
+|`fhirServer/security/oauth/smart/scopes`|Y|Y|Y|
+|`fhirServer/security/oauth/smart/capabilities`|Y|Y|Y|
+|`fhirServer/audit/serviceClassName`|N|N||
+|`fhirServer/audit/serviceProperties/auditTopic`|N|N||
+|`fhirServer/audit/serviceProperties/geoCity`|N|N||
+|`fhirServer/audit/serviceProperties/geoState`|N|N||
+|`fhirServer/audit/serviceProperties/geoCounty`|N|N||
+|`fhirServer/audit/serviceProperties/mapper`|N|N||
+|`fhirServer/audit/serviceProperties/load`|N|N||
+|`fhirServer/audit/hostname`|N|N||
+|`fhirServer/audit/ip`|N|N||
+|`fhirServer/bulkdata/enabled`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/url`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/user`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/password`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/truststore`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/truststorePassword`|Y|Y|Y|
+|`fhirServer/bulkdata/core/api/trustAll`|Y|Y|Y|
+|`fhirServer/bulkdata/core/cos/partUploadTriggerSizeMB`|N|N||
+|`fhirServer/bulkdata/core/cos/objectSizeThresholdMB`|N|N||
+|`fhirServer/bulkdata/core/cos/objectResourceCountThreshold`|N|N||
+|`fhirServer/bulkdata/core/cos/requestTimeout`|N|N||
+|`fhirServer/bulkdata/core/cos/socketTimeout`|N|N||
+|`fhirServer/bulkdata/core/cos/useServerTruststore`|Y|Y|Y|
+|`fhirServer/bulkdata/core/cos/presignedExpiry`|Y|Y|Y|
+|`fhirServer/bulkdata/core/azure/objectSizeThresholdMB`|N|N||
+|`fhirServer/bulkdata/core/azure/objectResourceCountThreshold`|N|N||
+|`fhirServer/bulkdata/core/batchIdEncryptionKey`|Y|N|Y|
+|`fhirServer/bulkdata/core/pageSize`|Y|Y|Y|
+|`fhirServer/bulkdata/core/maxPartitions`|Y|Y|Y|
+|`fhirServer/bulkdata/core/maxInputs`|Y|Y|Y|
+|`fhirServer/bulkdata/core/iamEndpoint`|N|N||
+|`fhirServer/bulkdata/core/fastTxTimeout`|N|N||
+|`fhirServer/bulkdata/core/defaultExportProvider`|Y|Y|Y|
+|`fhirServer/bulkdata/core/defaultImportProvider`|Y|Y|Y|
+|`fhirServer/bulkdata/core/defaultOutcomeProvider`|Y|Y|Y|
+|`fhirServer/bulkdata/core/enableSkippableUpdates`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/type`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/bucketName`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/location`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/endpointInternal`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/endpointExternal`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/fileBase`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/validBaseUrls`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/disableBaseUrlValidation`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/disableOperationOutcomes`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/duplicationCheck`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/validateResources`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/presigned`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/create`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/type`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/accessKeyId`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/secretAccessKey`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/iamApiKey`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/iamResourceInstanceId`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/username`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/password`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/auth/connection`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/operationOutcomeProvider`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/accessType`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/requiresAccessToken`|Y|Y|Y|
+|`fhirServer/bulkdata/storageProviders/<source>/allowAllResources`|Y|Y|Y|
+|`fhirServer/operations/erase/enabled`|Y|Y|Y|
+|`fhirServer/operations/erase/allowedRoles`|Y|Y|Y|
+|`fhirServer/operations/membermatch/enabled`|Y|Y|Y|
+|`fhirServer/operations/membermatch/strategy`|Y|Y|Y|
+|`fhirServer/operations/membermatch/extendedProps`|Y|Y|Y|
+|`fhirServer/operations/everything/includeTypes`|Y|Y|N|
 
 ## 5.2 Keystores, truststores, and the IBM FHIR server
 

--- a/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/FHIRConfiguration.java
@@ -128,34 +128,6 @@ public class FHIRConfiguration {
     @Deprecated
     public static final String PROPERTY_SEARCH_ENABLE_LEGACY_WHOLE_SYSTEM_SEARCH_PARAMS = "fhirServer/search/enableLegacyWholeSystemSearchParams";
 
-    // bulkdata
-    // JavaBatch Job id encryption key
-    public static final String PROPERTY_BULKDATA_BATCHJOBID_ENCRYPTION_KEY = "fhirServer/bulkdata/bulkDataBatchJobIdEncryptionKey";
-    // JavaBatch Job parameters
-    public static final String PROPERTY_BULKDATA_BATCHJOB_PARAMETERS  = "fhirServer/bulkdata/jobParameters";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_APPLICATIONNAME = "fhirServer/bulkdata/applicationName";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_MODULENAME = "fhirServer/bulkdata/moduleName";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_JOBXMLNAME = "fhirServer/bulkdata/jobXMLName";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_IMPTYPE = "fhirServer/bulkdata/implementation_type";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHURI = "fhirServer/bulkdata/batch-uri";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHUSER = "fhirServer/bulkdata/batch-user";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHUSERPWD = "fhirServer/bulkdata/batch-user-password";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTORE = "fhirServer/bulkdata/batch-truststore";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_BATCHTRUSTSTOREPWD = "fhirServer/bulkdata/batch-truststore-password";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_USEFHIRSERVERTRUSTSTORE = "fhirServer/bulkdata/useFhirServerTrustStore";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_ENABLEPARQUET = "fhirServer/bulkdata/enableParquet";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_SYSTEMEXPIMPL = "fhirServer/bulkdata/systemExportImpl";
-
-    public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_BASE_URLS = "fhirServer/bulkdata/validBaseUrls";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_VALID_URLS_DISABLED = "fhirServer/bulkdata/validBaseUrlsDisabled";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_MAX_INPUT_PER_TENANT =
-            "fhirServer/bulkdata/maxInputPerRequest";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXSIZE = "fhirServer/bulkdata/cosFileMaxSize";
-    public static final String PROPERTY_BULKDATA_BATCHJOB_COSFILEMAXRESOURCES = "fhirServer/bulkdata/cosFileMaxResources";
-    public static final String PROPERTY_BULKDATA_PATIENTEXPORT_PAGESIZE = "fhirServer/bulkdata/patientExportPageSize";
-    // Control if push OperationOutcomes to COS/S3.
-    public static final String PROPERTY_BULKDATA_IGNORE_IMPORT_OPERATION_OUTCOMES = "fhirServer/bulkdata/ignoreImportOutcomes";
-
     // Custom header names
     public static final String DEFAULT_TENANT_ID_HEADER_NAME = "X-FHIR-TENANT-ID";
     public static final String DEFAULT_DATASTORE_ID_HEADER_NAME = "X-FHIR-DSID";

--- a/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
+++ b/fhir-config/src/main/java/com/ibm/fhir/config/PropertyGroup.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -24,9 +24,6 @@ import jakarta.json.JsonValue;
  * resulting from loading the configuration, or it could be just a sub-structure within the overall config hierarchy, as
  * a property group can contain other property groups. Internally, there is a JsonObject which holds the actual group of
  * properties and this class provides a high-level API for accessing properties in a hierarchical manner.
- *
- * @author padams
- *
  */
 public class PropertyGroup {
 
@@ -110,9 +107,8 @@ public class PropertyGroup {
      *
      * @param propertyName the name of the property to retrieve
      * @return a List<String> containing the elements from the JSON array property; possibly null
-     * @throws Exception
      */
-    public List<String> getStringListProperty(String propertyName) throws Exception {
+    public List<String> getStringListProperty(String propertyName) {
         Object[] array = getArrayProperty(propertyName);
         List<String> strings = null;
         if (array != null) {
@@ -219,9 +215,8 @@ public class PropertyGroup {
      *
      * @param propertyName the name of the property to retrieve
      * @return an array of values from the specified array property or null if the property doesn't exist
-     * @throws Exception
      */
-    public Object[] getArrayProperty(String propertyName) throws Exception {
+    public Object[] getArrayProperty(String propertyName) {
         Object[] result = null;
         JsonValue jsonValue = getJsonValue(propertyName);
         if (jsonValue != null) {
@@ -238,9 +233,8 @@ public class PropertyGroup {
      * Returns the properties contained in the PropertyGroup in the form of a list of
      * PropertyEntry instances. If no properties exist, then an empty list will be returned.
      * Properties with a value of null will be omitted from the list.
-     * @throws Exception
      */
-    public List<PropertyEntry> getProperties() throws Exception {
+    public List<PropertyEntry> getProperties() {
         List<PropertyEntry> results = new ArrayList<>();
         for (Map.Entry<String, JsonValue> entry : jsonObj.entrySet()) {
             Object jsonValue = convertJsonValue(entry.getValue());
@@ -267,9 +261,8 @@ public class PropertyGroup {
      * Converts the specified JsonValue into the appropriate java.lang.* type.
      * @param jsonValue the JsonValue instance to be converted
      * @return either null or an instance of Boolean, Integer, String, PropertyGroup, or List<Object>
-     * @throws Exception
      */
-    public static Object convertJsonValue(JsonValue jsonValue) throws Exception {
+    public static Object convertJsonValue(JsonValue jsonValue) {
         Object result = null;
         switch (jsonValue.getValueType()) {
         case ARRAY:
@@ -308,9 +301,8 @@ public class PropertyGroup {
      * Converts the specified JsonArray into an Object[]
      * @param jsonArray the JsonArray to be converted
      * @return an Object[] containing the converted values found in the JsonArray
-     * @throws Exception
      */
-    private static Object[] convertJsonArray(JsonArray jsonArray) throws Exception {
+    private static Object[] convertJsonArray(JsonArray jsonArray) {
         Object[] result = new Object[jsonArray.size()];
         for (int i = 0; i < jsonArray.size(); i++) {
             result[i] = convertJsonValue(jsonArray.get(i));

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/FHIRPersistenceUtil.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/util/FHIRPersistenceUtil.java
@@ -17,11 +17,8 @@ import java.util.logging.Logger;
 
 import org.owasp.encoder.Encode;
 
-import com.ibm.fhir.config.FHIRConfigHelper;
-import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.Interaction;
-import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.config.ResourcesConfigAdapter;
 import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.model.resource.Resource;
@@ -95,18 +92,18 @@ public class FHIRPersistenceUtil {
      *
      * @param queryParameters
      * @param lenient
+     * @param resourcesConfig
      * @return
      * @throws FHIRPersistenceException
      */
-    public static FHIRSystemHistoryContext parseSystemHistoryParameters(Map<String, List<String>> queryParameters, boolean lenient) throws FHIRPersistenceException {
+    public static FHIRSystemHistoryContext parseSystemHistoryParameters(Map<String, List<String>> queryParameters, boolean lenient,
+            ResourcesConfigAdapter resourcesConfig) throws FHIRPersistenceException {
         log.entering(FHIRPersistenceUtil.class.getName(), "parseSystemHistoryParameters");
         FHIRSystemHistoryContextImpl context = new FHIRSystemHistoryContextImpl();
         context.setLenient(lenient);
         context.setHistorySortOrder(HistorySortOrder.DESC_LAST_UPDATED); // default is most recent first
         try {
-            PropertyGroup pg = FHIRConfigHelper.getPropertyGroup(FHIRConfiguration.PROPERTY_RESOURCES);
-            ResourcesConfigAdapter config = new ResourcesConfigAdapter(pg);
-            Set<String> typesSupportingHistory = config.getSupportedResourceTypes(Interaction.HISTORY);
+            Set<String> typesSupportingHistory = resourcesConfig.getSupportedResourceTypes(Interaction.HISTORY);
 
             for (String name : queryParameters.keySet()) {
                 List<String> values = queryParameters.get(name);
@@ -185,7 +182,7 @@ public class FHIRPersistenceUtil {
 
             // if no _type parameter was passed but the history interaction is only supported for some subset of types
             // then we need to set the supported resource types in the context
-            if (context.getResourceTypes().isEmpty() && config.isHistoryRestricted()) {
+            if (context.getResourceTypes().isEmpty() && resourcesConfig.isHistoryRestricted()) {
                 typesSupportingHistory.stream().forEach(context::addResourceType);
             }
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -45,6 +45,7 @@ import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
 import com.ibm.fhir.config.PropertyGroup;
 import com.ibm.fhir.config.PropertyGroup.PropertyEntry;
+import com.ibm.fhir.config.ResourcesConfigAdapter;
 import com.ibm.fhir.core.FHIRConstants;
 import com.ibm.fhir.core.HTTPHandlingPreference;
 import com.ibm.fhir.core.HTTPReturnPreference;
@@ -178,6 +179,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
     private final FHIRPersistence persistence;
     private final SearchHelper searchHelper;
+    private final ResourcesConfigAdapter resourcesConfig;
 
     // Used for correlating requests within a bundle.
     private String bundleRequestCorrelationId = null;
@@ -187,6 +189,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     public FHIRRestHelper(FHIRPersistence persistence, SearchHelper searchHelper) {
         this.persistence = persistence;
         this.searchHelper = searchHelper;
+        PropertyGroup resourcesPropertyGroup = FHIRConfigHelper.getPropertyGroup(FHIRConfiguration.PROPERTY_RESOURCES);
+        this.resourcesConfig = new ResourcesConfigAdapter(resourcesPropertyGroup);
     }
 
     @Override
@@ -2938,51 +2942,35 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
     @Override
     public void validateInteraction(Interaction interaction, String resourceType) throws FHIROperationException {
-        List<String> interactions = null;
-        boolean resourceValid = true;
-
-        // Retrieve the interaction configuration
-        try {
-            StringBuilder defaultInteractionsConfigPath = new StringBuilder(FHIRConfiguration.PROPERTY_RESOURCES).append("/Resource/")
-                    .append(FHIRConfiguration.PROPERTY_FIELD_RESOURCES_INTERACTIONS);
-            StringBuilder resourceSpecificInteractionsConfigPath = new StringBuilder(FHIRConfiguration.PROPERTY_RESOURCES).append("/")
-                    .append(resourceType).append("/").append(FHIRConfiguration.PROPERTY_FIELD_RESOURCES_INTERACTIONS);
-
-            // Get the 'interactions' property
-            List<String> resourceSpecificInteractions = FHIRConfigHelper.getStringListProperty(resourceSpecificInteractionsConfigPath.toString());
-            if (resourceSpecificInteractions != null) {
-                interactions = resourceSpecificInteractions;
-            } else {
-                // Check the 'open' property, and if that's false, check if resource was specified
-                if (!FHIRConfigHelper.getBooleanProperty(FHIRConfiguration.PROPERTY_RESOURCES + "/" + FHIRConfiguration.PROPERTY_FIELD_RESOURCES_OPEN, true)) {
-                    PropertyGroup resourceGroup = FHIRConfigHelper.getPropertyGroup(FHIRConfiguration.PROPERTY_RESOURCES + "/" + resourceType);
-                    if (resourceGroup == null) {
-                        resourceValid = false;
-                    }
+        if ("Resource".equals(resourceType)) {
+            switch (interaction) {
+            case SEARCH:
+                if (!resourcesConfig.isWholeSystemSearchSupported()) {
+                    throw buildRestException("Whole system search is disabled on the server.", IssueType.BUSINESS_RULE, IssueSeverity.ERROR);
                 }
-                if (resourceValid) {
-                    // Get the 'Resource' interaction property
-                    List<String> defaultInteractions = FHIRConfigHelper.getStringListProperty(defaultInteractionsConfigPath.toString());
-                    if (defaultInteractions != null) {
-                        interactions = defaultInteractions;
-                    }
+                return;
+            case HISTORY:
+                if (!resourcesConfig.isWholeSystemHistorySupported()) {
+                    throw buildRestException("Whole system history is disabled on the server.", IssueType.BUSINESS_RULE, IssueSeverity.ERROR);
                 }
+                return;
+            default:
+                throw new IllegalStateException("Search and history are the only supported system-level interactions");
             }
-
-            if (log.isLoggable(Level.FINE)) {
-                log.fine("Allowed interactions: " + interactions);
-            }
-        } catch (Exception e) {
-            throw buildRestException("Error retrieving interactions configuration.", IssueType.UNKNOWN, IssueSeverity.ERROR);
         }
 
-        // Perform validation of specified interaction against specified resourceType
-        if (interactions != null && !interactions.contains(interaction.value())) {
-            throw buildRestException("The requested interaction of type '" + interaction.value() + "' is not allowed for resource type '" + resourceType + "'",
-                IssueType.BUSINESS_RULE, IssueSeverity.ERROR);
-        } else if (!resourceValid) {
+        if (!resourcesConfig.getSupportedResourceTypes().contains(resourceType)) {
             throw buildRestException("The requested resource type '" + resourceType + "' is not found",
-                IssueType.NOT_FOUND, IssueSeverity.ERROR);
+                    IssueType.NOT_FOUND, IssueSeverity.ERROR);
+        }
+
+        // fhir-config and fhir-server have two different Interaction enums with the same values
+        // we should merge those into a single enum and put it somewhere common (fhir-core?)
+        com.ibm.fhir.config.Interaction configInteraction = com.ibm.fhir.config.Interaction.from(interaction.value());
+
+        if (!resourcesConfig.getSupportedResourceTypes(configInteraction).contains(resourceType)) {
+            throw buildRestException("The requested interaction of type '" + interaction.value() + "' is not allowed for resource type '" + resourceType + "'",
+                    IssueType.BUSINESS_RULE, IssueSeverity.ERROR);
         }
     }
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -2993,8 +2993,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             // are returned in the response bundle per the R4 spec.
             requestContext.setReturnPreference(HTTPReturnPreference.REPRESENTATION);
         }
-        FHIRSystemHistoryContext historyContext =
-                FHIRPersistenceUtil.parseSystemHistoryParameters(queryParameters, HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()));
+        FHIRSystemHistoryContext historyContext = FHIRPersistenceUtil.parseSystemHistoryParameters(queryParameters,
+                HTTPHandlingPreference.LENIENT.equals(requestContext.getHandlingPreference()), resourcesConfig);
 
         // If HTTPReturnPreference is REPRESENTATION, we fetch the resources and include them
         // in the response bundle. To make it simple, we make the records and resources the same

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -55,7 +55,7 @@ import com.ibm.fhir.server.util.FHIRRestHelper;
 public class InteractionValidationConfigTest {
 
     FHIRPersistence persistence;
-    FHIRRestHelper helper;
+    SearchHelper searchHelper;
 
     public static final OperationOutcome ALL_OK = OperationOutcome.builder()
             .issue(Issue.builder()
@@ -72,7 +72,7 @@ public class InteractionValidationConfigTest {
         FHIRConfiguration.setConfigHome("target/test-classes");
         FHIRRegistry.getInstance().addProvider(new MockRegistryResourceProvider());
         persistence = new MockPersistenceImpl();
-        helper = new FHIRRestHelper(persistence, new SearchHelper());
+        searchHelper = new SearchHelper();
     }
 
     @AfterClass
@@ -87,6 +87,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
                     .reference(string("Practitioner/1"))
@@ -114,6 +116,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .status(EncounterStatus.FINISHED)
                 .clazz(Coding.builder()
@@ -141,6 +145,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .status(EncounterStatus.FINISHED)
                 .clazz(Coding.builder()
@@ -168,6 +174,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
                     .reference(string("Practitioner/1"))
@@ -201,6 +209,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .status(EncounterStatus.FINISHED)
                 .clazz(Coding.builder()
@@ -234,6 +244,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Procedure procedure = Procedure.builder()
                 .text(Narrative.builder()
                     .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
@@ -274,6 +286,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Procedure procedure = Procedure.builder()
                 .text(Narrative.builder()
                     .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
@@ -314,6 +328,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testCreateNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Practitioner practitioner = Practitioner.builder()
                 .active(com.ibm.fhir.model.type.Boolean.TRUE)
                 .build();
@@ -328,8 +344,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -341,6 +357,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -359,6 +376,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -377,6 +395,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -395,6 +414,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -419,6 +439,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -443,6 +464,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -467,6 +489,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -491,6 +514,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testReadNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -502,8 +526,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -515,6 +539,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -533,6 +558,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -551,6 +577,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -569,6 +596,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -593,6 +621,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -617,6 +646,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -641,6 +671,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -665,6 +696,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testVReadNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -676,8 +708,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -689,6 +721,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -707,6 +740,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -725,6 +759,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -743,6 +778,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -767,6 +803,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -791,6 +828,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -815,6 +853,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -839,6 +878,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testHistoryNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -850,8 +890,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -863,6 +903,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -881,6 +922,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -899,6 +941,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -917,6 +960,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -941,6 +985,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -965,6 +1010,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -989,6 +1035,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1013,6 +1060,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testSearchNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1024,8 +1072,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -1037,6 +1085,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Patient patient = Patient.builder()
                 .id("1")
                 .generalPractitioner(Reference.builder()
@@ -1065,6 +1115,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .id("1")
                 .status(EncounterStatus.FINISHED)
@@ -1093,6 +1145,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .id("1")
                 .status(EncounterStatus.FINISHED)
@@ -1121,6 +1175,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
                     .reference(string("Practitioner/1"))
@@ -1154,6 +1210,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .status(EncounterStatus.FINISHED)
                 .clazz(Coding.builder()
@@ -1187,6 +1245,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Encounter encounter = Encounter.builder()
                 .status(EncounterStatus.FINISHED)
                 .clazz(Coding.builder()
@@ -1220,6 +1280,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Procedure procedure = Procedure.builder()
                 .text(Narrative.builder()
                     .div(Xhtml.of("<div xmlns=\"http://www.w3.org/1999/xhtml\">Some narrative</div>"))
@@ -1260,6 +1322,8 @@ public class InteractionValidationConfigTest {
     @Test
     public void testUpdateNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
+
         Practitioner practitioner = Practitioner.builder()
                 .active(com.ibm.fhir.model.type.Boolean.TRUE)
                 .build();
@@ -1274,8 +1338,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -1287,6 +1351,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1311,6 +1376,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1335,6 +1401,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1359,6 +1426,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1383,6 +1451,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testPatchNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1394,8 +1463,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -1407,6 +1476,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1430,6 +1500,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteValidGenericResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1453,6 +1524,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteValidAnyResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("default");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1475,6 +1547,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteNotValidEmptySpecificResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1499,6 +1572,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteNotValidEmptyGenericResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("empty");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1523,6 +1597,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteNotValidNotSpecifiedResourceList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1547,6 +1622,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteNotValidNotSpecifiedGenericList() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1571,6 +1647,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testDeleteNotValidOpenFalse() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         // Process request
         FHIRRequestContext.get().setOriginalRequestUri("test");
@@ -1582,8 +1659,8 @@ public class InteractionValidationConfigTest {
             // Validate results
             List<Issue> issues = e.getIssues();
             assertEquals(issues.size(), 1);
-            assertEquals("The requested resource type 'Practitioner' is not found",
-                issues.get(0).getDetails().getText().getValue());
+            assertEquals(issues.get(0).getDetails().getText().getValue(),
+                    "The requested resource type 'Practitioner' is not found");
             assertEquals(issues.get(0).getSeverity(), IssueSeverity.ERROR);
             assertEquals(issues.get(0).getCode(), IssueType.NOT_FOUND);
         }
@@ -1595,6 +1672,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testTransactionBundleWithCreateValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
@@ -1663,6 +1741,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testTransactionBundleWithCreateNotValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
@@ -1734,6 +1813,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testBatchBundleWithCreateValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest1");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()
@@ -1802,6 +1882,7 @@ public class InteractionValidationConfigTest {
     @Test
     public void testBatchBundleWithCreateNotValidSpecificResourceType() throws Exception {
         FHIRRequestContext.get().setTenantId("interactionConfigTest2");
+        FHIRRestHelper helper = new FHIRRestHelper(persistence, searchHelper);
 
         Patient patient = Patient.builder()
                 .generalPractitioner(Reference.builder()


### PR DESCRIPTION
Previously, validateInteraction was using FHIRConfigHelper to look up
sub-properties of fhirServer/resources which, due to fallback behavior,
may conflict with the configured interactions for the tenant.

Because validateInteraction is invoked by most interactions, I moved
ResourcesConfigAdapter initialization to the FHIRRestHelper constructor.
This should help a tad in bundle processing (no need to process this same
config over and over within the scope of a single request).

To avoid a potentially null ResourcesConfigAdapter, I updated
fhir-config to remove some unneccessary "throws Exception" cases...all
stemming from a possible UnsupportedEncodingException for UTF-8 from
FHIRUtilities.decode (a case we should never hit).

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>