### PR TITLE
Support additional extraResources types from Patient/$everything

### DIFF
--- a/docs/src/pages/guides/FHIRServerUsersGuide.md
+++ b/docs/src/pages/guides/FHIRServerUsersGuide.md
@@ -2268,7 +2268,7 @@ This section contains reference information about each of the configuration prop
 |`fhirServer/operations/membermatch/enabled`|boolean|Enables or disables the $member-match|
 |`fhirServer/operations/membermatch/strategy`|string|The key identifying the Member Match strategy|
 |`fhirServer/operations/membermatch/extendedProps`|object|The extended options for the extended member match implementation|
-|`fhirServer/operations/everything/includeTypes`|list|The list of related resources to retrieve, allowed entries are `Location`, `Medication`, `Organization`, and `Practitioner`|
+|`fhirServer/operations/everything/includeTypes`|list|The list of related resource types to include alongside the patient compartment resource types. Instances of these resource types will only be returned when they are referenced from one or more resource instances from the target patient compartment. Example values are like `Location`, `Medication`, `Organization`, and `Practitioner`|
 
 
 ### 5.1.2 Default property values

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/IncludesUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/IncludesUtil.java
@@ -7,8 +7,10 @@ package com.ibm.fhir.search.parameters;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,7 +25,7 @@ public class IncludesUtil {
     private static final Logger LOG = java.util.logging.Logger.getLogger(IncludesUtil.class.getName());
 
     /**
-     * Computes the list of supported include parameter values that target resource types from the passed resourcesToInclude list.
+     * Computes the list of supported include parameter values that target resource types from the passed set of resourceTypesToInclude.
      *
      * @param baseResourceType
      * @param resourceTypesToInclude
@@ -31,11 +33,13 @@ public class IncludesUtil {
      * @return The list of values to use for the _include search parameter.
      * @throws Exception
      */
-    public static List<String> computeIncludesParamValues(String baseResourceType, List<String> resourceTypesToInclude, SearchHelper searchHelper)
+    public static List<String> computeIncludesParamValues(String baseResourceType, Set<String> resourceTypesToInclude, SearchHelper searchHelper)
             throws Exception {
         List<String> result = new ArrayList<>();
 
-        List<String> allowedIncludes = FHIRConfigHelper.getSearchPropertyRestrictions(baseResourceType, FHIRConfigHelper.SEARCH_PROPERTY_TYPE_INCLUDE);
+        List<String> allowedIncludesList = FHIRConfigHelper.getSearchPropertyRestrictions(baseResourceType, FHIRConfigHelper.SEARCH_PROPERTY_TYPE_INCLUDE);
+        Set<String> allowedIncludes = (allowedIncludesList == null) ? null : new HashSet<>(allowedIncludesList);
+
         Map<ResourceType, List<String>> codesByType = IncludesUtil.getSearchCodesByType(baseResourceType, searchHelper);
 
         for (Map.Entry<ResourceType, List<String>> entry : codesByType.entrySet()) {
@@ -86,13 +90,13 @@ public class IncludesUtil {
     /**
      * @param compartmentMemberType the resource type that is the source of the includes
      * @param subResourceType the target resource type of the includes; null
-     * @param allowedIncludes the list of include parameter values to allow
+     * @param allowedIncludes the set of include parameter values to allow
      * @param codes the search parameter codes to include on
      * @return A list of parameter values to use for the _include query parameter.
      * @throws Exception
      */
     private static List<String> computeIncludes(String compartmentMemberType, ResourceType subResourceType,
-            List<String> allowedIncludes, List<String> codes) throws Exception {
+            Set<String> allowedIncludes, List<String> codes) throws Exception {
         List<String> includes = new ArrayList<>();
 
         for (String code : codes) {

--- a/fhir-search/src/main/java/com/ibm/fhir/search/parameters/IncludesUtil.java
+++ b/fhir-search/src/main/java/com/ibm/fhir/search/parameters/IncludesUtil.java
@@ -1,0 +1,116 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.search.parameters;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.ibm.fhir.config.FHIRConfigHelper;
+import com.ibm.fhir.core.ResourceType;
+import com.ibm.fhir.model.resource.SearchParameter;
+import com.ibm.fhir.model.type.code.ResourceTypeCode;
+import com.ibm.fhir.model.type.code.SearchParamType.Value;
+import com.ibm.fhir.search.util.SearchHelper;
+
+public class IncludesUtil {
+    private static final Logger LOG = java.util.logging.Logger.getLogger(IncludesUtil.class.getName());
+
+    /**
+     * Computes the list of supported include parameter values that target resource types from the passed resourcesToInclude list.
+     *
+     * @param baseResourceType
+     * @param resourceTypesToInclude
+     * @param searchHelper
+     * @return The list of values to use for the _include search parameter.
+     * @throws Exception
+     */
+    public static List<String> computeIncludesParamValues(String baseResourceType, List<String> resourceTypesToInclude, SearchHelper searchHelper)
+            throws Exception {
+        List<String> result = new ArrayList<>();
+
+        List<String> allowedIncludes = FHIRConfigHelper.getSearchPropertyRestrictions(baseResourceType, FHIRConfigHelper.SEARCH_PROPERTY_TYPE_INCLUDE);
+        Map<ResourceType, List<String>> codesByType = IncludesUtil.getSearchCodesByType(baseResourceType, searchHelper);
+
+        for (Map.Entry<ResourceType, List<String>> entry : codesByType.entrySet()) {
+            if (resourceTypesToInclude.contains(entry.getKey().value())) {
+                result.addAll(computeIncludes(baseResourceType, entry.getKey(), allowedIncludes, entry.getValue()));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param compartmentMemberType
+     * @param searchHelper
+     * @return a map from resource target type to the list of reference search parameter codes that can target that type
+     * @throws Exception
+     */
+    static Map<ResourceType, List<String>> getSearchCodesByType(String compartmentMemberType, SearchHelper searchHelper) throws Exception {
+        Map<ResourceType, List<String>> codesByType = new HashMap<>();
+
+        Map<String, SearchParameter> allSearchParameters = searchHelper.getSearchParameters(compartmentMemberType);
+        for (Map.Entry<String, SearchParameter> entry : allSearchParameters.entrySet()) {
+            SearchParameter sp = entry.getValue();
+            if (sp.getType().getValueAsEnum() != Value.REFERENCE) {
+                continue;
+            }
+
+            String expression = sp.getExpression().getValue();
+            for (ResourceTypeCode target : sp.getTarget()) {
+                // The search parameter target types come from the possible types of the target reference
+                // and don't take into account any "is X" filters from within the expression,
+                // so we use this heuristic to avoid adding the code when expression filtering applies
+                // and does not include a filter clause for this particular target type.
+                if (expression.contains(".is(") || expression.contains(" is ")) {
+                    if (!expression.contains(".is(" + target.getValue()) && !expression.contains(" is " + target.getValue())) {
+                        continue;
+                    }
+                }
+
+                codesByType.computeIfAbsent(target.getValueAsEnum(), rt -> new ArrayList<>())
+                        .add(entry.getKey());
+            }
+        }
+        return codesByType;
+    }
+
+
+    /**
+     * @param compartmentMemberType the resource type that is the source of the includes
+     * @param subResourceType the target resource type of the includes; null
+     * @param allowedIncludes the list of include parameter values to allow
+     * @param codes the search parameter codes to include on
+     * @return A list of parameter values to use for the _include query parameter.
+     * @throws Exception
+     */
+    private static List<String> computeIncludes(String compartmentMemberType, ResourceType subResourceType,
+            List<String> allowedIncludes, List<String> codes) throws Exception {
+        List<String> includes = new ArrayList<>();
+
+        for (String code : codes) {
+            // Need to make sure the search parameter has not been excluded
+            String parameterName = compartmentMemberType + ":" + code + ":" + subResourceType.value();
+            String simplifiedParameterName = compartmentMemberType + ":" + code;
+
+            boolean isAllowed = allowedIncludes == null ||
+                    allowedIncludes.contains(parameterName) ||
+                    allowedIncludes.contains(simplifiedParameterName);
+
+            if (isAllowed) {
+                includes.add(parameterName);
+            } else if (LOG.isLoggable(Level.FINE)) {
+                LOG.fine("Filtering out searchParameter include because it is not supported by the server config: " + parameterName);
+            }
+        }
+
+        return includes;
+    }
+}

--- a/fhir-search/src/test/java/com/ibm/fhir/search/parameters/IncludesUtilTest.java
+++ b/fhir-search/src/test/java/com/ibm/fhir/search/parameters/IncludesUtilTest.java
@@ -1,0 +1,258 @@
+/*
+ * (C) Copyright IBM Corp. 2022
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.ibm.fhir.search.parameters;
+
+import static com.ibm.fhir.core.ResourceType.LOCATION;
+import static com.ibm.fhir.core.ResourceType.MEDICATION;
+import static com.ibm.fhir.core.ResourceType.ORGANIZATION;
+import static com.ibm.fhir.core.ResourceType.PRACTITIONER;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.ibm.fhir.core.ResourceType;
+import com.ibm.fhir.search.compartment.CompartmentHelper;
+import com.ibm.fhir.search.util.SearchHelper;
+
+public class IncludesUtilTest {
+    private static boolean DEBUG = false;
+
+    @Test
+    void testPatientCompartmentIncludes() throws Exception {
+        CompartmentHelper compartmentHelper = new CompartmentHelper();
+        SearchHelper searchHelper = new SearchHelper();
+        for (String resourceType : compartmentHelper.getCompartmentResourceTypes("Patient")) {
+            Map<ResourceType,List<String>> oldSearchCodesByType = oldGetSearchCodesByType(resourceType);
+            Map<ResourceType,List<String>> newSearchCodesByType = IncludesUtil.getSearchCodesByType(resourceType, searchHelper);
+
+            for (ResourceType targetType : List.of(LOCATION, MEDICATION, PRACTITIONER, ORGANIZATION)) {
+                List<String> oldList = oldSearchCodesByType.get(targetType);
+                List<String> newList = newSearchCodesByType.get(targetType);
+
+                if (DEBUG && (oldList == null || oldList.size() != newList.size())) {
+                    System.out.println(resourceType + " to " + targetType.value());
+                    System.out.println("old: " + oldList);
+                    System.out.println("new: " + newList);
+                    System.out.println();
+                }
+
+                // the new list is expected to contain some search parameters that the old one was missing
+                // because the old list was gathered manually and did not include parameters that target "Any"
+                if (oldList != null) {
+                    assertTrue(newList.containsAll(oldList));
+                }
+            }
+        }
+    }
+
+
+    /**
+     * The old implementation that was manually computed.
+     */
+    private Map<ResourceType, List<String>> oldGetSearchCodesByType(String compartmentMemberType) {
+        Map<ResourceType, List<String>> codesByType = new HashMap<>();
+        if (compartmentMemberType.equals(ResourceType.ADVERSE_EVENT.value())) {
+            addLocationCodes(codesByType, "location");
+            addPractitionerCodes(codesByType, "recorder", "subject");
+            addMedicationCodes(codesByType, "substance");
+        } else if (compartmentMemberType.equals(ResourceType.ALLERGY_INTOLERANCE.value())) {
+            addPractitionerCodes(codesByType, "recorder", "asserter");
+        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT.value())) {
+            addLocationCodes(codesByType, "location");
+            addPractitionerCodes(codesByType, "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT_RESPONSE.value())) {
+            addLocationCodes(codesByType, "actor", "location");
+            addPractitionerCodes(codesByType, "actor", "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.ACCOUNT.value())) {
+            addOrganizationCodes(codesByType, "owner", "subject");
+            addLocationCodes(codesByType, "subject");
+            addPractitionerCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.AUDIT_EVENT.value())) {
+            addOrganizationCodes(codesByType, "agent", "source");
+            addPractitionerCodes(codesByType, "agent", "source");
+        } else if (compartmentMemberType.equals(ResourceType.BASIC.value())) {
+            addOrganizationCodes(codesByType, "author");
+            addPractitionerCodes(codesByType, "author");
+        } else if (compartmentMemberType.equals(ResourceType.CARE_PLAN.value())) {
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.CARE_TEAM.value())) {
+            addOrganizationCodes(codesByType, "participant");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals("ChargeHistory")) {
+            addOrganizationCodes(codesByType, "service");
+            addPractitionerCodes(codesByType, "enterer", "performer-actor");
+        } else if (compartmentMemberType.equals(ResourceType.CLAIM.value())) {
+            addOrganizationCodes(codesByType, "care-team", "insurer", "payee", "provider");
+            addPractitionerCodes(codesByType, "care-team", "enterer", "payee", "provider");
+            addLocationCodes(codesByType, "facility");
+        } else if (compartmentMemberType.equals(ResourceType.CLAIM_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "insurer", "requestor");
+            addPractitionerCodes(codesByType, "requestor");
+        } else if (compartmentMemberType.equals(ResourceType.CLINICAL_IMPRESSION.value())) {
+            addPractitionerCodes(codesByType, "assessor");
+        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION.value())) {
+            addPractitionerCodes(codesByType, "recipient", "sender");
+        } else if (compartmentMemberType.equals(ResourceType.COMPOSITION.value())) {
+            addPractitionerCodes(codesByType, "attester", "author");
+        } else if (compartmentMemberType.equals(ResourceType.CONDITION.value())) {
+            addPractitionerCodes(codesByType, "asserter");
+        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "recipient", "requester", "sender");
+            addPractitionerCodes(codesByType, "recipient", "requester", "sender");
+        } else if (compartmentMemberType.equals(ResourceType.CONSENT.value())) {
+            addOrganizationCodes(codesByType, "actor", "consentor", "organization");
+            addPractitionerCodes(codesByType, "actor", "consentor");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE.value())) {
+            addOrganizationCodes(codesByType, "payor", "policy-holder");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_REQUEST.value())) {
+            addPractitionerCodes(codesByType, "enterer", "provider");
+            addLocationCodes(codesByType, "facility");
+            addOrganizationCodes(codesByType, "provider");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "insurer", "requestor");
+            addPractitionerCodes(codesByType, "requestor");
+        } else if (compartmentMemberType.equals(ResourceType.DETECTED_ISSUE.value())) {
+            addPractitionerCodes(codesByType, "author");
+        } else if (compartmentMemberType.equals(ResourceType.DEVICE_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "performer", "requester");
+            addPractitionerCodes(codesByType, "performer", "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DIAGNOSTIC_REPORT.value())) {
+            addOrganizationCodes(codesByType, "performer", "results-interpreter");
+            addPractitionerCodes(codesByType, "performer", "results-interpreter");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_MANIFEST.value())) {
+            addOrganizationCodes(codesByType, "author", "recipient");
+            addPractitionerCodes(codesByType, "author", "recipient", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_REFERENCE.value())) {
+            addOrganizationCodes(codesByType, "authenticator", "author", "custodian");
+            addPractitionerCodes(codesByType, "authenticator", "author", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.ENCOUNTER.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "service-provider");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals(ResourceType.EPISODE_OF_CARE.value())) {
+            addPractitionerCodes(codesByType, "care-manager");
+            addOrganizationCodes(codesByType, "organization");
+        } else if (compartmentMemberType.equals(ResourceType.EXPLANATION_OF_BENEFIT.value())) {
+            // the old implementation erroneously included "insurer" here
+            addOrganizationCodes(codesByType, "care-team", "payee", "provider");
+            addPractitionerCodes(codesByType, "care-team", "enterer", "payee", "provider");
+            addLocationCodes(codesByType, "facility");
+        } else if (compartmentMemberType.equals(ResourceType.FLAG.value())) {
+            addOrganizationCodes(codesByType, "author", "subject");
+            addPractitionerCodes(codesByType, "author", "subject");
+            addLocationCodes(codesByType, "subject");
+            addMedicationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.GOAL.value())) {
+            addOrganizationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.GROUP.value())) {
+            addMedicationCodes(codesByType, "member");
+            addPractitionerCodes(codesByType, "member", "managing-entity");
+            addOrganizationCodes(codesByType, "managing-entity");
+        } else if (compartmentMemberType.equals(ResourceType.IMAGING_STUDY.value())) {
+            addPractitionerCodes(codesByType, "interpreter", "performer", "referrer");
+        } else if (compartmentMemberType.equals(ResourceType.IMMUNIZATION.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "manufacturer", "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.INVOICE.value())) {
+            addOrganizationCodes(codesByType, "issuer", "participant", "recipient");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals(ResourceType.LIST.value())) {
+            addPractitionerCodes(codesByType, "source");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEASURE_REPORT.value())) {
+            addLocationCodes(codesByType, "reporter", "subject");
+            addOrganizationCodes(codesByType, "reporter");
+            addPractitionerCodes(codesByType, "reporter", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEDIA.value())) {
+            addOrganizationCodes(codesByType, "operator");
+            addPractitionerCodes(codesByType, "operator", "subject");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_ADMINISTRATION.value())) {
+            addMedicationCodes(codesByType, "medication");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_DISPENSE.value())) {
+            addLocationCodes(codesByType, "destination");
+            addMedicationCodes(codesByType, "medication");
+            addPractitionerCodes(codesByType, "performer", "receiver", "responsibleparty");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "intended-dispenser", "intended-performer", "requester");
+            addPractitionerCodes(codesByType, "intended-performer", "requester");
+            addMedicationCodes(codesByType, "medication");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_STATEMENT.value())) {
+            addMedicationCodes(codesByType, "medication");
+            addOrganizationCodes(codesByType, "source");
+            addPractitionerCodes(codesByType, "source");
+        } else if (compartmentMemberType.equals("NutritionHistory")) {
+            addPractitionerCodes(codesByType, "provider");
+        } else if (compartmentMemberType.equals(ResourceType.OBSERVATION.value())) {
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.QUESTIONNAIRE_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "author");
+            addPractitionerCodes(codesByType, "author", "source");
+        } else if (compartmentMemberType.equals(ResourceType.PATIENT.value())) {
+            addOrganizationCodes(codesByType, "general-practitioner", "organization");
+            addPractitionerCodes(codesByType, "general-practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.PERSON.value())) {
+            addOrganizationCodes(codesByType, "organization");
+            addPractitionerCodes(codesByType, "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.PROCEDURE.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.PROVENANCE.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "agent");
+            addPractitionerCodes(codesByType, "agent");
+        } else if (compartmentMemberType.equals(ResourceType.REQUEST_GROUP.value())) {
+            addPractitionerCodes(codesByType, "author", "participant");
+        } else if (compartmentMemberType.equals(ResourceType.RISK_ASSESSMENT.value())) {
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.SCHEDULE.value())) {
+            addLocationCodes(codesByType, "actor");
+            addPractitionerCodes(codesByType, "actor");
+        } else if (compartmentMemberType.equals(ResourceType.SERVICE_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "performer", "requester");
+            addPractitionerCodes(codesByType, "performer", "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.SPECIMEN.value())) {
+            addPractitionerCodes(codesByType, "collector");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_DELIVERY.value())) {
+            addPractitionerCodes(codesByType, "receiver", "supplier");
+            addOrganizationCodes(codesByType, "supplier");
+        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "requester", "subject", "supplier");
+            addPractitionerCodes(codesByType, "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.VISION_PRESCRIPTION.value())) {
+            addPractitionerCodes(codesByType, "prescriber");
+        }
+        return codesByType;
+    }
+    private void addLocationCodes(Map<ResourceType, List<String>> codesByType, String... codes) {
+        codesByType.put(ResourceType.LOCATION, Arrays.asList(codes));
+    }
+    private void addMedicationCodes(Map<ResourceType, List<String>> codesByType, String... codes) {
+        codesByType.put(ResourceType.MEDICATION, Arrays.asList(codes));
+    }
+    private void addPractitionerCodes(Map<ResourceType, List<String>> codesByType, String... codes) {
+        codesByType.put(ResourceType.PRACTITIONER, Arrays.asList(codes));
+    }
+    private void addOrganizationCodes(Map<ResourceType, List<String>> codesByType, String... codes) {
+        codesByType.put(ResourceType.ORGANIZATION, Arrays.asList(codes));
+    }
+}

