### PR TITLE
issue #3592 - use compartment membership for patient resource type

### DIFF
--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
         try {
             if (queryParameters.containsKey("_id")) {
                 String id = queryParameters.getFirst("_id");
-                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, true, null);
+                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, true);
                 if (result.isSuccess()) {
                     resource = result.getResource();
                 }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
         try {
             if (queryParameters.containsKey("_id")) {
                 String id = queryParameters.getFirst("_id");
-                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, true);
+                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, FHIRResourceHelpers.THROW_EXC_ON_MISSING);
                 if (result.isSuccess()) {
                     resource = result.getResource();
                 }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
         try {
             if (queryParameters.containsKey("_id")) {
                 String id = queryParameters.getFirst("_id");
-                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, FHIRResourceHelpers.THROW_EXC_ON_MISSING);
+                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id);
                 if (result.isSuccess()) {
                     resource = result.getResource();
                 }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -38,7 +37,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
     private static final String DUMMY_REQUEST_URI = "https://localhost:9443/fhir-server/api/v4";
 
     private static Logger logger = Logger.getLogger(ServerFHIRRetrieveProvider.class.getName());
-    
+
     private FHIRResourceHelpers resourceHelpers;
 
     public ServerFHIRRetrieveProvider(FHIRResourceHelpers resourceHelpers, SearchParameterResolver searchParameterResolver) {
@@ -54,7 +53,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
             if( logger.isLoggable(Level.FINE) ) {
                 logger.fine(String.format("Executing query %s?%s", dataType, map.toString()));
             }
-            
+
             MultivaluedMap<String, String> queryParameters = getQueryParameters(map);
 
             // _total=none instructs the server to skip the count(*) query which improves performance
@@ -76,7 +75,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
                         throw new RuntimeException(ex);
                     }
                 }, (Bundle) resource);
-                
+
                 Iterator<?> it = cursor.iterator();
                 while(it.hasNext()) {
                     results.add(it.next());
@@ -95,7 +94,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
         try {
             if (queryParameters.containsKey("_id")) {
                 String id = queryParameters.getFirst("_id");
-                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, true, false, null);
+                SingleResourceResult<?> result = resourceHelpers.doRead(dataType, id, true, null);
                 if (result.isSuccess()) {
                     resource = result.getResource();
                 }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProvider.java
@@ -70,7 +70,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
                             logger.fine(String.format("Retrieving page %d / %s", nextPage, url));
                         }
                         queryParameters.putSingle(SearchConstants.PAGE, String.valueOf(nextPage));
-                        return resourceHelpers.doSearch(dataType, /*compartment=*/null, /*compartmentId=*/null, queryParameters, requestUri, /*contextResource=*/null);
+                        return resourceHelpers.doSearch(dataType, /*compartment=*/null, /*compartmentId=*/null, queryParameters, requestUri);
                     } catch (Exception ex) {
                         throw new RuntimeException(ex);
                     }
@@ -99,7 +99,7 @@ public class ServerFHIRRetrieveProvider extends SearchParameterFHIRRetrieveProvi
                     resource = result.getResource();
                 }
             } else {
-                resource = resourceHelpers.doSearch(dataType, /*compartment=*/null, /*compartmentId=*/null, queryParameters, DUMMY_REQUEST_URI, /*contextResource=*/null);
+                resource = resourceHelpers.doSearch(dataType, /*compartment=*/null, /*compartmentId=*/null, queryParameters, DUMMY_REQUEST_URI);
             }
         } catch (RuntimeException rex) {
             throw rex;

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,7 +33,7 @@ import com.ibm.fhir.term.util.ValueSetSupport;
  * the IBM FHIR Server FHIRTermService API to access the terminology data.
  */
 public class ServerFHIRTerminologyProvider implements TerminologyProvider {
-    
+
     private FHIRResourceHelpers resourceHelper;
 
     public ServerFHIRTerminologyProvider(FHIRResourceHelpers resourceHelper) {
@@ -55,7 +55,7 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
     public Iterable<Code> expand(ValueSetInfo valueSetInfo) {
         List<Code> codes;
 
-        ValueSet valueSet = resolveByUrl(valueSetInfo); 
+        ValueSet valueSet = resolveByUrl(valueSetInfo);
         ValueSet expanded = FHIRTermService.getInstance().expand(valueSet);
 
         codes = new ArrayList<>();
@@ -81,13 +81,13 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
     }
 
     /**
-     * Lookup a ValueSet that corresponds to the provided CQL ValueSetInfo. Only the 
+     * Lookup a ValueSet that corresponds to the provided CQL ValueSetInfo. Only the
      * ValueSetInfo.id property is supported at this time. Use of the ValueSetInfo.version
      * or ValueSetInfo.codesystems properties will cause an UnsupportedOperationException.
      * This method uses a search strategy that first treats the ValueSetInfo.id as a URL,
      * then attempts urn:oid or urn:uuid resolution, then finally attempts plain ID-based
      * resolution if nothing has been found and the value appears to be a FHIR ID.
-     *  
+     *
      * @param valueSet CQL ValueSetInfo with ID property populated
      * @return resolved ValueSet resource
      * @throws IllegalArgumentException if the ValueSetInfo.id could not be resolved
@@ -120,7 +120,7 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
             // See https://www.hl7.org/fhir/datatypes.html#id
             if (id.matches("[A-Za-z0-9\\-\\.]{1,64}")) {
                 try {
-                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, /*throwExOnMissing=*/false, /*includeDeleted=*/false, /*contextResource=*/null);
+                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, /*throwExOnMissing=*/false, /*contextResource=*/null);
                     if( result.isSuccess() ) {
                         valueSet = (ValueSet) result.getResource();
                     }
@@ -129,11 +129,11 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
                 }
             }
         }
-        
+
         if( valueSet == null ) {
             throw new IllegalArgumentException(String.format("Could not resolve value set %s.", valueSetInfo.getId()));
         }
-        
+
         return valueSet;
     }
 }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
@@ -7,7 +7,6 @@ package com.ibm.fhir.cql.engine.server.terminology;
 
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -121,7 +120,7 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
             // See https://www.hl7.org/fhir/datatypes.html#id
             if (id.matches("[A-Za-z0-9\\-\\.]{1,64}")) {
                 try {
-                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, !THROW_EXC_ON_MISSING);
+                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id);
                     if( result.isSuccess() ) {
                         valueSet = (ValueSet) result.getResource();
                     }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
@@ -7,6 +7,7 @@ package com.ibm.fhir.cql.engine.server.terminology;
 
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -120,7 +121,7 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
             // See https://www.hl7.org/fhir/datatypes.html#id
             if (id.matches("[A-Za-z0-9\\-\\.]{1,64}")) {
                 try {
-                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, /*throwExOnMissing=*/false);
+                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, !THROW_EXC_ON_MISSING);
                     if( result.isSuccess() ) {
                         valueSet = (ValueSet) result.getResource();
                     }

--- a/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
+++ b/cql/fhir-cql-server/src/main/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProvider.java
@@ -120,7 +120,7 @@ public class ServerFHIRTerminologyProvider implements TerminologyProvider {
             // See https://www.hl7.org/fhir/datatypes.html#id
             if (id.matches("[A-Za-z0-9\\-\\.]{1,64}")) {
                 try {
-                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, /*throwExOnMissing=*/false, /*contextResource=*/null);
+                    SingleResourceResult<? extends Resource> result = resourceHelper.doRead(ResourceType.VALUE_SET.getValue(), id, /*throwExOnMissing=*/false);
                     if( result.isSuccess() ) {
                         valueSet = (ValueSet) result.getResource();
                     }

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.cql.engine.searchparam.SearchParameterResolver;
 import com.ibm.fhir.cql.engine.server.terminology.ServerFHIRTerminologyProvider;
+import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Bundle.Link;
 import com.ibm.fhir.model.resource.Condition;
@@ -42,7 +43,6 @@ import com.ibm.fhir.model.type.UnsignedInt;
 import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.persistence.SingleResourceResult;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.search.util.SearchHelper;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
 
@@ -78,7 +78,7 @@ public class ServerFHIRRetrieveProviderTest {
         when(result.isSuccess()).thenReturn(true);
         when(result.getResource()).thenReturn(p1);
 
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), isNull())).thenReturn(result);
+        when(helpers.doRead(eq("Patient"), eq("123"), eq(true))).thenReturn(result);
 
         Iterable<Object> resources = provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
         assertNotNull(resources);
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProviderTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testQueryByIdNotFound() throws Exception {
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), isNull())).thenThrow(FHIRPersistenceResourceNotFoundException.class);
+        when(helpers.doRead(eq("Patient"), eq("123"), eq(true))).thenThrow(FHIROperationException.class);
 
         provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
     }

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
@@ -78,7 +78,7 @@ public class ServerFHIRRetrieveProviderTest {
         when(result.isSuccess()).thenReturn(true);
         when(result.getResource()).thenReturn(p1);
 
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true))).thenReturn(result);
+        when(helpers.doRead(eq("Patient"), eq("123"))).thenReturn(result);
 
         Iterable<Object> resources = provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
         assertNotNull(resources);
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProviderTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testQueryByIdNotFound() throws Exception {
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true))).thenThrow(FHIROperationException.class);
+        when(helpers.doRead(eq("Patient"), eq("123"))).thenThrow(FHIROperationException.class);
 
         provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
     }

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
@@ -78,7 +78,7 @@ public class ServerFHIRRetrieveProviderTest {
         when(result.isSuccess()).thenReturn(true);
         when(result.getResource()).thenReturn(p1);
 
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), eq(false), isNull())).thenReturn(result);
+        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), isNull())).thenReturn(result);
 
         Iterable<Object> resources = provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
         assertNotNull(resources);
