### PR TITLE
issue #3331 - update README.md and Conformance.md for FHIR R4B

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## IBM FHIR Server
-The IBM® FHIR® Server is a modular Java implementation of version 4 of the [HL7 FHIR specification](https://www.hl7.org/fhir/r4/http.html) with a focus on performance and configurability.
+The IBM® FHIR® Server is a modular Java implementation of version 4 of the [HL7 FHIR specification](https://hl7.org/fhir/R4B/http.html) with a focus on performance and configurability.
 
 For a detailed description of FHIR conformance, see https://ibm.github.io/FHIR/Conformance.
 
@@ -77,26 +77,30 @@ The IBM FHIR Server is modular and extensible. The following tables provide an o
 |------|-----------|----------|
 |fhir-parent|The parent project for all projects which make up the IBM FHIR Server|false|
 |fhir-core|Core helpers and utilities|false|
+|fhir-cache|Cache-related helpers and utilities|false|
 
 #### Model and Profile Support
 |Module|Description|Java API-stable|
 |------|-----------|----------|
-|fhir-model|An object model generated from the FHIR R4 specification and corresponding parsers and generators for XML and JSON|true|
-|fhir-registry|A resource registry, registry provider interfaces, and pre-registered resources shipped with the FHIR specification|false|
+|fhir-model|An object model generated from the FHIR R4B specification and corresponding parsers and generators for XML and JSON|true|
+|fhir-registry|A resource registry and registry provider interfaces for extending the registry|false|
 |term/fhir-term|A terminology service provider interface with a default implementation that implements terminology services from fully-defined CodeSystems in the registry|false|
-|term/fhir-term-graph|A terminology service provider that implements terminology services using JanusGraph|false|
-|term/fhir-term-graph-loader|Populates the terminology service backend when using JanusGraph|false|
+|term/fhir-term-graph|An expermental terminology service provider that implements terminology services using JanusGraph|false|
+|term/fhir-term-graph-loader|Utilities to populate the fhir-term-graph JanusGraph with concepts|false|
 |term/fhir-term-remote|A terminology service provider that connects to an external service using a REST client to access code system content|false|
 |fhir-profile|Helper methods for validating ValueSet membership and Profile conformance|false|
-|fhir-path|An implementation of version 2.0.0 of the FHIRPath specification assumed by FHIR R4|false|
-|fhir-validation|Validation utility for validating resource instances against the base specification and/or configured profiles|false|
-|fhir-ig-us-core|A packaging of the US Core Implementation Guide for extending the IBM FHIR Server with US Core Profile validation|false|
-|fhir-ig-mcode|A packaging of the minimal Common Oncology Data Elements for extending the IBM FHIR Server with minimal Common Oncology Data Elements Profile validation|false|
-|fhir-ig-carin-bb|A packaging of the Consumer-Directed Payer Data Exchange Guide for extending the IBM FHIR Server with  Consumer-Directed Payer Data Exchange Profile validation|false|
-|fhir-ig-davinci-pdex|A packaging of the Da Vinci Payer Data Exchange (PDEX) Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDEX) Profile validation|false|
-|fhir-ig-davinci-hrex|A packaging of the Da Vinci Health Record Exchange (HREX) Implementation Guide for extending the IBM FHIR Server with DaVinci Health Record Exchange (HREX) Profile validation|false|
-|fhir-ig-davinci-pdex-plan-net|A packaging of the Da Vinci Payer Data Exchange (PDEX) Plan Net Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDEX) Plan Net Profile validation|false|
-|fhir-ig-davinci-pdex-formulary|A packaging of the Da Vinci Payer Data Exchange (PDex) US Drug Formulary Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDex) US Drug Formulary validation|false|
+|fhir-path|An implementation of version 2.0.0 of the FHIRPath specification|false|
+|fhir-validation|Validation utility for validating resource instances against the base specification and configured profiles|false|
+|conformance/fhir-core-r4|Conformance artifacts for HL7 FHIR version 4.0.1|false|
+|conformance/fhir-core-r4b|Conformance artifacts for HL7 FHIR version 4.3.0|false|
+|conformance/fhir-hl7-terminology|CodeSystems and ValueSets from HL7 Terminology (THO) version 3.1.0|false|
+|conformance/fhir-ig-us-core|A packaging of the US Core Implementation Guide for extending the IBM FHIR Server with US Core profile validation|false|
+|conformance/fhir-ig-mcode|A packaging of the minimal Common Oncology Data Elements for extending the IBM FHIR Server with minimal Common Oncology Data Elements profile validation|false|
+|conformance/fhir-ig-carin-bb|A packaging of the Consumer-Directed Payer Data Exchange Guide for extending the IBM FHIR Server with  Consumer-Directed Payer Data Exchange profile validation|false|
+|conformance/fhir-ig-davinci-pdex|A packaging of the Da Vinci Payer Data Exchange (PDEX) Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDEX) profile validation|false|
+|conformance/fhir-ig-davinci-hrex|A packaging of the Da Vinci Health Record Exchange (HREX) Implementation Guide for extending the IBM FHIR Server with DaVinci Health Record Exchange (HREX) profile validation|false|
+|conformance/fhir-ig-davinci-pdex-plan-net|A packaging of the Da Vinci Payer Data Exchange (PDEX) Plan Net Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDEX) Plan Net profile validation|false|
+|conformance/fhir-ig-davinci-pdex-formulary|A packaging of the Da Vinci Payer Data Exchange (PDex) US Drug Formulary Implementation Guide for extending the IBM FHIR Server with DaVinci Payer Data Exchange (PDex) US Drug Formulary validation|false|
 
 #### Server
 |Module|Description|Java API-stable|
@@ -119,16 +123,16 @@ The IBM FHIR Server is modular and extensible. The following tables provide an o
 #### Extended Operations
 |Module|Description|Java API-stable|
 |------|-----------|----------|
-|fhir-operation-test|Sample operations for testing Extended Operations as describe at https://www.hl7.org/fhir/R4/operations.html |false|
+|fhir-operation-test|Sample operations for testing Extended Operations as describe at https://hl7.org/fhir/R4B/operations.html |false|
 |fhir-operation-bulkdata|`$import` and `$export` implementations which translate bulk data requests into JSR352 Java Batch jobs|false|
 |fhir-bulkdata-webapp|Standalone web application for serving bulk import and export requests via JSR352 Java Batch jobs|false|
