### PR TITLE
issue #3256 - change the default fhirclient MIME type to specify fhirVersion 4.3

### DIFF
--- a/build/docker/copy-server-config.sh
+++ b/build/docker/copy-server-config.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################################
-set -e
+set -ex
 
 if [[ -z "${WORKSPACE}" ]]; then
     echo "ERROR: WORKSPACE environment variable not set!"
@@ -16,14 +16,14 @@ CONFIG="${WORKSPACE}/build/docker/fhir-server/volumes/config"
 rm -rf $CONFIG/* 2> /dev/null
 mkdir -p $CONFIG
 
-BULKDATA="${WORKSPACE}/build/docker/fhir-server/volumes/bulkdata"
+BULKDATA="${WORKSPACE}/build/docker/fhir-server/volumes/bulkdata/"
 mkdir -p ${BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import.ndjson ${BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import-skip.ndjson ${BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import-neg.ndjson ${BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import-mismatch.ndjson ${BULKDATA}
 
-S3_BULKDATA="${WORKSPACE}/build/docker/minio/miniodata/fhirbulkdata"
+S3_BULKDATA="${WORKSPACE}/build/docker/minio/miniodata/fhirbulkdata/"
 mkdir -p ${S3_BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import.ndjson ${S3_BULKDATA}
 cp ${WORKSPACE}/fhir-server-test/src/test/resources/testdata/import-operation/test-import-skip.ndjson ${S3_BULKDATA}

--- a/build/docker/docker-compose.yml
+++ b/build/docker/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       BATCH_DB_SSL: "false"
       BATCH_DB_USER: fhirserver
       BATCH_DB_PASS: change-password
+      TRACE_SPEC: com.ibm.fhir.*=info
     volumes:
       - type: bind
         source: ./fhir-server/volumes/config

--- a/build/docker/minio/Dockerfile
+++ b/build/docker/minio/Dockerfile
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 
-# CICD Note: If there are issues with the CICD, it's worth checking the release, and setting the previous release
-# such as minio/minio:RELEASE.2021-08-31T05-46-54Z 
-FROM minio/minio
+# CI/CD Note: This used to use "latest" but occassionally MinIO would break us.
+# We should try to keep it recent, but lets continue pinning to a particular version.
+# RELEASE.2022-06-03T01-40-53Z is not working.
+FROM minio/minio:RELEASE.2022-05-26T05-48-41Z
 
 # Indicate that we expect to connect to the minio service on port 9000
 EXPOSE 9000

--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -897,7 +897,7 @@ The set of search parameters can filtered / refined via `fhirServer/resources/[r
 ## 4.7 FHIR client API
 
 ### 4.7.1 Overview
-In addition to the server, we also offer a Java API for invoking the FHIR REST APIs. The IBM FHIR Client API is based on the JAX-RS 2.0 standard and provides a simple properties-driven client that can be easily configured for a given endpoint, mutual authentication, request/response logging, and more.
+In addition to the server, we also offer a Java API for invoking FHIR REST APIs. The IBM FHIR Client is built on JAX-RS 2.1 and provides a simple properties-driven client that can be configured for a given endpoint, mutual authentication, request/response logging, and more.
 
 ### 4.7.2 Maven coordinates
 To use the FHIR Client from your application, specify the `fhir-client` artifact as a dependency within your `pom.xml` file, as in the following example:
@@ -910,7 +910,28 @@ To use the FHIR Client from your application, specify the `fhir-client` artifact
         </dependency>
 ```
 
-### 4.7.3 Sample usage
+### 4.7.3 Client properties
+Applicable client properties are documented in the FHIRClient interface.
+Below is a summary of the most pertinent ones:
+
+| Property | Default | Description |
+| -------- | ------- | ----------- |
+| fhirclient.rest.base.url<sup>*</sup> | | The target FHIR Server's [base URL](https://hl7.org/fhir/R4B/http.html#root) |
+| fhirclient.default.mimetype | application/fhir+json; fhirVersion=4.3 | The value to use in the HTTP headers (Accept and Content-Type) passed to the FHIR Server. |
+| fhirclient.truststore.location | | The client truststore's filename. The client truststore contains the server's public key certificates and is used to verify the server's identity. |
+| fhirclient.truststore.password | | The client truststore's password. |
+| fhirclient.hostnameVerification.enabled | true | Indicates whether or not to enable hostname verification when connecting over TLS. |
+| fhirclient.basicauth.enabled | false | Indicates whether Basic Authentication should be used. If enabled, then the username and password properties are required. |
+| fhirclient.basicauth.username | | The username to use with Basic Authentication. |
+| fhirclient.basicauth.password | | The password to use with Basic Authentication. |
+| fhirclient.clientauth.enabled | false | Indicates whether mutual TLS certificate-based authentication should be used. If enabled, then keystore properties are required. |
+| fhirclient.keystore.location | | The client keystore's filename. The client keystore constains the client's public/private key pair. When using client certificate-based authentication, this is now the client supplies its identity to the server|
+| fhirclient.keystore.password | | The client keystore's password. |
+| fhirclient.keystore.key.password | | The password associated with the client's certificate within the keystore. |
+| fhirclient.logging.enabled | false | Whether to enable request/response logging (useful for debug). |
+| fhirclient.http.receive.timeout | 130000 (130 seconds) | The time, in seconds, to wait for a server response. |
+
+### 4.7.4 Sample usage
 For examples on how to use the IBM FHIR Client, look for tests like `com.ibm.fhir.client.test.mains.FHIRClientSample` from the `fhir-client` project in git. Additionally, the FHIR Client is heavilly used from our integration tests in `fhir-server-test`.
 
 ## 4.8 Using local references within request bundles

--- a/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
@@ -179,49 +179,70 @@ public interface FHIRClient {
      * @return a FHIRResponse that contains a Conformance object which describes the
      * FHIR Server's capabilities
      * @throws Exception
+     * @deprecated use {@link #capabilities(FHIRRequestHeader...)}
      */
