### PR TITLE
issue #3735 - remove invoke(String,String,Resource) special processing

### DIFF
--- a/fhir-server/pom.xml
+++ b/fhir-server/pom.xml
@@ -67,6 +67,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>fhir-profile</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>fhir-validation</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/FHIRResource.java
@@ -336,7 +336,8 @@ public class FHIRResource {
         if (status.getFamily() == Status.Family.SERVER_ERROR) {
             log.log(Level.SEVERE, e.getMessage(), e);
         } else if (log.isLoggable(Level.FINE)) {
-            log.log(Level.FINE, e.getMessage(), e);
+            // purposefully logged at level INFO because otherwise liberty suppresses the stacktrace
+            log.log(Level.INFO, e.getMessage(), e);
         } else if (log.isLoggable(Level.INFO)) {
             log.log(Level.INFO, e.getMessage());
         }

--- a/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
+++ b/fhir-server/src/main/java/com/ibm/fhir/server/resources/Operation.java
@@ -264,21 +264,8 @@ public class Operation extends FHIRResource {
             status = Response.Status.fromStatusCode(response.getStatus());
             return response;
         } catch (FHIROperationException e) {
-            // response 200 OK if no failure issue found.
-            boolean isFailure = false;
-            for (Issue issue : e.getIssues()) {
-                if (FHIRUtil.isFailure(issue.getSeverity())) {
-                    isFailure = true;
-                    break;
-                }
-            }
-            if (isFailure) {
-                status = issueListToStatus(e.getIssues());
-                return exceptionResponse(e, status);
-            } else {
-                status = Status.OK;
-                return exceptionResponse(e, Response.Status.OK);
-            }
+            status = issueListToStatus(e.getIssues());
+            return exceptionResponse(e, status);
         } catch (Exception e) {
             status = Status.INTERNAL_SERVER_ERROR;
             return exceptionResponse(e, status);


### PR DESCRIPTION
For some reason, our exception handling for
`invoke(String,String,Resource)` differs from the exception handling in
all the other invoke methods.

I assume that was done so that the $invoke operation properly returns a
200 OK in cases where the data is invalid.
But this is not the right level for that logic and it can prevent us
from seeing important server issues in the logs.
I double-checked and the ValidateOperation is
already returning a valid OperationOutcome response for successful
validation of invalid resources, so I think we just need to remove the
special handling at the Operation JAX-RS resource.

Additionally, we found "interesting" liberty behavior that was
preventing us from seeing the exception stack trace even when FINE
logging is enabled; that log message is now level INFO so that the stack
trace gets printed (but it will still only be printed when the FINE
level is enabled).

Finally, I snuck in a small pom.xml fixup for fhir-server.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>