--- a/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
+++ b/operation/fhir-operation-everything/src/main/java/com/ibm/fhir/operation/everything/EverythingOperation.java
@@ -11,8 +11,10 @@ import static com.ibm.fhir.model.util.ModelSupport.FHIR_STRING;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -442,262 +444,7 @@ public class EverythingOperation extends AbstractOperation {
         }
 
         // Add in _includes for all search parameters that are Location, Medication, Organization, or Practitioner
-        if (compartmentMemberType.equals(ResourceType.ADVERSE_EVENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recorder", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "substance", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.ALLERGY_INTOLERANCE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recorder", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "asserter", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "practitioner", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT_RESPONSE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "practitioner", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.ACCOUNT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "owner", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.AUDIT_EVENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "agent", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "agent", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.BASIC.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CARE_PLAN.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CARE_TEAM.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.ORGANIZATION,searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals("ChargeHistory")) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "service", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "enterer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer-actor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CLAIM.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "care-team", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "care-team", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "enterer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "facility", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "insurer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "payee", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "payee", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CLAIM_RESPONSE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "insurer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requestor", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requestor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CLINICAL_IMPRESSION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "assessor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "sender", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COMPOSITION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "attester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CONDITION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "asserter", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "sender", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "sender", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.CONSENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "consentor", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "consentor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "organization", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COVERAGE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "payor", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "policy-holder", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "enterer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "facility", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_RESPONSE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "insurer",ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requestor", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requestor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.DETECTED_ISSUE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.DEVICE_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.DIAGNOSTIC_REPORT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "results-interpreter", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "results-interpreter", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_MANIFEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_REFERENCE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "authenticator", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "authenticator", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "custodian", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.ENCOUNTER.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "service-provider", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.EPISODE_OF_CARE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "care-manager", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "organization", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.EXPLANATION_OF_BENEFIT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "care-team", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "care-team", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "enterer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "facility", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "insurer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "payee", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "payee", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.FLAG.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.GOAL.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.GROUP.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "member", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "member", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "managing-entity", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "managing-entity", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.IMAGING_STUDY.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "interpreter", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "referrer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.IMMUNIZATION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "manufacturer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.INVOICE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "issuer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "recipient", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.LIST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEASURE_REPORT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "reporter", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "reporter", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "reporter", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEDIA.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "operator", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "operator", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_ADMINISTRATION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "medication", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_DISPENSE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "destination", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "medication", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "receiver", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "responsibleparty", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "intended-dispenser", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "intended-performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "intended-performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "medication", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_STATEMENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "medication", ResourceType.MEDICATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals("NutritionHistory")) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "provider", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.OBSERVATION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.QUESTIONNAIRE_RESPONSE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "source", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.PATIENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "general-practitioner", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "general-practitioner", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "organization", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.PERSON.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "organization", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "practitioner", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.PROCEDURE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.PROVENANCE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "location", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "agent", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "agent", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(Reference.class.getSimpleName())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "authenticator", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "authenticator", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "custodian", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.REQUEST_GROUP.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "author", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "participant", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.RISK_ASSESSMENT.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.SCHEDULE.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "actor", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.SERVICE_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "performer", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.SPECIMEN.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "collector", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_DELIVERY.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "receiver", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "supplier", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "supplier", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_REQUEST.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "requester", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.LOCATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "subject", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-            addSearchParameterIfNotExcluded(compartmentMemberType, "supplier", ResourceType.ORGANIZATION, searchParameters, allowedIncludes, extraResources, searchHelper);
-        } else if (compartmentMemberType.equals(ResourceType.VISION_PRESCRIPTION.value())) {
-            addSearchParameterIfNotExcluded(compartmentMemberType, "prescriber", ResourceType.PRACTITIONER, searchParameters, allowedIncludes, extraResources, searchHelper);
-        }
+        Map<ResourceType, String[]> codesByType = getSearchCodesByType(compartmentMemberType);
 
         // BodyStructure, ResearchSubject, and RelatedPerson have no references to:
         // Location, Medication, Organization, and Practitioner