@@ -94,7 +94,7 @@ public class ServerFHIRRetrieveProviderTest {
 
     @Test(expectedExceptions = RuntimeException.class)
     public void testQueryByIdNotFound() throws Exception {
-        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), eq(false), isNull())).thenThrow(FHIRPersistenceResourceNotFoundException.class);
+        when(helpers.doRead(eq("Patient"), eq("123"), eq(true), isNull())).thenThrow(FHIRPersistenceResourceNotFoundException.class);
 
         provider.retrieve("Patient", "id", "123", "Patient", null, null, null, null, null, null, null, null);
     }

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/retrieve/ServerFHIRRetrieveProviderTest.java
@@ -111,8 +111,8 @@ public class ServerFHIRRetrieveProviderTest {
 
         Bundle page2 = Bundle.builder().type(BundleType.SEARCHSET).total(UnsignedInt.of(1)).entry(Bundle.Entry.builder().resource(c2).build()).build();
 
-        when(helpers.doSearch(eq("Condition"), isNull(), isNull(), not(hasEntry("_page")), anyString(), isNull())).thenReturn(page1);
-        when(helpers.doSearch(eq("Condition"), isNull(), isNull(), hasEntry("_page"), anyString(), isNull())).thenReturn(page2);
+        when(helpers.doSearch(eq("Condition"), isNull(), isNull(), not(hasEntry("_page")), anyString())).thenReturn(page1);
+        when(helpers.doSearch(eq("Condition"), isNull(), isNull(), hasEntry("_page"), anyString())).thenReturn(page2);
 
         Iterable<Object> resources = provider.retrieve("Patient", "subject", "123", "Condition", null, null, null, null, null, null, null, null);
         assertNotNull(resources);
@@ -126,7 +126,7 @@ public class ServerFHIRRetrieveProviderTest {
         expected.add(c2.getId());
         assertEquals(results.keySet(), expected);
 
-        verify(helpers, times(2)).doSearch(eq("Condition"), isNull(), isNull(), ArgumentMatchers.<MultivaluedMap<String, String>> any(), anyString(), isNull());
+        verify(helpers, times(2)).doSearch(eq("Condition"), isNull(), isNull(), ArgumentMatchers.<MultivaluedMap<String, String>> any(), anyString());
     }
 
     private String getBaseUrl() {

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.cql.engine.server.terminology;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirboolean;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -175,10 +176,10 @@ public class ServerFHIRTerminologyProviderTest {
         if( matchByID ) {
             when(result.isSuccess()).thenReturn(true);
             when(result.getResource()).thenReturn(valueSet);
-            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, false)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, !THROW_EXC_ON_MISSING)).thenReturn(result);
         } else {
             when(result.isSuccess()).thenReturn(false);
-            when(resourceHelper.doRead("ValueSet", idInCQL, false)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", idInCQL, !THROW_EXC_ON_MISSING)).thenReturn(result);
         }
 
         termProvider.resolveByUrl(info);

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -175,10 +175,10 @@ public class ServerFHIRTerminologyProviderTest {
         if( matchByID ) {
             when(result.isSuccess()).thenReturn(true);
             when(result.getResource()).thenReturn(valueSet);
-            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, false, null)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, false)).thenReturn(result);
         } else {
             when(result.isSuccess()).thenReturn(false);
-            when(resourceHelper.doRead("ValueSet", idInCQL, false, null)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", idInCQL, false)).thenReturn(result);
         }
 
         termProvider.resolveByUrl(info);

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
@@ -8,26 +8,27 @@ package com.ibm.fhir.cql.engine.server.terminology;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirboolean;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.opencds.cqf.cql.engine.runtime.Code;
 import org.opencds.cqf.cql.engine.terminology.CodeSystemInfo;
 import org.opencds.cqf.cql.engine.terminology.ValueSetInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import com.ibm.fhir.cql.Constants;
 import com.ibm.fhir.model.resource.ValueSet;
@@ -55,7 +56,7 @@ public class ServerFHIRTerminologyProviderTest {
 
     private ServerFHIRTerminologyProvider termProvider;
     private FHIRResourceHelpers resourceHelper;
-    
+
     @BeforeMethod
     public void setup() {
         termService = Mockito.mock(FHIRTermService.class);
@@ -129,27 +130,27 @@ public class ServerFHIRTerminologyProviderTest {
         assertNotNull(actual);
         assertEquals(actual.getDisplay(), "test");
     }
-    
+
     @Test
     public void testResolveByUrlURNOID() throws Exception {
         runResolveByIdTest(Constants.URN_OID + TEST_VALUE_SET_ID, true, true);
     }
-    
+
     @Test
     public void testResolveByUrlURNUUID() throws Exception {
         runResolveByIdTest(Constants.URN_UUID  + TEST_VALUE_SET_ID, true, true);
     }
-    
+
     @Test
     public void testResolveByUrlURNValidFHIRID() throws Exception {
         runResolveByIdTest(TEST_VALUE_SET_ID, true, true);
     }
-    
+
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testResolveByUrlURNInvalidFHIRID() throws Exception {
         runResolveByIdTest("***", false, false);
     }
-    
+
     @Test(expectedExceptions = {IllegalArgumentException.class})
     public void testResolveByUrlURNMissingFHIRID() throws Exception {
         runResolveByIdTest("9999", false, false);
@@ -158,7 +159,7 @@ public class ServerFHIRTerminologyProviderTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected void runResolveByIdTest(String idInCQL, boolean matchByURL, boolean matchByID) throws Exception {
         ValueSetInfo info = new ValueSetInfo().withId(idInCQL);
-        
+
         Set<String> expected = Arrays.asList("123", "456", "789").stream().collect(Collectors.toSet());
 
         ValueSet.Builder valueSetBuilder = getBaseValueSet(info);
@@ -169,17 +170,17 @@ public class ServerFHIRTerminologyProviderTest {
         if( matchByURL ) {
             staticValueSetSupport.when(() -> ValueSetSupport.getValueSet(info.getId())).thenReturn(valueSet);
         }
-        
+
         SingleResourceResult result = mock(SingleResourceResult.class);
         if( matchByID ) {
             when(result.isSuccess()).thenReturn(true);
             when(result.getResource()).thenReturn(valueSet);
-            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, false, false, null)).thenReturn(result);
-        } else { 
+            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, false, null)).thenReturn(result);
+        } else {
             when(result.isSuccess()).thenReturn(false);
-            when(resourceHelper.doRead("ValueSet", idInCQL, false, false, null)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", idInCQL, false, null)).thenReturn(result);
         }
-        
+
         termProvider.resolveByUrl(info);
     }
 

--- a/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
+++ b/cql/fhir-cql-server/src/test/java/com/ibm/fhir/cql/engine/server/terminology/ServerFHIRTerminologyProviderTest.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.cql.engine.server.terminology;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirboolean;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -176,10 +175,10 @@ public class ServerFHIRTerminologyProviderTest {
         if( matchByID ) {
             when(result.isSuccess()).thenReturn(true);
             when(result.getResource()).thenReturn(valueSet);
-            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID, !THROW_EXC_ON_MISSING)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", TEST_SYSTEM_ID)).thenReturn(result);
         } else {
             when(result.isSuccess()).thenReturn(false);
-            when(resourceHelper.doRead("ValueSet", idInCQL, !THROW_EXC_ON_MISSING)).thenReturn(result);
+            when(resourceHelper.doRead("ValueSet", idInCQL)).thenReturn(result);
         }
 
         termProvider.resolveByUrl(info);

--- a/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
+++ b/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
@@ -207,9 +207,9 @@ public class ApplyOperation extends AbstractOperation {
         return result;
     }
 
-    /*
+    /**
      * Transforms the CarePlan resource.
-     * @param resource
+     * @param planDefinition
      * @param subjects
      * @param encounter
      * @param practitioner
@@ -222,10 +222,9 @@ public class ApplyOperation extends AbstractOperation {
      * @return
      */
     private CarePlan transform(PlanDefinition planDefinition, List<String> subjects,
-        String encounter,
-        String practitioner, String organization, CodeableConcept userType,
-        CodeableConcept userLanguage, CodeableConcept userTaskContext, CodeableConcept setting,
-        CodeableConcept settingContext) {
+            String encounter, String practitioner, String organization, CodeableConcept userType,
+            CodeableConcept userLanguage, CodeableConcept userTaskContext, CodeableConcept setting,
+            CodeableConcept settingContext) {
         CarePlan.Builder builder = CarePlan.builder();
 
         if (planDefinition.getUrl() != null) {
@@ -381,27 +380,6 @@ public class ApplyOperation extends AbstractOperation {
         }
         builder.activity(activities);
         builder.intent(CarePlanIntent.PLAN);
-
-        /**
-         * A single activity represented by a RequestGroup.
-         * <p>
-         * RequestGroup has multiple actions for each of the applicable actions in the plan based on evaluating the
-         * applicability condition in context.
-         * <p>
-         * For each applicable action, the definition is applied as described in the $apply operation of the
-         * ActivityDefinition resource, and the resulting resource is added as an activity to the CarePlan.
-         * <p>
-         * If the ActivityDefinition includes library references, those libraries will be available to the evaluated
-         * expressions.
-         * <p>
-         * If those libraries have parameters, those parameters will be bound by name to the parameters given to the
-         * operation.
-         * <p>
-         * In addition, parameters to the $apply operation are available within dynamicValue expressions as context
-         * variables, accessible by the name of the parameter, prefixed with a percent (%) symbol.
-         * <p>
-         * For a more detailed description, refer to the PlanDefinition and ActivityDefinition resource documentation
-         */
     }
 
     private List<Action> getActions(List<Action> actions) {
@@ -415,16 +393,16 @@ public class ApplyOperation extends AbstractOperation {
         return result;
     }
 
-    /*
+    /**
      * reads the plan definition and converts to PlanDefinition resource.
      * @param resourceHelper
      * @param planDefinitionId
      * @return
      */
     private PlanDefinition checkAndRetrievePlanDefinition(FHIRResourceHelpers resourceHelper,
-        String planDefinitionId) throws Exception {
+            String planDefinitionId) throws Exception {
         Resource resource =
-                resourceHelper.doRead("PlanDefinition", planDefinitionId, false, false, null).getResource();
+                resourceHelper.doRead("PlanDefinition", planDefinitionId, false, null).getResource();
         if (resource == null) {
             throw buildOperationExceptionNotFound("Could not find 'PlanDefinition' with id: ["
                     + planDefinitionId + "]");
@@ -432,18 +410,18 @@ public class ApplyOperation extends AbstractOperation {
         return (PlanDefinition) resource;
     }
 
-    /*
+    /**
      * validates the resource is of the PlanDefinition type.
      * @param resourceType
      */
     private void checkAndValidateResourceType(Class<? extends Resource> resourceType)
-        throws FHIROperationException {
+            throws FHIROperationException {
         if ("PlanDefinition".compareTo(resourceType.getSimpleName()) != 0) {
             throw buildOperationException("$apply operation is available for PlanDefinition only");
         }
     }
 
-    /*
+    /**
      * checks the plan definition logical Id.
      * @param logicalId
      * @param queryParameters
@@ -451,7 +429,7 @@ public class ApplyOperation extends AbstractOperation {
      * @throws FHIROperationException
      */
     private String checkPlanDefintionLogicalId(String logicalId,
-        MultivaluedMap<String, String> queryParameters) throws FHIROperationException {
+            MultivaluedMap<String, String> queryParameters) throws FHIROperationException {
         String checkedLogicalId = logicalId;
 
         // Instance
@@ -480,14 +458,14 @@ public class ApplyOperation extends AbstractOperation {
         return checkedLogicalId;
     }
 
-    /*
+    /**
      * Checks each of the subjects to see if they are valid. If the subject is invalid, the code throws and exception.
      * @param queryParameters
      * @return
      * @throws FHIROperationException
      */
     private List<String> checkSubjects(MultivaluedMap<String, String> queryParameters)
-        throws FHIROperationException {
+            throws FHIROperationException {
         List<String> subjects = queryParameters.get(PARAM_SUBJECT);
 
         // Null and Empty Check

--- a/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
+++ b/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
@@ -7,7 +7,6 @@
 package com.ibm.fhir.operation.apply;
 
 import static com.ibm.fhir.model.type.String.string;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -403,7 +402,7 @@ public class ApplyOperation extends AbstractOperation {
     private PlanDefinition checkAndRetrievePlanDefinition(FHIRResourceHelpers resourceHelper,
             String planDefinitionId) throws Exception {
         Resource resource =
-                resourceHelper.doRead("PlanDefinition", planDefinitionId, !THROW_EXC_ON_MISSING).getResource();
+                resourceHelper.doRead("PlanDefinition", planDefinitionId).getResource();
         if (resource == null) {
             throw buildOperationExceptionNotFound("Could not find 'PlanDefinition' with id: ["
                     + planDefinitionId + "]");

--- a/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
+++ b/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
@@ -402,7 +402,7 @@ public class ApplyOperation extends AbstractOperation {
     private PlanDefinition checkAndRetrievePlanDefinition(FHIRResourceHelpers resourceHelper,
             String planDefinitionId) throws Exception {
         Resource resource =
-                resourceHelper.doRead("PlanDefinition", planDefinitionId, false, null).getResource();
+                resourceHelper.doRead("PlanDefinition", planDefinitionId, false).getResource();
         if (resource == null) {
             throw buildOperationExceptionNotFound("Could not find 'PlanDefinition' with id: ["
                     + planDefinitionId + "]");

--- a/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
+++ b/cql/operation/fhir-operation-apply/src/main/java/com/ibm/fhir/operation/apply/ApplyOperation.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.operation.apply;
 
 import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -402,7 +403,7 @@ public class ApplyOperation extends AbstractOperation {
     private PlanDefinition checkAndRetrievePlanDefinition(FHIRResourceHelpers resourceHelper,
             String planDefinitionId) throws Exception {
         Resource resource =
-                resourceHelper.doRead("PlanDefinition", planDefinitionId, false).getResource();
+                resourceHelper.doRead("PlanDefinition", planDefinitionId, !THROW_EXC_ON_MISSING).getResource();
         if (resource == null) {
             throw buildOperationExceptionNotFound("Could not find 'PlanDefinition' with id: ["
                     + planDefinitionId + "]");

--- a/cql/operation/fhir-operation-cpg/pom.xml
+++ b/cql/operation/fhir-operation-cpg/pom.xml
@@ -37,6 +37,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -69,12 +74,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
@@ -62,7 +62,7 @@ public class LibraryEvaluateOperation extends AbstractCqlOperation {
         try {
             Library primaryLibrary = null;
             if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true);
                 primaryLibrary = (Library) readResult.getResource();
             } else if (operationContext.getType().equals(FHIROperationContext.Type.RESOURCE_TYPE)) {
                 Parameter param = paramMap.getSingletonParameter("library");

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
@@ -62,7 +62,7 @@ public class LibraryEvaluateOperation extends AbstractCqlOperation {
         try {
             Library primaryLibrary = null;
             if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, false, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, null);
                 primaryLibrary = (Library) readResult.getResource();
             } else if (operationContext.getType().equals(FHIROperationContext.Type.RESOURCE_TYPE)) {
                 Parameter param = paramMap.getSingletonParameter("library");

--- a/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
+++ b/cql/operation/fhir-operation-cpg/src/main/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperation.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.operation.cpg;
 
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.io.InputStream;
 import java.util.List;
@@ -62,7 +63,7 @@ public class LibraryEvaluateOperation extends AbstractCqlOperation {
         try {
             Library primaryLibrary = null;
             if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, THROW_EXC_ON_MISSING);
                 primaryLibrary = (Library) readResult.getResource();
             } else if (operationContext.getType().equals(FHIROperationContext.Type.RESOURCE_TYPE)) {
                 Parameter param = paramMap.getSingletonParameter("library");

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
@@ -107,7 +107,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -156,7 +156,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -203,7 +203,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -250,7 +250,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -298,7 +298,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pExpression, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
@@ -328,7 +328,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -360,7 +360,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Condition"), anyString(), anyString(), any(MultivaluedMap.class), anyString(), any(Resource.class))).thenReturn(ModelHelper.bundle());
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
@@ -39,7 +39,6 @@ import com.ibm.fhir.model.resource.Library;
 import com.ibm.fhir.model.resource.Parameters;
 import com.ibm.fhir.model.resource.Parameters.Parameter;
 import com.ibm.fhir.model.resource.Patient;
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.Canonical;
 import com.ibm.fhir.model.type.Code;
 import com.ibm.fhir.model.type.Coding;
@@ -108,7 +107,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
 
@@ -157,7 +156,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
 
@@ -204,7 +203,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
 
@@ -251,7 +250,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
 
@@ -299,7 +298,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -361,7 +360,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
-        when(resourceHelper.doSearch(eq("Condition"), anyString(), anyString(), any(MultivaluedMap.class), anyString(), any(Resource.class))).thenReturn(ModelHelper.bundle());
+        when(resourceHelper.doSearch(eq("Condition"), anyString(), anyString(), any(MultivaluedMap.class), anyString())).thenReturn(ModelHelper.bundle());
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
@@ -11,7 +11,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.concept;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirboolean;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -106,7 +105,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -155,7 +154,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -202,7 +201,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -249,7 +248,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -297,7 +296,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pExpression, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
@@ -327,7 +326,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -359,7 +358,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Condition"), anyString(), anyString(), any(MultivaluedMap.class), anyString())).thenReturn(ModelHelper.bundle());
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/CqlOperationTest.java
@@ -106,7 +106,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -155,7 +155,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -202,7 +202,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -249,7 +249,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         // Library fhirHelpers = TestHelper.getTestLibraryResource("FHIRHelpers-4.0.1.json");
@@ -297,7 +297,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pExpression, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
@@ -327,7 +327,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -359,7 +359,7 @@ public class CqlOperationTest extends BaseCqlOperationTest<CqlOperation> {
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pDebug).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
         when(resourceHelper.doSearch(eq("Condition"), anyString(), anyString(), any(MultivaluedMap.class), anyString())).thenReturn(ModelHelper.bundle());
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
@@ -86,7 +86,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));
@@ -139,7 +139,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));
@@ -212,7 +212,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
@@ -86,7 +86,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
@@ -139,7 +139,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
@@ -212,7 +212,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
@@ -88,8 +88,8 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -141,8 +141,8 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -214,8 +214,8 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(encounter));
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn(bundle(procedure));
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
+++ b/cql/operation/fhir-operation-cpg/src/test/java/com/ibm/fhir/operation/cpg/LibraryEvaluateOperationTest.java
@@ -12,7 +12,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.fhirboolean;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.valueset;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -86,7 +85,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
@@ -139,7 +138,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         ParameterMap paramMap = new ParameterMap(parameters);
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));
@@ -212,7 +211,7 @@ public class LibraryEvaluateOperationTest extends BaseCqlOperationTest<LibraryEv
         Parameters parameters = Parameters.builder().parameter(pSubject, pLibrary, pUseServerData, pData, pPrefetchData, pDataEndpoint, pContentEndpoint, pTerminologyEndpoint).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/CareGapsOperation.java
@@ -73,13 +73,13 @@ public class CareGapsOperation extends AbstractMeasureOperation {
         searchParameters.putSingle("_total", "none");
 
         try {
-            Bundle bundle = resourceHelper.doSearch(ResourceType.MEASURE.getValue(), null, null, searchParameters, null, null);
+            Bundle bundle = resourceHelper.doSearch(ResourceType.MEASURE.getValue(), null, null, searchParameters, null);
 
             AtomicInteger pageNumber = new AtomicInteger(1);
             FHIRBundleCursor cursor = new FHIRBundleCursor(url -> {
                 try {
                     searchParameters.putSingle(SearchConstants.PAGE, String.valueOf(pageNumber.incrementAndGet()));
-                    return resourceHelper.doSearch(ResourceType.MEASURE.getValue(), null, null, searchParameters, null, null);
+                    return resourceHelper.doSearch(ResourceType.MEASURE.getValue(), null, null, searchParameters, null);
                 } catch (Exception ex) {
                     throw new RuntimeException(ex);
                 }

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
@@ -5,6 +5,8 @@
  */
 package com.ibm.fhir.operation.cqf;
 
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
+
 import java.util.List;
 
 import com.ibm.fhir.cql.helpers.LibraryHelper;
@@ -38,7 +40,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
         Library library = null;
         if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, THROW_EXC_ON_MISSING);
                 library = (Library) readResult.getResource();
             } catch (Exception ex) {
                 throw new FHIROperationException("Failed to read resource", ex);
@@ -66,7 +68,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
             }
 
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, true);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, THROW_EXC_ON_MISSING);
                 if( readResult.getResource() instanceof Library ) {
                     library = (Library) readResult.getResource();
                 } else {

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
@@ -38,7 +38,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
         Library library = null;
         if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true);
                 library = (Library) readResult.getResource();
             } catch (Exception ex) {
                 throw new FHIROperationException("Failed to read resource", ex);
@@ -66,7 +66,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
             }
 
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, true, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, true);
                 if( readResult.getResource() instanceof Library ) {
                     library = (Library) readResult.getResource();
                 } else {

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
@@ -5,8 +5,6 @@
  */
 package com.ibm.fhir.operation.cqf;
 
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
-
 import java.util.List;
 
 import com.ibm.fhir.cql.helpers.LibraryHelper;
@@ -38,47 +36,49 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
         Parameters parameters, FHIRResourceHelpers resourceHelper, SearchHelper searchHelper) throws FHIROperationException {
 
         Library library = null;
-        if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
-            try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, THROW_EXC_ON_MISSING);
+
+        try {
+            if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId);
                 library = (Library) readResult.getResource();
-            } catch (Exception ex) {
-                throw new FHIROperationException("Failed to read resource", ex);
-            }
-        } else if (operationContext.getType().equals(FHIROperationContext.Type.SYSTEM)) {
-            ParameterMap paramMap = new ParameterMap(parameters);
-            Parameter p = paramMap.getSingletonParameter(PARAM_IN_TARGET);
+                if (library == null) {
+                    throw new FHIROperationException("Failed to resolve library with resource id: " + logicalId);
+                }
+            } else if (operationContext.getType().equals(FHIROperationContext.Type.SYSTEM)) {
+                ParameterMap paramMap = new ParameterMap(parameters);
+                Parameter p = paramMap.getSingletonParameter(PARAM_IN_TARGET);
 
-            String target = ((com.ibm.fhir.model.type.String) p.getValue()).getValue();
+                String target = ((com.ibm.fhir.model.type.String) p.getValue()).getValue();
 
-            //The meaning of the target parameter is somewhat ambiguous in the base spec. I talked with the spec
-            //author and the intention was for target to be a library ID. The operation should probably have been
-            //defined instance level instead of system level. Things have improved in the QM IG, so I'm not going
-            //to spend a lot of time trying to finagle this into something less confusing here. It can be improved
-            //when we implement the IGs.
-            //https://chat.fhir.org/#narrow/stream/179220-cql/topic/Library.20data-requirements.20operation
+                //The meaning of the target parameter is somewhat ambiguous in the base spec. I talked with the spec
+                //author and the intention was for target to be a library ID. The operation should probably have been
+                //defined instance level instead of system level. Things have improved in the QM IG, so I'm not going
+                //to spend a lot of time trying to finagle this into something less confusing here. It can be improved
+                //when we implement the IGs.
+                //https://chat.fhir.org/#narrow/stream/179220-cql/topic/Library.20data-requirements.20operation
 
-            String [] parts = target.split("/");
+                String [] parts = target.split("/");
 
-            logicalId = target;
-            String targetType = ResourceType.LIBRARY.getValue();
-            if( parts.length > 1 ) {
-                targetType = parts[ parts.length - 2 ];
-                logicalId = parts[ parts.length - 1 ];
-            }
+                logicalId = target;
+                String targetType = ResourceType.LIBRARY.getValue();
+                if( parts.length > 1 ) {
+                    targetType = parts[ parts.length - 2 ];
+                    logicalId = parts[ parts.length - 1 ];
+                }
 
-            try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, THROW_EXC_ON_MISSING);
-                if( readResult.getResource() instanceof Library ) {
+                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId);
+                if (readResult.getResource() instanceof Library) {
                     library = (Library) readResult.getResource();
                 } else {
-                    throw new IllegalStateException("The target parameter must be a Library resource");
+                    throw new FHIROperationException("Failed to resolve library: " + target);
                 }
-            } catch (Exception ex) {
-                throw new FHIROperationException("Failed to read resource", ex);
+            } else {
+                throw new IllegalStateException("Unsupported context " + operationContext.getType().toString());
             }
-        } else {
-            throw new IllegalStateException("Unsupported context " + operationContext.getType().toString());
+        } catch (FHIROperationException fex) {
+            throw fex;
+        } catch (Exception ex) {
+            throw new FHIROperationException("Unexpected error while reading Library", ex);
         }
 
         List<Library> fhirLibraries = LibraryHelper.loadLibraries(library);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/LibraryDataRequirementsOperation.java
@@ -38,7 +38,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
         Library library = null;
         if (operationContext.getType().equals(FHIROperationContext.Type.INSTANCE)) {
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, false, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.LIBRARY.getValue(), logicalId, true, null);
                 library = (Library) readResult.getResource();
             } catch (Exception ex) {
                 throw new FHIROperationException("Failed to read resource", ex);
@@ -66,7 +66,7 @@ public class LibraryDataRequirementsOperation extends AbstractDataRequirementsOp
             }
 
             try {
-                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, true, false, null);
+                SingleResourceResult<?> readResult = resourceHelper.doRead(targetType, logicalId, true, null);
                 if( readResult.getResource() instanceof Library ) {
                     library = (Library) readResult.getResource();
                 } else {

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
@@ -108,7 +108,7 @@ public class MeasureCollectDataOperation extends EvaluateMeasureOperation {
 
                         if( ! resourceMap.containsKey(id) ) {
                             try {
-                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, /*throwExOnNull=*/true, /*includeDeleted=*/false, /*contextResource=*/null);
+                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, /*throwExOnNull=*/true, /*contextResource=*/null);
                                 if( readResult.isSuccess() ) {
                                     Resource fetchedResource = readResult.getResource();
                                     parameters.parameter(Parameter.builder().name(fhirstring(PARAM_OUT_RESOURCE)).resource(fetchedResource).build());

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
@@ -108,7 +108,7 @@ public class MeasureCollectDataOperation extends EvaluateMeasureOperation {
 
                         if( ! resourceMap.containsKey(id) ) {
                             try {
-                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, /*throwExOnNull=*/true, /*contextResource=*/null);
+                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, /*throwExOnNull=*/true);
                                 if( readResult.isSuccess() ) {
                                     Resource fetchedResource = readResult.getResource();
                                     parameters.parameter(Parameter.builder().name(fhirstring(PARAM_OUT_RESOURCE)).resource(fetchedResource).build());

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperation.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.operation.cqf;
 
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,7 +109,7 @@ public class MeasureCollectDataOperation extends EvaluateMeasureOperation {
 
                         if( ! resourceMap.containsKey(id) ) {
                             try {
-                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, /*throwExOnNull=*/true);
+                                SingleResourceResult<? extends Resource> readResult = resourceHelper.doRead(type, id, THROW_EXC_ON_MISSING);
                                 if( readResult.isSuccess() ) {
                                     Resource fetchedResource = readResult.getResource();
                                     parameters.parameter(Parameter.builder().name(fhirstring(PARAM_OUT_RESOURCE)).resource(fetchedResource).build());

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -5,6 +5,8 @@
  */
 package com.ibm.fhir.operation.cqf;
 
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public class MeasureDataRequirementsOperation extends AbstractDataRequirementsOp
 
         Measure measure = null;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, true);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, THROW_EXC_ON_MISSING);
             measure = (Measure) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException("Failed to read resource", ex);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -38,7 +38,7 @@ public class MeasureDataRequirementsOperation extends AbstractDataRequirementsOp
 
         Measure measure = null;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, true, null);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, true);
             measure = (Measure) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException("Failed to read resource", ex);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -5,8 +5,6 @@
  */
 package com.ibm.fhir.operation.cqf;
 
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,8 +38,13 @@ public class MeasureDataRequirementsOperation extends AbstractDataRequirementsOp
 
         Measure measure = null;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, THROW_EXC_ON_MISSING);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId);
             measure = (Measure) readResult.getResource();
+            if (measure == null) {
+                throw new FHIROperationException("Failed to resolve measure with resource id: " + logicalId);
+            }
+        } catch (FHIROperationException fex) {
+            throw fex;
         } catch (Exception ex) {
             throw new FHIROperationException("Failed to read resource", ex);
         }

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperation.java
@@ -38,7 +38,7 @@ public class MeasureDataRequirementsOperation extends AbstractDataRequirementsOp
 
         Measure measure = null;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, true, false, null);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(ResourceType.MEASURE.getValue(), logicalId, true, null);
             measure = (Measure) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException("Failed to read resource", ex);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -29,7 +29,7 @@ public class OperationHelper {
     /**
      * Create a library loader that will server up the CQL library content of the
      * provided list of FHIR Library resources.
-     * 
+     *
      * @param libraries
      *            FHIR library resources
      * @return LibraryLoader that will serve the CQL Libraries for the provided FHIR resources
@@ -43,7 +43,7 @@ public class OperationHelper {
      * Load the CQL Library content for each of the provided FHIR Library resources with
      * translation as needed for Libraries with CQL attachments and no corresponding
      * ELM attachment.
-     * 
+     *
      * @param libraries
      *            FHIR Libraries
      * @return CQL Libraries
@@ -56,9 +56,9 @@ public class OperationHelper {
                 libraries.stream().flatMap(fl -> LibraryHelper.loadLibrary(translator, fl).stream()).filter(Objects::nonNull).collect(Collectors.toList());
         return result;
     }
-    
+
     /**
-     * Load a Measure resource by reference. 
+     * Load a Measure resource by reference.
      * @see loadResourceByReference
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param reference Resource reference either in ResourceType/ID or canonical URL format
@@ -71,7 +71,7 @@ public class OperationHelper {
 
     /**
      * Load a Measure resource by ID.
-     * 
+     *
      * @see loadResourceById
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param resourceId Resource ID
@@ -81,9 +81,9 @@ public class OperationHelper {
     public static Measure loadMeasureById(FHIRResourceHelpers resourceHelper, String resourceId) throws FHIROperationException {
         return loadResourceById(resourceHelper, ResourceType.MEASURE, resourceId);
     }
-    
+
     /**
-     * Load a Library resource by reference. 
+     * Load a Library resource by reference.
      * @see loadResourceByReference
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param reference Resource reference either in ResourceType/ID or canonical URL format
@@ -93,10 +93,10 @@ public class OperationHelper {
     public static Library loadLibraryByReference(FHIRResourceHelpers resourceHelper, String reference) throws FHIROperationException {
         return loadResourceByReference(resourceHelper, ResourceType.LIBRARY, Library.class, reference);
     }
-    
+
     /**
      * Load a Library resource by ID.
-     * 
+     *
      * @see loadResourceById
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param resourceId Resource ID
@@ -106,11 +106,11 @@ public class OperationHelper {
     public static Library loadLibraryById(FHIRResourceHelpers resourceHelper, String resourceId) throws FHIROperationException {
         return loadResourceById(resourceHelper, ResourceType.LIBRARY, resourceId);
     }
-    
+
     /**
      * Load a resource by reference. If the reference is of the format, ResourceType/ID or
      * does not contain any forward slash characters, it will be loaded directly. Otherwise,
-     * the reference will be treated as a canonical URL and resolved from the FHIR registry. 
+     * the reference will be treated as a canonical URL and resolved from the FHIR registry.
      *
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param reference Resource reference either in ResourceType/ID or canonical URL format
@@ -125,7 +125,7 @@ public class OperationHelper {
             String resourceId = reference;
             if( pos > -1 ) {
                 resourceId = reference.substring(pos + 1);
-            } 
+            }
             resource = (T) loadResourceById(resourceHelper, resourceType, resourceId);
         } else {
             resource = FHIRRegistry.getInstance().getResource(reference, resourceClass);
@@ -133,14 +133,14 @@ public class OperationHelper {
                 throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), reference));
             }
         }
-        
+
         return resource;
     }
 
     /**
      * Load a resource by ID. ID values are expected to already be separated
      * from the ResourceType in a reference.
-     * 
+     *
      * @param <T> Resource class to load
      * @param resourceHelper FHIRResourceHelpers for resource reads
      * @param resourceType ResourceType of the resource to load
@@ -152,7 +152,7 @@ public class OperationHelper {
     public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String resourceId) throws FHIROperationException {
         T resource;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true, false, null);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true, null);
             resource = (T) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId), ex);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -5,8 +5,6 @@
  */
 package com.ibm.fhir.operation.cqf;
 
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -154,10 +152,15 @@ public class OperationHelper {
     public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String resourceId) throws FHIROperationException {
         T resource;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, THROW_EXC_ON_MISSING);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId);
             resource = (T) readResult.getResource();
+            if (resource == null) {
+                throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId));
+            }
+        } catch (FHIROperationException fex) {
+            throw fex;
         } catch (Exception ex) {
-            throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId), ex);
+            throw new FHIROperationException("Unexpected error while reading " + resourceType.getValue() + "/" + resourceId, ex);
         }
         return resource;
     }

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -152,7 +152,7 @@ public class OperationHelper {
     public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String resourceId) throws FHIROperationException {
         T resource;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true, null);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true);
             resource = (T) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId), ex);