-|fhir-operation-convert|A limited implementation of the FHIR [$convert operation](https://www.hl7.org/fhir/R4/resource-operation-convert.html), able to convert between JSON and XML but *not* between FHIR versions|false|
-|fhir-operation-document|Basic support for the Composition `$document` operation defined at https://www.hl7.org/fhir/operation-composition-document.html |false|
+|fhir-operation-convert|A limited implementation of the FHIR [$convert operation](https://hl7.org/fhir/R4B/resource-operation-convert.html), able to convert between JSON and XML but *not* between FHIR versions|false|
+|fhir-operation-document|Basic support for the Composition `$document` operation defined at https://hl7.org/fhir/R4B/operation-composition-document.html |false|
 |fhir-operation-healthcheck|The `$healthcheck` operation checks for a valid connection to the database and returns the server status|false|
-|fhir-operation-term|[Terminology service](https://www.hl7.org/fhir/terminology-service.html) operations which use the default fhir-term TerminologyServiceProvider to implement $expand, $lookup, $subsumes, $closure, $validate and $translate|false|
+|fhir-operation-term|[Terminology service](https://hl7.org/fhir/R4B/terminology-service.html) operations which use the default fhir-term TerminologyServiceProvider to implement $expand, $lookup, $subsumes, $closure, $validate and $translate|false|
 |fhir-operation-term-cache|Add-on module that provides operations for clearing the terminology subsystem caches for non-production scenarios|false|
-|fhir-operation-validate|An implementation of the FHIR resource [$validate operation](https://www.hl7.org/fhir/R4/operation-resource-validate.html)|false|
-|fhir-operation-everything|An implementation of the FHIR patient [`$everything`](https://www.hl7.org/fhir/operation-patient-everything.html) operation|false|
+|fhir-operation-validate|An implementation of the FHIR resource [$validate operation](https://hl7.org/fhir/R4B/operation-resource-validate.html)|false|
+|fhir-operation-everything|An implementation of the FHIR patient [`$everything`](https://hl7.org/fhir/R4B/operation-patient-everything.html) operation|false|
 |fhir-operation-erase|A hard delete operation for resource instances referred to as the `$erase` operation. See the [README.md](operation/fhir-operation-erase/README.md)|false|
 |fhir-operation-member-match|An extensible framework and reference implementation for Davinci HREX $member-match using the default IBM FHIR Server. See the [README.md](operation/fhir-operation-member-match/README.md) *experimental*|false|
 
@@ -147,7 +151,7 @@ The IBM FHIR Server is modular and extensible. The following tables provide an o
 |cql/fhir-quality-measure|FHIR Quality Measure evaluation logic|false|
 |cql/operation/fhir-operation-cpg|*Optional* module that implements CQL operations|false|
 |cql/operation/fhir-operation-cqf|*Optional* module that implements CQF operation|false|
-|cql/operation/fhir-operation-apply|A naive implementation of the `$apply` operation defined at https://www.hl7.org/fhir/operation-activitydefinition-apply.html |false|
+|cql/operation/fhir-operation-apply|A naive implementation of the `$apply` operation defined at https://hl7.org/fhir/R4B/operation-activitydefinition-apply.html |false|
 
 #### Tools and Utilities
 |Module|Description|Java API-stable|

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,9 @@
 # Jekyll Configuration for Static Pages
 
 title: IBM FHIR Server
-description: >- 
-  The IBM FHIR Server is a modular Java implementation of version 4 
-  of the <a href="https://www.hl7.org/fhir/r4/http.html">HL7 FHIR specification</a> with 
+description: >-
+  The IBM FHIR Server is a modular Java implementation of version 4
+  of the <a href="https://hl7.org/fhir/R4B/http.html">HL7 FHIR specification</a> with 
   a focus on performance and configurability.
 baseurl: ""
-url: "https://ibm.github.io/fhir" 
+url: "https://ibm.github.io/fhir"

--- a/docs/src/pages/guides/BringYourOwnPersistence.md
+++ b/docs/src/pages/guides/BringYourOwnPersistence.md
@@ -2,7 +2,6 @@
 layout: post
 title: Bring your own Persistence Layer
 description: Learn how to build and test a persistence layer for the IBM FHIR Server
-date:   2021-06-01
 permalink: /BringYourOwnPersistence/
 ---
 
@@ -84,7 +83,7 @@ You might also want to set up `fhir-persistence-jdbc` to use an example.
 ### Implementing the FHIRPersistence Interface
 As described [above](#interfaces), implementing your own persistence layer boils down to configuring the server to use your own FHIRPersistenceFactory and returning your own implementation of FHIRPersistence. The REST layer processes HTTP requests and distills them into one or more calls to this instance. Parameters are passed via a combination of the passed FHIRPersistenceContext and the ThreadLocal FHIRRequestContext.
 
-Although the HL7 FHIR specification [doesn't strictly require all servers to support versioning](https://www.hl7.org/fhir/R4/http.html#versions), the IBM FHIR Server is built to be version-aware. This means that all FHIRPersistence implementations should implement the `vread` and `history` interactions.
+Although the HL7 FHIR specification [doesn't strictly require all servers to support versioning](https://hl7.org/fhir/R4B/http.html#versions), the IBM FHIR Server is built to be version-aware. This means that all FHIRPersistence implementations should implement the `vread` and `history` interactions.
 Similarly, the IBM FHIR Server was written for read/write datastores and so `create` and `update` should be supported as well.
 If you have a use case for a read-only or non-version-aware server, please contact us and consider contributing the necessary modifications to the server to make this supported.
 
@@ -140,12 +139,12 @@ In addition to setting the MultiResourceResult success indicator and the resourc
 The FHIRPersistence also supports whole system `_history`. If supported, `isChangesSupported` must return true, and `changes` must be implemented to return a list of ResourceChangeLogRecord DTOs.
 
 #### Search
-The [FHIR Search specification](https://www.hl7.org/fhir/R4/search.html) is sprawling and difficult to implement in its entirety. At the persistence layer, search requests will include a FHIRPersistenceContext with an embedded FHIRSearchContext and a Class object to indicate the resource type(s) to search on.
+The [FHIR Search specification](https://hl7.org/fhir/R4B/search.html) is sprawling and difficult to implement in its entirety. At the persistence layer, search requests will include a FHIRPersistenceContext with an embedded FHIRSearchContext and a Class object to indicate the resource type(s) to search on.
 A Class of `com.ibm.fhir.model.type.Resource` is passed for searches performed at the "whole-system" level.
 
 The query parameters passed in the HTTP request are parsed at the REST layer and passed to the persistence layer in the form of a FHIRSearchContext.
 The FHIRSearchContext separates "return" parameters (like `_include`, `_revinclude`, `_sort`, etc.) from search parameters and makes them available through dedicated getters.
-Each search parameter is parsed into a QueryParameter and a QueryParameterValue. [Compartment](https://www.hl7.org/fhir/R4/compartmentdefinition.html) searches are converted into [chained parameters](https://www.hl7.org/fhir/R4/search.html#chaining), which are represented through nested QueryParameter objects within the outermost QueryParameter.
+Each search parameter is parsed into a QueryParameter and a QueryParameterValue. [Compartment](https://hl7.org/fhir/R4B/compartmentdefinition.html) searches are converted into [chained parameters](https://hl7.org/fhir/R4B/search.html#chaining), which are represented through nested QueryParameter objects within the outermost QueryParameter.
 Check `com.ibm.fhir.search.util.SearchUtil.parseQueryParameters()` for more information.
 
 FHIRSearchContext extends FHIRPagingContext and provides the requested page size and page number to return.
@@ -157,7 +156,7 @@ On failure, set `MultiResourceResult.success` to false and set `MultiResourceRes
 
 #### Extended Operations
 
-The IBM FHIR Server supports [extended operations](https://www.hl7.org/fhir/operations.html). The IBM FHIR Server has some operations which use custom persistence interactions: 
+The IBM FHIR Server supports [extended operations](https://hl7.org/fhir/R4B/operations.html). The IBM FHIR Server has some operations which use custom persistence interactions:
 
 | Operation Name | Interfaces to implement |
 |----------------|-------------------------|

--- a/docs/src/pages/guides/FHIRClinicalReasoningGuide.md
+++ b/docs/src/pages/guides/FHIRClinicalReasoningGuide.md
@@ -8,7 +8,7 @@ permalink: /FHIRClinicalReasoningGuide/
 
 # Overview
 
-(Experimental) IBM FHIR Server added initial support for the [Clinical Quality Language (CQL)](https://cql.hl7.org/) and FHIR operations defined in the [Clinical Practice Guidelines (CPG) ](https://build.fhir.org/ig/HL7/cqf-recommendations/) and [Quality Measure (cqf-measures)](http://hl7.org/fhir/us/cqfmeasures/stu2/) Implementation Guides (IG) that leverage CQL. These IGs build upon the resources and operations defined in the [FHIR Clinical Reasoning Module](http://www.hl7.org/FHIR/clinicalreasoning-module.html). 
+(Experimental) IBM FHIR Server added initial support for the [Clinical Quality Language (CQL)](https://cql.hl7.org/) and FHIR operations defined in the [Clinical Practice Guidelines (CPG) ](https://build.fhir.org/ig/HL7/cqf-recommendations/) and [Quality Measure (cqf-measures)](http://hl7.org/fhir/us/cqfmeasures/stu2/) Implementation Guides (IG) that leverage CQL. These IGs build upon the resources and operations defined in the [FHIR Clinical Reasoning Module](http://hl7.org/fhir/R4B/clinicalreasoning-module.html).
 
 The IBM FHIR Server's module builds upon the work of other open source projects including [cqframework/clinical_quality_language](https://github.com/cqframework/clinical_quality_language/), [DBCG/cql_engine](https://github.com/DBCG/cql_engine/), and [DBCG/cql-evaluator](https://github.com/DBCG/cql-evaluator/) projects and much of the work is to expose these functions with the necessary hooks to perform CQL to ELM translation and ELM evaluation natively inside the IBM FHIR server or externally using an IBM FHIR Server client and model objects. Additionally, support is provided for evaluating and reporting on clinical quality measures and care gaps.
 
@@ -21,12 +21,12 @@ There was some prior work done on `ActivityDefinition/$apply` and `PlanDefinitio
 The CPG IG defines operations that work directly with CQL either as ad-hoc queries via the `/$cql` operation or via Library resources stored in the FHIR Registry (`/Library/$evaluate` and `/Library/[id]/$evaluate`). These operations are exposed by the *optional* module operation/fhir-operation-cpg. In order to make these operations available to the server, you must build the fhir-operation-cpg module and copy the target/fhir-operation-cpg-X.X.X-shaded.jar into the userlib directory of your FHIR server installation.
 
 * /$cql
-* /Library/$evaluate 
+* /Library/$evaluate
 * /Library/[id]/$evaluate
 
 # CQF Operations
 
-The cqf-measures IG builds upon the resources and operations defined in the [FHIR Clincial Reasoning Module](http://www.hl7.org/FHIR/clinicalreasoning-module.html) to define a workflow of operations that support electronic Clinical Quality Measures (eCQMs) and reporting. These operations are exposed by the *optional* module operation/fhir-operation-cqf. In order to make these operations available to the server, you must build the fhir-operation-cqf module and copy the target/fhir-operation-cqf-X.X.X-shaded.jar into the userlib directory of your FHIR server installation.
+The cqf-measures IG builds upon the resources and operations defined in the [FHIR Clincial Reasoning Module](http://hl7.org/fhir/R4B/clinicalreasoning-module.html) to define a workflow of operations that support electronic Clinical Quality Measures (eCQMs) and reporting. These operations are exposed by the *optional* module operation/fhir-operation-cqf. In order to make these operations available to the server, you must build the fhir-operation-cqf module and copy the target/fhir-operation-cqf-X.X.X-shaded.jar into the userlib directory of your FHIR server installation.
 
 * /Library/$data-requirements
 * /Measure/[id]/$data-requirements
@@ -48,4 +48,3 @@ The cqf-measures IG builds upon the resources and operations defined in the [FHI
 |fhir-quality-measure|FHIR Quality Measure evaluation logic|
 |operation/fhir-operation-cpg|*Optional* module that implements CQL operations|
 |operation/fhir-operation-cqf|*Optional* module that implements CQF operations|
-

--- a/docs/src/pages/guides/FHIROperationFramework.md
+++ b/docs/src/pages/guides/FHIROperationFramework.md
@@ -6,9 +6,9 @@ date:  2020-10-05
 
 # IBM FHIR Server - Extended Operations Framework
 
-The HL7 FHIR Specification describes a [framework](https://www.hl7.org/fhir/r4/operations.html) of extended operations for the REST API.
+The HL7 FHIR Specification describes a [framework](https://hl7.org/fhir/R4B/operations.html) of extended operations for the REST API.
 
-This framework defines REST endpoints at the Base Server (System), scoped to specific resources (Type) and scoped to specific instances. 
+This framework defines REST endpoints at the Base Server (System), scoped to specific resources (Type) and scoped to specific instances.
 - **System** - https://my-server.com/fhir-server/api/v4/$convert - Convert from one format to another
 - **Type** - https://my-server.com/fhir-server/api/v4/Patient/$export - Retrieve all the data from the Patient compartment
 - **Instance** - https://my-server.com/fhir-server/api/v4/Patient/1-2-3-4/$export - Retrieve a specific Patient data from the Patient compartment data
@@ -16,7 +16,7 @@ This framework defines REST endpoints at the Base Server (System), scoped to spe
 A list of operations supported by the IBM FHIR Server is listed at https://ibm.github.io/FHIR/Conformance/#extended-operations
 
 ## Calling an Operation
-There are two types of operation invocation requests: 
+There are two types of operation invocation requests:
 - Complex (via POST)
   - All operations can be invoked by passing a Parameters resource instance in the body of the request.
   - For operations with no input parameters, no body is required.
@@ -92,14 +92,14 @@ curl --location --request POST 'https://localhost:9443/fhir-server/api/v4/Patien
 ### Example: Simple
 
 *Request*
-``` sh 
+``` sh
 curl --location --request GET 'https://localhost:9443/fhir-server/api/v4/$healthcheck' \
 --header 'Authorization: Basic CHANGEME' \
 --header 'Content-Type: application/json'
 ```
 
-*Response* 
-``` json 
+*Response*
+``` json
 {
   "resourceType": "OperationOutcome",
   "issue": [
@@ -115,9 +115,9 @@ curl --location --request GET 'https://localhost:9443/fhir-server/api/v4/$health
 ```
 
 ## Inspecting a FHIR Server’s Capability Statement (Operations)
-Each FHIR server is expected to have a Capability Statement outlining the System, Type and Instance operations, and advertising them via the metadata endpoint. 
+Each FHIR server is expected to have a Capability Statement outlining the System, Type and Instance operations, and advertising them via the metadata endpoint.
 
-To check the Type and Instance operations, you can check using this curl/jq command. 
+To check the Type and Instance operations, you can check using this curl/jq command.
 
 `curl -k --location --request GET 'https://localhost:9443/fhir-server/api/v4/metadata' | jq -r '.rest[].resource[].operation[].name' | sort -u`
 
@@ -135,11 +135,11 @@ validate
 validate-code
 ```
 
-To check the System Level operations, you can check using this curl/jq command. 
+To check the System Level operations, you can check using this curl/jq command.
 
 `curl -k --location --request GET 'https://localhost:9443/fhir-server/api/v4/metadata' | jq -r '.rest[].operation[].name'`
 
-``` 
+```
 bulkdata-status
 closure
 convert
@@ -149,11 +149,11 @@ hello
 import
 ```
 
-# The Specification in More Detail 
+# The Specification in More Detail
 
-Each Operation per [the specification](https://www.hl7.org/fhir/r4/operations.html#defining) is an [OperationDefinition](https://www.hl7.org/fhir/r4/operationdefinition.html) Resource.
+Each Operation per [the specification](https://hl7.org/fhir/R4B/operations.html#defining) is an [OperationDefinition](https://hl7.org/fhir/R4B/operationdefinition.html) Resource.
 
-The elements needed are: 
+The elements needed are:
 - Unique Name of the Operation - `OperationDefinition.name`
   - For instance, `"name": "import"`
 - Code used to activate the Operation - `OperationDefinition.code`
@@ -163,16 +163,16 @@ The elements needed are:
   - For instance, `"system": true`
 - Kind - always an `operation` - `OperationDefinition.kind`
 - Status - `OperationDefinition.status`, for implementers that are not intending to manage the lifecycle, best to put `draft`
-- Parameter - The list of parameters for the Operation - `OperationDefinition.parameter` - [Link](https://www.hl7.org/fhir/r4/operationdefinition-definitions.html#OperationDefinition.parameter)
+- Parameter - The list of parameters for the Operation - `OperationDefinition.parameter` - [Link](https://hl7.org/fhir/R4B/operationdefinition-definitions.html#OperationDefinition.parameter)
   - Specificy your Query Parameter
   - Be sure to have a return parameter
   - Typically this is a FHIR Resource
 
-An example operation is [$validate](https://www.hl7.org/fhir/r4/resource-operation-validate.html). The OperationDefinition is at [validation.json](https://github.com/IBM/FHIR/blob/main/operation/fhir-operation-validate/src/main/resources/validate.json).
+An example operation is [$validate](https://hl7.org/fhir/R4B/resource-operation-validate.html). The OperationDefinition is at [validation.json](https://github.com/IBM/FHIR/blob/main/operation/fhir-operation-validate/src/main/resources/validate.json).
 
 # IBM FHIR Server Extended Operations Framework
 
-The IBM FHIR Server has integrated the Extended Operations Framework into the code base. 
+The IBM FHIR Server has integrated the Extended Operations Framework into the code base.
 
 ![Framework](https://raw.githubusercontent.com/wiki/IBM/FHIR/operation/operation-framework.png)
 
@@ -180,7 +180,7 @@ Upon startup of the IBM FHIR Server webapplication, the FHIR Operation Registry 
 
 Upon receiving a request, the REST Layer checks to see if the JAX-RS path parameter `${operationName}` from a System, Type or Instance call is a registered Operation. If the operationName exists and is valid, the framework invokes the specific Operation for that specific Operation type.
 
-The Operation's custom logic is executed using the specific Operation logic, and the Persistence Helper is used to access the helper methods to start and end the transaction. 
+The Operation's custom logic is executed using the specific Operation logic, and the Persistence Helper is used to access the helper methods to start and end the transaction.
 
 The Operation's custom logic builds a valid Parameters resource as a response to the client, and the framework serializes back to the client.
 
@@ -194,14 +194,14 @@ The Operations are installed into the `userlib` folder of the IBM FHIR Server. S
 
 ![install location](https://raw.githubusercontent.com/wiki/IBM/FHIR/operation/installation-location.png)
 
-## Building a FHIR Operation 
+## Building a FHIR Operation
 To build a FHIR Operation, a great starting point is the GitHub repo.
 
 1. Create a Maven Java project. Prefix the artifactid with `fhir-operation-` and give it a useful name, such as fhir-operation-myop.
 2. Add the relevant dependencies, such as `fhir-server`.
-The pom.xml should look like: 
+The pom.xml should look like:
 
-``` xml 
+``` xml
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -227,10 +227,10 @@ The pom.xml should look like:
 </project>
 ```
 
-Note, if you are using the persistence layer, you naturally get the fhir-persistence libraries as a dependency. 
-Note, if you are including some custom libraries or other libraries, you should shade the dependencies into a single jar or deliverable. 
+Note, if you are using the persistence layer, you naturally get the fhir-persistence libraries as a dependency.
+Note, if you are including some custom libraries or other libraries, you should shade the dependencies into a single jar or deliverable.
 
-3. Add your OperationDefinition to the `src/main/resources`, such as healthcare.json. 
+3. Add your OperationDefinition to the `src/main/resources`, such as healthcare.json.
 4. Extend the AbstractOperation in your package, such as, `com.ibm.fhir.demo.MyOperation`
 5. Create the Services Loader file `com.ibm.fhir.server.operation.spi.FHIROperation` in `src/main/resources/META-INF/services/`
 6. Put a single line in the package for each of the Operations that are going to be hosted in the package.
@@ -238,7 +238,7 @@ Note, if you are including some custom libraries or other libraries, you should 
   com.ibm.fhir.demo.MyOperation
   com.ibm.fhir.demo.DemoOperation
   ```
-7. Add the constructor, such as: 
+7. Add the constructor, such as:
 ``` java
     public HealthcheckOperation() {
         super();
@@ -257,7 +257,7 @@ Note, if you are including some custom libraries or other libraries, you should 
     }
 ```
 
-9. Override the `doInvoke`. 
+9. Override the `doInvoke`.
 
 ``` java
 @Override
@@ -291,10 +291,10 @@ The following are some tips and tricks:
 ## Length of Interaction
 The framework is best suited for non-long poll requests such that an operation.
 
-If you need to dispatch an operation, use two operations - one request operation, and one status/response operation. 
+If you need to dispatch an operation, use two operations - one request operation, and one status/response operation.
 
 ## Transactions
-If you need to access the underlying persistence layer, you should request a transaction, and rollback or end it using on the FHIRPersistenceTransaction. 
+If you need to access the underlying persistence layer, you should request a transaction, and rollback or end it using on the FHIRPersistenceTransaction.
 
 ``` java
   FHIRPersistence pl =
@@ -302,7 +302,7 @@ If you need to access the underlying persistence layer, you should request a tra
 
   FHIRPersistenceTransaction tx = resourceHelper.getTransaction();
   tx.begin();
-  
+
   try {
       // Do Operation
       return FHIROperationUtil.getOutputParameters(operationOutcome);
@@ -326,7 +326,7 @@ By default, all tenants have access to an operation. Each Operation, if it has a
 
 ## Mutating the Response Code and Non-FHIR Resource Type responses
 
-To break out of the default response, use the `FHIROperationContext` which is ThreadSafe to mutate the Response. 
+To break out of the default response, use the `FHIROperationContext` which is ThreadSafe to mutate the Response.
 
 *Mutated Status*
 
@@ -342,7 +342,7 @@ operationContext.setProperty(FHIROperationContext.PROPNAME_RESPONSE, response);
 You can return null as a Parameters object - `return FHIROperationUtil.getOutputParameters(null);`
 
 # Questions and Support
-If you need further support, you can reach out to the development team at: 
+If you need further support, you can reach out to the development team at:
 
 - [Zulip: ibm](https://chat.fhir.org/#narrow/stream/212434-ibm)
 - [GitHub: issues](https://github.com/IBM/FHIR/issues)

--- a/docs/src/pages/guides/FHIRPerformanceGuide.md
+++ b/docs/src/pages/guides/FHIRPerformanceGuide.md
@@ -1,9 +1,6 @@
 ---
 layout: post
 title:  IBM FHIR Server Performance Guide
-description: IBM FHIR Server Performance Guide
-Copyright: years 2020, 2021
-lastupdated: "2020-06-01"
 permalink: /FHIRServerPerformanceGuide/
 ---
 
@@ -484,7 +481,7 @@ Avoiding these unnecessary updates is important for two reasons:
 1. ingestion performance (each update performs work in the database)
 2. database size (each version of each resource is stored in the database)
 
-The HL7 FHIR specification defines experimental support for both [conditional create](https://www.hl7.org/fhir/R4/http.html#ccreate) and [conditional update](https://www.hl7.org/fhir/R4/http.html#cond-update) and the IBM FHIR server implements each of these. However, this approach suffers multiple issues:
+The HL7 FHIR specification defines experimental support for both [conditional create](https://hl7.org/fhir/R4B/http.html#ccreate) and [conditional update](https://hl7.org/fhir/R4B/http.html#cond-update) and the IBM FHIR server implements each of these. However, this approach suffers multiple issues:
 1. each update must perform a search which can be more costly than simply performing read before the update
 2. conditional requests require intricate locking techniques to avoid race conditions and the currently-implemented approach has [significant limitations](https://github.com/IBM/FHIR/issues/2051)
 
@@ -495,7 +492,7 @@ Two resources will be considered equivalent based on the following criteria:
 * the server-assigned fields (`Resource.meta.lastUpdated` and `Resource.meta.versionId`) are ignored
 * the value of all other fields in the resource must be equivalent
 
-When the update is skipped, the response will contain a Location header that points to the *existing* resource version (e.g. `[base]/Patient/1234/_history/1`) instead of a newly created instance of this resource (`[base]/Patient/1234/_history/2`) and the response body will be sent according to the client's [return preference](https://www.hl7.org/fhir/R4/http.html#ops).
+When the update is skipped, the response will contain a Location header that points to the *existing* resource version (e.g. `[base]/Patient/1234/_history/1`) instead of a newly created instance of this resource (`[base]/Patient/1234/_history/2`) and the response body will be sent according to the client's [return preference](https://hl7.org/fhir/R4B/http.html#ops).
 If the client indicates a return preference of OperationOutcome and the update is skipped on the server, the response will contain an informational issue to indicate this case.
 
 To opt out of this optimization, users can force the server to perform an update by setting an
@@ -606,11 +603,11 @@ In most cases the history queries will execute very quickly. Performance will be
 **Omitting the count**
 
 For search queries with low specificity, the response time is dominated by the "count query" that is used to determine how many total results match the query.
-The IBM FHIR Server supports skipping this step when clients set a query parameter named `_total` to the value of `none` as described at https://www.hl7.org/fhir/search.html#total.
+The IBM FHIR Server supports skipping this step when clients set a query parameter named `_total` to the value of `none` as described at https://hl7.org/fhir/R4B/search.html#total.
 
 **Resource subsetting**
 
-For search queries that return lots of data (e.g. ones that return large resources such as Patient resources that embed a profile picture), the response time can be dominated by the network between the client and the server. By default, a FHIR search response bundle will contain the entire contents of each resource being returned. However, it is possible to request the server to return a subset of each resource through either the [`_summary`](https://www.hl7.org/fhir/search.html#summary) or [`_elements`](https://www.hl7.org/fhir/search.html#elements) parameters.
+For search queries that return lots of data (e.g. ones that return large resources such as Patient resources that embed a profile picture), the response time can be dominated by the network between the client and the server. By default, a FHIR search response bundle will contain the entire contents of each resource being returned. However, it is possible to request the server to return a subset of each resource through either the [`_summary`](https://hl7.org/fhir/R4B/search.html#summary) or [`_elements`](https://hl7.org/fhir/R4B/search.html#elements) parameters.
 
 **Predicate Order**
 

--- a/docs/src/pages/guides/FHIRSearchConfiguration.md
+++ b/docs/src/pages/guides/FHIRSearchConfiguration.md
@@ -1,13 +1,11 @@
 ---
 layout: default
 title: Search Configuration Overview
-date:   2021-11-08
 permalink: /FHIRSearchConfiguration/
-markdown: kramdown
 ---
 
 # IBM FHIR Server - Search Configuration Overview
-The [FHIR Specification](https://www.hl7.org/fhir/r4/search.html) defines a set of searchable fields for each resource type. The IBM FHIR Server supports searching via both specification-defined search parameters and tenant-specific search parameters.
+The [FHIR Specification](https://hl7.org/fhir/R4B/search.html) defines a set of searchable fields for each resource type. The IBM FHIR Server supports searching via both specification-defined search parameters and tenant-specific search parameters.
 
 Specifically, the IBM FHIR Server supports searching on additional fields, including:
 * fields that are defined in the base specification, which are not configured for search; and
@@ -15,7 +13,7 @@ Specifically, the IBM FHIR Server supports searching on additional fields, inclu
 
 The IBM FHIR Server allows deployers to define search parameters on a tenant-specific basis. This allows each tenant to share an instance of the IBM FHIR Server while maintaining the ability to have their own set of search parameters. Additionally, specification-defined search parameters can be filtered out in order to avoid the cost of extracting and storing the corresponding indices.
 
-Tenant search parameters are defined via a [Bundle](https://www.hl7.org/fhir/r4/bundle.html) of [SearchParameter](https://www.hl7.org/fhir/r4/searchparameter.html) resources that define the additional search parameters which describe the searchable field and define the FHIRPath expression for extraction.  For example, a tenant that extends the `Patient` resource type with the `favorite-color` extension, enables search on `favorite-color` by defining a SearchParameter as part of this bundle.
+Tenant search parameters are defined via a [Bundle](https://hl7.org/fhir/R4B/bundle.html) of [SearchParameter](https://hl7.org/fhir/R4B/searchparameter.html) resources that define the additional search parameters which describe the searchable field and define the FHIRPath expression for extraction.  For example, a tenant that extends the `Patient` resource type with the `favorite-color` extension, enables search on `favorite-color` by defining a SearchParameter as part of this bundle.
 
 ## 1 Configuration
 Since IBM FHIR Server 4.10.0, *all* SearchParameter definitions are loaded from the `fhir-registry` by the `fhir-search` module during server startup.
@@ -36,7 +34,7 @@ To configure tenant-specific search parameters, create a file called `extension-
 If a tenant-specific extension-search-parameters.json file does not exist, the server falls back to the default `extension-search-parameters.json` file found at `${server.config.dir}/config/default/extension-search-parameters.json`. For performance reasons, we recommend having an `extension-search-parameters.json` for each tenant.
 
 #### 1.2 SearchParameter details
-The `fhir-search` module requires that the [expression](https://www.hl7.org/fhir/r4/searchparameter-definitions.html#SearchParameter.expression), [type](https://www.hl7.org/fhir/r4/searchparameter-definitions.html#SearchParameter.type) and [code](https://www.hl7.org/fhir/r4/searchparameter-definitions.html#SearchParameter.code) be set, as in the following example:
+The `fhir-search` module requires that the [expression](https://hl7.org/fhir/R4B/searchparameter-definitions.html#SearchParameter.expression), [type](https://hl7.org/fhir/R4B/searchparameter-definitions.html#SearchParameter.type) and [code](https://hl7.org/fhir/R4B/searchparameter-definitions.html#SearchParameter.code) be set, as in the following example:
 ```json
 {
   "fullUrl": "http://ibm.com/fhir/SearchParameter/Patient-favorite-color",
@@ -194,11 +192,11 @@ Filtered search parameters are handled exactly the same as undefined search para
 
 #### 1.2.2 Compartment search considerations with filtering
 For each compartment type, the rules for determining if a resource is a member of a compartment of that type, and thus if that resource should be returned on an associated compartment search, are based on inclusion criteria. Inclusion criteria is one or more search parameters whose value is a reference to the compartment resource type. These membership rules are defined by the FHIR specification for the following compartments:
-- [Device](https://www.hl7.org/fhir/R4/compartmentdefinition-device.html)
-- [Encounter](https://www.hl7.org/fhir/R4/compartmentdefinition-encounter.html)
-- [Patient](https://www.hl7.org/fhir/R4/compartmentdefinition-patient.html)
-- [Practitioner](https://www.hl7.org/fhir/R4/compartmentdefinition-practitioner.html)
-- [RelatedPerson](https://www.hl7.org/fhir/R4/compartmentdefinition-relatedperson.html)
+- [Device](https://hl7.org/fhir/R4B/compartmentdefinition-device.html)
+- [Encounter](https://hl7.org/fhir/R4B/compartmentdefinition-encounter.html)
+- [Patient](https://hl7.org/fhir/R4B/compartmentdefinition-patient.html)
+- [Practitioner](https://hl7.org/fhir/R4B/compartmentdefinition-practitioner.html)
+- [RelatedPerson](https://hl7.org/fhir/R4B/compartmentdefinition-relatedperson.html)
 
 For example, for the `Patient` compartment, to determine if an `Observation` is a member, the inclusion criteria search parameters are `subject` and `performer`. If the `Observation` resource fields associated with these search parameters reference a `Patient` resource, the `Observation` resource is a member of that `Patient` compartment.
 

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -1,9 +1,6 @@
 ---
 layout: post
 title:  IBM FHIR Server User's Guide
-description: IBM FHIR Server User's Guide
-Copyright: years 2017, 2022
-lastupdated: "2022-02-09"
 permalink: /FHIRServerUsersGuide/
 ---
 
@@ -46,8 +43,8 @@ This FHIR server is intended to be a common component for providing FHIR capabil
 ## 2.1 Installing a new server
 0.  Prereqs: The IBM FHIR Server requires Java 11 and has been tested with OpenJDK 11. To install Java on your system, we recommend downloading and installing OpenJDK 11 from https://adoptium.net/.
 
-1.  To install the IBM FHIR Server, build or download the `fhir-install` zip installer (e.g. `fhir-server-distribution.zip` or `fhir-install-4.0.0-rc1-20191014-1610`).
-The Maven build creates the zip package under `fhir-install/target`. Alternatively, releases will be made available from the [Releases tab](https://github.com/ibm/fhir/releases).
+1.  To install the IBM FHIR Server, build or download the `fhir-install` zip installer.
+The Maven build creates the zip package under `fhir-install/target`. Alternatively, releases are available from the [Releases tab](https://github.com/ibm/fhir/releases).
 
 2.  Unzip the `.zip` package into a clean directory (referred to as `fhir-installer` here):
     ```
@@ -513,7 +510,7 @@ You can modify the default server implementation by taking advantage of the IBM 
  * Resource validation:  FHIRPath-based validation of FHIR resources on create or update with the ability to extend the system with custom constraints.
 
 ## 4.1 Extended operations
-In addition to the standard REST API (create, update, search, and so forth), the IBM FHIR Server supports the FHIR operations framework as described in the [FHIR specification](https://www.hl7.org/fhir/r4/operations.html).
+In addition to the standard REST API (create, update, search, and so forth), the IBM FHIR Server supports the [FHIR operations framework](https://hl7.org/fhir/R4B/operations.html).
 
 ### 4.1.1 Packaged operations
 The FHIR team provides implementations for the standard `$validate`, `$document`, `$everything`, `$expand`, `$lookup`, `$subsumes`, `$closure`, `$export`, `$import`, `$convert`, `$apply` and `$translate` operations, as well as a custom operation named `$healthcheck`, which queries the configured persistence layer to report its health.
@@ -527,15 +524,9 @@ The `$validate` operation checks whether the attached content would be acceptabl
 * If a profile is specified via the optional `profile` parameter, the $validate operation will validate a resource against the base specification and the specified profile only. It will not validate against any other profiles asserted in the `Resource.meta.profile` element.
 * If the `profile` parameter is not specified, but the `mode` parameter is specified, and the `mode` parameter value is either `create` or `update`, the $validate operation will validate a resource against the base specification and any profiles asserted in its `Resource.meta.profile` element, but will do so based on profile configuration properties specified in the `fhirServer/resources/<resourceType>/profiles` section of the `fhir-server-config.json` file (see the [Configuration properties reference](#51-configuration-properties-reference) for configuration details).
 
+https://hl7.org/fhir/R4B/resource-operation-validate.html
 
-https://www.hl7.org/fhir/r4/resource-operations.html#validate
-
-#### 4.1.1.2 $document
-The `$document` operation generates a fully bundled document from a composition resource.
-
-https://www.hl7.org/fhir/r4/composition-operations.html#document
-
-#### 4.1.1.3 $healthcheck
+#### 4.1.1.2 $healthcheck
 The `$healthcheck` operation returns the health of the FHIR server and its datastore. In the default JDBC persistence layer, this operation creates a connection to the configured database and return its status. The operations returns `200 OK` when healthy. Otherwise, it returns an HTTP error code and an `OperationOutcome` with one or more issues.
 
 ### 4.1.2 Custom operations
@@ -550,10 +541,10 @@ To contribute an operation:
 
 4. Restart the FHIR server. Changes to custom operations require a server restart, because the server discovers and instantiates operations during server startup only.
 
-After you register your operation with the server, it is available via HTTP POST at `[base]/api/1/$<yourCode>`, where `<yourCode>` is the value of your OperationDefinition's [code](https://www.hl7.org/fhir/r4/operationdefinition-definitions.html#OperationDefinition.code).
+After you register your operation with the server, it is available via HTTP POST at `[base]/api/1/$<yourCode>`, where `<yourCode>` is the value of your OperationDefinition's [code](https://hl7.org/fhir/R4B/operationdefinition-definitions.html#OperationDefinition.code).
 
 ## 4.2 Notification Service
-The FHIR server provides a notification service that publishes notifications about persistence events, specifically _create_, _update_, and _delete_ operations. The notification service can be used by other Healthcare components to trigger specific actions that need to occur as resources are being updated in the FHIR server datastore.
+The FHIR server provides a notification service that publishes notifications about persistence events, specifically _create_, _update_, and _delete_ operations. The notification service can be used by other components to trigger specific actions that need to occur as resources are being updated in the FHIR server datastore.
 
 The notification service supports two implementations: WebSocket and Kafka.
 
@@ -737,7 +728,7 @@ To implement a persistence interceptor, complete the following steps:
 
 ## 4.4 Registry resources
 The IBM FHIR Server includes a dynamic registry of conformance resources.
-The registry pre-packages all [FHIR Definitions from the specification](https://www.hl7.org/fhir/R4/downloads.html)
+The server pre-packages conformance artifacts from [HL7 FHIR version 4.3.0](https://hl7.org/fhir/R4B/downloads.html)
 and uses a Java ServiceLoader to discover additional registry resource providers on the classpath.
 
 The server consults this registry for:
@@ -746,7 +737,7 @@ The server consults this registry for:
 * ValueSet and CodeSystem resources for terminology operations.
 * And more.
 
-One common technique for extending FHIR with a set of conformance resources is to build or reference an [Implementation Guide](https://www.hl7.org/fhir/implementationguide.html).
+One common technique for extending FHIR with a set of conformance resources is to build or reference an [Implementation Guide](https://hl7.org/fhir/R4B/implementationguide.html).
 
 The IBM FHIR Server includes a [PackageRegistryResourceProvider](https://ibm.github.io/FHIR/guides/FHIRValidationGuide#making-profiles-available-to-the-fhir-registry-component-fhirregistry) for registering implementation guide resources.
 
@@ -963,7 +954,7 @@ The following processing rules apply for the use of local references within a re
 2.  Local references will only be recognized for local identifiers associated with request bundle entries with a request method of `POST` or `PUT`.
 3.  `POST` requests will be processed before `PUT` requests.
 4.  <a id="order-dependency-rule"></a>There is no order dependency within a request bundle for bundle entries defining local identifiers and bundle entries which reference those local identifiers via local references.
-5.  <a id="relative-reference-rule"></a>If a resource in a request bundle entry contains a field of type `Reference` having a value which is a relative URL, and if that bundle entry has a local identifier (`fullUrl`) which is an absolute URL conforming to the FHIR specification's [RESTful URL definition](https://www.hl7.org/fhir/references.html#regex), then the FHIR server will attempt to resolve the local reference as follows, based on the [FHIR specification](https://www.hl7.org/fhir/bundle.html#references):
+5.  <a id="relative-reference-rule"></a>If a resource in a request bundle entry contains a field of type `Reference` having a value which is a relative URL, and if that bundle entry has a local identifier (`fullUrl`) which is an absolute URL conforming to the FHIR specification's [RESTful URL definition](https://hl7.org/fhir/R4B/references.html#regex), then the FHIR server will attempt to resolve the local reference as follows, based on the [FHIR specification](https://hl7.org/fhir/R4B/bundle.html#references):
     - it will extract the FHIR base URL from the local identifier and append the local reference to it
     - it will then try to resolve the reference within the request bundle using the updated local reference
 
@@ -1127,7 +1118,7 @@ In the above example, even though the `Patient` request entry is a conditional c
 }
 ```
 
-In this example, we demonstrate the [relative reference processing rule](#relative-reference-rule). The local identifiers for the request bundle entries (`https://fhirserver1:9443/fhir-server/api/v4/Patient/new` and `https://fhirserver1:9443/fhir-server/api/v4/Observation/new`) are absolute URLs that conform to the FHIR specification's [RESTful URL definition](https://www.hl7.org/fhir/references.html#regex) . When the FHIR server attempts to resolve the `Observation` request entry's `subject` reference (`Patient/new`), it will apply the processing rule for relative references, since the reference is a relative URL. The `subject` reference will be modified to be the original local reference (`Patient/new`) appended to the FHIR base URL extracted from the `Observation` entry's local identifier (`https://fhirserver1:9443/fhir-server/api/v4/`). The resulting local reference  (`https://fhirserver1:9443/fhir-server/api/v4/Patient/new`) will then be a valid reference  to the `Patient` request bundle entry.
+In this example, we demonstrate the [relative reference processing rule](#relative-reference-rule). The local identifiers for the request bundle entries (`https://fhirserver1:9443/fhir-server/api/v4/Patient/new` and `https://fhirserver1:9443/fhir-server/api/v4/Observation/new`) are absolute URLs that conform to the FHIR specification's [RESTful URL definition](https://hl7.org/fhir/R4B/references.html#regex) . When the FHIR server attempts to resolve the `Observation` request entry's `subject` reference (`Patient/new`), it will apply the processing rule for relative references, since the reference is a relative URL. The `subject` reference will be modified to be the original local reference (`Patient/new`) appended to the FHIR base URL extracted from the `Observation` entry's local identifier (`https://fhirserver1:9443/fhir-server/api/v4/`). The resulting local reference  (`https://fhirserver1:9443/fhir-server/api/v4/Patient/new`) will then be a valid reference  to the `Patient` request bundle entry.
 
 ## 4.9 Multi-tenancy
 The FHIR server includes features that allow a single instance of the server to simultaneously support multiple tenants. A tenant is defined as a group of one or more FHIR REST API consumers that share a FHIR server configuration along with one or more data stores associated with that configuration. A tenant could be a single application using the FHIR REST API, or it could be a group of applications belonging to a single customer. The main idea behind multi-tenancy is that each tenant can experience its own customized FHIR server runtime behavior and its data can be physically isolated from other tenants' data for increased security and privacy.
@@ -1626,7 +1617,7 @@ Because the IBM FHIR Server's notifications feature is implemented as a persiste
 ## 4.11 Audit logging service
 The Audit logging service pushes FHIR server audit events for FHIR operations in [Cloud Auditing Data Federation (CADF)](https://www.dmtf.org/standards/cadf) standard format to a Kafka backend, such as *IBM Cloud Event Streams service*.
 
-There is early support for the [FHIR Standard: AuditEvent format](https://www.hl7.org/fhir/auditevent.html).
+There is early support for the [FHIR Standard: AuditEvent format](https://hl7.org/fhir/R4B/auditevent.html).
 
 ### 4.11.1 CADF audit log entry
 
@@ -2746,7 +2737,7 @@ SMART on FHIR applications should use the `.well-known/smart-configuration` endp
 but the entries in the Capability Statement are needed for backwards compatibility.
 
 ### 5.3.3 SMART App Launch
-To support [SMART App Launch](https://www.hl7.org/fhir/smart-app-launch), the IBM FHIR Server can be used with a SMART-enabled authorization server. For an example of a SMART-enabled Authorization Server, see the [Alvearie Keycloak extensions for FHIR](https://github.com/Alvearie/keycloak-extensions-for-fhir).
+To support [SMART App Launch](https://hl7.org/fhir/smart-app-launch), the IBM FHIR Server can be used with a SMART-enabled authorization server. For an example of a SMART-enabled Authorization Server, see the [Alvearie Keycloak extensions for FHIR](https://github.com/Alvearie/keycloak-extensions-for-fhir).
 
 The OAuth configuration described in the previous sections will restrict API access to clients with a valid access token.
 However, SMART defines additional access controls via OAuth 2.0 scopes and context parameters.


### PR DESCRIPTION
Added new conformance modules (fhir-core-r4, fhir-core-r4b, and fhir-hl7-terminology) to the README.

For Conformance.md, I added a section titled "FHIR Versions" near the top and detailed the
behavior with respect to supporting both versions 4.0.1 and 4.3.0 and
the use of the fhirVersion MIME-type parameter.

I also normalized all the links to https://hl7.org/fhir/R4B
...previously there was a lot of www.hl7.org links and a mix of
versioned (`fhir/R4/`) and non-versioned (`fhir/`) URLs.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>