@@ -706,33 +453,53 @@ public class EverythingOperation extends AbstractOperation {
         // ImmunizationEvaluation, ImmunizationRecommendation, MolecularSequence,
         // and NutritionOrder have no search parameters that reference:
         // Location, Medication, Organization, and Practitioner
+
+        for (Map.Entry<ResourceType, String[]> entry : codesByType.entrySet()) {
+            List<String> includes = computeIncludes(compartmentMemberType, entry.getKey(), allowedIncludes, extraResources, searchHelper, entry.getValue());
+            searchParameters.addAll("_include", includes);
+        }
     }
 
-    private void addSearchParameterIfNotExcluded(String compartmentMemberType, String code,
-            ResourceType subResourceType, MultivaluedMap<String, String> searchParameters,
-            List<String> allowedIncludes, List<String> extraResources, SearchHelper searchHelper)
+    /**
+     * @param compartmentMemberType the resource type that is the source of the includes
+     * @param subResourceType the target resource type of the includes; null
+     * @param allowedIncludes the list of include parameter values to allow
+     * @param extraResources the resource types to include
+     * @param searchHelper the source of truth for configured search parameters
+     * @param codes the search parameter codes to include on
+     * @return A list of parameter values to use for the _include query parameter
+     * @throws Exception
+     */
+    private List<String> computeIncludes(String compartmentMemberType, ResourceType subResourceType,
+            List<String> allowedIncludes, List<String> extraResources, SearchHelper searchHelper, String... codes)
             throws Exception {
-        // Need to make sure the search parameter has not been excluded
-        String parameterName = compartmentMemberType + ":" + code + ":" + subResourceType.value();
-        String simplifiedParameterName = compartmentMemberType + ":" + code;
+        List<String> includes = new ArrayList<>();
 
-        boolean isAllowed = allowedIncludes == null ||
-                allowedIncludes.contains(parameterName) ||
-                allowedIncludes.contains(simplifiedParameterName);
+        for (String code : codes) {
+            // Need to make sure the search parameter has not been excluded
+            String parameterName = compartmentMemberType + ":" + code + ":" + subResourceType.value();
+            String simplifiedParameterName = compartmentMemberType + ":" + code;
 
-        boolean isConfigured = extraResources != null &&
-                extraResources.contains(subResourceType.value());
+            boolean isAllowed = allowedIncludes == null ||
+                    allowedIncludes.contains(parameterName) ||
+                    allowedIncludes.contains(simplifiedParameterName);
 
-        // Also check if the parameter is supported by retrieving it from the SearchHelper
-        SearchParameter searchParam = searchHelper.getSearchParameter(compartmentMemberType, code);
+            boolean isConfigured = extraResources != null &&
+                    extraResources.contains(subResourceType.value());
 
-        if (isAllowed && isConfigured && searchParam != null) {
-            searchParameters.add("_include", parameterName);
-        } else {
-            if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("Filtering out searchParameter because it is not supported by the server config: " + parameterName);
+            // Also check if the parameter is supported by retrieving it from the SearchHelper
+            SearchParameter searchParam = searchHelper.getSearchParameter(compartmentMemberType, code);
+
+            if (isAllowed && isConfigured && searchParam != null) {
+                includes.add(parameterName);
+            } else {
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.fine("Filtering out searchParameter because it is not supported by the server config: " + parameterName);
+                }
             }
         }
+
+        return includes;
     }
 
     /**
@@ -834,5 +601,209 @@ public class EverythingOperation extends AbstractOperation {
         }
 
         bundleBuilder.entry(entryBuilder.build());
+    }
+
+    /**
+     * This couple be static if we wrap it in one more map...
+     */
+    private Map<ResourceType, String[]> getSearchCodesByType(String compartmentMemberType) {
+        Map<ResourceType, String[]> codesByType = new HashMap<>();
+        if (compartmentMemberType.equals(ResourceType.ADVERSE_EVENT.value())) {
+            addLocationCodes(codesByType, "location");
+            addPractitionerCodes(codesByType, "recorder", "subject");
+            addMedicationCodes(codesByType, "substance");
+        } else if (compartmentMemberType.equals(ResourceType.ALLERGY_INTOLERANCE.value())) {
+            addPractitionerCodes(codesByType, "recorder", "asserter");
+        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT.value())) {
+            addLocationCodes(codesByType, "location");
+            addPractitionerCodes(codesByType, "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.APPOINTMENT_RESPONSE.value())) {
+            addLocationCodes(codesByType, "actor", "location");
+            addPractitionerCodes(codesByType, "actor", "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.ACCOUNT.value())) {
+            addOrganizationCodes(codesByType, "owner", "subject");
+            addLocationCodes(codesByType, "subject");
+            addPractitionerCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.AUDIT_EVENT.value())) {
+            addOrganizationCodes(codesByType, "agent", "source");
+            addPractitionerCodes(codesByType, "agent", "source");
+        } else if (compartmentMemberType.equals(ResourceType.BASIC.value())) {
+            addOrganizationCodes(codesByType, "author");
+            addPractitionerCodes(codesByType, "author");
+        } else if (compartmentMemberType.equals(ResourceType.CARE_PLAN.value())) {
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.CARE_TEAM.value())) {
+            addOrganizationCodes(codesByType, "participant");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals("ChargeHistory")) {
+            addOrganizationCodes(codesByType, "service");
+            addPractitionerCodes(codesByType, "enterer", "performer-actor");
+        } else if (compartmentMemberType.equals(ResourceType.CLAIM.value())) {
+            addOrganizationCodes(codesByType, "care-team", "insurer", "payee", "provider");
+            addPractitionerCodes(codesByType, "care-team", "enterer", "payee", "provider");
+            addLocationCodes(codesByType, "facility");
+        } else if (compartmentMemberType.equals(ResourceType.CLAIM_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "insurer", "requestor");
+            addPractitionerCodes(codesByType, "requestor");
+        } else if (compartmentMemberType.equals(ResourceType.CLINICAL_IMPRESSION.value())) {
+            addPractitionerCodes(codesByType, "assessor");
+        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION.value())) {
+            addPractitionerCodes(codesByType, "recipient", "sender");
+        } else if (compartmentMemberType.equals(ResourceType.COMPOSITION.value())) {
+            addPractitionerCodes(codesByType, "attester", "author");
+        } else if (compartmentMemberType.equals(ResourceType.CONDITION.value())) {
+            addPractitionerCodes(codesByType, "asserter");
+        } else if (compartmentMemberType.equals(ResourceType.COMMUNICATION_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "recipient", "requester", "sender");
+            addPractitionerCodes(codesByType, "recipient", "requester", "sender");
+        } else if (compartmentMemberType.equals(ResourceType.CONSENT.value())) {
+            addOrganizationCodes(codesByType, "actor", "consentor", "organization");
+            addPractitionerCodes(codesByType, "actor", "consentor");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE.value())) {
+            addOrganizationCodes(codesByType, "payor", "policy-holder");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_REQUEST.value())) {
+            addPractitionerCodes(codesByType, "enterer", "provider");
+            addLocationCodes(codesByType, "facility");
+            addOrganizationCodes(codesByType, "provider");
+        } else if (compartmentMemberType.equals(ResourceType.COVERAGE_ELIGIBILITY_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "insurer", "requestor");
+            addPractitionerCodes(codesByType, "requestor");
+        } else if (compartmentMemberType.equals(ResourceType.DETECTED_ISSUE.value())) {
+            addPractitionerCodes(codesByType, "author");
+        } else if (compartmentMemberType.equals(ResourceType.DEVICE_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "performer", "requester");
+            addPractitionerCodes(codesByType, "performer", "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DIAGNOSTIC_REPORT.value())) {
+            addOrganizationCodes(codesByType, "performer", "results-interpreter");
+            addPractitionerCodes(codesByType, "performer", "results-interpreter");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_MANIFEST.value())) {
+            addOrganizationCodes(codesByType, "author", "recipient");
+            addPractitionerCodes(codesByType, "author", "recipient", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.DOCUMENT_REFERENCE.value())) {
+            addOrganizationCodes(codesByType, "authenticator", "author", "custodian");
+            addPractitionerCodes(codesByType, "authenticator", "author", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.ENCOUNTER.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "service-provider");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals(ResourceType.EPISODE_OF_CARE.value())) {
+            addPractitionerCodes(codesByType, "care-manager");
+            addOrganizationCodes(codesByType, "organization");
+        } else if (compartmentMemberType.equals(ResourceType.EXPLANATION_OF_BENEFIT.value())) {
+            addOrganizationCodes(codesByType, "care-team", "insurer", "payee", "provider");
+            addPractitionerCodes(codesByType, "care-team", "enterer", "payee", "provider");
+            addLocationCodes(codesByType, "facility");
+        } else if (compartmentMemberType.equals(ResourceType.FLAG.value())) {
+            addOrganizationCodes(codesByType, "author", "subject");
+            addPractitionerCodes(codesByType, "author", "subject");
+            addLocationCodes(codesByType, "subject");
+            addMedicationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.GOAL.value())) {
+            addOrganizationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.GROUP.value())) {
+            addMedicationCodes(codesByType, "member");
+            addOrganizationCodes(codesByType, "member", "managing-entity");
+            addPractitionerCodes(codesByType, "managing-entity");
+        } else if (compartmentMemberType.equals(ResourceType.IMAGING_STUDY.value())) {
+            addPractitionerCodes(codesByType, "interpreter", "performer", "referrer");
+        } else if (compartmentMemberType.equals(ResourceType.IMMUNIZATION.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "manufacturer", "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.INVOICE.value())) {
+            addOrganizationCodes(codesByType, "issuer", "participant", "recipient");
+            addPractitionerCodes(codesByType, "participant");
+        } else if (compartmentMemberType.equals(ResourceType.LIST.value())) {
+            addPractitionerCodes(codesByType, "source");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEASURE_REPORT.value())) {
+            addLocationCodes(codesByType, "reporter", "subject");
+            addOrganizationCodes(codesByType, "reporter");
+            addPractitionerCodes(codesByType, "reporter", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEDIA.value())) {
+            addOrganizationCodes(codesByType, "operator");
+            addPractitionerCodes(codesByType, "operator", "subject");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_ADMINISTRATION.value())) {
+            addMedicationCodes(codesByType, "medication");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_DISPENSE.value())) {
+            addLocationCodes(codesByType, "destination");
+            addMedicationCodes(codesByType, "medication");
+            addPractitionerCodes(codesByType, "performer", "receiver", "responsibleparty");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "intended-dispenser", "intended-performer", "requester");
+            addPractitionerCodes(codesByType, "intended-performer", "requester");
+            addMedicationCodes(codesByType, "medication");
+        } else if (compartmentMemberType.equals(ResourceType.MEDICATION_STATEMENT.value())) {
+            addMedicationCodes(codesByType, "medication");
+            addOrganizationCodes(codesByType, "source");
+            addPractitionerCodes(codesByType, "source");
+        } else if (compartmentMemberType.equals("NutritionHistory")) {
+            addPractitionerCodes(codesByType, "provider");
+        } else if (compartmentMemberType.equals(ResourceType.OBSERVATION.value())) {
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.QUESTIONNAIRE_RESPONSE.value())) {
+            addOrganizationCodes(codesByType, "author");
+            addPractitionerCodes(codesByType, "author", "source");
+        } else if (compartmentMemberType.equals(ResourceType.PATIENT.value())) {
+            addOrganizationCodes(codesByType, "general-practitioner", "organization");
+            addPractitionerCodes(codesByType, "general-practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.PERSON.value())) {
+            addOrganizationCodes(codesByType, "organization");
+            addPractitionerCodes(codesByType, "practitioner");
+        } else if (compartmentMemberType.equals(ResourceType.PROCEDURE.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "performer");
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.PROVENANCE.value())) {
+            addLocationCodes(codesByType, "location");
+            addOrganizationCodes(codesByType, "agent");
+            addPractitionerCodes(codesByType, "agent");
+        } else if (compartmentMemberType.equals(Reference.class.getSimpleName())) {
+            addOrganizationCodes(codesByType, "authenticator", "author", "custodian");
+            addPractitionerCodes(codesByType, "authenticator", "author", "subject");
+        } else if (compartmentMemberType.equals(ResourceType.REQUEST_GROUP.value())) {
+            addPractitionerCodes(codesByType, "author", "participant");
+        } else if (compartmentMemberType.equals(ResourceType.RISK_ASSESSMENT.value())) {
+            addPractitionerCodes(codesByType, "performer");
+        } else if (compartmentMemberType.equals(ResourceType.SCHEDULE.value())) {
+            addLocationCodes(codesByType, "actor");
+            addPractitionerCodes(codesByType, "actor");
+        } else if (compartmentMemberType.equals(ResourceType.SERVICE_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "performer", "requester");
+            addPractitionerCodes(codesByType, "performer", "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.SPECIMEN.value())) {
+            addPractitionerCodes(codesByType, "collector");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_DELIVERY.value())) {
+            addPractitionerCodes(codesByType, "receiver", "supplier");
+            addOrganizationCodes(codesByType, "supplier");
+        } else if (compartmentMemberType.equals(ResourceType.SUPPLY_REQUEST.value())) {
+            addOrganizationCodes(codesByType, "requester", "subject", "supplier");
+            addPractitionerCodes(codesByType, "requester");
+            addLocationCodes(codesByType, "subject");
+        } else if (compartmentMemberType.equals(ResourceType.VISION_PRESCRIPTION.value())) {
+            addPractitionerCodes(codesByType, "prescriber");
+        }
+        return codesByType;
+    }
+    private void addLocationCodes(Map<ResourceType, String[]> codesByType, String... codes) {
+        codesByType.put(ResourceType.LOCATION, codes);
+    }
+    private void addMedicationCodes(Map<ResourceType, String[]> codesByType, String... codes) {
+        codesByType.put(ResourceType.MEDICATION, codes);
+    }
+    private void addPractitionerCodes(Map<ResourceType, String[]> codesByType, String... codes) {
+        codesByType.put(ResourceType.PRACTITIONER, codes);
+    }
+    private void addOrganizationCodes(Map<ResourceType, String[]> codesByType, String... codes) {
+        codesByType.put(ResourceType.ORGANIZATION, codes);
     }
 }