--- a/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/main/java/com/ibm/fhir/operation/cqf/OperationHelper.java
@@ -5,6 +5,8 @@
  */
 package com.ibm.fhir.operation.cqf;
 
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -152,7 +154,7 @@ public class OperationHelper {
     public static <T extends Resource> T loadResourceById(FHIRResourceHelpers resourceHelper, ResourceType resourceType, String resourceId) throws FHIROperationException {
         T resource;
         try {
-            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, true);
+            SingleResourceResult<?> readResult = resourceHelper.doRead(resourceType.getValue(), resourceId, THROW_EXC_ON_MISSING);
             resource = (T) readResult.getResource();
         } catch (Exception ex) {
             throw new FHIROperationException(String.format("Failed to resolve %s resource \"%s\"", resourceType.getValue(), resourceId), ex);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -104,7 +104,7 @@ public abstract class BaseDataRequirementsOperationTest {
         List<Library> fhirLibraries = Arrays.asList(primaryLibrary, getSupplementalDataElementsLibrary(), getFHIRHelpers(), getFHIRModelInfo());
 
         if (exists) {
-            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
+            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
 
             fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
         }

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -12,7 +12,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.fhirinteger;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhiruri;
 import static com.ibm.fhir.cql.helpers.ModelHelper.relatedArtifact;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -104,7 +103,7 @@ public abstract class BaseDataRequirementsOperationTest {
         List<Library> fhirLibraries = Arrays.asList(primaryLibrary, getSupplementalDataElementsLibrary(), getFHIRHelpers(), getFHIRModelInfo());
 
         if (exists) {
-            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
+            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
 
             fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
         }

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/BaseDataRequirementsOperationTest.java
@@ -12,7 +12,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.fhirinteger;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhiruri;
 import static com.ibm.fhir.cql.helpers.ModelHelper.relatedArtifact;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -103,7 +102,7 @@ public abstract class BaseDataRequirementsOperationTest {
         List<Library> fhirLibraries = Arrays.asList(primaryLibrary, getSupplementalDataElementsLibrary(), getFHIRHelpers(), getFHIRModelInfo());
 
         if (exists) {
-            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
+            when(resourceHelper.doRead(eq("Library"), eq(primaryLibrary.getId()))).thenAnswer(x -> TestHelper.asResult(primaryLibrary));
 
             fhirLibraries.stream().forEach( l -> when(mockRegistry.getResource( canonical(l.getUrl(), l.getVersion()).getValue(), Library.class )).thenReturn(l) );
         }

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
@@ -114,7 +114,7 @@ public class CareGapsOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pTopic, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
@@ -114,7 +114,7 @@ public class CareGapsOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pTopic, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), nullable(String.class), nullable(String.class), any(), nullable(String.class), nullable(Resource.class))).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), nullable(String.class), nullable(String.class), any(), nullable(String.class), nullable(Resource.class))).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
@@ -116,9 +116,9 @@ public class CareGapsOperationTest {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean(), any())).thenAnswer(x -> asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), nullable(String.class), nullable(String.class), any(), nullable(String.class), nullable(Resource.class))).thenReturn(bundle(encounter));
-        when(resourceHelper.doSearch(eq("Procedure"), nullable(String.class), nullable(String.class), any(), nullable(String.class), nullable(Resource.class))).thenReturn(bundle(procedure));
-        when(resourceHelper.doSearch(eq("Measure"), nullable(String.class), nullable(String.class), any(), nullable(String.class), nullable(Resource.class))).thenReturn(bundle(measure));
+        when(resourceHelper.doSearch(eq("Encounter"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(encounter));
+        when(resourceHelper.doSearch(eq("Procedure"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(procedure));
+        when(resourceHelper.doSearch(eq("Measure"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(measure));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/CareGapsOperationTest.java
@@ -12,7 +12,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.concept;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.valueset;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -114,7 +113,7 @@ public class CareGapsOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pTopic, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), anyString(), anyBoolean())).thenAnswer(x -> asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), anyString())).thenAnswer(x -> asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(encounter));
         when(resourceHelper.doSearch(eq("Procedure"), nullable(String.class), nullable(String.class), any(), nullable(String.class))).thenReturn(bundle(procedure));

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -118,7 +118,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(procedure) );
@@ -181,7 +181,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -224,7 +224,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -267,7 +267,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -309,7 +309,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -12,7 +12,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.concept;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.valueset;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -118,7 +117,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
@@ -181,7 +180,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -194,7 +193,7 @@ public class EvaluateMeasureOperationTest {
                     Measure.class, null, null, parameters, resourceHelper, searchHelper);
             fail("Operation was expected to fail");
         } catch( FHIROperationException fex ) {
-            assertEquals(fex.getMessage(), "Failed to resolve Measure resource \"NOT VALID\"");
+            assertEquals(fex.getMessage(), "Unexpected error while reading Measure/NOT VALID");
         }
     }
 
@@ -224,7 +223,8 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Measure"), eq("NOT_VALID"))).thenAnswer(x -> TestHelper.asResult(null));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -267,7 +267,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -309,7 +309,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -120,8 +120,8 @@ public class EvaluateMeasureOperationTest {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(encounter) );
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(procedure) );
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
+        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/EvaluateMeasureOperationTest.java
@@ -118,7 +118,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
@@ -181,7 +181,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -224,7 +224,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -267,7 +267,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);
@@ -309,7 +309,7 @@ public class EvaluateMeasureOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
@@ -13,7 +13,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.reference;
 import static com.ibm.fhir.cql.helpers.ModelHelper.valueset;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -112,7 +111,7 @@ public class MeasureCollectDataOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
@@ -158,7 +157,7 @@ public class MeasureCollectDataOperationTest {
                 .build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()))).thenAnswer(x -> TestHelper.asResult(patient));
 
         Parameters.Builder builder = Parameters.builder();
         operation.resolveReferences(encounter, builder, new HashMap<>(), resourceHelper);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
@@ -112,7 +112,7 @@ public class MeasureCollectDataOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(procedure) );
@@ -158,7 +158,7 @@ public class MeasureCollectDataOperationTest {
                 .build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
         Parameters.Builder builder = Parameters.builder();
         operation.resolveReferences(encounter, builder, new HashMap<>(), resourceHelper);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
@@ -114,8 +114,8 @@ public class MeasureCollectDataOperationTest {
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
         when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
 
-        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(encounter) );
-        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString(), any())).thenReturn( bundle(procedure) );
+        when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
+        when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
 
         try (MockedStatic<FHIRRegistry> staticRegistry = mockStatic(FHIRRegistry.class)) {
             FHIRRegistry mockRegistry = spy(FHIRRegistry.class);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureCollectDataOperationTest.java
@@ -112,7 +112,7 @@ public class MeasureCollectDataOperationTest {
         Parameters parameters = Parameters.builder().parameter(pPeriodStart, pPeriodEnd, pReportType, pMeasure, pSubject).build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         when(resourceHelper.doSearch(eq("Encounter"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(encounter) );
         when(resourceHelper.doSearch(eq("Procedure"), anyString(), anyString(), any(), anyString())).thenReturn( bundle(procedure) );
@@ -158,7 +158,7 @@ public class MeasureCollectDataOperationTest {
                 .build();
 
         FHIRResourceHelpers resourceHelper = mock(FHIRResourceHelpers.class);
-        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(patient));
+        when(resourceHelper.doRead(eq("Patient"), eq(patient.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(patient));
 
         Parameters.Builder builder = Parameters.builder();
         operation.resolveReferences(encounter, builder, new HashMap<>(), resourceHelper);

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
@@ -10,7 +10,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.concept;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhiruri;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -102,7 +101,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
 
         measure = measure.toBuilder().library( canonical(primaryLibrary) ).build();
 
-        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(measure));
+        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(measure));
         when(mockRegistry.getResource( canonical(measure.getUrl(), measure.getVersion()).getValue(), Measure.class )).thenReturn(measure);
 
         return primaryLibrary;

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
@@ -61,7 +61,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
                                 .build()).build())
                     .build())
                 .build();
-        
+
         primaryLibraryExists = true;
     }
 
@@ -81,7 +81,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
         Library moduleDefinition = (Library) outParams.getParameter().get(0).getResource();
         assertEquals(moduleDefinition.getRelatedArtifact().stream().filter( ra -> ra.getResource().getValue().equals(measure.getLibrary().get(0).getValue()) ).count(), 1);
     }
-    
+
     @Test(expectedExceptions = { FHIROperationException.class } , expectedExceptionsMessageRegExp  = "Failed to resolve Library resource.*")
     public void testInstanceExecutionMissingPrimaryLibrary() throws Exception {
         primaryLibraryExists = false;
@@ -91,7 +91,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
                 .parameter(Parameters.Parameter.builder().name(fhirstring("periodStart")).value(Date.of("2000-01-01")).build())
                 .parameter(Parameters.Parameter.builder().name(fhirstring("periodEnd")).value(Date.of("2001-01-01")).build())
                 .build();
- 
+
         runTest(FHIROperationContext.createInstanceOperationContext("data-requirements"),
             Measure.class, primaryLibrary -> measureId, primaryLibrary -> inParams);
     }
@@ -102,7 +102,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
 
         measure = measure.toBuilder().library( canonical(primaryLibrary) ).build();
 
-        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()), anyBoolean(), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(measure));
+        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()), anyBoolean(), any())).thenAnswer(x -> TestHelper.asResult(measure));
         when(mockRegistry.getResource( canonical(measure.getUrl(), measure.getVersion()).getValue(), Measure.class )).thenReturn(measure);
 
         return primaryLibrary;

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/MeasureDataRequirementsOperationTest.java
@@ -10,7 +10,6 @@ import static com.ibm.fhir.cql.helpers.ModelHelper.concept;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhircode;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhirstring;
 import static com.ibm.fhir.cql.helpers.ModelHelper.fhiruri;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -101,7 +100,7 @@ public class MeasureDataRequirementsOperationTest extends BaseDataRequirementsOp
 
         measure = measure.toBuilder().library( canonical(primaryLibrary) ).build();
 
-        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()), anyBoolean())).thenAnswer(x -> TestHelper.asResult(measure));
+        when(resourceHelper.doRead(eq("Measure"), eq(measure.getId()))).thenAnswer(x -> TestHelper.asResult(measure));
         when(mockRegistry.getResource( canonical(measure.getUrl(), measure.getVersion()).getValue(), Measure.class )).thenReturn(measure);
 
         return primaryLibrary;

--- a/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/TestHelper.java
+++ b/cql/operation/fhir-operation-cqf/src/test/java/com/ibm/fhir/operation/cqf/TestHelper.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,10 +43,10 @@ public class TestHelper {
     }
     
     @SuppressWarnings("unchecked")
-    public static SingleResourceResult<? extends Resource> asResult(Resource patient) {
+    public static SingleResourceResult<? extends Resource> asResult(Resource resource) {
         SingleResourceResult<Resource> result = (SingleResourceResult<Resource>) mock(SingleResourceResult.class);
         when(result.isSuccess()).thenReturn(true);
-        when(result.getResource()).thenReturn(patient);
+        when(result.getResource()).thenReturn(resource);
         return result;
     }
 }

--- a/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
+++ b/fhir-bulkdata-webapp/src/main/java/com/ibm/fhir/bulkdata/jbatch/load/ChunkWriter.java
@@ -284,7 +284,7 @@ public class ChunkWriter extends AbstractItemWriter {
                                 FHIRPersistenceEvent event = new FHIRPersistenceEvent(fhirResource, props);
 
                                 // Set up the persistence context to include the deleted resources when we read
-                                FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event, true);
+                                FHIRPersistenceContext persistenceContext = FHIRPersistenceContextFactory.createPersistenceContext(event);
                                 operationOutcome = conditionalFingerprintUpdate(chunkData, skip, fhirPersistence,
                                         persistenceContext, id, fhirResource, ctx,
                                         failedNum + cur + chunkData.getNumOfProcessedResources());

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/ReindexResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/dao/ReindexResourceDAO.java
@@ -22,7 +22,6 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import com.ibm.fhir.database.utils.api.IDatabaseTranslator;
 import com.ibm.fhir.database.utils.common.CalendarHelper;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.connection.FHIRDbFlavor;
 import com.ibm.fhir.persistence.jdbc.dao.api.IResourceReferenceDAO;
@@ -314,7 +313,7 @@ public class ReindexResourceDAO extends ResourceDAOImpl {
                 } else {
                     // Can't really happen, because the resource is selected for update, so it can't disappear
                     logger.severe("Logical resource no longer exists: logical_resource_id=" + result.getLogicalResourceId());
-                    throw new FHIRPersistenceResourceNotFoundException("resource not found");
+                    throw new IllegalStateException("resource not found");
                 }
             } catch (SQLException x) {
                 logger.log(Level.SEVERE, SELECT_RESOURCE_TYPE, x);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -29,7 +29,6 @@ import com.ibm.fhir.database.utils.derby.DerbyMaster;
 import com.ibm.fhir.database.utils.derby.DerbyTranslator;
 import com.ibm.fhir.persistence.InteractionStatus;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceVersionIdMismatchException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.connection.FHIRDbFlavor;
@@ -84,7 +83,7 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
     }
 
     @Override
-    public Resource  insert(Resource resource, List<ExtractedParameterValue> parameters, String parameterHashB64, ParameterDAO parameterDao,
+    public Resource insert(Resource resource, List<ExtractedParameterValue> parameters, String parameterHashB64, ParameterDAO parameterDao,
             Integer ifNoneMatch)
             throws FHIRPersistenceException {
         final String METHODNAME = "insert";
@@ -125,7 +124,6 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
                 outIfNoneMatchVersion
                 );
 
-
             dbCallDuration = (System.nanoTime() - dbCallStartTime)/1e6;
 
             if (outInteractionStatus.get() == INTERACTION_STATUS_IF_NONE_MATCH) {
@@ -150,7 +148,7 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
                 throw new FHIRPersistenceVersionIdMismatchException("Encountered version id mismatch while inserting Resource");
             } else if (FHIRDAOConstants.SQLSTATE_CURRENTLY_DELETED.equals((e.getSQLState()))) {
                 // the resource is already deleted, which should be handled before the persistence layer is called
-                throw new FHIRPersistenceResourceDeletedException("Unexpected attempt to delete a Resource which is currently deleted.");
+                throw new FHIRPersistenceException("Unexpected attempt to delete a Resource which is currently deleted.");
             } else {
                 FHIRPersistenceException fx = new FHIRPersistenceException("SQLException encountered while inserting Resource.");
                 throw severe(logger, fx, e);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/derby/DerbyResourceDAO.java
@@ -146,9 +146,6 @@ public class DerbyResourceDAO extends ResourceDAOImpl {
             if (FHIRDAOConstants.SQLSTATE_WRONG_VERSION.equals(e.getSQLState())) {
                 // this is just a concurrent update, so there's no need to log the SQLException here
                 throw new FHIRPersistenceVersionIdMismatchException("Encountered version id mismatch while inserting Resource");
-            } else if (FHIRDAOConstants.SQLSTATE_CURRENTLY_DELETED.equals((e.getSQLState()))) {
-                // the resource is already deleted, which should be handled before the persistence layer is called
-                throw new FHIRPersistenceException("Unexpected attempt to delete a Resource which is currently deleted.");
             } else {
                 FHIRPersistenceException fx = new FHIRPersistenceException("SQLException encountered while inserting Resource.");
                 throw severe(logger, fx, e);

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -1051,8 +1051,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
             // Create a new Resource DTO instance to represent the deletion marker.
             final int newVersionId = versionId + 1;
             com.ibm.fhir.persistence.jdbc.dto.Resource resourceDTO =
-                    createResourceDTO(resourceType, logicalId, newVersionId, lastUpdated, null,
-                        null);
+                    createResourceDTO(resourceType, logicalId, newVersionId, lastUpdated, null, null);
             resourceDTO.setDeleted(true);
 
             // Persist the logically deleted Resource DTO.

--- a/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
+++ b/fhir-persistence-jdbc/src/main/java/com/ibm/fhir/persistence/jdbc/impl/FHIRPersistenceJDBCImpl.java
@@ -103,8 +103,6 @@ import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.erase.EraseDTO;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceNotSupportedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.jdbc.FHIRPersistenceJDBCCache;
 import com.ibm.fhir.persistence.jdbc.FHIRResourceDAOFactory;
 import com.ibm.fhir.persistence.jdbc.JDBCConstants;
@@ -1065,19 +1063,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 log.fine("Deleted FHIR Resource '" + resourceDTO.getResourceType() + "/" + resourceDTO.getLogicalId() + "' id=" + resourceDTO.getId()
                             + ", version=" + resourceDTO.getVersionId());
             }
-        }
-        catch(FHIRPersistenceFKVException e) {
+        } catch(FHIRPersistenceException e) {
             throw e;
-        }
-        catch(FHIRPersistenceException e) {
-            throw e;
-        }
-        catch(Throwable e) {
+        } catch(Throwable e) {
             FHIRPersistenceException fx = new FHIRPersistenceException("Unexpected error while performing a delete operation.");
             log.log(Level.SEVERE, fx.getMessage(), e);
             throw fx;
-        }
-        finally {
+        } finally {
             log.exiting(CLASSNAME, METHODNAME);
         }
     }
@@ -1127,10 +1119,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             resourceDTO = resourceDao.read(logicalId, resourceType.getSimpleName());
             boolean resourceIsDeleted = resourceDTO != null && resourceDTO.isDeleted();
-            if (resourceIsDeleted && !context.includeDeleted()) {
-                throw new FHIRPersistenceResourceDeletedException("Resource '" +
-                        resourceType.getSimpleName() + "/" + logicalId + "' is deleted.");
-            }
 
             // Fetch the resource payload if needed and convert to a model object
             final T resource = convertResourceDTO(resourceDTO, resourceType, elements);
@@ -1145,8 +1133,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                     .build();
 
             return result;
-        } catch(FHIRPersistenceResourceDeletedException e) {
-            throw e;
         } catch(Throwable e) {
             FHIRPersistenceException fx = new FHIRPersistenceException("Unexpected error while performing a read operation.");
             log.log(Level.SEVERE, fx.getMessage(), e);
@@ -1354,10 +1340,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
             version = Integer.parseInt(versionId);
             resourceDTO = resourceDao.versionRead(logicalId, resourceType.getSimpleName(), version);
-            if (resourceDTO != null && resourceDTO.isDeleted() && !context.includeDeleted()) {
-                throw new FHIRPersistenceResourceDeletedException("Resource '" +
-                        resourceType.getSimpleName() + "/" + logicalId + "' version " + versionId + " is deleted.");
-            }
             resource = this.convertResourceDTO(resourceDTO, resourceType, elements);
 
             SingleResourceResult<T> result = new SingleResourceResult.Builder<T>()
@@ -1370,19 +1352,13 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                     .build();
 
             return result;
-        }
-        catch(FHIRPersistenceResourceDeletedException e) {
-            throw e;
-        }
-        catch (NumberFormatException e) {
+        } catch (NumberFormatException e) {
             throw new FHIRPersistenceException("Invalid version id specified for vread operation: " + versionId);
-        }
-        catch(Throwable e) {
+        } catch(Throwable e) {
             FHIRPersistenceException fx = new FHIRPersistenceException("Unexpected error while performing a version read operation.");
             log.log(Level.SEVERE, fx.getMessage(), e);
             throw fx;
-        }
-        finally {
+        } finally {
             log.exiting(CLASSNAME, METHODNAME);
         }
     }
