### PR TITLE
issue #3665 - handle coding in valueset when we can't validate display

### DIFF
--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
@@ -246,7 +246,7 @@ public class MemberOfFunction extends FHIRPathAbstractFunction {
         if (Boolean.FALSE.equals(outcome.getResult())) {
             generateIssue(outcome, evaluationContext, elementNode, strength);
             return false;
-        } else if (outcome.getMessage() != null){
+        } else if (outcome.getMessage() != null) {
             // this uses inside knowledge about the reason an outcome might come back true but with a message;
             // is there a cleaner way to get this supplemental detail back from the validateCode?
             generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.NOT_SUPPORTED, outcome.getMessage().getValue(), elementNode.path());

--- a/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
+++ b/fhir-path/src/main/java/com/ibm/fhir/path/function/MemberOfFunction.java
@@ -242,9 +242,14 @@ public class MemberOfFunction extends FHIRPathAbstractFunction {
         } else {
             outcome = service.validateCode(valueSet, codeableConcept);
         }
+
         if (Boolean.FALSE.equals(outcome.getResult())) {
             generateIssue(outcome, evaluationContext, elementNode, strength);
             return false;
+        } else if (outcome.getMessage() != null){
+            // this uses inside knowledge about the reason an outcome might come back true but with a message;
+            // is there a cleaner way to get this supplemental detail back from the validateCode?
+            generateIssue(evaluationContext, IssueSeverity.INFORMATION, IssueType.NOT_SUPPORTED, outcome.getMessage().getValue(), elementNode.path());
         }
         return true;
     }

--- a/fhir-validation/src/test/java/com/ibm/fhir/validation/test/BloodPressureObservationTest.java
+++ b/fhir-validation/src/test/java/com/ibm/fhir/validation/test/BloodPressureObservationTest.java
@@ -28,6 +28,7 @@ import com.ibm.fhir.model.type.Meta;
 import com.ibm.fhir.model.type.Quantity;
 import com.ibm.fhir.model.type.Reference;
 import com.ibm.fhir.model.type.Uri;
+import com.ibm.fhir.model.type.code.IssueSeverity;
 import com.ibm.fhir.model.type.code.ObservationStatus;
 import com.ibm.fhir.validation.FHIRValidator;
 
@@ -113,9 +114,10 @@ public class BloodPressureObservationTest {
         // validate the blood pressure observation in debug mode and print issues to console
         List<Issue> issues = FHIRValidator.validator().validate(bloodPressureObservation);
         issues.forEach(System.out::println);
-        Assert.assertEquals(issues.size(), 2);
+        Assert.assertEquals(issues.size(), 3);
         Assert.assertTrue(issues.get(0).getDetails().getText().getValue().startsWith("generated-bp-8"));
         Assert.assertTrue(issues.get(1).getDetails().getText().getValue().startsWith("dom-6"));
+        Assert.assertTrue(issues.get(2).getSeverity().equals(IssueSeverity.INFORMATION));
 
         System.out.println("");
     }


### PR DESCRIPTION
Previously, FHIRTermServer.validateCode(ValueSet, CodeableConcept)
returned a false ValidationOutcome in cases where the code was a valid
member of the ValueSet but includes a display value that we couldn't
validate (e.g. due to missing the corresponding CodeSystem).

Now, we will return true in the ValidationOutcome for this case, but we
include a message alongside it to indicate that we didn't actually
validate the display value. From the FHIRPath MemberOfFunction, we
translate that into an informational OperationOutcomeIssue and add it to
the EvaluationContext.

For example:
> Unable to validate display value 'Diastolic Blood Pressure' for code
'8462-4' in system 'http://loinc.org'

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>