--- a/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
+++ b/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2021
+ * (C) Copyright IBM Corp. 2021, 2022
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -29,22 +29,17 @@ import com.ibm.fhir.search.SearchConstants;
 import com.ibm.fhir.search.exception.FHIRSearchException;
 
 /**
- *
+ * Unit tests for the $everything operation
  */
 public class EverythingOperationTest {
-
-
     private EverythingOperation everythingOperation;
 
-    /**
-     *
-     */
     public EverythingOperationTest() {
         everythingOperation = new EverythingOperation();
     }
 
     /**
-     *
+     * Build the OperationDefinition and ensure its not null
      */
     @Test
     public void testEverythingOperation() {

--- a/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
+++ b/operation/fhir-operation-everything/src/test/java/com/ibm/fhir/operation/everything/EverythingOperationTest.java
@@ -42,7 +42,7 @@ public class EverythingOperationTest {
      * Build the OperationDefinition and ensure its not null
      */
     @Test
-    public void testEverythingOperation() {
+    public void testEverythingOperationDefinition() {
         EverythingOperation exportOperation = new EverythingOperation();
         OperationDefinition operationDefinition = exportOperation.buildOperationDefinition();
         assertNotNull(operationDefinition);


### PR DESCRIPTION
Instead of a big if/else with all the manually preconfigured search parameters, we now look up the applicable search parameters for the given resource type for this tenant and then process those into the set of includes.

It should work mostly the same, except that:
1. we now support "includeTypes" for all resource types; previously it only supported "Medication", "Location", "Practitioner", and "Organization
2. for the 4 types that were previously supported, we include a few additional includes that were missed in the manually computed list
3. we fix a single issue with an include value from ExplanationOfBenefit (it used to add "insurer" but this is not a valid search parameter in the core specification)