@@ -2939,8 +2915,6 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
                 eraseDao.clearErasedResourcesInGroup(eraseResourceGroupId);
             }
 
-        } catch(FHIRPersistenceResourceNotFoundException e) {
-            throw e;
         } catch(FHIRPersistenceException e) {
             // Other Peristence exceptions are implied, such as FHIRPersistenceFKVException.
             getTransaction().setRollbackOnly();
@@ -3078,7 +3052,7 @@ public class FHIRPersistenceJDBCImpl implements FHIRPersistence, SchemaNameSuppl
 
         // Make sure we read deleted resources...this is important because the result list must
         // line up row-for-row with the provided records list
-        FHIRPersistenceContext readContext = FHIRPersistenceContextFactory.createPersistenceContext(null, true);
+        FHIRPersistenceContext readContext = FHIRPersistenceContextFactory.createPersistenceContext(null);
         List<Resource> result = new ArrayList<>(records.size());
         for (ResourceChangeLogRecord r: records) {
             Class<? extends Resource> resourceType = ModelSupport.getResourceType(r.getResourceTypeName());

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/SingleResourceResult.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/SingleResourceResult.java
@@ -13,8 +13,6 @@ import com.ibm.fhir.model.util.ValidationSupport;
 /**
  * A Result wrapper for FHIR interactions that return a single resource.
  * Instances are immutable and can be constructed via {@code new SingleResourceResult.Builder<T>()}.
- *
- * @author lmsurpre
  */
 public class SingleResourceResult<T extends Resource> {
     // The resourceResult will only be set if success == true
@@ -22,13 +20,13 @@ public class SingleResourceResult<T extends Resource> {
     private final boolean success;
     private final OperationOutcome outcome;
     private final InteractionStatus interactionStatus;
-    
+
     // The current version of the resource returned by the database if we hit IfNoneMatch
     final Integer ifNoneMatchVersion;
-    
+
     private SingleResourceResult(Builder<T> builder) {
         success = ValidationSupport.requireNonNull(builder.success, "success");
-        
+
         if (success) {
             resourceResult = builder.resourceResultBuilder.build();
         } else {
@@ -37,15 +35,15 @@ public class SingleResourceResult<T extends Resource> {
         outcome = builder.outcome;
         interactionStatus = builder.interactionStatus;
         ifNoneMatchVersion = builder.ifNoneMatchVersion;
-        
+
         if (!success && (outcome == null || outcome.getIssue().isEmpty())) {
             throw new IllegalStateException("Failed interaction results must include an OperationOutcome with one or more issue.");
         }
-        
+
         if (interactionStatus == null) {
             throw new IllegalStateException("All interaction results must include a valid InteractionStatus");
         }
-        
+
         if (interactionStatus == InteractionStatus.IF_NONE_MATCH_EXISTED && ifNoneMatchVersion == null) {
             throw new IllegalStateException("Must specify ifNoneMatchVersion when IF_NON_MATCH_EXISTED is true");
         }
@@ -100,7 +98,7 @@ public class SingleResourceResult<T extends Resource> {
     public Integer getIfNoneMatchVersion() {
         return this.ifNoneMatchVersion;
     }
-    
+
     /**
      * An OperationOutcome that represents the outcome of the interaction
      *
@@ -164,7 +162,7 @@ public class SingleResourceResult<T extends Resource> {
 
         /**
          * Sets the interaction status
-         * 
+         *
          * @param status
          * @return a reference to this Builder instance
          */
@@ -175,7 +173,7 @@ public class SingleResourceResult<T extends Resource> {
 
         /**
          * Sets the version we found hitting IfNoneMatch. Null in other cases.
-         * 
+         *
          * @param versionId
          * @return
          */
@@ -186,7 +184,7 @@ public class SingleResourceResult<T extends Resource> {
 
         /**
          * Whether or not the resource is deleted
-         * 
+         *
          * @param flag
          * @return A reference to this Builder instance
          */
@@ -228,7 +226,7 @@ public class SingleResourceResult<T extends Resource> {
         /**
          * The type name of the resource which should be set when the resource
          * value itself is null
-         * 
+         *
          * @param resourceTypeName
          *     The type name of the resource this result represents
          * @return
@@ -242,7 +240,7 @@ public class SingleResourceResult<T extends Resource> {
         /**
          * Sets the logicalId of the resource which should be set when the resource
          * value itself is null
-         * 
+         *
          * @param logicalId
          *     The logicalId of this resource
          * @return
@@ -256,7 +254,7 @@ public class SingleResourceResult<T extends Resource> {
         /**
          * Sets the version of the resource which should be set when the resource
          * value itself is null
-         * 
+         *
          * @param version
          *     The version of this resource
          * @return

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceContext.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceContext.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -35,11 +35,6 @@ public interface FHIRPersistenceContext {
     FHIRSearchContext getSearchContext();
 
     /**
-     * Indicates whether the persistence layer should include "deleted" resources in the operation response.
-     */
-    boolean includeDeleted();
-    
-    /**
      * Get the encoded ifNoneMatch value which is interpreted as follows:
      * <pre>
      *    null: create-on-update proceeds as normal
@@ -48,9 +43,9 @@ public interface FHIRPersistenceContext {
      * @return the value from the If-None-Match header in the PUT request
      */
     Integer getIfNoneMatch();
-    
+
     /**
-     * Get the payload persistence response 
+     * Get the payload persistence response
      * @return
      */
     PayloadPersistenceResponse getOffloadResponse();

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceContextFactory.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -34,17 +34,6 @@ public class FHIRPersistenceContextFactory {
                 .build();
     }
 
-    /**
-     * Returns a FHIRPersistenceContext that contains a FHIRPersistenceEvent instance.
-     * @param event the FHIRPersistenceEvent instance to be contained in the FHIRPersistenceContext instance
-     * @param includeDeleted flag to tell the persistence layer to include deleted resources in the operation results.
-     */
-    public static FHIRPersistenceContext createPersistenceContext(FHIRPersistenceEvent event, boolean includeDeleted) {
-        return FHIRPersistenceContextImpl.builder(event)
-                .withIncludeDeleted(includeDeleted)
-                .build();
-    }
-    
     /**
      * Returns a FHIRPersistenceContext that contains a FHIRPersistenceEvent instance.
      * @param event the FHIRPersistenceEvent instance to be contained in the FHIRPersistenceContext instance
@@ -96,18 +85,5 @@ public class FHIRPersistenceContextFactory {
         ctx.setMaxPageSize(maxPageSize);
         ctx.setMaxPageIncludeCount(maxPageIncludeCount);
         return ctx;
-    }
-
-    /**
-     * Returns a FHIRPersistenceContext that contains a FHIRPersistenceEvent instance.
-     * @param event the FHIRPersistenceEvent instance to be contained in the FHIRPersistenceContext instance
-     * @param includeDeleted flag to tell the persistence layer to include deleted resources in the operation results
-     * @param searchContext the FHIRSearchContext instance to be contained in the FHIRPersistenceContext instance
-     */
-    public static FHIRPersistenceContext createPersistenceContext(FHIRPersistenceEvent event, boolean includeDeleted, FHIRSearchContext searchContext) {
-        return FHIRPersistenceContextImpl.builder(event)
-                .withIncludeDeleted(includeDeleted)
-                .withSearchContext(searchContext)
-                .build();
     }
 }

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/FHIRPersistenceEvent.java
@@ -49,7 +49,8 @@ public class FHIRPersistenceEvent {
 
     /**
      * This property is of type String and contains the version id associated with a
-     * vread operation.   For other operations, this property will be null.
+     * vread operation.
+     * For other operations, this property will be null.
      */
     public static final String PROPNAME_VERSION_ID = "VERSION_ID";
 
@@ -85,9 +86,17 @@ public class FHIRPersistenceEvent {
     }
 
     /**
-     * Ctor which accepts the FHIR resource and a collection of properties.
+     * Ctor that accepts a collection of properties.
+     * @param properties the set of properties associated with the event
+     */
+    public FHIRPersistenceEvent(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Ctor that accepts the FHIR resource and a collection of properties.
      * @param fhirResource the FHIR resource associated with the event
-     * @param properties the set of properties associated with the event.
+     * @param properties the set of properties associated with the event
      */
     public FHIRPersistenceEvent(Resource fhirResource, Map<String, Object> properties) {
         this.fhirResource = fhirResource;
@@ -96,7 +105,8 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the resource associated with the REST API request that triggered the
-     * interceptor invocation.  This will be non-null before and after a create or update operation,
+     * interceptor invocation.
+     * This will be non-null before and after a create or update operation,
      * and will be non-null after a read, vread, history or search operation.
      */
     public Resource getFhirResource() {
@@ -105,7 +115,8 @@ public class FHIRPersistenceEvent {
 
     /**
      * Sets the specific resource in 'this'.
-     * Interceptor implementations should *not* call this method.  This method is reserved for use by the FHIR Server.
+     * Interceptor implementations should *not* call this method.
+     * This method is reserved for use by the FHIR Server.
      */
     public void setFhirResource(Resource resource) {
         this.fhirResource = resource;
@@ -113,7 +124,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the "previous" resource associated with the REST API request that triggered
-     * the interceptor invocation.  This field is set only for an "update" operation and represents
+     * the interceptor invocation. This field is set only for an "update" operation and represents
      * the existing version of the resource prior to the new resource being stored.
      */
     public Resource getPrevFhirResource() {
@@ -134,7 +145,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * This method returns true if and only if the "previous resource" field has in fact
-     * been set.   This flag exists so that we can differentiate between these two scenarios:
+     * been set. This flag exists so that we can differentiate between these two scenarios:
      * <ul>
      * <li>The "previous resource" field is explicitly set to null.</li>
      * <li>The "previous resource" field is not explicitly set at all.</li>
@@ -149,7 +160,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the resource type associated with the FHIR REST API request that triggered the
-     * interceptor invocation.   This will be non-null for a
+     * interceptor invocation. This will be non-null for a
      * create, update, read, vread, history, search, or delete operation.
      */
     public String getFhirResourceType() {
@@ -158,7 +169,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the resource id associated with the FHIR REST API request that triggered the
-     * interceptor invocation.   This will be non-null for a read, vread, non-whole-system history, or non-conditional update/delete operation.
+     * interceptor invocation. This will be non-null for a read, vread, non-whole-system history, or non-conditional update/delete operation.
      */
     public String getFhirResourceId() {
         return (String) getProperty(PROPNAME_RESOURCE_ID);
@@ -166,7 +177,7 @@ public class FHIRPersistenceEvent {
 
     /**
      * Returns the version id associated with the FHIR REST API request that triggered the
-     * interceptor invocation.  This will be non-null for a vread operation.
+     * interceptor invocation. This will be non-null for a vread operation.
      */
     public String getFhirVersionId() {
         return (String) getProperty(PROPNAME_VERSION_ID);

--- a/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/impl/FHIRPersistenceContextImpl.java
+++ b/fhir-persistence/src/main/java/com/ibm/fhir/persistence/context/impl/FHIRPersistenceContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2021
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -21,9 +21,8 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
     private FHIRPersistenceEvent persistenceEvent;
     private FHIRHistoryContext historyContext;
     private FHIRSearchContext searchContext;
-    private boolean includeDeleted = false;
     private Integer ifNoneMatch;
-    
+
     // The response from the payload persistence (offloading) call, if any
     private PayloadPersistenceResponse offloadResponse;
 
@@ -43,10 +42,9 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
         private FHIRPersistenceEvent persistenceEvent;
         private FHIRHistoryContext historyContext;
         private FHIRSearchContext searchContext;
-        private boolean includeDeleted;
         private Integer ifNoneMatch;
         private PayloadPersistenceResponse offloadResponse;
-        
+
         /**
          * Protected constructor
          * @param event
@@ -54,14 +52,14 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
         protected Builder(FHIRPersistenceEvent event) {
             this.persistenceEvent = event;
         }
-        
+
         /**
          * Build the FHIRPersistenceContext implementation
          * @return
          */
         public FHIRPersistenceContext build() {
             FHIRPersistenceContextImpl impl;
-            
+
             if (historyContext != null) {
                 impl = new FHIRPersistenceContextImpl(persistenceEvent, historyContext);
             } else if (searchContext != null) {
@@ -70,12 +68,11 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
                 impl = new FHIRPersistenceContextImpl(persistenceEvent);
             }
             impl.setIfNoneMatch(ifNoneMatch);
-            impl.setIncludeDeleted(includeDeleted);
             impl.setOffloadResponse(offloadResponse);
-            
+
             return impl;
         }
-        
+
         /**
          * Build with the given searchContext
          * @param searchContext
@@ -107,16 +104,6 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
         }
 
         /**
-         * Build with the includeDeleted value
-         * @param includeDeleted
-         * @return
-         */
-        public Builder withIncludeDeleted(boolean includeDeleted) {
-            this.includeDeleted = includeDeleted;
-            return this;
-        }
-
-        /**
          * Build with the given offloadResponse
          * @param offloadResponse
          * @return
@@ -135,11 +122,6 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
         this.persistenceEvent = pe;
     }
 
-    private FHIRPersistenceContextImpl(FHIRPersistenceEvent pe, boolean includeDeleted) {
-        this.persistenceEvent = pe;
-        setIncludeDeleted(includeDeleted);
-    }
-
     /**
      * Public constructor
      * @param pe
@@ -149,19 +131,13 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
         this.persistenceEvent = pe;
         setIfNoneMatch(ifNoneMatch);
     }
-    
+
     private FHIRPersistenceContextImpl(FHIRPersistenceEvent pe, FHIRHistoryContext hc) {
         this.persistenceEvent = pe;
         this.historyContext = hc;
     }
     private FHIRPersistenceContextImpl(FHIRPersistenceEvent pe, FHIRSearchContext sc) {
         this.persistenceEvent = pe;
-        this.searchContext = sc;
-    }
-
-    private FHIRPersistenceContextImpl(FHIRPersistenceEvent pe, boolean includeDeleted, FHIRSearchContext sc) {
-        this.persistenceEvent = pe;
-        setIncludeDeleted(includeDeleted);
         this.searchContext = sc;
     }
 
@@ -178,19 +154,6 @@ public class FHIRPersistenceContextImpl implements FHIRPersistenceContext {
     @Override
     public FHIRSearchContext getSearchContext() {
         return this.searchContext;
-    }
-
-    @Override
-    public boolean includeDeleted() {
-        return includeDeleted;
-    }
-
-    /**
-     * Setter for the includeDeleted flag
-     * @param includeDeleted
-     */
-    public void setIncludeDeleted(boolean includeDeleted) {
-        this.includeDeleted = includeDeleted;
     }
 
     /**

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceContextTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/FHIRPersistenceContextTest.java
@@ -7,10 +7,8 @@
 package com.ibm.fhir.persistence.test;
 
 import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
-import static org.testng.AssertJUnit.assertTrue;
 
 import org.testng.annotations.Test;
 
@@ -18,7 +16,6 @@ import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.context.impl.FHIRPersistenceContextImpl;
 import com.ibm.fhir.search.context.FHIRSearchContext;
 import com.ibm.fhir.search.context.FHIRSearchContextFactory;
 
@@ -26,16 +23,15 @@ import com.ibm.fhir.search.context.FHIRSearchContextFactory;
  * Tests associated with the FHIRPersistenceContextImpl class.
  */
 public class FHIRPersistenceContextTest {
-    
+
     @Test
     public void test1() {
         FHIRPersistenceEvent pe = new FHIRPersistenceEvent();
-        
+
         FHIRPersistenceContext ctxt = FHIRPersistenceContextFactory.createPersistenceContext(pe);
         assertNotNull(ctxt);
         assertNotNull(ctxt.getPersistenceEvent());
         assertEquals(pe, ctxt.getPersistenceEvent());
-        assertFalse(ctxt.includeDeleted());
         assertNull(ctxt.getHistoryContext());
         assertNull(ctxt.getSearchContext());
     }
@@ -43,48 +39,30 @@ public class FHIRPersistenceContextTest {
     @Test
     public void test2() {
         FHIRPersistenceEvent pe = new FHIRPersistenceEvent();
-        
-        FHIRPersistenceContext ctxt = FHIRPersistenceContextFactory.createPersistenceContext(pe, true);
-        assertNotNull(ctxt);
-        assertNotNull(ctxt.getPersistenceEvent());
-        assertEquals(pe, ctxt.getPersistenceEvent());
-        assertTrue(ctxt.includeDeleted());
-        assertNull(ctxt.getHistoryContext());
-        assertNull(ctxt.getSearchContext());
-    }
-    
-    @Test
-    public void test3() {
-        FHIRPersistenceEvent pe = new FHIRPersistenceEvent();
         FHIRHistoryContext hc = FHIRPersistenceContextFactory.createHistoryContext();
         assertNotNull(hc);
-        
+
         FHIRPersistenceContext ctxt = FHIRPersistenceContextFactory.createPersistenceContext(pe, hc);
         assertNotNull(ctxt);
         assertNotNull(ctxt.getPersistenceEvent());
         assertEquals(pe, ctxt.getPersistenceEvent());
         assertNotNull(ctxt.getHistoryContext());
         assertEquals(hc, ctxt.getHistoryContext());
-        assertFalse(ctxt.includeDeleted());
         assertNull(ctxt.getSearchContext());
-        
-        ((FHIRPersistenceContextImpl)ctxt).setIncludeDeleted(true);
-        assertTrue(ctxt.includeDeleted());
     }
 
     @Test
-    public void test4() {
+    public void test3() {
         FHIRPersistenceEvent pe = new FHIRPersistenceEvent();
         FHIRSearchContext sc = FHIRSearchContextFactory.createSearchContext();
         assertNotNull(sc);
-        
+
         FHIRPersistenceContext ctxt = FHIRPersistenceContextFactory.createPersistenceContext(pe, sc);
         assertNotNull(ctxt);
         assertNotNull(ctxt.getPersistenceEvent());
         assertEquals(pe, ctxt.getPersistenceEvent());
         assertNotNull(ctxt.getSearchContext());
         assertEquals(sc, ctxt.getSearchContext());
-        assertFalse(ctxt.includeDeleted());
         assertNull(ctxt.getHistoryContext());
     }
 }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/MockPersistenceImpl.java
@@ -22,7 +22,6 @@ import com.ibm.fhir.persistence.ResourcePayload;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 
 /**
@@ -32,20 +31,20 @@ import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 public class MockPersistenceImpl implements FHIRPersistence {
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) 
+    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource)
             throws FHIRPersistenceException {
         return null;
     }
 
     @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
-            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
         return null;
     }
 
     @Override
     public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
-            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
         return null;
     }
 
@@ -93,7 +92,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public List<ResourceChangeLogRecord> changes(int resourceCount, Instant fromLastModified, Instant beforeLastModified, Long afterResourceId, List<String> resourceTypeNames, 
+    public List<ResourceChangeLogRecord> changes(int resourceCount, Instant fromLastModified, Instant beforeLastModified, Long afterResourceId, List<String> resourceTypeNames,
             boolean excludeTransactionTimeoutWindow, HistorySortOrder historySortOrder) throws FHIRPersistenceException {
         return Collections.emptyList();
     }

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -37,7 +37,6 @@ import com.ibm.fhir.persistence.context.FHIRHistoryContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContextFactory;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.util.FHIRPersistenceTestSupport;
 import com.ibm.fhir.persistence.util.FHIRPersistenceUtil;
 import com.ibm.fhir.search.context.FHIRSearchContext;
@@ -279,11 +278,12 @@ public abstract class AbstractPersistenceTest {
     }
 
     /**
-     * Soft delete the resource
+     * Soft delete the resource in a manner that is mostly-consistent with the REST layer.
+     *
      * @param <T>
      * @param context
      * @param resource
-     * @throws FHIRPersistenceException
+     * @throws FHIRPersistenceException if the resource was not found, but not if it was previously deleted.
      */
     protected <T extends Resource> void delete(FHIRPersistenceContext context, T resource) throws FHIRPersistenceException {
         // before attempting the delete, we need to make sure the resource actually exists
@@ -298,7 +298,7 @@ public abstract class AbstractPersistenceTest {
 
         // If we weren't able to read the resource, we need to bail on the delete, just like the FHIRRestHelper.
         if (srr.getResource() == null) {
-            throw new FHIRPersistenceResourceNotFoundException("Resource '"
+            throw new FHIRPersistenceException("Resource '"
                     + resourceType.getSimpleName() + "/" + resource.getId() + "' not found.");
         }
 

--- a/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
+++ b/fhir-persistence/src/test/java/com/ibm/fhir/persistence/test/common/AbstractPersistenceTest.java
@@ -291,6 +291,11 @@ public abstract class AbstractPersistenceTest {
         Class<? extends Resource> resourceType = resource.getClass();
         SingleResourceResult<? extends Resource> srr = persistence.read(context, resourceType, resource.getId());
 
+        // If its already deleted, then nothing to do
+        if (srr.isDeleted()) {
+            return;
+        }
+
         // If we weren't able to read the resource, we need to bail on the delete, just like the FHIRRestHelper.
         if (srr.getResource() == null) {
             throw new FHIRPersistenceResourceNotFoundException("Resource '"

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -37,6 +37,8 @@ public interface FHIRResourceHelpers {
     public static final boolean DO_VALIDATION = true;
     // Constant for indicating whether an update can be skipped when the requested update resource matches the existing one
     public static final boolean SKIPPABLE_UPDATE = true;
+    // Constant for indicating whether an interaction should throw when the corresponding resource could not be read
+    public static final boolean THROW_EXC_ON_MISSING = true;
 
     // Constant for when we don't use the If-Not-Match header value
     public static final Integer IF_NOT_MATCH_NULL = null;

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -311,7 +311,7 @@ public interface FHIRResourceHelpers {
      * @param throwExcOnNull
      *            whether to throw an exception on null
      * @param queryParameters
-     *            for supporting _elements and _summary for resource read
+     *            for supporting _elements and _summary for resource read; allows null
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -293,8 +293,6 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param includeDeleted
-     *            allow the read, even if the resource has been deleted
      * @param contextResource
      *            the resource
      * @param queryParameters
@@ -302,9 +300,9 @@ public interface FHIRResourceHelpers {
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */
-    default SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+    default SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
             Resource contextResource) throws Exception {
-        return doRead(type, id, throwExcOnNull, includeDeleted, contextResource, null);
+        return doRead(type, id, throwExcOnNull, contextResource, null);
     }
 
     /**
@@ -316,8 +314,6 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param includeDeleted
-     *            allow the read, even if the resource has been deleted
      * @param contextResource
      *            the resource
      * @param queryParameters
@@ -325,7 +321,7 @@ public interface FHIRResourceHelpers {
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */
-    SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+    SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
             Resource contextResource, MultivaluedMap<String, String> queryParameters) throws Exception;
 
     /**
@@ -340,7 +336,7 @@ public interface FHIRResourceHelpers {
      * @return the Resource
      * @throws Exception
      */
-    default Resource doVRead(String type, String id, String versionId) throws Exception {
+    default SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId) throws Exception {
         return doVRead(type, id, versionId, null);
     }
 
@@ -358,7 +354,7 @@ public interface FHIRResourceHelpers {
      * @return the Resource
      * @throws Exception
      */
-    Resource doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception;
+    SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception;
 
     /**
      * Performs the work of retrieving versions of a Resource.

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -293,14 +293,13 @@ public interface FHIRResourceHelpers {
      *            the resource type associated with the Resource to be retrieved
      * @param id
      *            the id of the Resource to be retrieved
-     * @param throwExcOnNull
-     *            whether to throw an exception on null
-     * @return a SingleResourceResult wrapping the resource and including its deletion status
+     * @return a SingleResourceResult thats wraps a ResourceResult which contains the possibly-null resource
+     *         that was read from the datastore
      * @throws Exception
      */
-    default SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull)
+    default SingleResourceResult<? extends Resource> doRead(String type, String id)
             throws Exception {
-        return doRead(type, id, throwExcOnNull, null);
+        return doRead(type, id, !THROW_EXC_ON_MISSING, null);
     }
 
     /**

--- a/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
+++ b/fhir-server-spi/src/main/java/com/ibm/fhir/server/spi/operation/FHIRResourceHelpers.java
@@ -293,16 +293,12 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param contextResource
-     *            the resource
-     * @param queryParameters
-     *            for supporting _elements and _summary for resource read
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */
-    default SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
-            Resource contextResource) throws Exception {
-        return doRead(type, id, throwExcOnNull, contextResource, null);
+    default SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull)
+            throws Exception {
+        return doRead(type, id, throwExcOnNull, null);
     }
 
     /**
@@ -314,15 +310,13 @@ public interface FHIRResourceHelpers {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param contextResource
-     *            the resource
      * @param queryParameters
      *            for supporting _elements and _summary for resource read
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */
     SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
-            Resource contextResource, MultivaluedMap<String, String> queryParameters) throws Exception;
+            MultivaluedMap<String, String> queryParameters) throws Exception;
 
     /**
      * Performs a 'vread' operation by retrieving the specified version of a Resource with no query parameters
@@ -419,13 +413,11 @@ public interface FHIRResourceHelpers {
      *            a Map containing the query parameters from the request URL
      * @param requestUri
      *            the request URI
-     * @param contextResource
-     *            the resource context
      * @return a Bundle containing the search result set
      * @throws Exception
      */
     Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
-            String requestUri, Resource contextResource) throws Exception;
+            String requestUri) throws Exception;
 
     /**
      * Performs heavy lifting associated with a 'search' operation.
@@ -440,8 +432,6 @@ public interface FHIRResourceHelpers {
      *            a Map containing the query parameters from the request URL
      * @param requestUri
      *            the request URI
-     * @param contextResource
-     *            the resource context
      * @param checkIfInteractionAllowed
      *            if true, check that the search interaction is permitted
      * @param alwaysIncludeResources
@@ -450,7 +440,7 @@ public interface FHIRResourceHelpers {
      * @throws Exception
      */
     Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
-        String requestUri, Resource contextResource, boolean checkIfInteractionAllowed, boolean alwaysIncludeResources) throws Exception;
+            String requestUri, boolean checkIfInteractionAllowed, boolean alwaysIncludeResources) throws Exception;
 
     /**
      * Helper method which invokes a custom operation.

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/FHIRPatchTest.java
@@ -55,6 +55,9 @@ import com.ibm.fhir.model.type.code.NarrativeStatus;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 
+/**
+ * Tests for JSON and FHIRPath patch interactions
+ */
 public class FHIRPatchTest extends FHIRServerTestBase {
     @Test(groups = { "fhir-patch" })
     public void testJSONPatchAddOperation() throws Exception {
@@ -1110,10 +1113,10 @@ public class FHIRPatchTest extends FHIRServerTestBase {
         response = target.path("Patient/" + patient.getId())
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .method("PATCH", patchEntity, Response.class);
-        assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
+        assertResponse(response, Response.Status.GONE.getStatusCode());
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
         assertNotNull(oo);
-        assertEquals("Resource 'Patient/" + patient.getId() + "' not found.", oo.getIssue().get(0).getDetails().getText().getValue());
+        assertEquals("Resource 'Patient/" + patient.getId() + "' is deleted.", oo.getIssue().get(0).getDetails().getText().getValue());
     }
 
     @Test(groups = { "fhir-patch" })
@@ -1143,10 +1146,10 @@ public class FHIRPatchTest extends FHIRServerTestBase {
         response = target.path("Patient/" + patient.getId())
                 .request(FHIRMediaType.APPLICATION_FHIR_JSON)
                 .method("PATCH", patchEntity, Response.class);
-        assertResponse(response, Response.Status.NOT_FOUND.getStatusCode());
+        assertResponse(response, Response.Status.GONE.getStatusCode());
         OperationOutcome oo = response.readEntity(OperationOutcome.class);
         assertNotNull(oo);
-        assertEquals("Resource 'Patient/" + patient.getId() + "' not found.", oo.getIssue().get(0).getDetails().getText().getValue());
+        assertEquals("Resource 'Patient/" + patient.getId() + "' is deleted.", oo.getIssue().get(0).getDetails().getText().getValue());
     }
 
     private void assertGoodGetResponse(Bundle.Entry entry, int expectedStatusCode, HTTPReturnPreference returnPref) throws Exception {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/exception/FHIRResourceDeletedException.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/exception/FHIRResourceDeletedException.java
@@ -4,28 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.persistence.exception;
+package com.ibm.fhir.server.exception;
 
+import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.FHIRUtil;
 
-public class FHIRPersistenceResourceDeletedException extends FHIRPersistenceException {
+public class FHIRResourceDeletedException extends FHIROperationException {
     private static final long serialVersionUID = 1L;
 
     /**
      * Create an exception with a single OperationOutcome.Issue of type DELETED,
      * both with the passed message
      */
-    public FHIRPersistenceResourceDeletedException(String message) {
+    public FHIRResourceDeletedException(String message) {
         super(message);
         withIssue(FHIRUtil.buildOperationOutcomeIssue(message, IssueType.DELETED));
     }
 
     /**
-     * Create an exception with the passed message and cause and 
+     * Create an exception with the passed message and cause and
      * a single OperationOutcome.Issue with the passed message and an IssueType of NOT_FOUND
      */
-    public FHIRPersistenceResourceDeletedException(String message, Throwable cause) {
+    public FHIRResourceDeletedException(String message, Throwable cause) {
         super(message, cause);
         withIssue(FHIRUtil.buildOperationOutcomeIssue(message, IssueType.DELETED));
     }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/exception/FHIRResourceNotFoundException.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/exception/FHIRResourceNotFoundException.java
@@ -4,28 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package com.ibm.fhir.persistence.exception;
+package com.ibm.fhir.server.exception;
 
+import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.FHIRUtil;
 
-public class FHIRPersistenceResourceNotFoundException extends FHIRPersistenceException {
+public class FHIRResourceNotFoundException extends FHIROperationException {
     private static final long serialVersionUID = 1L;
 
     /**
      * Create an exception with a single OperationOutcome.Issue of type NOT_FOUND,
      * both with the passed message
      */
-    public FHIRPersistenceResourceNotFoundException(String message) {
+    public FHIRResourceNotFoundException(String message) {
         super(message);
         withIssue(FHIRUtil.buildOperationOutcomeIssue(message, IssueType.NOT_FOUND));
     }
 
     /**
-     * Create an exception with the passed message and cause and 
+     * Create an exception with the passed message and cause and
      * a single OperationOutcome.Issue with the passed message and an IssueType of NOT_FOUND
      */
-    public FHIRPersistenceResourceNotFoundException(String message, Throwable cause) {
+    public FHIRResourceNotFoundException(String message, Throwable cause) {
         super(message, cause);
         withIssue(FHIRUtil.buildOperationOutcomeIssue(message, IssueType.NOT_FOUND));
     }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Patch.java
@@ -38,8 +38,8 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.path.patch.FHIRPathPatch;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.server.annotation.PATCH;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.spi.operation.FHIRRestOperationResponse;
 import com.ibm.fhir.server.util.FHIRRestHelper;
 import com.ibm.fhir.server.util.RestAuditLogger;
@@ -94,7 +94,7 @@ public class Patch extends FHIRResource {
             }
             response = addETagAndLastModifiedHeaders(response, resource);
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             status = Status.NOT_FOUND;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
@@ -154,7 +154,7 @@ public class Patch extends FHIRResource {
             }
             response = addETagAndLastModifiedHeaders(response, resource);
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             status = Status.NOT_FOUND;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
@@ -219,7 +219,7 @@ public class Patch extends FHIRResource {
             response = addETagAndLastModifiedHeaders(response, ior.getResource());
 
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             status = Status.NOT_FOUND;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {
@@ -285,7 +285,7 @@ public class Patch extends FHIRResource {
             response = addETagAndLastModifiedHeaders(response, ior.getResource());
 
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             status = Status.NOT_FOUND;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -66,7 +66,7 @@ public class Read extends FHIRResource {
             long modifiedSince = parseIfModifiedSince();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            Resource resource = helper.doRead(type, id, true, false, null, queryParameters).getResource();
+            Resource resource = helper.doRead(type, id, true, null, queryParameters).getResource();
             int version2Match = -1;
             // Support ETag value with or without " (and W/)
             // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -66,7 +66,7 @@ public class Read extends FHIRResource {
             long modifiedSince = parseIfModifiedSince();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            Resource resource = helper.doRead(type, id, true, null, queryParameters).getResource();
+            Resource resource = helper.doRead(type, id, true, queryParameters).getResource();
             int version2Match = -1;
             // Support ETag value with or without " (and W/)
             // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Read.java
@@ -6,6 +6,7 @@
 
 package com.ibm.fhir.server.resources;
 
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 import static com.ibm.fhir.server.util.IssueTypeToHttpStatusMapper.issueListToStatus;
 
 import java.time.Instant;
@@ -66,7 +67,7 @@ public class Read extends FHIRResource {
             long modifiedSince = parseIfModifiedSince();
 
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            Resource resource = helper.doRead(type, id, true, queryParameters).getResource();
+            Resource resource = helper.doRead(type, id, THROW_EXC_ON_MISSING, queryParameters).getResource();
             int version2Match = -1;
             // Support ETag value with or without " (and W/)
             // e.g:  1, "1", W/1, W/"1" (the first format is used by TouchStone)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Search.java
@@ -69,7 +69,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri(), null);
+            bundle = helper.doSearch(type, null, null, queryParameters, getRequestUri());
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
@@ -118,7 +118,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri(), null);
+            bundle = helper.doSearch(type, compartment, compartmentId, queryParameters, getRequestUri());
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {
@@ -163,7 +163,7 @@ public class Search extends FHIRResource {
 
             queryParameters = uriInfo.getQueryParameters();
             FHIRRestHelper helper = new FHIRRestHelper(getPersistenceImpl(), getSearchHelper());
-            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri(), null);
+            bundle = helper.doSearch("Resource", null, null, queryParameters, getRequestUri());
             status = Status.OK;
             return Response.status(status).entity(bundle).build();
         } catch (FHIROperationException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Update.java
@@ -35,7 +35,7 @@ import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceIfNoneMatchException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.spi.operation.FHIRRestOperationResponse;
 import com.ibm.fhir.server.util.FHIRRestHelper;
 import com.ibm.fhir.server.util.RestAuditLogger;
@@ -96,7 +96,7 @@ public class Update extends FHIRResource {
                 response = addHeaders(response, ior.getLocationURI());
             }
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             // By default, NOT_FOUND is mapped to HTTP 404, so explicitly set it to HTTP 405
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
@@ -161,7 +161,7 @@ public class Update extends FHIRResource {
             response = addETagAndLastModifiedHeaders(response, updatedResource);
 
             return response.build();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             status = Status.METHOD_NOT_ALLOWED;
             return exceptionResponse(e, status);
         } catch (FHIROperationException e) {

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionRead.java
@@ -19,7 +19,6 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
     private final String type;
     private final String id;
     private final boolean throwExcOnNull;
-    private final boolean includeDeleted;
     private final Resource contextResource;
     private final MultivaluedMap<String, String> queryParameters;
     private final boolean checkInteractionAllowed;
@@ -33,19 +32,17 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
      * @param type
      * @param id
      * @param throwExcOnNull
-     * @param includeDeleted
      * @param contextResource
      * @param queryParameters
      * @param checkInteractionAllowed
      */
     public FHIRRestInteractionRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
-            String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            String type, String id, boolean throwExcOnNull,
             Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) {
         super(entryIndex, requestDescription, requestURL);
         this.type = type;
         this.id = id;
         this.throwExcOnNull = throwExcOnNull;
-        this.includeDeleted = includeDeleted;
         this.contextResource = contextResource;
         this.queryParameters = queryParameters;
         this.checkInteractionAllowed = checkInteractionAllowed;
@@ -53,6 +50,7 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
 
     @Override
     public void process(FHIRRestInteractionVisitor visitor) throws Exception {
-        visitor.doRead(getEntryIndex(), getRequestDescription(), getRequestURL(), getAccumulatedTime(), type, id, throwExcOnNull, includeDeleted, contextResource, queryParameters, checkInteractionAllowed);
+        visitor.doRead(getEntryIndex(), getRequestDescription(), getRequestURL(), getAccumulatedTime(),
+                type, id, throwExcOnNull, contextResource, queryParameters, checkInteractionAllowed);
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionRead.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionRead.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,6 @@ package com.ibm.fhir.server.rest;
 
 import javax.ws.rs.core.MultivaluedMap;
 
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.server.util.FHIRUrlParser;
 
 /**
@@ -19,7 +18,6 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
     private final String type;
     private final String id;
     private final boolean throwExcOnNull;
-    private final Resource contextResource;
     private final MultivaluedMap<String, String> queryParameters;
     private final boolean checkInteractionAllowed;
 
@@ -32,18 +30,16 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
      * @param type
      * @param id
      * @param throwExcOnNull
-     * @param contextResource
      * @param queryParameters
      * @param checkInteractionAllowed
      */
     public FHIRRestInteractionRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
             String type, String id, boolean throwExcOnNull,
-            Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) {
+            MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) {
         super(entryIndex, requestDescription, requestURL);
         this.type = type;
         this.id = id;
         this.throwExcOnNull = throwExcOnNull;
-        this.contextResource = contextResource;
         this.queryParameters = queryParameters;
         this.checkInteractionAllowed = checkInteractionAllowed;
     }
@@ -51,6 +47,6 @@ public class FHIRRestInteractionRead extends FHIRRestInteractionBase {
     @Override
     public void process(FHIRRestInteractionVisitor visitor) throws Exception {
         visitor.doRead(getEntryIndex(), getRequestDescription(), getRequestURL(), getAccumulatedTime(),
-                type, id, throwExcOnNull, contextResource, queryParameters, checkInteractionAllowed);
+                type, id, throwExcOnNull, queryParameters, checkInteractionAllowed);
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionSearch.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionSearch.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -8,7 +8,6 @@ package com.ibm.fhir.server.rest;
 
 import javax.ws.rs.core.MultivaluedMap;
 
-import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.server.util.FHIRUrlParser;
 
 /**
@@ -21,7 +20,6 @@ public class FHIRRestInteractionSearch extends FHIRRestInteractionBase {
     private final String compartmentId;
     private final MultivaluedMap<String, String> queryParameters;
     private final String requestUri;
-    private final Resource contextResource;
     private final boolean checkInteractionAllowed;
 
     /**
@@ -35,25 +33,23 @@ public class FHIRRestInteractionSearch extends FHIRRestInteractionBase {
      * @param compartmentId
      * @param queryParameters
      * @param requestUri
-     * @param contextResource
      * @param checkInteractionAllowed
      */
     public FHIRRestInteractionSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
-            String type, String compartment, String compartmentId,
-            MultivaluedMap<String, String> queryParameters, String requestUri, Resource contextResource,
-            boolean checkInteractionAllowed) {
+            String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
+            String requestUri, boolean checkInteractionAllowed) {
         super(entryIndex, requestDescription, requestURL);
         this.type = type;
         this.compartment = compartment;
         this.compartmentId = compartmentId;
         this.queryParameters = queryParameters;
         this.requestUri = requestUri;
-        this.contextResource = contextResource;
         this.checkInteractionAllowed = checkInteractionAllowed;
     }
 
     @Override
     public void process(FHIRRestInteractionVisitor visitor) throws Exception {
-        visitor.doSearch(getEntryIndex(), getRequestDescription(), getRequestURL(), getAccumulatedTime(), type, compartment, compartmentId, queryParameters, requestUri, contextResource, checkInteractionAllowed);
+        visitor.doSearch(getEntryIndex(), getRequestDescription(), getRequestURL(), getAccumulatedTime(),
+                type, compartment, compartmentId, queryParameters, requestUri, checkInteractionAllowed);
     }
 }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitor.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitor.java
@@ -89,8 +89,6 @@ public interface FHIRRestInteractionVisitor {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param includeDeleted
-     *            allow the read, even if the resource has been deleted
      * @param contextResource
      *            the resource
      * @param queryParameters
@@ -99,7 +97,7 @@ public interface FHIRRestInteractionVisitor {
      * @throws Exception
      */
     FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
-            long accumulatedTime, String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            long accumulatedTime, String type, String id, boolean throwExcOnNull,
             Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
             throws Exception;
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitor.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitor.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -43,8 +43,6 @@ public interface FHIRRestInteractionVisitor {
      *            a Map containing the query parameters from the request URL
      * @param requestUri
      *            the request URI
-     * @param contextResource
-     *            the resource context
      * @param checkIfInteractionAllowed
      *            if true, check that the search interaction is permitted
      * @return a FHIRRestOperationResponse containing the search result bundle
@@ -53,7 +51,7 @@ public interface FHIRRestInteractionVisitor {
     FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
             long accumulatedTime, String type, String compartment, String compartmentId,
             MultivaluedMap<String, String> queryParameters, String requestUri,
-            Resource contextResource, boolean checkInteractionAllowed) throws Exception;
+            boolean checkInteractionAllowed) throws Exception;
 
     /**
      * Performs a 'vread' operation by retrieving the specified version of a Resource with no query parameters
@@ -89,16 +87,16 @@ public interface FHIRRestInteractionVisitor {
      *            the id of the Resource to be retrieved
      * @param throwExcOnNull
      *            whether to throw an exception on null
-     * @param contextResource
-     *            the resource
      * @param queryParameters
      *            for supporting _elements and _summary for resource read
+     * @param checkInteractionAllowed
+     *            if true, check that the read interaction is permitted
      * @return a SingleResourceResult wrapping the resource and including its deletion status
      * @throws Exception
      */
     FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
             long accumulatedTime, String type, String id, boolean throwExcOnNull,
-            Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
+            MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
             throws Exception;
 
     /**

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
@@ -90,7 +90,7 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, boolean includeDeleted, Resource contextResource,
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
         MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         logStart(entryIndex, requestDescription, requestURL);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
@@ -37,11 +37,11 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.util.CollectingVisitor;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.server.exception.FHIRResourceDeletedException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.spi.operation.FHIROperationContext;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.Interaction;
@@ -401,7 +401,7 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
         final long start = System.nanoTime();
         try {
             return v.call();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             if (failFast) {
                 updateIssuesWithEntryIndexAndThrow(entryIndex, e);
             }
@@ -415,7 +415,7 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
                     .build();
             final long elapsed = System.nanoTime() - start;
             setEntryComplete(entryIndex, entry, requestDescription, accumulatedTime + elapsed);
-        } catch (FHIRPersistenceResourceDeletedException e) {
+        } catch (FHIRResourceDeletedException e) {
             if (failFast) {
                 updateIssuesWithEntryIndexAndThrow(entryIndex, e);
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorMeta.java
@@ -68,38 +68,43 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
      * Public constructor
      * @param helpers
      */
-    public FHIRRestInteractionVisitorMeta(boolean transaction, FHIRResourceHelpers helpers, Map<String, String> localRefMap, Entry[] responseBundleEntries) {
+    public FHIRRestInteractionVisitorMeta(boolean transaction, FHIRResourceHelpers helpers, Map<String, String> localRefMap,
+            Entry[] responseBundleEntries) {
         super(helpers, localRefMap, responseBundleEntries);
         this.transaction = transaction;
     }
 
     @Override
-    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String compartment, String compartmentId,
-        MultivaluedMap<String, String> queryParameters, String requestUri, Resource contextResource, boolean checkInteractionAllowed) throws Exception {
+    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
+            String requestUri, boolean checkInteractionAllowed) throws Exception {
         // NOP. Nothing to do
         logStart(entryIndex, requestDescription, requestURL);
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doVRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, String versionId, MultivaluedMap<String, String> queryParameters)
-        throws Exception {
+    public FHIRRestOperationResponse doVRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, String versionId,
+            MultivaluedMap<String, String> queryParameters) throws Exception {
         // NOP for now. TODO: when offloading payload, start an async read of the id/version payload
         logStart(entryIndex, requestDescription, requestURL);
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
-        MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, boolean throwExcOnNull,
+            MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         logStart(entryIndex, requestDescription, requestURL);
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doHistory(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri)
-        throws Exception {
+    public FHIRRestOperationResponse doHistory(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri)
+            throws Exception {
         // NOP for now. TODO: optimistic async reads, if we can scope them properly
         logStart(entryIndex, requestDescription, requestURL);
         return null;
@@ -108,7 +113,8 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
     @Override
     public FHIRRestOperationResponse doCreate(int entryIndex, FHIRPersistenceEvent event, List<Issue> warnings,
             Entry validationResponseEntry, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime,
-            String type, Resource resource, String ifNoneExist, String localIdentifier, PayloadPersistenceResponse offloadResponse) throws Exception {
+            String type, Resource resource, String ifNoneExist, String localIdentifier, PayloadPersistenceResponse offloadResponse)
+            throws Exception {
         logStart(entryIndex, requestDescription, requestURL);
 
         // Skip CREATE if validation failed
@@ -159,7 +165,8 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
     public FHIRRestOperationResponse doUpdate(int entryIndex, FHIRPersistenceEvent event, Entry validationResponseEntry,
             String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id,
             Resource resource, Resource prevResource, String ifMatchValue, String searchQueryString, boolean skippableUpdate,
-            String localIdentifier, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch, PayloadPersistenceResponse offloadResponse) throws Exception {
+            String localIdentifier, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch, PayloadPersistenceResponse offloadResponse)
+            throws Exception {
         logStart(entryIndex, requestDescription, requestURL);
 
         // Skip UPDATE if validation failed
@@ -247,14 +254,16 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
     }
 
     @Override
-    public FHIRRestOperationResponse doDelete(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, String searchQueryString) throws Exception {
+    public FHIRRestOperationResponse doDelete(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, String searchQueryString) throws Exception {
         logStart(entryIndex, requestDescription, requestURL);
         // NOP
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse validationResponse(int entryIndex, Entry validationResponseEntry, String requestDescription, long accumulatedTime) throws Exception {
+    public FHIRRestOperationResponse validationResponse(int entryIndex, Entry validationResponseEntry, String requestDescription,
+            long accumulatedTime) throws Exception {
         // NOP
         return null;
     }
@@ -272,7 +281,8 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
     }
 
     @Override
-    public FHIRRestOperationResponse issue(int entryIndex, String requestDescription, long accumulatedTime, Status status, Entry responseEntry) throws Exception {
+    public FHIRRestOperationResponse issue(int entryIndex, String requestDescription, long accumulatedTime, Status status, Entry responseEntry)
+            throws Exception {
         // NOP
         return null;
     }
@@ -329,7 +339,7 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
             queryParameters.add("_count", "1");
 
             // Do a search, but no need to check if the interaction is allowed
-            Bundle bundle = helpers.doSearch(type, null, null, queryParameters, null, resource, false, true);
+            Bundle bundle = helpers.doSearch(type, null, null, queryParameters, null, false, true);
 
             int total = bundle.getTotal().getValue();
 
@@ -384,7 +394,8 @@ public class FHIRRestInteractionVisitorMeta extends FHIRRestInteractionVisitorBa
      * @param accumulatedTime
      * @throws Exception
      */
-    private FHIRRestOperationResponse doInteraction(int entryIndex, String requestDescription, long accumulatedTime, Callable<FHIRRestOperationResponse> v) throws Exception {
+    private FHIRRestOperationResponse doInteraction(int entryIndex, String requestDescription, long accumulatedTime,
+            Callable<FHIRRestOperationResponse> v) throws Exception {
         // If we're a transaction bundle, we want to fail as soon as we hit a problem
         final boolean failFast = transaction;
         final long start = System.nanoTime();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
@@ -23,10 +23,10 @@ import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.server.exception.FHIRResourceDeletedException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.spi.operation.FHIROperationContext;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
@@ -192,7 +192,7 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
         final long start = System.nanoTime();
         try {
             return v.call();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             if (failFast) {
                 String msg = "Error while processing request bundle.";
                 throw new FHIRRestBundledRequestException(msg, e).withIssue(e.getIssues());
@@ -207,7 +207,7 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
                     .build();
             final long elapsed = System.nanoTime() - start;
             setEntryComplete(entryIndex, entry, requestDescription, accumulatedTime + elapsed);
-        } catch (FHIRPersistenceResourceDeletedException e) {
+        } catch (FHIRResourceDeletedException e) {
             if (failFast) {
                 String msg = "Error while processing request bundle.";
                 throw new FHIRRestBundledRequestException(msg, e).withIssue(e.getIssues());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
@@ -67,7 +67,7 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, boolean includeDeleted, Resource contextResource,
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
             MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         return null;
@@ -113,7 +113,7 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
             // Resource doesn't change, so no need to return it
             FHIRRestOperationResponse result = new FHIRRestOperationResponse(null, null, actualOffloadResponse);
             result.setDeleted(isDeleted);
-            
+
             return result;
         });
     }
@@ -163,8 +163,8 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
     /**
      * If payload offloading is supported by the persistence layer, store the given resource. This
      * can be an async operation which we resolve at the end just prior to the transaction being
-     * committed. If offloading isn't enabled, the operation is a NOP and the persistence layer 
-     * returns null. 
+     * committed. If offloading isn't enabled, the operation is a NOP and the persistence layer
+     * returns null.
      * @param resource
      * @param logicalId
      * @param newVersionNumber
@@ -177,7 +177,7 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
 
     /**
      * Unified exception handling for each of the operation calls
-     * 
+     *
      * @param entryIndex
      * @param requestDescription
      * @param accumulatedTime

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorOffload.java
@@ -53,8 +53,9 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
     }
 
     @Override
-    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String compartment, String compartmentId,
-            MultivaluedMap<String, String> queryParameters, String requestUri, Resource contextResource, boolean checkInteractionAllowed) throws Exception {
+    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String compartment, String compartmentId,
+            MultivaluedMap<String, String> queryParameters, String requestUri, boolean checkInteractionAllowed) throws Exception {
         // NOP. Nothing to do
         return null;
     }
@@ -67,7 +68,8 @@ public class FHIRRestInteractionVisitorOffload extends FHIRRestInteractionVisito
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, boolean throwExcOnNull,
             MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         return null;

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
@@ -26,10 +26,10 @@ import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceIfNoneMatchException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.server.exception.FHIRResourceDeletedException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.spi.operation.FHIROperationContext;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
 import com.ibm.fhir.server.spi.operation.FHIRRestOperationResponse;
@@ -276,7 +276,7 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
                 final long elapsed = System.nanoTime() - start;
                 setEntryComplete(entryIndex, entry, requestDescription, accumulatedTime + elapsed);
             }
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             if (failFast) {
                 updateIssuesWithEntryIndexAndThrow(entryIndex, e);
             }
@@ -290,7 +290,7 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
                     .build();
             final long elapsed = System.nanoTime() - start;
             setEntryComplete(entryIndex, entry, requestDescription, accumulatedTime + elapsed);
-        } catch (FHIRPersistenceResourceDeletedException e) {
+        } catch (FHIRResourceDeletedException e) {
             if (failFast) {
                 updateIssuesWithEntryIndexAndThrow(entryIndex, e);
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
@@ -66,12 +66,12 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
     @Override
     public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
             long accumulatedTime, String type, String compartment, String compartmentId,
-            MultivaluedMap<String, String> queryParameters, String requestUri, Resource contextResource,
+            MultivaluedMap<String, String> queryParameters, String requestUri,
             boolean checkInteractionAllowed) throws Exception {
 
         doInteraction(entryIndex, requestDescription, accumulatedTime, () -> {
             Bundle searchResults = helpers.doSearch(type, compartment, compartmentId, queryParameters, requestUri,
-                    contextResource, checkInteractionAllowed, true);
+                    checkInteractionAllowed, true);
 
             return Bundle.Entry.builder()
                     .resource(searchResults)
@@ -106,12 +106,12 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
     @Override
     public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
             long accumulatedTime, String type, String id, boolean throwExcOnNull,
-            Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
+            MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
             throws Exception {
 
         doInteraction(entryIndex, requestDescription, accumulatedTime, () -> {
             // Perform the VREAD and return the result entry we want in the response bundle
-            SingleResourceResult<? extends Resource> readResult = helpers.doRead(type, id, throwExcOnNull, contextResource, queryParameters);
+            SingleResourceResult<? extends Resource> readResult = helpers.doRead(type, id, throwExcOnNull, queryParameters);
             return Entry.builder()
                     .response(Entry.Response.builder()
                         .status(SC_OK_STRING)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorPersist.java
@@ -91,12 +91,12 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
 
         doInteraction(entryIndex, requestDescription, accumulatedTime, () -> {
             // Perform the VREAD and return the result entry we want in the response bundle
-            Resource resource = helpers.doVRead(type, id, versionId, queryParameters);
+            SingleResourceResult<? extends Resource> srr = helpers.doVRead(type, id, versionId, queryParameters);
             return Entry.builder()
                     .response(Entry.Response.builder()
                         .status(SC_OK_STRING)
                         .build())
-                    .resource(resource)
+                    .resource(srr.getResource())
                     .build();
         });
 
@@ -105,13 +105,13 @@ public class FHIRRestInteractionVisitorPersist extends FHIRRestInteractionVisito
 
     @Override
     public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
-            long accumulatedTime, String type, String id, boolean throwExcOnNull, boolean includeDeleted,
+            long accumulatedTime, String type, String id, boolean throwExcOnNull,
             Resource contextResource, MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed)
             throws Exception {
 
         doInteraction(entryIndex, requestDescription, accumulatedTime, () -> {
             // Perform the VREAD and return the result entry we want in the response bundle
-            SingleResourceResult<? extends Resource> readResult = helpers.doRead(type, id, throwExcOnNull, includeDeleted, contextResource, queryParameters);
+            SingleResourceResult<? extends Resource> readResult = helpers.doRead(type, id, throwExcOnNull, contextResource, queryParameters);
             return Entry.builder()
                     .response(Entry.Response.builder()
                         .status(SC_OK_STRING)

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
@@ -52,35 +52,40 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
     }
 
     @Override
-    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String compartment, String compartmentId,
-        MultivaluedMap<String, String> queryParameters, String requestUri, Resource contextResource, boolean checkInteractionAllowed) throws Exception {
+    public FHIRRestOperationResponse doSearch(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String compartment, String compartmentId,
+            MultivaluedMap<String, String> queryParameters, String requestUri, boolean checkInteractionAllowed) throws Exception {
         // NOP. Nothing to do
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doVRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, String versionId, MultivaluedMap<String, String> queryParameters)
-        throws Exception {
+    public FHIRRestOperationResponse doVRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, String versionId, MultivaluedMap<String, String> queryParameters)
+            throws Exception {
         // NOP for now. TODO: when offloading payload, start an async optimistic read of the id/version payload
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
-        MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, boolean throwExcOnNull,
+            MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doHistory(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri)
-        throws Exception {
+    public FHIRRestOperationResponse doHistory(int entryIndex, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, String id, MultivaluedMap<String, String> queryParameters, String requestUri)
+            throws Exception {
         // NOP for now. TODO: optimistic async reads, if we can scope them properly
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doCreate(int entryIndex, FHIRPersistenceEvent event, List<Issue> warnings, Entry validationResponseEntry, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, Resource resource, String ifNoneExist, String localIdentifier, PayloadPersistenceResponse offloadResponse) throws Exception {
+    public FHIRRestOperationResponse doCreate(int entryIndex, FHIRPersistenceEvent event, List<Issue> warnings, Entry validationResponseEntry, String requestDescription, FHIRUrlParser requestURL,
+            long accumulatedTime, String type, Resource resource, String ifNoneExist, String localIdentifier, PayloadPersistenceResponse offloadResponse) throws Exception {
 
         // Use doOperation so we can implement common exception handling in one place
         return doOperation(entryIndex, requestDescription, accumulatedTime, () -> {
@@ -97,8 +102,8 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
 
     @Override
     public FHIRRestOperationResponse doUpdate(int entryIndex, FHIRPersistenceEvent event, Entry validationResponseEntry, String requestDescription, FHIRUrlParser requestURL,
-        long accumulatedTime, String type, String id, Resource resource, Resource prevResource, String ifMatchValue, String searchQueryString,
-        boolean skippableUpdate, String localIdentifier, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch, PayloadPersistenceResponse offloadResponse) throws Exception {
+            long accumulatedTime, String type, String id, Resource resource, Resource prevResource, String ifMatchValue, String searchQueryString,
+            boolean skippableUpdate, String localIdentifier, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch, PayloadPersistenceResponse offloadResponse) throws Exception {
 
         // Use doOperation for common exception handling
         return doOperation(entryIndex, requestDescription, accumulatedTime, () -> {
@@ -122,8 +127,8 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
 
     @Override
     public FHIRRestOperationResponse doPatch(int entryIndex, FHIRPersistenceEvent event, Entry validationResponseEntry, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime,
-        String type, String id, Resource resource, Resource prevResource, FHIRPatch patch, String ifMatchValue, String searchQueryString,
-        boolean skippableUpdate, List<Issue> warnings, String localIdentifier, PayloadPersistenceResponse offloadResponse) throws Exception {
+            String type, String id, Resource resource, Resource prevResource, FHIRPatch patch, String ifMatchValue, String searchQueryString,
+            boolean skippableUpdate, List<Issue> warnings, String localIdentifier, PayloadPersistenceResponse offloadResponse) throws Exception {
         // Use doOperation for common exception handling
         return doOperation(entryIndex, requestDescription, accumulatedTime, () -> {
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
@@ -66,7 +66,7 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
     }
 
     @Override
-    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, boolean includeDeleted, Resource contextResource,
+    public FHIRRestOperationResponse doRead(int entryIndex, String requestDescription, FHIRUrlParser requestURL, long accumulatedTime, String type, String id, boolean throwExcOnNull, Resource contextResource,
         MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         // NOP for now. TODO: when offloading payload, try an optimistic async read of the latest payload
         return null;
@@ -115,7 +115,7 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
             // Pass back the updated resource so it can be used in the next phase
             FHIRRestOperationResponse result = new FHIRRestOperationResponse(newResource, null, null);
             result.setDeleted(isDeleted);
-            
+
             return result;
         });
     }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/rest/FHIRRestInteractionVisitorReferenceMapping.java
@@ -23,10 +23,10 @@ import com.ibm.fhir.model.resource.Resource;
 import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.model.util.ReferenceMappingVisitor;
 import com.ibm.fhir.persistence.context.FHIRPersistenceEvent;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.search.exception.FHIRSearchException;
+import com.ibm.fhir.server.exception.FHIRResourceDeletedException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.exception.FHIRRestBundledRequestException;
 import com.ibm.fhir.server.spi.operation.FHIROperationContext;
 import com.ibm.fhir.server.spi.operation.FHIRResourceHelpers;
@@ -185,7 +185,7 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
         final long start = System.nanoTime();
         try {
             return v.call();
-        } catch (FHIRPersistenceResourceNotFoundException e) {
+        } catch (FHIRResourceNotFoundException e) {
             if (failFast) {
                 String msg = "Error while processing request bundle.";
                 throw new FHIRRestBundledRequestException(msg, e).withIssue(e.getIssues());
@@ -200,7 +200,7 @@ public class FHIRRestInteractionVisitorReferenceMapping extends FHIRRestInteract
                     .build();
             final long elapsed = System.nanoTime() - start;
             setEntryComplete(entryIndex, entry, requestDescription, accumulatedTime + elapsed);
-        } catch (FHIRPersistenceResourceDeletedException e) {
+        } catch (FHIRResourceDeletedException e) {
             if (failFast) {
                 String msg = "Error while processing request bundle.";
                 throw new FHIRRestBundledRequestException(msg, e).withIssue(e.getIssues());

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
@@ -460,7 +460,7 @@ public class FHIRRestBundleHelper {
         } else if (pathTokens.length == 2) {
             // This is a 'read' request.
             checkResourceType(pathTokens[0]);
-            result = new FHIRRestInteractionRead(entryIndex, requestDescription, requestURL, pathTokens[0], pathTokens[1], true, false, null, null, true);
+            result = new FHIRRestInteractionRead(entryIndex, requestDescription, requestURL, pathTokens[0], pathTokens[1], true, null, null, true);
         } else if (pathTokens.length == 3) {
             if ("_history".equals(pathTokens[2])) {
                 // This is a 'history' request.

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestBundleHelper.java
@@ -452,15 +452,15 @@ public class FHIRRestBundleHelper {
         } else if (pathTokens.length == 1) {
             // This is a 'search' request.
             if ("_search".equals(pathTokens[0])) {
-                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, "Resource", null, null, queryParams, absoluteUri, null, true);
+                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, "Resource", null, null, queryParams, absoluteUri, true);
             } else {
                 checkResourceType(pathTokens[0]);
-                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[0], null, null, queryParams, absoluteUri, null, true);
+                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[0], null, null, queryParams, absoluteUri, true);
             }
         } else if (pathTokens.length == 2) {
             // This is a 'read' request.
             checkResourceType(pathTokens[0]);
-            result = new FHIRRestInteractionRead(entryIndex, requestDescription, requestURL, pathTokens[0], pathTokens[1], true, null, null, true);
+            result = new FHIRRestInteractionRead(entryIndex, requestDescription, requestURL, pathTokens[0], pathTokens[1], true, null, true);
         } else if (pathTokens.length == 3) {
             if ("_history".equals(pathTokens[2])) {
                 // This is a 'history' request.
@@ -469,7 +469,7 @@ public class FHIRRestBundleHelper {
             } else {
                 // This is a compartment based search
                 checkResourceType(pathTokens[2]);
-                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[2], pathTokens[0], pathTokens[1], queryParams, absoluteUri, null, true);
+                result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[2], pathTokens[0], pathTokens[1], queryParams, absoluteUri, true);
             }
         } else if (pathTokens.length == 4 && pathTokens[2].equals("_history")) {
             // This is a 'vread' request.
@@ -546,7 +546,7 @@ public class FHIRRestBundleHelper {
         } else if (pathTokens.length == 2 && "_search".equals(pathTokens[1])) {
             // This is a 'search' request.
             checkResourceType(pathTokens[0]);
-            result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[0], null, null, queryParams, absoluteUri, null, true);
+            result = new FHIRRestInteractionSearch(entryIndex, requestDescription, requestURL, pathTokens[0], null, null, queryParams, absoluteUri, true);
         } else if (pathTokens.length == 1) {
             // This is a 'create' request.
             checkResourceType(pathTokens[0]);

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -109,8 +109,6 @@ import com.ibm.fhir.persistence.context.impl.FHIRPersistenceContextImpl;
 import com.ibm.fhir.persistence.erase.EraseDTO;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceIfNoneMatchException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.helper.FHIRTransactionHelper;
 import com.ibm.fhir.persistence.jdbc.exception.FHIRPersistenceDataAccessException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
@@ -126,6 +124,8 @@ import com.ibm.fhir.search.util.ReferenceUtil;
 import com.ibm.fhir.search.util.ReferenceValue;
 import com.ibm.fhir.search.util.ReferenceValue.ReferenceType;
 import com.ibm.fhir.search.util.SearchHelper;
+import com.ibm.fhir.server.exception.FHIRResourceDeletedException;
+import com.ibm.fhir.server.exception.FHIRResourceNotFoundException;
 import com.ibm.fhir.server.interceptor.FHIRPersistenceInterceptorMgr;
 import com.ibm.fhir.server.operation.FHIROperationRegistry;
 import com.ibm.fhir.server.rest.FHIRRestInteraction;
@@ -648,7 +648,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
                 if (srr.getResource() == null && (!persistence.isUpdateCreateEnabled() || (patch != null))) {
                     String msg = "Resource '" + type + "/" + id + "' not found.";
                     log.log(Level.SEVERE, msg);
-                    throw new FHIRPersistenceResourceNotFoundException(msg);
+                    throw new FHIRResourceNotFoundException(msg);
                 }
             }
 
@@ -1078,11 +1078,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
     }
 
     @Override
-    public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull) throws Exception {
-        return doRead(type, id, throwExcOnNull, null);
-    }
-
-    @Override
     public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
             MultivaluedMap<String, String> queryParameters) throws Exception {
         return doRead(type, id, throwExcOnNull, queryParameters, true);
@@ -1104,7 +1099,6 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      * @return a {@link SingleResourceResult} containing the Resource
      * @throws Exception
      */
-    // TODO remove contextResource?  it doesn't seem to ever be populated...
     private SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
             MultivaluedMap<String, String> queryParameters, boolean checkInteractionAllowed) throws Exception {
         log.entering(this.getClass().getName(), "doRead");
@@ -1152,9 +1146,9 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             if (result.getResource() == null && throwExcOnNull) {
                 if (result.isDeleted()) {
-                    throw new FHIRPersistenceResourceDeletedException("Resource '" + type + "/" + id + "' is deleted.");
+                    throw new FHIRResourceDeletedException("Resource '" + type + "/" + id + "' is deleted.");
                 } else {
-                    throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
+                    throw new FHIRResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
                 }
             }
 
@@ -1222,10 +1216,10 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
 
             if (srr.getResource() == null) {
                 if (srr.isDeleted()) {
-                    throw new FHIRPersistenceResourceDeletedException("Resource '" + type + "/" + id + "'"
+                    throw new FHIRResourceDeletedException("Resource '" + type + "/" + id + "'"
                             + " version " + versionId + " is deleted.");
                 } else {
-                    throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "'"
+                    throw new FHIRResourceNotFoundException("Resource '" + type + "/" + id + "'"
                             + " version " + versionId + " not found.");
                 }
             }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1152,15 +1152,14 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
             FHIRPersistenceContext persistenceContext =
                     FHIRPersistenceContextFactory.createPersistenceContext(event, includeDeleted, searchContext);
             result = persistence.read(persistenceContext, resourceType, id);
-            if (!result.isSuccess() && throwExcOnNull) {
-                throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
-            }
-
-            Resource resource = result.getResource();
-            event.setFhirResource(resource);
+            event.setFhirResource(result.getResource());
 
             // Invoke the 'afterRead' interceptor methods.
             getInterceptorMgr().fireAfterReadEvent(event);
+
+            if (!result.isSuccess() && throwExcOnNull) {
+                throw new FHIRPersistenceResourceNotFoundException("Resource '" + type + "/" + id + "' not found.");
+            }
 
             // Commit our transaction if we started one before.
             txn.commit();

--- a/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/util/FHIRRestHelper.java
@@ -1096,7 +1096,7 @@ public class FHIRRestHelper implements FHIRResourceHelpers {
      *            for supporting _elements and _summary for resource read
      * @param checkInteractionAllowed
      *            if true, check if this interaction is allowed per the tenant configuration; if false, assume interaction is allowed
-     * @return a {@link SingleResourceResult} containing the Resource
+     * @return a {@link SingleResourceResult} containing the ResourceResult for the interaction
      * @throws Exception
      */
     private SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -365,7 +365,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Patient", "1", false, null, null).getResource();
+            Resource resource = helper.doRead("Patient", "1", false, null).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -384,7 +384,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false, null, null).getResource();
+            Resource resource = helper.doRead("Encounter", "1", false, null).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -403,7 +403,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false, null, null).getResource();
+            Resource resource = helper.doRead("Encounter", "1", false).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -422,7 +422,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Patient", "1", false, null, null);
+            helper.doRead("Patient", "1", false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -447,7 +447,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Encounter", "1", false, null, null);
+            helper.doRead("Encounter", "1", false, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -472,7 +472,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, null, null);
+            helper.doRead("Procedure", "1", false, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -497,7 +497,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, null, null);
+            helper.doRead("Procedure", "1", false, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -522,7 +522,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Practitioner", "1", false, null, null);
+            helper.doRead("Practitioner", "1", false, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -914,7 +914,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -933,7 +933,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -952,7 +952,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test", null);
+            Bundle bundle = helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), "test");
             assertNotNull(bundle);
         } catch (FHIROperationException e) {
             fail();
@@ -971,7 +971,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), null, null);
+            helper.doSearch("Patient", null, null, new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -996,7 +996,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), null, null);
+            helper.doSearch("Encounter", null, null, new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1021,7 +1021,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null);
+            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1046,7 +1046,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null, null);
+            helper.doSearch("Procedure", null, null, new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -1071,7 +1071,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doSearch("Practitioner", null, null, new MultivaluedHashMap<>(), null, null);
+            helper.doSearch("Practitioner", null, null, new MultivaluedHashMap<>(), null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -6,6 +6,7 @@
 package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -365,7 +366,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Patient", "1", false).getResource();
+            Resource resource = helper.doRead("Patient", "1", !THROW_EXC_ON_MISSING).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -384,7 +385,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false).getResource();
+            Resource resource = helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -403,7 +404,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false).getResource();
+            Resource resource = helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -422,7 +423,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Patient", "1", false);
+            helper.doRead("Patient", "1", !THROW_EXC_ON_MISSING);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -447,7 +448,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Encounter", "1", false);
+            helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -472,7 +473,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false);
+            helper.doRead("Procedure", "1", !THROW_EXC_ON_MISSING);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -497,7 +498,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, null);
+            helper.doRead("Procedure", "1", !THROW_EXC_ON_MISSING);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -522,7 +523,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Practitioner", "1", false);
+            helper.doRead("Practitioner", "1", !THROW_EXC_ON_MISSING);
             fail();
         } catch (FHIROperationException e) {
             // Validate results

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -6,7 +6,6 @@
 package com.ibm.fhir.server.test;
 
 import static com.ibm.fhir.model.type.String.string;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -366,7 +365,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Patient", "1", !THROW_EXC_ON_MISSING).getResource();
+            Resource resource = helper.doRead("Patient", "1").getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -385,7 +384,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING).getResource();
+            Resource resource = helper.doRead("Encounter", "1").getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -404,7 +403,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING).getResource();
+            Resource resource = helper.doRead("Encounter", "1").getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -423,7 +422,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Patient", "1", !THROW_EXC_ON_MISSING);
+            helper.doRead("Patient", "1");
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -448,7 +447,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Encounter", "1", !THROW_EXC_ON_MISSING);
+            helper.doRead("Encounter", "1");
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -473,7 +472,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", !THROW_EXC_ON_MISSING);
+            helper.doRead("Procedure", "1");
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -498,7 +497,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", !THROW_EXC_ON_MISSING);
+            helper.doRead("Procedure", "1");
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -523,7 +522,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Practitioner", "1", !THROW_EXC_ON_MISSING);
+            helper.doRead("Practitioner", "1");
             fail();
         } catch (FHIROperationException e) {
             // Validate results

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -365,7 +365,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Patient", "1", false, null).getResource();
+            Resource resource = helper.doRead("Patient", "1", false).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -384,7 +384,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false, null).getResource();
+            Resource resource = helper.doRead("Encounter", "1", false).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -447,7 +447,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Encounter", "1", false, null);
+            helper.doRead("Encounter", "1", false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -472,7 +472,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, null);
+            helper.doRead("Procedure", "1", false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -522,7 +522,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Practitioner", "1", false, null);
+            helper.doRead("Practitioner", "1", false);
             fail();
         } catch (FHIROperationException e) {
             // Validate results

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/InteractionValidationConfigTest.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.server.test;
 import static com.ibm.fhir.model.type.String.string;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.util.List;
@@ -47,6 +48,7 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.NarrativeStatus;
 import com.ibm.fhir.model.type.code.ProcedureStatus;
 import com.ibm.fhir.persistence.FHIRPersistence;
+import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.search.util.SearchHelper;
 import com.ibm.fhir.server.spi.operation.FHIRRestOperationResponse;
@@ -363,7 +365,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Patient", "1", false, false, null, null).getResource();
+            Resource resource = helper.doRead("Patient", "1", false, null, null).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -382,7 +384,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false, false, null, null).getResource();
+            Resource resource = helper.doRead("Encounter", "1", false, null, null).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -401,7 +403,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doRead("Encounter", "1", false, false, null, null).getResource();
+            Resource resource = helper.doRead("Encounter", "1", false, null, null).getResource();
             assertNotNull(resource);
         } catch (FHIROperationException e) {
             fail();
@@ -420,7 +422,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Patient", "1", false, false, null, null);
+            helper.doRead("Patient", "1", false, null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -445,7 +447,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Encounter", "1", false, false, null, null);
+            helper.doRead("Encounter", "1", false, null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -470,7 +472,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, false, null, null);
+            helper.doRead("Procedure", "1", false, null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -495,7 +497,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Procedure", "1", false, false, null, null);
+            helper.doRead("Procedure", "1", false, null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -520,7 +522,7 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            helper.doRead("Practitioner", "1", false, false, null, null);
+            helper.doRead("Practitioner", "1", false, null, null);
             fail();
         } catch (FHIROperationException e) {
             // Validate results
@@ -545,8 +547,9 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doVRead("Patient", "1", "1", null);
-            assertNotNull(resource);
+            SingleResourceResult<? extends Resource> srr = helper.doVRead("Patient", "1", "1", null);
+            assertTrue(srr.isSuccess());
+            assertNotNull(srr.getResource());
         } catch (FHIROperationException e) {
             fail();
         }
@@ -564,8 +567,9 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doVRead("Encounter", "1", "1", null);
-            assertNotNull(resource);
+            SingleResourceResult<? extends Resource> srr = helper.doVRead("Encounter", "1", "1", null);
+            assertTrue(srr.isSuccess());
+            assertNotNull(srr.getResource());
         } catch (FHIROperationException e) {
             fail();
         }
@@ -583,8 +587,9 @@ public class InteractionValidationConfigTest {
         FHIRRequestContext.get().setOriginalRequestUri("test");
         FHIRRequestContext.get().setReturnPreference(HTTPReturnPreference.OPERATION_OUTCOME);
         try {
-            Resource resource = helper.doVRead("Encounter", "1", "1", null);
-            assertNotNull(resource);
+            SingleResourceResult<? extends Resource> srr = helper.doVRead("Encounter", "1", "1", null);
+            assertTrue(srr.isSuccess());
+            assertNotNull(srr.getResource());
         } catch (FHIROperationException e) {
             fail();
         }

--- a/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
+++ b/fhir-server/src/test/java/com/ibm/fhir/server/test/MockPersistenceImpl.java
@@ -27,7 +27,6 @@ import com.ibm.fhir.persistence.ResourceResult;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 import com.ibm.fhir.server.util.FHIRRestHelperTest;
 
@@ -38,9 +37,9 @@ public class MockPersistenceImpl implements FHIRPersistence {
     int id = 0;
 
     @Override
-    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource) 
+    public <T extends Resource> SingleResourceResult<T> create(FHIRPersistenceContext context, T resource)
             throws FHIRPersistenceException {
-        
+
         SingleResourceResult.Builder<T> resultBuilder = new SingleResourceResult.Builder<T>()
                 .success(true)
                 .interactionStatus(InteractionStatus.MODIFIED)
@@ -51,7 +50,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
-            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
         // TODO. Why this logic? Definitely worthy of a comment
         if (logicalId.startsWith("generated")) {
             return new SingleResourceResult.Builder<T>()
@@ -70,7 +69,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     @SuppressWarnings("unchecked")
     @Override
     public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
-            throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
         if (logicalId.startsWith("generated")) {
             return new SingleResourceResult.Builder<T>()
                     .success(true)
@@ -100,11 +99,8 @@ public class MockPersistenceImpl implements FHIRPersistence {
         return resultBuilder.build();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public MultiResourceResult history(FHIRPersistenceContext context, Class<? extends Resource> resourceType, String logicalId) throws FHIRPersistenceException {
-
-        
         Instant lastUpdated = Instant.now(ZoneOffset.UTC);
         Patient updatedResource = Patient.builder().id("test").meta(Meta.builder().versionId(Id.of("1")).lastUpdated(lastUpdated).build()).build();
         ResourceResult<Resource> resourceResult = ResourceResult.builder()
@@ -153,7 +149,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
     }
 
     @Override
-    public <T extends Resource> void delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, int versionId, 
+    public <T extends Resource> void delete(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, int versionId,
             com.ibm.fhir.model.type.Instant lastUpdated) throws FHIRPersistenceException {
         // NOP. No need to do anything in this very simple mock
     }

--- a/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
+++ b/fhir-smart/src/test/java/com/ibm/fhir/smart/test/MockPersistenceImpl.java
@@ -21,6 +21,7 @@ import com.ibm.fhir.model.test.TestUtil;
 import com.ibm.fhir.model.type.Id;
 import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Reference;
+import com.ibm.fhir.model.util.FHIRUtil;
 import com.ibm.fhir.persistence.FHIRPersistence;
 import com.ibm.fhir.persistence.FHIRPersistenceTransaction;
 import com.ibm.fhir.persistence.HistorySortOrder;
@@ -31,8 +32,6 @@ import com.ibm.fhir.persistence.ResourcePayload;
 import com.ibm.fhir.persistence.SingleResourceResult;
 import com.ibm.fhir.persistence.context.FHIRPersistenceContext;
 import com.ibm.fhir.persistence.exception.FHIRPersistenceException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceNotFoundException;
 import com.ibm.fhir.persistence.payload.PayloadPersistenceResponse;
 
 /**
@@ -72,7 +71,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
 
     @Override
     public <T extends Resource> SingleResourceResult<T> read(FHIRPersistenceContext context, Class<T> resourceType, String logicalId)
-        throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
 
         if (resourceType == Patient.class) {
             return new SingleResourceResult.Builder<T>()
@@ -104,7 +103,11 @@ public class MockPersistenceImpl implements FHIRPersistence {
                         .resource((T)encounter_not_in_patient_compartment)
                         .build();
             } else {
-                throw new FHIRPersistenceResourceNotFoundException("Not found");
+                return new SingleResourceResult.Builder<T>()
+                        .success(false)
+                        .interactionStatus(InteractionStatus.READ)
+                        .outcome(FHIRUtil.buildOperationOutcome("Resource '" + resourceType + "/" + logicalId + "' not found.", null, null))
+                        .build();
             }
         }
 
@@ -113,7 +116,7 @@ public class MockPersistenceImpl implements FHIRPersistence {
 
     @Override
     public <T extends Resource> SingleResourceResult<T> vread(FHIRPersistenceContext context, Class<T> resourceType, String logicalId, String versionId)
-        throws FHIRPersistenceException, FHIRPersistenceResourceDeletedException {
+            throws FHIRPersistenceException {
 
         if (resourceType == Patient.class) {
             return new SingleResourceResult.Builder<T>()

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -51,7 +51,7 @@ public class DocumentOperation extends AbstractOperation {
         try {
             Composition composition = null;
 
-            Resource resource = resourceHelper.doRead("Composition", logicalId, false, null).getResource();
+            Resource resource = resourceHelper.doRead("Composition", logicalId, false).getResource();
             if (resource == null) {
                 throw FHIROperationUtil.buildExceptionWithIssue("Could not find composition with id: " + logicalId, IssueType.INVALID);
             }
@@ -178,7 +178,7 @@ public class DocumentOperation extends AbstractOperation {
             String resourceTypeName = referenceTokens[0];
             String logicalId = referenceTokens[1];
 
-            resource = resourceHelper.doRead(resourceTypeName, logicalId, false, null).getResource();
+            resource = resourceHelper.doRead(resourceTypeName, logicalId, false).getResource();
 
             if (resource == null) {
                 throw new FHIROperationException("Could not find resource for reference value: " + referenceValue);

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -7,7 +7,6 @@
 package com.ibm.fhir.operation.document;
 
 import static com.ibm.fhir.model.type.String.string;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.net.URI;
 import java.time.ZoneOffset;
@@ -52,7 +51,7 @@ public class DocumentOperation extends AbstractOperation {
         try {
             Composition composition = null;
 
-            Resource resource = resourceHelper.doRead("Composition", logicalId, !THROW_EXC_ON_MISSING).getResource();
+            Resource resource = resourceHelper.doRead("Composition", logicalId).getResource();
             if (resource == null) {
                 throw FHIROperationUtil.buildExceptionWithIssue("Could not find composition with id: " + logicalId, IssueType.INVALID);
             }
@@ -179,7 +178,7 @@ public class DocumentOperation extends AbstractOperation {
             String resourceTypeName = referenceTokens[0];
             String logicalId = referenceTokens[1];
 
-            resource = resourceHelper.doRead(resourceTypeName, logicalId, !THROW_EXC_ON_MISSING).getResource();
+            resource = resourceHelper.doRead(resourceTypeName, logicalId).getResource();
 
             if (resource == null) {
                 throw new FHIROperationException("Could not find resource for reference value: " + referenceValue);

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.operation.document;
 
 import static com.ibm.fhir.model.type.String.string;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.net.URI;
 import java.time.ZoneOffset;
@@ -51,7 +52,7 @@ public class DocumentOperation extends AbstractOperation {
         try {
             Composition composition = null;
 
-            Resource resource = resourceHelper.doRead("Composition", logicalId, false).getResource();
+            Resource resource = resourceHelper.doRead("Composition", logicalId, !THROW_EXC_ON_MISSING).getResource();
             if (resource == null) {
                 throw FHIROperationUtil.buildExceptionWithIssue("Could not find composition with id: " + logicalId, IssueType.INVALID);
             }
@@ -178,7 +179,7 @@ public class DocumentOperation extends AbstractOperation {
             String resourceTypeName = referenceTokens[0];
             String logicalId = referenceTokens[1];
 
-            resource = resourceHelper.doRead(resourceTypeName, logicalId, false).getResource();
+            resource = resourceHelper.doRead(resourceTypeName, logicalId, !THROW_EXC_ON_MISSING).getResource();
 
             if (resource == null) {
                 throw new FHIROperationException("Could not find resource for reference value: " + referenceValue);

--- a/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
+++ b/operation/fhir-operation-document/src/main/java/com/ibm/fhir/operation/document/DocumentOperation.java
@@ -51,7 +51,7 @@ public class DocumentOperation extends AbstractOperation {
         try {
             Composition composition = null;
 
-            Resource resource = resourceHelper.doRead("Composition", logicalId, false, false, null).getResource();
+            Resource resource = resourceHelper.doRead("Composition", logicalId, false, null).getResource();
             if (resource == null) {
                 throw FHIROperationUtil.buildExceptionWithIssue("Could not find composition with id: " + logicalId, IssueType.INVALID);
             }
@@ -178,7 +178,7 @@ public class DocumentOperation extends AbstractOperation {
             String resourceTypeName = referenceTokens[0];
             String logicalId = referenceTokens[1];
 
-            resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null).getResource();
+            resource = resourceHelper.doRead(resourceTypeName, logicalId, false, null).getResource();
 
             if (resource == null) {
                 throw new FHIROperationException("Could not find resource for reference value: " + referenceValue);

--- a/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
+++ b/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
@@ -126,14 +126,14 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted, Resource contextResource,
+    public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, Resource contextResource,
         MultivaluedMap<String, String> queryParameters) throws Exception {
 
         return null;
     }
 
     @Override
-    public Resource doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception {
+    public SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception {
 
         return null;
     }

--- a/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
+++ b/operation/fhir-operation-erase/src/test/java/com/ibm/fhir/operation/erase/mock/MockFHIRResourceHelpers.java
@@ -106,15 +106,15 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue, String searchQueryString,
-        boolean skippableUpdate, boolean doValidation, Integer ifNoneMatch) throws Exception {
+    public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue,
+            String searchQueryString, boolean skippableUpdate, boolean doValidation, Integer ifNoneMatch) throws Exception {
 
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue, String searchQueryString, boolean skippableUpdate)
-        throws Exception {
+    public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue,
+            String searchQueryString, boolean skippableUpdate) throws Exception {
 
         return null;
     }
@@ -126,14 +126,15 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, Resource contextResource,
-        MultivaluedMap<String, String> queryParameters) throws Exception {
+    public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
+            MultivaluedMap<String, String> queryParameters) throws Exception {
 
         return null;
     }
 
     @Override
-    public SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception {
+    public SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId,
+            MultivaluedMap<String, String> queryParameters) throws Exception {
 
         return null;
     }
@@ -151,15 +152,15 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters, String requestUri,
-        Resource contextResource) throws Exception {
+    public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
+            String requestUri) throws Exception {
 
         return null;
     }
 
     @Override
     public Resource doInvoke(FHIROperationContext operationContext, String resourceTypeName, String logicalId, String versionId,
-        Resource resource, MultivaluedMap<String, String> queryParameters) throws Exception {
+            Resource resource, MultivaluedMap<String, String> queryParameters) throws Exception {
 
         return null;
     }
@@ -171,14 +172,16 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
     }
 
     @Override
-    public List<Long> doRetrieveIndex(FHIROperationContext operationContext, String resourceTypeName, int count, java.time.Instant notModifiedAfter, Long afterIndexId) throws Exception {
+    public List<Long> doRetrieveIndex(FHIROperationContext operationContext, String resourceTypeName, int count,
+            java.time.Instant notModifiedAfter, Long afterIndexId) throws Exception {
 
         return null;
     }
 
     @Override
-    public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters, String requestUri,
-        Resource contextResource, boolean checkIfInteractionAllowed, boolean alwaysIncludeResource) throws Exception {
+    public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters,
+            String requestUri, boolean checkIfInteractionAllowed, boolean alwaysIncludeResource) throws Exception {
+
         return null;
     }
 
@@ -198,30 +201,33 @@ public class MockFHIRResourceHelpers implements FHIRResourceHelpers {
 
     @Override
     public FHIRRestOperationResponse doCreateMeta(FHIRPersistenceEvent event, List<Issue> warnings, String type, Resource resource,
-        String ifNoneExist) throws Exception {
+            String ifNoneExist) throws Exception {
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doCreatePersist(FHIRPersistenceEvent event, List<Issue> warnings, Resource resource, PayloadPersistenceResponse offloadResponse) throws Exception {
+    public FHIRRestOperationResponse doCreatePersist(FHIRPersistenceEvent event, List<Issue> warnings, Resource resource,
+            PayloadPersistenceResponse offloadResponse) throws Exception {
         return null;
     }
 
     @Override
-    public FHIRRestOperationResponse doUpdateMeta(FHIRPersistenceEvent event, String type, String id, FHIRPatch patch, Resource newResource, String ifMatchValue, String searchQueryString,
-        boolean skippableUpdate, boolean doValidation, List<Issue> warnings) throws Exception {
+    public FHIRRestOperationResponse doUpdateMeta(FHIRPersistenceEvent event, String type, String id, FHIRPatch patch,
+            Resource newResource, String ifMatchValue, String searchQueryString, boolean skippableUpdate, boolean doValidation,
+            List<Issue> warnings) throws Exception {
         return null;
     }
 
     @Override
     public FHIRRestOperationResponse doPatchOrUpdatePersist(FHIRPersistenceEvent event, String type, String id, boolean isPatch,
-        Resource newResource, Resource prevResource, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch, PayloadPersistenceResponse offloadResponse) throws Exception {
+            Resource newResource, Resource prevResource, List<Issue> warnings, boolean isDeleted, Integer ifNoneMatch,
+            PayloadPersistenceResponse offloadResponse) throws Exception {
         return null;
     }
 
     @Override
-    public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext, FHIRSystemHistoryContext systemHistoryContext)
-        throws FHIRPersistenceException {
+    public Map<String, Object> buildPersistenceEventProperties(String type, String id, String version, FHIRSearchContext searchContext,
+            FHIRSystemHistoryContext systemHistoryContext) throws FHIRPersistenceException {
         return null;
     }
 

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -8,6 +8,7 @@ package com.ibm.fhir.operation.everything;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_DATE;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_INSTANT;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,7 +167,7 @@ public class EverythingOperation extends AbstractOperation {
 
         Patient patient = null;
         try {
-            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false).getResource();
+            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, !THROW_EXC_ON_MISSING).getResource();
         } catch (Exception e) {
             FHIROperationException exceptionWithIssue = buildExceptionWithIssue("An unexpected error occurred while "
                     + "reading patient '" + logicalId + "'", IssueType.EXCEPTION, e);

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -236,7 +236,7 @@ public class EverythingOperation extends AbstractOperation {
                 if (retrieveAdditionalResources) {
                     addIncludesSearchParameters(compartmentMemberType, tempSearchParameters, extraResources, searchHelper);
                 }
-                results = resourceHelper.doSearch(compartmentMemberType, PATIENT, logicalId, tempSearchParameters, null, null);
+                results = resourceHelper.doSearch(compartmentMemberType, PATIENT, logicalId, tempSearchParameters, null);
                 int countBeforeAddingNewResources = allEntries.size();
                 processResults(results, compartmentMemberType, results.getEntry(), allEntries, resourceIds, resourceHelper, extraResources, retrieveAdditionalResources);
                 currentResourceCount = results.getTotal().getValue();
@@ -268,7 +268,7 @@ public class EverythingOperation extends AbstractOperation {
                     }
                     try {
                         tempSearchParameters.putSingle(SearchConstants.PAGE, page++ + "");
-                        results = resourceHelper.doSearch(compartmentMemberType, PATIENT, logicalId, tempSearchParameters, null, null);
+                        results = resourceHelper.doSearch(compartmentMemberType, PATIENT, logicalId, tempSearchParameters, null);
                         processResults(results, compartmentMemberType, results.getEntry(), allEntries, resourceIds, resourceHelper, extraResources, retrieveAdditionalResources);
                     } catch (Exception e) {
                         FHIROperationException exceptionWithIssue = buildExceptionWithIssue("Error retrieving "

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -47,7 +47,6 @@ import com.ibm.fhir.model.type.code.IssueType;
 import com.ibm.fhir.model.type.code.ResourceType;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.ReferenceFinder;
-import com.ibm.fhir.persistence.exception.FHIRPersistenceResourceDeletedException;
 import com.ibm.fhir.registry.FHIRRegistry;
 import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.compartment.CompartmentHelper;
@@ -167,11 +166,7 @@ public class EverythingOperation extends AbstractOperation {
 
         Patient patient = null;
         try {
-            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false, false, null).getResource();
-        } catch (FHIRPersistenceResourceDeletedException fde) {
-            FHIROperationException exceptionWithIssue = buildExceptionWithIssue("Patient with ID '" + logicalId + "' "
-                    + "does not exist.", IssueType.NOT_FOUND);
-            throw exceptionWithIssue;
+            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false, null).getResource();
         } catch (Exception e) {
             FHIROperationException exceptionWithIssue = buildExceptionWithIssue("An unexpected error occurred while "
                     + "reading patient '" + logicalId + "'", IssueType.EXCEPTION, e);

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -8,7 +8,6 @@ package com.ibm.fhir.operation.everything;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_DATE;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_INSTANT;
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -167,7 +166,7 @@ public class EverythingOperation extends AbstractOperation {
 
         Patient patient = null;
         try {
-            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, !THROW_EXC_ON_MISSING).getResource();
+            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId).getResource();
         } catch (Exception e) {
             FHIROperationException exceptionWithIssue = buildExceptionWithIssue("An unexpected error occurred while "
                     + "reading patient '" + logicalId + "'", IssueType.EXCEPTION, e);

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -166,7 +166,7 @@ public class EverythingOperation extends AbstractOperation {
 
         Patient patient = null;
         try {
-            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false, null).getResource();
+            patient = (Patient) resourceHelper.doRead(PATIENT, logicalId, false).getResource();
         } catch (Exception e) {
             FHIROperationException exceptionWithIssue = buildExceptionWithIssue("An unexpected error occurred while "
                     + "reading patient '" + logicalId + "'", IssueType.EXCEPTION, e);

--- a/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
+++ b/operation/fhir-operation-member-match/src/main/java/com/ibm/fhir/operation/davinci/hrex/provider/strategy/DefaultMemberMatchStrategy.java
@@ -56,7 +56,7 @@ import com.ibm.fhir.validation.exception.FHIRValidationException;
  * 2. HealthPlan (Match) checks the incoming Parameters validates against the profile.
  * 3. HealthPlan (Match) executes a local Search to find the Coverage
  * 4. HealhPlan (Match) (optionally) augments the Coverage details on the local system with a LINK.
- * 
+ *
  * @implNote the following search parameters are needed.
  * Patient = identifier (USUAL, OFFICIAL), telecom, name, address, address-city, address-state, address-postalcode, address-country, gender, birthdate (uses eq), language
  * Coverage = patient, subscriber, payor, subscriber-id, identifier, beneficiary
@@ -157,8 +157,7 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.fine("Search Parameters used to find the member in 'Patient' " + patientCompiler.getSearchParameters());
             }
-            Bundle patientBundle = resourceHelper()
-                    .doSearch("Patient", null, null, patientCompiler.getSearchParameters(), requestUri, null);
+            Bundle patientBundle = resourceHelper().doSearch("Patient", null, null, patientCompiler.getSearchParameters(), requestUri);
             int size = patientBundle.getEntry().size();
             if (size == 0) {
                 returnNoMatchException();
@@ -182,7 +181,7 @@ public class DefaultMemberMatchStrategy extends AbstractMemberMatch {
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.fine("Search Parameters used to find the member's Coverage " + coverageCompiler.getSearchParameters());
             }
-            Bundle coverageBundle = resourceHelper().doSearch("Coverage", null, null, coverageCompiler.getSearchParameters(), requestUri, null);
+            Bundle coverageBundle = resourceHelper().doSearch("Coverage", null, null, coverageCompiler.getSearchParameters(), requestUri);
 
             if (coverageBundle.getEntry().isEmpty()) {
                 // This may warrant a separate exception in custom implementations.

--- a/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
+++ b/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
@@ -1675,13 +1675,13 @@ public class MemberMatchTest {
         }
 
         @Override
-        public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, boolean includeDeleted, Resource contextResource,
+        public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, Resource contextResource,
             MultivaluedMap<String, String> queryParameters) throws Exception {
             throw new AssertionError("Unused");
         }
 
         @Override
-        public Resource doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception {
+        public SingleResourceResult<? extends Resource> doVRead(String type, String id, String versionId, MultivaluedMap<String, String> queryParameters) throws Exception {
             throw new AssertionError("Unused");
         }
 

--- a/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
+++ b/operation/fhir-operation-member-match/src/test/java/com/ibm/fhir/operation/davinci/hrex/test/MemberMatchTest.java
@@ -96,23 +96,18 @@ import com.ibm.fhir.validation.exception.FHIRValidationException;
  */
 public class MemberMatchTest {
 
-    private static final Extension DATA_ABSENT =
-            Extension
-                .builder()
-                .url("http://hl7.org/fhir/StructureDefinition/data-absent-reason")
-                .value(Code.of("unknown"))
-                .build();
+    private static final Extension DATA_ABSENT = Extension.builder()
+            .url("http://hl7.org/fhir/StructureDefinition/data-absent-reason")
+            .value(Code.of("unknown"))
+            .build();
 
-    private static final com.ibm.fhir.model.type.String DATA_ABSENT_STRING =
-            com.ibm.fhir.model.type.String
-                .builder()
-                .extension(DATA_ABSENT)
-                .build();
+    private static final com.ibm.fhir.model.type.String DATA_ABSENT_STRING = com.ibm.fhir.model.type.String.builder()
+            .extension(DATA_ABSENT)
+            .build();
 
-    private static final Reference DATA_ABSENT_REFERENCE = Reference
-        .builder()
-        .extension(DATA_ABSENT)
-        .build();
+    private static final Reference DATA_ABSENT_REFERENCE = Reference.builder()
+            .extension(DATA_ABSENT)
+            .build();
 
     private static final Uri DATA_ABSENT_URI = Uri.builder().extension(DATA_ABSENT).build();
 
@@ -1553,15 +1548,15 @@ public class MemberMatchTest {
         }
 
         @Override
-        public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters, String requestUri,
-            Resource contextResource) throws Exception {
+        public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters, String requestUri)
+                throws Exception {
             // TODO Auto-generated method stub
-            return doSearch(type, compartment, compartmentId, queryParameters, requestUri, contextResource, false, true);
+            return doSearch(type, compartment, compartmentId, queryParameters, requestUri, false, true);
         }
 
         @Override
         public Bundle doSearch(String type, String compartment, String compartmentId, MultivaluedMap<String, String> queryParameters, String requestUri,
-            Resource contextResource, boolean checkIfInteractionAllowed, boolean alwaysIncludeResource) throws Exception {
+                boolean checkIfInteractionAllowed, boolean alwaysIncludeResource) throws Exception {
             if (throwException) {
                 throw new Exception("Test");
             }
@@ -1659,13 +1654,13 @@ public class MemberMatchTest {
 
         @Override
         public FHIRRestOperationResponse doUpdate(String type, String id, Resource newResource, String ifMatchValue, String searchQueryString,
-            boolean skippableUpdate, boolean doValidation, Integer ifNoneMatch) throws Exception {
+                boolean skippableUpdate, boolean doValidation, Integer ifNoneMatch) throws Exception {
             throw new AssertionError("Unused");
         }
 
         @Override
         public FHIRRestOperationResponse doPatch(String type, String id, FHIRPatch patch, String ifMatchValue, String searchQueryString,
-            boolean skippableUpdate) throws Exception {
+                boolean skippableUpdate) throws Exception {
             throw new AssertionError("Unused");
         }
 
@@ -1675,8 +1670,8 @@ public class MemberMatchTest {
         }
 
         @Override
-        public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull, Resource contextResource,
-            MultivaluedMap<String, String> queryParameters) throws Exception {
+        public SingleResourceResult<? extends Resource> doRead(String type, String id, boolean throwExcOnNull,
+                MultivaluedMap<String, String> queryParameters) throws Exception {
             throw new AssertionError("Unused");
         }
 

--- a/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -56,7 +56,7 @@ public abstract class AbstractTermOperation extends AbstractOperation {
         String resourceParameterName = resourceTypeName.substring(0, 1).toLowerCase() + resourceTypeName.substring(1);
         String resourceVersionParameterName = resourceParameterName + "Version";
         if (FHIROperationContext.Type.INSTANCE.equals(operationContext.getType())) {
-            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false, null).getResource();
+            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false).getResource();
             if (resource == null) {
                 throw buildExceptionWithIssue(resourceTypeName + " with id '" + logicalId + "' was not found", IssueType.NOT_FOUND);
             }

--- a/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -56,7 +56,7 @@ public abstract class AbstractTermOperation extends AbstractOperation {
         String resourceParameterName = resourceTypeName.substring(0, 1).toLowerCase() + resourceTypeName.substring(1);
         String resourceVersionParameterName = resourceParameterName + "Version";
         if (FHIROperationContext.Type.INSTANCE.equals(operationContext.getType())) {
-            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false, false, null).getResource();
+            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false, null).getResource();
             if (resource == null) {
                 throw buildExceptionWithIssue(resourceTypeName + " with id '" + logicalId + "' was not found", IssueType.NOT_FOUND);
             }

--- a/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -7,7 +7,6 @@
 package com.ibm.fhir.operation.term;
 
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
-import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationDefinition;
@@ -57,7 +56,7 @@ public abstract class AbstractTermOperation extends AbstractOperation {
         String resourceParameterName = resourceTypeName.substring(0, 1).toLowerCase() + resourceTypeName.substring(1);
         String resourceVersionParameterName = resourceParameterName + "Version";
         if (FHIROperationContext.Type.INSTANCE.equals(operationContext.getType())) {
-            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, !THROW_EXC_ON_MISSING).getResource();
+            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId).getResource();
             if (resource == null) {
                 throw buildExceptionWithIssue(resourceTypeName + " with id '" + logicalId + "' was not found", IssueType.NOT_FOUND);
             }

--- a/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
+++ b/term/operation/fhir-operation-term/src/main/java/com/ibm/fhir/operation/term/AbstractTermOperation.java
@@ -7,6 +7,7 @@
 package com.ibm.fhir.operation.term;
 
 import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
+import static com.ibm.fhir.server.spi.operation.FHIRResourceHelpers.THROW_EXC_ON_MISSING;
 
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationDefinition;
@@ -56,7 +57,7 @@ public abstract class AbstractTermOperation extends AbstractOperation {
         String resourceParameterName = resourceTypeName.substring(0, 1).toLowerCase() + resourceTypeName.substring(1);
         String resourceVersionParameterName = resourceParameterName + "Version";
         if (FHIROperationContext.Type.INSTANCE.equals(operationContext.getType())) {
-            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, false).getResource();
+            Resource resource = resourceHelper.doRead(resourceTypeName, logicalId, !THROW_EXC_ON_MISSING).getResource();
             if (resource == null) {
                 throw buildExceptionWithIssue(resourceTypeName + " with id '" + logicalId + "' was not found", IssueType.NOT_FOUND);
             }


### PR DESCRIPTION
Previously, for scopes granting patient-scoped Patient resource access
(patient/Patient.read or patient/Patient.write), the beforeRead, beforeVread, and beforeHistory
methods prevented any interaction with any Patient resource unless that
resource had one of the ids passed in the `patient_id` claim of the
access token.

Now we attempt to perform those interactions and rely on the afterRead, 
afterVread, and afterHistory methods to ensure that this is part of the 
in-context patient(s)' record.
To avoid leaking "does patient id xyz exist" info, we reject reading of
non-existent patient resources with a 403 (unlike the usual 404)...this
also prevents 'create-on-update' behavior for this resource type.

To accommodate the change, FHIRRestHelper.doRead is updated so that
`afterRead` is invoked prior to throwing the
FHIRPersistenceResourceNotFoundException that becomes a 404.

To avoid leaking the existence (or nonexistence) of a patient resource id 
in the case of a read for a deleted resource, I changed the persistence layer to
avoid throwing.  That was needed to ensure that the `afterRead` gets
called for this case.  This partially addresses #194.

After that change, the 'includeDeleted' flag in our FHIRRestHelper doRead
methods didn't really make sense and so I removed that. To keep the refactor
manageable, the FHIRRestHelper will still throw (conditionally) in the case of
a null resource in the SingleResourceResult from the persistence layer.

Finally, since we already had this signature change to some FHIRRestHelper methods,
I also addressed #3606 by removing the "contextResource" parameter from
doRead and doSearch.