### PR TITLE
issue #3242 - use the fhirVersion from the import/export request

### DIFF
--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ExportOperation.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import javax.ws.rs.core.MediaType;
 
 import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationDefinition;
 import com.ibm.fhir.model.resource.Parameters;
@@ -66,7 +67,8 @@ public class ExportOperation extends AbstractOperation {
         Parameters response = null;
         OperationConstants.ExportType exportType = export.checkExportType(operationContext.getType(), resourceType);
 
-        Set<String> types = export.checkAndValidateTypes(exportType, getParameters(parameters, OperationConstants.PARAM_TYPE));
+        FHIRVersionParam fhirVersion = (FHIRVersionParam) operationContext.getProperty(FHIROperationContext.PROPNAME_FHIR_VERSION);
+        Set<String> types = export.checkAndValidateTypes(exportType, fhirVersion, getParameters(parameters, OperationConstants.PARAM_TYPE));
 
         if (!ExportType.INVALID.equals(exportType)) {
 

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/ImportOperation.java
@@ -9,6 +9,7 @@ package com.ibm.fhir.operation.bulkdata;
 import java.io.InputStream;
 import java.util.List;
 
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
 import com.ibm.fhir.model.parser.FHIRParser;
@@ -70,7 +71,8 @@ public class ImportOperation extends AbstractOperation {
         String inputSource = util.retrieveInputSource();
 
         // Parameter: input
-        List<Input> inputs = util.retrieveInputs();
+        FHIRVersionParam fhirVersion = (FHIRVersionParam) operationContext.getProperty(FHIROperationContext.PROPNAME_FHIR_VERSION);
+        List<Input> inputs = util.retrieveInputs(fhirVersion);
 
         // Parameter: storageDetail
         StorageDetail storageDetail = util.retrieveStorageDetails();
@@ -86,7 +88,7 @@ public class ImportOperation extends AbstractOperation {
         // Check Import Type is System.  We only support system right now.
 
         if (!FHIROperationContext.Type.SYSTEM.equals(type)) {
-            throw buildExceptionWithIssue("Invalid call $import operation call only system is allowed",
+            throw buildExceptionWithIssue("Invalid call; $import can only be invoked at the system level",
                     IssueType.INVALID);
         }
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/AzurePreflight.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/config/preflight/impl/AzurePreflight.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -41,13 +41,13 @@ public class AzurePreflight extends NopPreflight {
     /**
      * validates the azure provider is properly configured.
      *
-     * @param source
+     * @param storageProvider
      * @throws FHIROperationException
      */
-    public void validate(String source) throws FHIROperationException {
+    public void validate(String storageProvider) throws FHIROperationException {
         ConfigurationAdapter adapter = ConfigurationFactory.getInstance();
-        if (adapter.isStorageProviderAuthTypeConnectionString(source)) {
-            String conn = adapter.getStorageProviderAuthTypeConnectionString(source);
+        if (adapter.isStorageProviderAuthTypeConnectionString(storageProvider)) {
+            String conn = adapter.getStorageProviderAuthTypeConnectionString(storageProvider);
             if (conn == null || conn.isEmpty()) {
                 throw export.buildOperationException("bad configuration for the Azure Blob Container's connection configuration", IssueType.EXCEPTION);
             }
@@ -56,7 +56,7 @@ public class AzurePreflight extends NopPreflight {
         }
 
         // Used to get the Azure Container
-        if (adapter.getStorageProviderBucketName(source) == null || adapter.getStorageProviderBucketName(source).isEmpty()) {
+        if (adapter.getStorageProviderBucketName(storageProvider) == null || adapter.getStorageProviderBucketName(storageProvider).isEmpty()) {
             throw export.buildOperationException("bad configuration for the basic configuration with bucketname", IssueType.EXCEPTION);
         }
     }

--- a/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
+++ b/operation/fhir-operation-bulkdata/src/main/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtil.java
@@ -22,6 +22,7 @@ import org.owasp.encoder.Encode;
 
 import com.ibm.fhir.config.FHIRConfigHelper;
 import com.ibm.fhir.core.FHIRMediaType;
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.OperationOutcome.Issue;
 import com.ibm.fhir.model.resource.Parameters;
@@ -161,11 +162,13 @@ public class BulkDataExportUtil {
      * processes both the Parameters object and the query parameters
      *
      * @param exportType
+     * @param fhirVersion
      * @param parameters
      * @return
      * @throws FHIROperationException
      */
-    public Set<String> checkAndValidateTypes(OperationConstants.ExportType exportType, List<Parameter> parameters) throws FHIROperationException {
+    public Set<String> checkAndValidateTypes(OperationConstants.ExportType exportType, FHIRVersionParam fhirVersion, List<Parameter> parameters)
+            throws FHIROperationException {
         /*
          * Only resources of the specified resource types(s) SHALL be included in the response. If this parameter is
          * omitted, the server SHALL return all supported resources within the scope of the client authorization. For
@@ -179,7 +182,7 @@ public class BulkDataExportUtil {
          * within the file set. For example _type=Practitioner could be used to bulk data extract all Practitioner
          * resources from a FHIR endpoint.
          */
-        Set<String> supportedResourceTypes = FHIRConfigHelper.getSupportedResourceTypes();
+        Set<String> supportedResourceTypes = FHIRConfigHelper.getSupportedResourceTypes(fhirVersion);
         Set<String> result = new HashSet<>();
         if (parameters != null) {
             for (Parameters.Parameter parameter : parameters) {
@@ -203,7 +206,7 @@ public class BulkDataExportUtil {
             }
         }
 
-        // The case where no resourceTypes are specified, inlining only the supported ResourceTypes
+        // The case where no resourceTypes are specified on a system export, inlining only the supported ResourceTypes
         if (result.isEmpty() && ExportType.SYSTEM.equals(exportType)) {
             result = new HashSet<>(supportedResourceTypes);
         } else if (ExportType.PATIENT.equals(exportType) || ExportType.GROUP.equals(exportType)) {
@@ -234,7 +237,7 @@ public class BulkDataExportUtil {
                 result.add(resourceType);
             } else {
                 LOG.info("Requested type '" + Encode.forHtml(resourceType) + "' cannot be in the Patient compartment;"
-                        + "this is not supported for Patient/Group export and so this type will be skipped");
+                        + " this is not supported for Patient/Group export and so this type will be skipped");
             }
         }
 

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataExportUtilTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.resource.Group;
@@ -281,42 +282,42 @@ public class BulkDataExportUtilTest {
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesEmpty() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("1")).build());
-        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesNull() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value((Element)null).build());
-        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         fail();
     }
 
     @Test(expectedExceptions = { com.ibm.fhir.exception.FHIROperationException.class })
     public void testCheckAndValidateTypesNullQPS() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value((Element) null).build());
-        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         fail();
     }
 
     @Test
     public void testCheckAndValidateTypesPatientWithoutComma() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient")).build());
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         assertNotNull(types);
     }
 
     @Test
     public void testCheckAndValidateTypesPatientWithComma() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,")).build());
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         assertNotNull(types);
     }
 
     @Test
     public void testCheckAndValidateTypesPatientMedicationWithComma() throws FHIROperationException {
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,Medication")).build());
-        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        Set<String> types = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         assertNotNull(types);
     }
 
@@ -324,7 +325,7 @@ public class BulkDataExportUtilTest {
     public void testCheckAndValidateTypesPatientMedicationWithExtraComma() throws FHIROperationException {
         // parameters
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string("Patient,,Medication")).build());
-        util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         fail();
     }
 
@@ -332,7 +333,7 @@ public class BulkDataExportUtilTest {
     public void testCheckAndValidateTypesWithExtraComma() throws FHIROperationException {
         // parameters
         List<Parameter> parameters = List.of(Parameter.builder().name(string("_type")).value(string(",,")).build());
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
@@ -341,14 +342,14 @@ public class BulkDataExportUtilTest {
     public void testCheckAndValidateTypesNoParameters() throws FHIROperationException {
         // parameters
         List<Parameter> parameters = List.of(Parameter.builder().name(string("french")).value(string("Patient,,Medication")).build());
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, parameters);
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, parameters);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }
 
     @Test
     public void testCheckAndValidateTypesEmptyParameters() throws FHIROperationException {
-        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, null);
+        Set<String> result = util.checkAndValidateTypes(ExportType.SYSTEM, FHIRVersionParam.VERSION_43, null);
         assertNotNull(result);
         assertFalse(result.isEmpty());
     }

--- a/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataImportUtilTest.java
+++ b/operation/fhir-operation-bulkdata/src/test/java/com/ibm/fhir/operation/bulkdata/util/BulkDataImportUtilTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 
 import com.ibm.fhir.config.FHIRConfiguration;
 import com.ibm.fhir.config.FHIRRequestContext;
+import com.ibm.fhir.core.FHIRVersionParam;
 import com.ibm.fhir.exception.FHIRException;
 import com.ibm.fhir.exception.FHIROperationException;
 import com.ibm.fhir.model.format.Format;
@@ -66,8 +67,8 @@ public class BulkDataImportUtilTest {
         FHIRRequestContext.set(context);
         context.setTenantId("not-config");
         BulkDataImportUtil util = new BulkDataImportUtil(getContext(), loadTestFile("/testdata/import/import-demo.json"));
-        assertFalse(util.retrieveInputs().isEmpty());
-        assertEquals(util.retrieveInputs().size(), 2);
+        assertFalse(util.retrieveInputs(FHIRVersionParam.VERSION_43).isEmpty());
+        assertEquals(util.retrieveInputs(FHIRVersionParam.VERSION_43).size(), 2);
     }
 
     @Test
@@ -160,7 +161,7 @@ public class BulkDataImportUtilTest {
         FHIRRequestContext.set(context);
         context.setTenantId("config");
         BulkDataImportUtil util = new BulkDataImportUtil(getContext(), loadTestFile("/testdata/import/import-demo-config.json"));
-        util.retrieveInputs();
+        util.retrieveInputs(FHIRVersionParam.VERSION_43);
     }
 
     @Test(expectedExceptions = { FHIROperationException.class })
@@ -169,7 +170,7 @@ public class BulkDataImportUtilTest {
         FHIRRequestContext.set(context);
         context.setTenantId("not-config");
         BulkDataImportUtil util = new BulkDataImportUtil(getContext(), loadTestFile("/testdata/import/import-demo-not-config.json"));
-        util.retrieveInputs();
+        util.retrieveInputs(FHIRVersionParam.VERSION_43);
     }
 
     public Parameters loadTestFile(String file) throws FHIRParserException, IOException {

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -46,7 +46,6 @@ import com.ibm.fhir.model.type.Uri;
 import com.ibm.fhir.model.type.code.BundleType;
 import com.ibm.fhir.model.type.code.HTTPVerb;
 import com.ibm.fhir.model.type.code.IssueType;
-import com.ibm.fhir.model.type.code.SearchEntryMode;
 import com.ibm.fhir.model.util.ModelSupport;
 import com.ibm.fhir.model.util.ReferenceFinder;
 import com.ibm.fhir.registry.FHIRRegistry;
@@ -205,7 +204,7 @@ public class EverythingOperation extends AbstractOperation {
         MultivaluedMap<String, String> queryParametersWithoutDates = new MultivaluedHashMap<String,String>(queryParameters);
         boolean startOrEndProvided = queryParametersWithoutDates.remove(DATE_QUERY_PARAMETER) != null;
 
-        List<String> defaultResourceTypes = new ArrayList<String>(0);
+        List<String> defaultResourceTypes = new ArrayList<String>();
         try {
             FHIRVersionParam fhirVersion = (FHIRVersionParam) operationContext.getProperty(FHIROperationContext.PROPNAME_FHIR_VERSION);
             defaultResourceTypes = getDefaultIncludedResourceTypes(resourceHelper, fhirVersion);


### PR DESCRIPTION
In the case of export, validate any `_type` parameters against the
resource types for the configured fhirVersion. If none was specified,
use an appropriate list for that version.

In the case of import, validate the input parameters against the
supported types for the fhirVersion.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>