### PR TITLE
issue #3576 - remove unnecessary guard against null resourceId

### DIFF
--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -195,7 +195,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
     @Override
     public FHIRRestOperationResponse doCreate(String type, Resource resource, String ifNoneExist,
-        boolean doValidation) throws Exception {
+            boolean doValidation) throws Exception {
 
         // Validate that interaction is allowed for given resource type
         validateInteraction(Interaction.CREATE, type);
@@ -244,7 +244,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
     @Override
     public FHIRRestOperationResponse doCreateMeta(FHIRPersistenceEvent event, List<Issue> warnings, String type, Resource resource,
-        String ifNoneExist) throws Exception {
+            String ifNoneExist) throws Exception {
         log.entering(this.getClass().getName(), "doCreateMeta");
 
         // Save the current request context.
@@ -343,7 +343,8 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     @Override
-    public FHIRRestOperationResponse doCreatePersist(FHIRPersistenceEvent event, List<Issue> warnings, Resource resource, PayloadPersistenceResponse offloadResponse) throws Exception {
+    public FHIRRestOperationResponse doCreatePersist(FHIRPersistenceEvent event, List<Issue> warnings, Resource resource, 
+            PayloadPersistenceResponse offloadResponse) throws Exception {
         log.entering(this.getClass().getName(), "doCreatePersist");
 
         FHIRRestOperationResponse ior = new FHIRRestOperationResponse();


### PR DESCRIPTION
Now that our persistence layer requires resources to have proper
metadata (id, versionId, and lastUpdated) prior to calling create/update/delete, I thought that resources
will always have an id before we call the persistence interceptors.

However, it turns out that we call the beforeCreate from the REST layer
BEFORE setting this metadata on the resource.
After a brief discussion, we decided to leave that as-is and update the
interceptor to allow a null resourceId.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>