-    FHIRResponse metadata(FHIRRequestHeader... headers) throws Exception;
+    @Deprecated
+    default FHIRResponse metadata(FHIRRequestHeader... headers) throws Exception {
+        return capabilities(headers);
+    }
 
     /**
-     * Invokes the 'create' FHIR REST API operation.
+     * Invokes the 'capabilities' FHIR REST API operation to get a capability statement for the target server.
+     * @param headers an optional list of request headers to be added to the request
+     * @return a FHIRResponse that contains a Conformance object which describes the
+     * FHIR Server's capabilities
+     * @throws Exception
+     */
+    FHIRResponse capabilities(FHIRRequestHeader... headers) throws Exception;
+
+    /**
+     * Invokes the 'create' FHIR REST API operation to create a new resource with a server assigned id.
      * @param resource the FHIR resource to be created
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'create' operation
      * @throws Exception
+     * @implSpec Per the FHIR specification, the server is expected to assign the resource
+     *     a new id and meta.lastUpdated, so any existing value in those fields will be ignored.
      */
     FHIRResponse create(Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'conditional create' FHIR REST API operation.
+     * Invokes the 'conditional create' FHIR REST API operation to conditionally create a new resource with a server assigned id.
      * @param resource the FHIR resource to be created
      * @param parameters search-related query parameters to be included in the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'conditional create' operation
      * @throws Exception
+     * @implSpec Per the FHIR specification, the server is expected to assign the resource
+     *     a new id and meta.lastUpdated, so any existing value in those fields will be ignored.
      */
     FHIRResponse conditionalCreate(Resource resource, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'create' FHIR REST API operation.
+     * Invokes the 'create' FHIR REST API operation to create a new resource with a server assigned id.
      * @param resource the resource (in the form of a JsonObject) to be created
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'create' operation
      * @throws Exception
+     * @implSpec Per the FHIR specification, the server is expected to assign the resource
+     *     a new id and meta.lastUpdated, so any existing value in those fields will be ignored.
      */
     FHIRResponse create(JsonObject resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'conditional create' FHIR REST API operation.
+     * Invokes the 'conditional create' FHIR REST API operation to conditionally create a new resource with a server assigned id.
      * @param resource the resource (in the form of a JsonObject) to be created
      * @param parameters search-related query parameters to be included in the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'conditional create' operation
      * @throws Exception
+     * @implSpec Per the FHIR specification, the server is expected to assign the resource
+     *     a new id and meta.lastUpdated, so any existing value in those fields will be ignored.
      */
     FHIRResponse conditionalCreate(JsonObject resource, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'update' FHIR REST API operation.
+     * Invokes the 'update' FHIR REST API operation to update an existing resource by its id (or create it if it is new).
      * @param resource the FHIR resource to be updated
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'update' operation
@@ -230,7 +251,7 @@ public interface FHIRClient {
     FHIRResponse update(Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'conditional update' FHIR REST API operation.
+     * Invokes the 'conditional update' FHIR REST API operation to conditionally update an existing resource by its id (or create it if it is new).
      * @param resource the FHIR resource to be created
      * @param parameters search-related query parameters to be included in the request
      * @param headers an optional list of request headers to be added to the request
@@ -240,7 +261,7 @@ public interface FHIRClient {
     FHIRResponse conditionalUpdate(Resource resource, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'update' FHIR REST API operation.
+     * Invokes the 'update' FHIR REST API operation to update an existing resource by its id (or create it if it is new).
      * @param resource the resource (in the form of a JsonObject) to be updated
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'update' operation
@@ -249,7 +270,7 @@ public interface FHIRClient {
     FHIRResponse update(JsonObject resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'conditional update' FHIR REST API operation.
+     * Invokes the 'conditional update' FHIR REST API operation to conditionally update an existing resource by its id (or create it if it is new).
      * @param resource the resource (in the form of a JsonObject) to be updated
      * @param parameters search-related query parameters to be included in the request
      * @param headers an optional list of request headers to be added to the request
@@ -259,7 +280,7 @@ public interface FHIRClient {
     FHIRResponse conditionalUpdate(JsonObject resource, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'delete' FHIR REST API operation.
+     * Invokes the 'delete' FHIR REST API operation to delete a resource.
      * @param resourceType a string representing the name of the resource type
      * to be deleted (e.g. "Patient")
      * @param resourceId the id of the resource to be deleted
@@ -270,7 +291,7 @@ public interface FHIRClient {
     FHIRResponse delete(String resourceType, String resourceId, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'conditional delete' FHIR REST API operation.
+     * Invokes the 'conditional delete' FHIR REST API operation to conditionally delete a resource.
      * @param resourceType a string representing the name of the resource type
      * to be deleted (e.g. "Patient")
      * @param parameters search-related query parameters to be included in the request
@@ -281,7 +302,7 @@ public interface FHIRClient {
     FHIRResponse conditionalDelete(String resourceType, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'read' FHIR REST API operation.
+     * Invokes the 'read' FHIR REST API operation to read the current state of a resource.
      * @param resourceType a string representing the name of the resource type
      * to be retrieved (e.g. "Patient")
      * @param resourceId the id of the resource to be retrieved
@@ -292,7 +313,7 @@ public interface FHIRClient {
     FHIRResponse read(String resourceType, String resourceId, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'vread' FHIR REST API operation.
+     * Invokes the 'vread' FHIR REST API operation to read the state of a specific version of a resource.
      * @param resourceType a string representing the name of the resource type
      * to be retrieved (e.g. "Patient")
      * @param resourceId the id of the resource to be retrieved
@@ -304,7 +325,7 @@ public interface FHIRClient {
     FHIRResponse vread(String resourceType, String resourceId, String versionId, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'history' FHIR REST API operation.
+     * Invokes the type-level 'history' FHIR REST API operation to retrieve the change history for a particular resource type.
      * @param resourceType a string representing the name of the resource type
      * to be retrieved (e.g. "Patient")
      * @param resourceId the id of the resource to be retrieved
@@ -317,7 +338,7 @@ public interface FHIRClient {
     FHIRResponse history(String resourceType, String resourceId, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes system level history FHIR REST API operation
+     * Invokes the system-level 'history' FHIR REST API operation to retrieve the change history for all resources.
      * @param parameters an optional collection of request parameters for the 'history' operation;
      * may be specified as null if no parameters need to be passed to the 'history' operation
      * @param headers an optional list of request headers to be added to the request
@@ -327,7 +348,7 @@ public interface FHIRClient {
     FHIRResponse history(FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'search' FHIR REST API operation.
+     * Invokes the type-level 'search' FHIR REST API operation to search the resource type based on some filter criteria.
      * @param resourceType a string representing the name of the resource type to search for (e.g. "Patient")
      * @param parameters  an optional collection of request parameters for the 'search' operation;
      * may be specified as null if no parameters need to be passed to the 'search' operation
@@ -338,7 +359,7 @@ public interface FHIRClient {
     FHIRResponse search(String resourceType, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the '_search' FHIR REST API operation.
+     * Invokes the type-level 'search' FHIR REST API operation via HTTP POST.
      * @param resourceType a string representing the name of the resource type to search for (e.g. "Patient")
      * @param parameters  an optional collection of request parameters for the '_search' operation;
      * may be specified as null if no parameters need to be passed to the '_search' operation;
@@ -349,7 +370,7 @@ public interface FHIRClient {
     FHIRResponse _search(String resourceType, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'search-all' FHIR REST API operation with HTTP POST.
+     * Invokes the system-level 'search' FHIR REST API operation to search across all resource types based on some filter criteria.
      * @param parameters  an optional collection of request parameters for the 'search-all' operation;
      * may be specified as null if no parameters need to be passed to the 'search' operation;
      * for Post, search parameters for this operation will go in the request body as FORM parameters
@@ -360,7 +381,7 @@ public interface FHIRClient {
     FHIRResponse searchAll(FHIRParameters parameters, boolean isPost, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'validate' FHIR REST API operation.
+     * Invokes the 'validate' FHIR extended operation.
      * @param resource the resource to be validated
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'validate' operation
@@ -369,7 +390,7 @@ public interface FHIRClient {
     FHIRResponse validate(Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'validate' FHIR REST API operation.
+     * Invokes the 'validate' FHIR extended operation.
      * @param resource the resource (in the form of a JsonObject) to be validated
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'validate' operation
@@ -396,8 +417,9 @@ public interface FHIRClient {
     FHIRResponse transaction(Bundle bundle, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the system level via HTTP GET.
      * @param operationName name of the operation to be performed
+     * @param parameters query parameters to use for the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -405,9 +427,9 @@ public interface FHIRClient {
     FHIRResponse invoke(String operationName, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the system level via HTTP POST.
      * @param operationName name of the operation to be performed
-     * @param resource the FHIR resource used in context for the operation
+     * @param resource the FHIR resource to use as the input for the operation
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -415,9 +437,10 @@ public interface FHIRClient {
     FHIRResponse invoke(String operationName, Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the type level via HTTP GET.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
+     * @param parameters query parameters to use for the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -425,10 +448,10 @@ public interface FHIRClient {
     FHIRResponse invoke(String resourceType, String operationName, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the type level via HTTP POST.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
-     * @param resource the FHIR resource used in context for the operation
+     * @param resource the FHIR resource to use as the input for the operation
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -436,10 +459,11 @@ public interface FHIRClient {
     FHIRResponse invoke(String resourceType, String operationName, Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the instance level via HTTP GET.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
      * @param resourceId the FHIR resource instance used in context for the operation
+     * @param parameters query parameters to use for the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -447,11 +471,11 @@ public interface FHIRClient {
     FHIRResponse invoke(String resourceType, String operationName, String resourceId, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the instance level via HTTP POST.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
      * @param resourceId the FHIR resource instance used in context for the operation
-     * @param resource the FHIR resource used in context for the operation
+     * @param resource the FHIR resource to use as the input for the operation
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -459,11 +483,12 @@ public interface FHIRClient {
     FHIRResponse invoke(String resourceType, String operationName, String resourceId, Resource resource, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the instance version level via HTTP GET.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
      * @param resourceId the FHIR resource instance used in context for the operation
      * @param versionId version of the FHIR resource instance used in context for the operation
+     * @param parameters query parameters to use for the request
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception
@@ -471,12 +496,12 @@ public interface FHIRClient {
     FHIRResponse invoke(String resourceType, String operationName, String resourceId, String versionId, FHIRParameters parameters, FHIRRequestHeader... headers) throws Exception;
 
     /**
-     * Invokes the 'invoke' FHIR REST API operation.
+     * Invokes a FHIR extended operation at the instance version level via HTTP POST.
      * @param resourceType the FHIR resource type used in context for the operation
      * @param operationName name of the operation to be performed
      * @param resourceId the FHIR resource instance used in context for the operation
      * @param versionId version of the FHIR resource instance used in context for the operation
-     * @param resource the FHIR resource used in context for the operation
+     * @param resource the FHIR resource to use as the input for the operation
      * @param headers an optional list of request headers to be added to the request
      * @return a FHIRResponse that contains the results of the 'invoke' operation
      * @throws Exception

--- a/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/FHIRClient.java
@@ -27,14 +27,14 @@ public interface FHIRClient {
 
     /**
      * Specifies the default mimetype to be used by the FHIRClient instance when invoking
-     * FHIR REST APIs.   If not specified a value of "application/fhir+json" will be used.
+     * FHIR REST APIs.  If not specified a value of "application/fhir+json; fhirVersion=4.3" will be used.
      */
     public static final String PROPNAME_DEFAULT_MIMETYPE    = "fhirclient.default.mimetype";
 
     /**
      * Indicates whether OAuth 2.0 should be used when invoking REST API requests.
-     * Valid values are "true" and "false" (the default).   If enabled, then the authorizeURL, tokenURL and grantType properties
-     * are required as well.
+     * Valid values are "true" and "false" (the default).  If enabled, then fhirclient.oAuth2.accessToken
+     * is required as well.
      */
     public static final String PROPNAME_OAUTH2_ENABLED    = "fhirclient.oAuth2.enabled";
 
@@ -45,7 +45,7 @@ public interface FHIRClient {
 
     /**
      * Indicates whether Basic Authentication should be used when invoking REST API requests.
-     * Valid values are "true" and "false" (the default).   If enabled, then the username and password properties
+     * Valid values are "true" and "false" (the default).  If enabled, then the username and password properties
      * are required as well.
      */
     public static final String PROPNAME_BASIC_AUTH_ENABLED    = "fhirclient.basicauth.enabled";
@@ -61,9 +61,9 @@ public interface FHIRClient {
     public static final String PROPNAME_CLIENT_PASSWORD       = "fhirclient.basicauth.password";
 
     /**
-     * Indicates whether Client Certificate-based Authentication should be used when invoking REST API requests.
-     * Valid values are "true" and "false" (the default).  If enabled, then the rest of the "clientauth"-related properties
-     * are required as well.
+     * Indicates whether client certificate-based authentication should be used when invoking REST API requests.
+     * Valid values are "true" and "false" (the default).  If enabled, then the keystore properties
+     * are required.
      */
     public static final String PROPNAME_CLIENT_AUTH_ENABLED   = "fhirclient.clientauth.enabled";
 

--- a/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
@@ -45,6 +45,7 @@ import com.ibm.fhir.client.FHIRResponse;
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.core.FHIRMediaType;
 import com.ibm.fhir.core.FHIRUtilities;
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.core.HTTPReturnPreference;
 import com.ibm.fhir.model.resource.Bundle;
 import com.ibm.fhir.model.resource.Parameters;
@@ -67,7 +68,7 @@ public class FHIRClientImpl implements FHIRClient {
     private Client client = null;
     private Properties clientProperties = null;
     private String baseEndpointURL = null;
-    private String defaultMimeType = FHIRMediaType.APPLICATION_FHIR_JSON;
+    private String defaultMimeType = FHIRMediaType.APPLICATION_FHIR_JSON + "; fhirVersion=" + FHIRVersionParam.VERSION_43.value();
 
     private boolean basicAuthEnabled = false;
     private String basicAuthUsername = null;

--- a/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
+++ b/fhir-client/src/main/java/com/ibm/fhir/client/impl/FHIRClientImpl.java
@@ -178,7 +178,7 @@ public class FHIRClientImpl implements FHIRClient {
     }
 
     @Override
-    public FHIRResponse metadata(FHIRRequestHeader... headers) throws Exception {
+    public FHIRResponse capabilities(FHIRRequestHeader... headers) throws Exception {
         WebTarget endpoint = getWebTarget();
         Invocation.Builder builder = endpoint.path("metadata").request(getDefaultMimeType());
         builder = addRequestHeaders(builder, headers);

--- a/fhir-client/src/test/java/com/ibm/fhir/client/sample/FHIRClientSample.java
+++ b/fhir-client/src/test/java/com/ibm/fhir/client/sample/FHIRClientSample.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2016, 2020
+ * (C) Copyright IBM Corp. 2016, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -33,6 +33,9 @@ public class FHIRClientSample {
         // Create properties to be used to configure the client.
         Properties clientProperties = new Properties();
         clientProperties.setProperty(FHIRClient.PROPNAME_BASE_URL, "https://localhost:9443/fhir-server/api/v4");
+        clientProperties.setProperty(FHIRClient.PROPNAME_TRUSTSTORE_LOCATION, "src/test/resources/fhirClientTrustStore.p12");
+        clientProperties.setProperty(FHIRClient.PROPNAME_TRUSTSTORE_PASSWORD, "change-password");
+        clientProperties.setProperty(FHIRClient.PROPNAME_LOGGING_ENABLED, "false");
 
         // Retrieve an instance of the FHIRClient interface.
         FHIRClient client = FHIRClientFactory.getClient(clientProperties);

--- a/fhir-client/src/test/resources/test.basic.properties
+++ b/fhir-client/src/test/resources/test.basic.properties
@@ -3,20 +3,12 @@
 fhirclient.rest.base.url = https://jigsaw.w3.org/HTTP/Basic/
 fhirclient.default.mimetype = application/fhir+json
 
-fhirclient.basicauth.enabled = true
-fhirclient.basicauth.username = guest
-fhirclient.basicauth.password = guest
-
-fhirclient.clientauth.enabled = false
-fhirclient.keystore.location = fhirClientKeyStore.p12
-fhirclient.keystore.password = change-password
-fhirclient.keystore.key.password = change-password
 fhirclient.truststore.location = fhirClientTrustStore.p12
 fhirclient.truststore.password = change-password
 
-fhirclient.oAuth2.enabled = false
-
-fhirclient.encryption.enabled = false
+fhirclient.basicauth.enabled = true
+fhirclient.basicauth.username = guest
+fhirclient.basicauth.password = guest
 
 fhirclient.logging.enabled = false
 

--- a/fhir-client/src/test/resources/test.properties
+++ b/fhir-client/src/test/resources/test.properties
@@ -1,27 +1,15 @@
 # Properties file containing test-related properties
 
 fhirclient.rest.base.url = https://localhost:9443/fhir-server/api/v4
-fhirclient.default.mimetype = application/fhir+json
+fhirclient.default.mimetype = application/fhir+json; fhirVersion=4.3
 
-fhirclient.basicauth.enabled = false
-fhirclient.basicauth.username = fhiruser
-fhirclient.basicauth.password = change-password
+fhirclient.truststore.location = fhirClientTrustStore.p12
+fhirclient.truststore.password = change-password
 
 fhirclient.clientauth.enabled = true
 fhirclient.keystore.location = fhirClientKeyStore.p12
 fhirclient.keystore.password = change-password
 fhirclient.keystore.key.password = change-password
-fhirclient.truststore.location = fhirClientTrustStore.p12
-fhirclient.truststore.password = change-password
-
-fhirclient.oAuth2.enabled = false
-#Use fhir-client > FHIROAuth2Test.java to generate the accessToken and encode it using "wlp/bin/securityUtility encode" command
-fhirclient.oAuth2.accessToken = change-password
-
-fhirclient.encryption.enabled = false
-fhirclient.encryption.keystore.location = fhirkeys.jceks
-fhirclient.encryption.keystore.password = change-password
-fhirclient.encryption.key.password = change-password
 
 fhirclient.logging.enabled = false
 

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -16,6 +16,7 @@ COPY target/fhir-server-distribution.zip /tmp/
 RUN unzip -qq /tmp/fhir-server-distribution.zip -d /tmp && \
     /tmp/fhir-server-dist/install-fhir.sh /opt/ol/wlp && \
     mv /tmp/fhir-server-dist/tools /opt/ibm-fhir-server/tools
+COPY src/main/docker/ibm-fhir-server/bootstrap.properties /opt/ol/wlp/usr/servers/defaultServer/
 COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 
 # ----------------------------------------------------------------------------

--- a/fhir-install/Dockerfile
+++ b/fhir-install/Dockerfile
@@ -16,7 +16,6 @@ COPY target/fhir-server-distribution.zip /tmp/
 RUN unzip -qq /tmp/fhir-server-distribution.zip -d /tmp && \
     /tmp/fhir-server-dist/install-fhir.sh /opt/ol/wlp && \
     mv /tmp/fhir-server-dist/tools /opt/ibm-fhir-server/tools
-COPY src/main/docker/ibm-fhir-server/bootstrap.properties /opt/ol/wlp/usr/servers/defaultServer/
 COPY src/main/docker/ibm-fhir-server/bootstrap.sh /opt/ibm-fhir-server/
 
 # ----------------------------------------------------------------------------

--- a/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
+++ b/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
@@ -1,0 +1,5 @@
+# disable writing to trace.log by only sending trace data to console
+com.ibm.ws.logging.trace.format=BASIC
+com.ibm.ws.logging.trace.file.name=stdout
+
+jaxrs.cxf.use.noop.requestPreprocessor=true

--- a/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
+++ b/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
@@ -2,4 +2,5 @@
 com.ibm.ws.logging.trace.format=BASIC
 com.ibm.ws.logging.trace.file.name=stdout
 
+# Required to avoid conflict between CXF and FHIR interpretation of the _type query param
 jaxrs.cxf.use.noop.requestPreprocessor=true

--- a/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
+++ b/fhir-install/src/main/docker/ibm-fhir-server/bootstrap.properties
@@ -1,3 +1,0 @@
-# disable writing to trace.log by only sending trace data to console
-com.ibm.ws.logging.trace.format=BASIC
-com.ibm.ws.logging.trace.file.name=stdout

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/SearchAllTest.java
@@ -846,7 +846,7 @@ public class SearchAllTest extends FHIRServerTestBase {
         List<Link> links = bundle.getLink();
 
         /*
-         * Runs through the links and checks for self and rel.
+         * Runs through the links and checks for self and next.
          * It subsequently connects to the self to verify it's 200.
          */
         boolean validSelf = false;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
@@ -174,7 +174,9 @@ public class ImportOperationTest extends FHIRServerTestBase {
             // 200 mean export is finished
             status = response.getStatus();
 
-            assertTrue(status == Response.Status.OK.getStatusCode() || status == Response.Status.ACCEPTED.getStatusCode());
+            if (status != Response.Status.OK.getStatusCode() && status != Response.Status.ACCEPTED.getStatusCode()) {
+                fail("Unexpected " + status + " response from " + statusUrl + ": " + response.readEntity(String.class));
+            }
 
             Thread.sleep(5000);
             totalTime += 5000;

--- a/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
+++ b/fhir-server-test/src/test/java/com/ibm/fhir/server/test/bulkdata/ImportOperationTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -168,7 +169,7 @@ public class ImportOperationTest extends FHIRServerTestBase {
         Response response = null;
         System.out.println("Started Checking");
         while (Response.Status.ACCEPTED.getStatusCode() == status) {
-            response = doGet(statusUrl, FHIRMediaType.APPLICATION_FHIR_JSON);
+            response = doGet(statusUrl, MediaType.APPLICATION_JSON);
             // 202 accept means the request is still under processing
             // 200 mean export is finished
             status = response.getStatus();

--- a/fhir-server-test/src/test/resources/test.properties
+++ b/fhir-server-test/src/test/resources/test.properties
@@ -3,7 +3,10 @@
 
 # FHIRClient properties:
 fhirclient.rest.base.url = https://localhost:9443/fhir-server/api/v4
-fhirclient.default.mimetype = application/fhir+json
+fhirclient.default.mimetype = application/fhir+json; fhirVersion=4.3
+
+fhirclient.truststore.location = fhirClientTrustStore.p12
+fhirclient.truststore.password = change-password
 
 fhirclient.basicauth.enabled = false
 fhirclient.basicauth.username = fhiruser
@@ -16,17 +19,6 @@ fhirclient.clientauth.enabled = true
 fhirclient.keystore.location = fhirClientKeyStore.p12
 fhirclient.keystore.password = change-password
 fhirclient.keystore.key.password = change-password
-fhirclient.truststore.location = fhirClientTrustStore.p12
-fhirclient.truststore.password = change-password
-
-fhirclient.oAuth2.enabled = false
-#Use fhir-client > FHIROAuth2Test.java to generate the accessToken and encode it using "wlp/bin/securityUtility encode" command
-fhirclient.oAuth2.accessToken = change-password
-
-#fhirclient.encryption.enabled = false
-#fhirclient.encryption.keystore.location = fhirkeys.jceks
-#fhirclient.encryption.keystore.password = change-password
-#fhirclient.encryption.key.password = change-password
 
 # Properties supported by FHIRServerTestBase:
 test.websocket.url = wss://localhost:9443/fhir-server/api/v4/notification

--- a/fhir-server-webapp/src/main/liberty/config/bootstrap.properties
+++ b/fhir-server-webapp/src/main/liberty/config/bootstrap.properties
@@ -2,4 +2,5 @@ javax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl
 javax.xml.stream.XMLOutputFactory=com.sun.xml.internal.stream.XMLOutputFactoryImpl
 javax.xml.stream.XMLTransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
 
+# Required to avoid conflict between CXF and FHIR interpretation of the _type query param
 jaxrs.cxf.use.noop.requestPreprocessor=true

--- a/fhir-server-webapp/src/main/liberty/config/bootstrap.properties
+++ b/fhir-server-webapp/src/main/liberty/config/bootstrap.properties
@@ -1,3 +1,5 @@
 javax.xml.stream.XMLInputFactory=com.sun.xml.internal.stream.XMLInputFactoryImpl
 javax.xml.stream.XMLOutputFactory=com.sun.xml.internal.stream.XMLOutputFactoryImpl
 javax.xml.stream.XMLTransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
+
+jaxrs.cxf.use.noop.requestPreprocessor=true

--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -12,7 +12,7 @@
             <param-value>com.ibm.fhir.server.FHIRApplication</param-value>
         </init-param>
         <init-param>
-            <!-- Required to avoid conflict between CXF and FHIR interpretation of the _type query param -->
+            <!-- Shouldn't be required any more, but kept for backwards-compatibility -->
             <param-name>org.apache.cxf.jaxrs.mediaTypeCheck.strict</param-name>
             <param-value>false</param-value>
         </init-param>

--- a/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/fhir-server-webapp/src/main/webapp/WEB-INF/web.xml
@@ -11,11 +11,6 @@
             <param-name>javax.ws.rs.Application</param-name>
             <param-value>com.ibm.fhir.server.FHIRApplication</param-value>
         </init-param>
-        <init-param>
-            <!-- Shouldn't be required any more, but kept for backwards-compatibility -->
-            <param-name>org.apache.cxf.jaxrs.mediaTypeCheck.strict</param-name>
-            <param-value>false</param-value>
-        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/filters/FHIRVersionRequestFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/filters/FHIRVersionRequestFilter.java
@@ -46,9 +46,15 @@ public class FHIRVersionRequestFilter implements ContainerRequestFilter {
         FHIRVersionParam fhirVersion;
 
         switch (requestContext.getMethod()) {
-        case HttpMethod.POST:
         case HttpMethod.PUT:
             fhirVersion = getFhirVersionFromContentTypeHeader(requestContext);
+            break;
+        case HttpMethod.POST:
+            if (requestContext.getUriInfo().getPath().endsWith("_search")) {
+                fhirVersion = getFhirVersionFromAcceptHeader(requestContext);
+            } else {
+                fhirVersion = getFhirVersionFromContentTypeHeader(requestContext);
+            }
             break;
         case HttpMethod.GET:
         default:

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/filters/FHIRVersionRequestFilter.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/filters/FHIRVersionRequestFilter.java
@@ -50,6 +50,8 @@ public class FHIRVersionRequestFilter implements ContainerRequestFilter {
             fhirVersion = getFhirVersionFromContentTypeHeader(requestContext);
             break;
         case HttpMethod.POST:
+            // HTTP POST is used for 'create', but also can be used for 'search', 'batch/transaction', and invoking extended operations.
+            // If it's a POST search, then the request path must in '_search', and thats our clue to use the Accept header for the fhirVersion.
             if (requestContext.getUriInfo().getPath().endsWith("_search")) {
                 fhirVersion = getFhirVersionFromAcceptHeader(requestContext);
             } else {


### PR DESCRIPTION
and document how to set it via the `fhirclient.default.mimetype`
configuration property (PROPNAME_DEFAULT_MIMETYPE)

The change highlighted an underlying issue with our FHIRVersionRequestFilter and also with how we're processing `_type` query parameters, and so I've addressed those issues in this PR as well.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>